### PR TITLE
Accidentally removed CA should trigger crt recreation (and rolling update)

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -234,14 +234,14 @@ public class ModelUtils {
             reasons.add("certificate doesn't exist yet");
             shouldBeRegenerated = true;
         } else {
-            if (clusterCa.certRenewed() || (clusterCa.isExpiring(secret, keyCertName + ".crt") && isMaintenanceTimeWindowsSatisfied)) {
+            if (clusterCa.keyCreated() || clusterCa.certRenewed() || (clusterCa.isExpiring(secret, keyCertName + ".crt") && isMaintenanceTimeWindowsSatisfied)) {
                 reasons.add("certificate needs to be renewed");
                 shouldBeRegenerated = true;
             }
         }
 
         if (shouldBeRegenerated) {
-            log.debug("Certificate for pod {} need to be regenerated because:", keyCertName, String.join(", ", reasons));
+            log.debug("Certificate for pod {} need to be regenerated because: {}", keyCertName, String.join(", ", reasons));
 
             try {
                 certAndKey = clusterCa.generateSignedCert(commonName, Ca.IO_STRIMZI);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -234,7 +234,7 @@ public class ModelUtils {
             reasons.add("certificate doesn't exist yet");
             shouldBeRegenerated = true;
         } else {
-            if (clusterCa.keyCreated() || clusterCa.certRenewed() || (clusterCa.isExpiring(secret, keyCertName + ".crt") && isMaintenanceTimeWindowsSatisfied)) {
+            if (clusterCa.keyCreated() || clusterCa.certRenewed() || (isMaintenanceTimeWindowsSatisfied && clusterCa.isExpiring(secret, keyCertName + ".crt"))) {
                 reasons.add("certificate needs to be renewed");
                 shouldBeRegenerated = true;
             }

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -387,8 +387,12 @@ public abstract class Ca {
                 reasons.add("certificate is expiring");
             }
 
+            if (renewalType == RenewalType.CREATE) {
+                reasons.add("certificate added");
+            }
+
             if (!reasons.isEmpty())  {
-                log.debug("Certificate for pod {} need to be regenerated because:", podName, String.join(", ", reasons));
+                log.debug("Certificate for pod {} need to be regenerated because: {}", podName, String.join(", ", reasons));
 
                 CertAndKey newCertAndKey = generateSignedCert(subject, brokerCsrFile, brokerKeyFile, brokerCertFile, brokerKeyStoreFile);
                 certs.put(podName, newCertAndKey);
@@ -735,6 +739,10 @@ public abstract class Ca {
      */
     public boolean keyReplaced() {
         return renewalType == RenewalType.REPLACE_KEY;
+    }
+
+    public boolean keyCreated() {
+        return renewalType == RenewalType.CREATE;
     }
 
     private int removeExpiredCerts(Map<String, String> newData) {

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -387,7 +387,7 @@ public abstract class Ca {
                 reasons.add("certificate is expiring");
             }
 
-            if (renewalType == RenewalType.CREATE) {
+            if (renewalType.equals(RenewalType.CREATE)) {
                 reasons.add("certificate added");
             }
 
@@ -556,7 +556,7 @@ public abstract class Ca {
         Map<String, String> certAnnotations = new HashMap<>(2);
         certAnnotations.put(ANNO_STRIMZI_IO_CA_CERT_GENERATION, String.valueOf(caCertGeneration));
 
-        if (renewalType == RenewalType.POSTPONED
+        if (renewalType.equals(RenewalType.POSTPONED)
                 && this.caCertSecret.getMetadata() != null
                 && Annotations.hasAnnotation(caCertSecret, ANNO_STRIMZI_IO_FORCE_RENEW))   {
             certAnnotations.put(ANNO_STRIMZI_IO_FORCE_RENEW, Annotations.stringAnnotation(caCertSecret, ANNO_STRIMZI_IO_FORCE_RENEW, "false"));
@@ -565,7 +565,7 @@ public abstract class Ca {
         Map<String, String> keyAnnotations = new HashMap<>(2);
         keyAnnotations.put(ANNO_STRIMZI_IO_CA_KEY_GENERATION, String.valueOf(caKeyGeneration));
 
-        if (renewalType == RenewalType.POSTPONED
+        if (renewalType.equals(RenewalType.POSTPONED)
                 && this.caKeySecret.getMetadata() != null
                 && Annotations.hasAnnotation(caKeySecret, ANNO_STRIMZI_IO_FORCE_REPLACE))   {
             keyAnnotations.put(ANNO_STRIMZI_IO_FORCE_REPLACE, Annotations.stringAnnotation(caKeySecret, ANNO_STRIMZI_IO_FORCE_REPLACE, "false"));
@@ -654,13 +654,13 @@ public abstract class Ca {
                 break;
         }
         if (!generateCa) {
-            if (renewalType == RenewalType.RENEW_CERT) {
+            if (renewalType.equals(RenewalType.RENEW_CERT)) {
                 log.warn("The certificate (data.{}) in Secret {} in namespace {} needs to be renewed " +
                                 "and it is not configured to automatically renew. This needs to be manually updated before that date. " +
                                 "Alternatively, configure Kafka.spec.tlsCertificates.generateCertificateAuthority=true in the Kafka resource with name {} in namespace {}.",
                         CA_CRT.replace(".", "\\."), this.caCertSecretName, namespace,
                         currentCert.getNotAfter());
-            } else if (renewalType == RenewalType.REPLACE_KEY) {
+            } else if (renewalType.equals(RenewalType.REPLACE_KEY)) {
                 log.warn("The private key (data.{}) in Secret {} in namespace {} needs to be renewed " +
                                 "and it is not configured to automatically renew. This needs to be manually updated before that date. " +
                                 "Alternatively, configure Kafka.spec.tlsCertificates.generateCertificateAuthority=true in the Kafka resource with name {} in namespace {}.",
@@ -729,7 +729,7 @@ public abstract class Ca {
      * @return Whether the certificate was renewed.
      */
     public boolean certRenewed() {
-        return renewalType == RenewalType.RENEW_CERT || renewalType == RenewalType.REPLACE_KEY;
+        return renewalType.equals(RenewalType.RENEW_CERT) || renewalType.equals(RenewalType.REPLACE_KEY);
     }
 
     /**
@@ -738,11 +738,11 @@ public abstract class Ca {
      * @return Whether the key was replaced.
      */
     public boolean keyReplaced() {
-        return renewalType == RenewalType.REPLACE_KEY;
+        return renewalType.equals(RenewalType.REPLACE_KEY);
     }
 
     public boolean keyCreated() {
-        return renewalType == RenewalType.CREATE;
+        return renewalType.equals(RenewalType.CREATE);
     }
 
     private int removeExpiredCerts(Map<String, String> newData) {


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/542

### Checklist
- [ ] Update/write design documentation in `./design`
- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

