### PR TITLE
feat: Context succeeding - Part 4 - operator-common

### DIFF
--- a/operator-common/src/test/java/io/strimzi/operator/common/BackOffTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/BackOffTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BackOffTest {
 
@@ -35,12 +35,9 @@ public class BackOffTest {
         assertThat(b.delayMs(), is(3200L));
         assertThat(b.cumulativeDelayMs(), is(6200L));
         assertThat(b.done(), is(true));
-        try {
-            b.delayMs();
-            fail("Should throw");
-        } catch (MaxAttemptsExceededException e) {
 
-        }
+        assertThrows(MaxAttemptsExceededException.class, () -> b.delayMs());
+
         assertThat(b.done(), is(true));
         assertThat(b.totalDelayMs(), is(6200L));
     }
@@ -59,12 +56,8 @@ public class BackOffTest {
         assertThat(b.delayMs(), is(100L));
         //attempt
         assertThat(b.delayMs(), is(1000L));
-        try {
-            b.delayMs();
-            fail("Should throw");
-        } catch (MaxAttemptsExceededException e) {
 
-        }
+        assertThrows(MaxAttemptsExceededException.class, () -> b.delayMs());
 
         assertThat(b.totalDelayMs(), is(1111L));
     }
@@ -75,12 +68,9 @@ public class BackOffTest {
         assertThat(b.delayMs(), is(0L));
         assertThat(b.delayMs(), is(200L));
         assertThat(b.delayMs(), is(400L));
-        try {
-            b.delayMs();
-            fail("Should throw");
-        } catch (MaxAttemptsExceededException e) {
 
-        }
+        assertThrows(MaxAttemptsExceededException.class, () -> b.delayMs());
+
         assertThat(b.totalDelayMs(), is(600L));
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
@@ -9,8 +9,9 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static io.strimzi.operator.common.Util.parseMap;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UtilTest {
@@ -20,15 +21,15 @@ public class UtilTest {
                 "key2=value2";
 
         Map<String, String> m = parseMap(stringMap);
-        assertThat(m.size(), is(2));
-        assertThat(m.get("key1"), is("value1"));
-        assertThat(m.get("key2"), is("value2"));
+        assertThat(m, aMapWithSize(2));
+        assertThat(m, hasEntry("key1", "value1"));
+        assertThat(m, hasEntry("key2", "value2"));
     }
 
     @Test
     public void testParseMapNull() {
         Map<String, String> m = parseMap(null);
-        assertThat(m.size(), is(0));
+        assertThat(m, aMapWithSize(0));
     }
 
     @Test
@@ -36,7 +37,7 @@ public class UtilTest {
         String stringMap = "";
 
         Map<String, String> m = parseMap(null);
-        assertThat(m.size(), is(0));
+        assertThat(m, aMapWithSize(0));
     }
 
     @Test
@@ -45,9 +46,9 @@ public class UtilTest {
                 "key2=";
 
         Map<String, String> m = parseMap(stringMap);
-        assertThat(m.size(), is(2));
-        assertThat(m.get("key1"), is("value1"));
-        assertThat(m.get("key2"), is(""));
+        assertThat(m, aMapWithSize(2));
+        assertThat(m, hasEntry("key1", "value1"));
+        assertThat(m, hasEntry("key2", ""));
     }
 
     @Test
@@ -57,9 +58,9 @@ public class UtilTest {
                     "key2";
 
             Map<String, String> m = parseMap(stringMap);
-            assertThat(m.size(), is(2));
-            assertThat(m.get("key1"), is("value1"));
-            assertThat(m.get("key2"), is(""));
+            assertThat(m, aMapWithSize(2));
+            assertThat(m, hasEntry("key1", "value1"));
+            assertThat(m, hasEntry("key2", ""));
         });
     }
 
@@ -69,8 +70,8 @@ public class UtilTest {
                 "key2=value2=value3";
 
         Map<String, String> m = parseMap(stringMap);
-        assertThat(m.size(), is(2));
-        assertThat(m.get("key1"), is("value1"));
-        assertThat(m.get("key2"), is("value2=value3"));
+        assertThat(m, aMapWithSize(2));
+        assertThat(m, hasEntry("key1", "value1"));
+        assertThat(m, hasEntry("key2", "value2=value3"));
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
@@ -151,15 +151,13 @@ public class LabelsTest {
     }
 
     @Test
-    public void testWithInvalidUserLabels()   {
-        assertThrows(IllegalArgumentException.class, () -> {
-            Map userLabelsWithStrimzi = new HashMap<String, String>(2);
-            userLabelsWithStrimzi.put("key1", "value1");
-            userLabelsWithStrimzi.put("key2", "value2");
-            userLabelsWithStrimzi.put(Labels.STRIMZI_DOMAIN + "something", "value3");
+    public void testWithInvalidUserSuppliedLabels()   {
+        Map userLabelsWithStrimzi = new HashMap<String, String>(3);
+        userLabelsWithStrimzi.put("key1", "value1");
+        userLabelsWithStrimzi.put("key2", "value2");
+        userLabelsWithStrimzi.put(Labels.STRIMZI_DOMAIN + "something", "value3");
 
-            Labels nonNullLabels = Labels.EMPTY.withAdditionalLabels(userLabelsWithStrimzi);
-        });
+        assertThrows(IllegalArgumentException.class, () -> Labels.EMPTY.withAdditionalLabels(userLabelsWithStrimzi));
     }
 
     @Test

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorIT.java
@@ -10,7 +10,6 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.test.k8s.cluster.KubeCluster;
-import io.strimzi.test.k8s.exceptions.NoClusterException;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
@@ -24,7 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  * The main purpose of the Integration Tests for the operators is to test them against a real Kubernetes cluster.
@@ -40,11 +39,7 @@ public abstract class AbstractNonNamespacedResourceOperatorIT<C extends Kubernet
 
     @BeforeAll
     public static void before() {
-        try {
-            KubeCluster.bootstrap();
-        } catch (NoClusterException e) {
-            assumeTrue(false, e.getMessage());
-        }
+        assertDoesNotThrow(() -> KubeCluster.bootstrap(), "Could not bootstrap server");
         vertx = Vertx.vertx();
         client = new DefaultKubernetesClient();
     }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorIT.java
@@ -11,7 +11,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.cluster.KubeCluster;
-import io.strimzi.test.k8s.exceptions.NoClusterException;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
@@ -29,7 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  * The main purpose of the Integration Tests for the operators is to test them against a real Kubernetes cluster.
@@ -52,11 +51,7 @@ public abstract class AbstractResourceOperatorIT<C extends KubernetesClient, T e
         cluster = KubeClusterResource.getInstance();
         cluster.setTestNamespace(namespace);
 
-        try {
-            KubeCluster.bootstrap();
-        } catch (NoClusterException e) {
-            assumeTrue(false, e.getMessage());
-        }
+        assertDoesNotThrow(() -> KubeCluster.bootstrap(), "Could not bootstrap server");
         vertx = Vertx.vertx();
         client = new DefaultKubernetesClient();
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaBridgeCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaBridgeCrdOperatorIT.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridgeBuilder;
 import io.strimzi.api.kafka.model.status.ConditionBuilder;
+
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.common.operator.resource;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
@@ -27,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.net.URL;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -100,15 +101,14 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
         when(mockCall.execute()).thenReturn(response);
 
         Checkpoint async = context.checkpoint();
-        CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> op = createResourceOperations(vertx, mockClient);
-        op.updateStatusAsync(resource()).setHandler(res -> {
-            context.verify(() -> assertThat(res.succeeded(), is(true)));
-            async.flag();
-        });
+
+        createResourceOperations(vertx, mockClient)
+            .updateStatusAsync(resource())
+            .setHandler(context.succeeding(kafka -> async.flag()));
     }
 
     @Test
-    public void testHttp422AfterUpgrade(VertxTestContext context) throws IOException {
+    public void testUpdateStatusWorksAfterUpgradeWithHttp422ResponseAboutApiVersionField(VertxTestContext context) throws IOException {
         KubernetesClient mockClient = mock(KubernetesClient.class);
 
         OkHttpClient mockOkHttp = mock(OkHttpClient.class);
@@ -122,15 +122,14 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
         when(mockCall.execute()).thenReturn(response);
 
         Checkpoint async = context.checkpoint();
-        CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> op = createResourceOperations(vertx, mockClient);
-        op.updateStatusAsync(resource()).setHandler(res -> {
-            context.verify(() -> assertThat(res.succeeded(), is(true)));
-            async.flag();
-        });
+        createResourceOperations(vertx, mockClient)
+            .updateStatusAsync(resource())
+            .setHandler(context.succeeding(kafka -> async.flag()));
+
     }
 
     @Test
-    public void testHttp422DifferentError(VertxTestContext context) throws IOException {
+    public void testUpdateStatusThrowsWhenHttp422ResponseWithOtherField(VertxTestContext context) throws IOException {
         KubernetesClient mockClient = mock(KubernetesClient.class);
 
         OkHttpClient mockOkHttp = mock(OkHttpClient.class);
@@ -144,15 +143,17 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
         when(mockCall.execute()).thenReturn(response);
 
         Checkpoint async = context.checkpoint();
-        CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> op = createResourceOperations(vertx, mockClient);
-        op.updateStatusAsync(resource()).setHandler(res -> {
-            context.verify(() -> assertThat(res.succeeded(), is(false)));
-            async.flag();
-        });
+        createResourceOperations(vertx, mockClient)
+            .updateStatusAsync(resource())
+            .setHandler(context.failing(e -> context.verify(() -> {
+                assertThat(e, instanceOf(KubernetesClientException.class));
+                async.flag();
+            })));
+
     }
 
     @Test
-    public void testHttp422NoBody(VertxTestContext context) throws IOException {
+    public void testUpdateStatusThrowsWhenHttp422ResponseWithNoBody(VertxTestContext context) throws IOException {
         KubernetesClient mockClient = mock(KubernetesClient.class);
 
         OkHttpClient mockOkHttp = mock(OkHttpClient.class);
@@ -166,15 +167,16 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
         when(mockCall.execute()).thenReturn(response);
 
         Checkpoint async = context.checkpoint();
-        CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> op = createResourceOperations(vertx, mockClient);
-        op.updateStatusAsync(resource()).setHandler(res -> {
-            context.verify(() -> assertThat(res.succeeded(), is(false)));
-            async.flag();
-        });
+        createResourceOperations(vertx, mockClient)
+            .updateStatusAsync(resource())
+            .setHandler(context.failing(e -> context.verify(() -> {
+                assertThat(e, instanceOf(KubernetesClientException.class));
+                async.flag();
+            })));
     }
 
     @Test
-    public void testHttp409(VertxTestContext context) throws IOException {
+    public void testUpdateStatusThrowsWhenHttp409Response(VertxTestContext context) throws IOException {
         KubernetesClient mockClient = mock(KubernetesClient.class);
 
         OkHttpClient mockOkHttp = mock(OkHttpClient.class);
@@ -188,10 +190,11 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
         when(mockCall.execute()).thenReturn(response);
 
         Checkpoint async = context.checkpoint();
-        CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> op = createResourceOperations(vertx, mockClient);
-        op.updateStatusAsync(resource()).setHandler(res -> {
-            context.verify(() -> assertThat(res.succeeded(), is(false)));
-            async.flag();
-        });
+        createResourceOperations(vertx, mockClient)
+            .updateStatusAsync(resource())
+            .setHandler(context.failing(e -> context.verify(() -> {
+                assertThat(e, instanceOf(KubernetesClientException.class));
+                async.flag();
+            })));
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMaker2CrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMaker2CrdOperatorIT.java
@@ -33,7 +33,6 @@ public class KafkaMirrorMaker2CrdOperatorIT extends AbstractCustomResourceOperat
     @Override
     protected CrdOperator operator() {
         return new CrdOperator(vertx, client, KafkaMirrorMaker2.class, KafkaMirrorMaker2List.class, DoneableKafkaMirrorMaker2.class);
-
     }
 
     @Override

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/StorageClassOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/StorageClassOperatorIT.java
@@ -57,11 +57,13 @@ public class StorageClassOperatorIT extends AbstractNonNamespacedResourceOperato
     }
 
     @Override
-    protected void assertResources(VertxTestContext context, StorageClass expected, StorageClass actual)   {
-        context.verify(() -> assertThat(actual.getMetadata().getName(), is(expected.getMetadata().getName())));
-        context.verify(() -> assertThat(actual.getMetadata().getLabels(), is(expected.getMetadata().getLabels())));
-        context.verify(() -> assertThat(actual.getReclaimPolicy(), is(expected.getReclaimPolicy())));
-        context.verify(() -> assertThat(actual.getProvisioner(), is(expected.getProvisioner())));
-        context.verify(() -> assertThat(actual.getParameters(), is(expected.getParameters())));
+    protected void assertResources(VertxTestContext context, StorageClass expected, StorageClass actual) {
+        context.verify(() -> {
+            assertThat(actual.getMetadata().getName(), is(expected.getMetadata().getName()));
+            assertThat(actual.getMetadata().getLabels(), is(expected.getMetadata().getLabels()));
+            assertThat(actual.getReclaimPolicy(), is(expected.getReclaimPolicy()));
+            assertThat(actual.getProvisioner(), is(expected.getProvisioner()));
+            assertThat(actual.getParameters(), is(expected.getParameters()));
+        });
     }
 }


### PR DESCRIPTION
For this Pull request I have continued the context
succeeding work, and taken the opportunity to remove
unneeded concurrency based dependencies.
minor test renames, hamcrest additions and variable
renames to improve clarity.

This finishes off the improvements to the test in operator-common
partially done in previous PRs

Contributes to: #2647

Signed-off-by: Samuel Hawker samuel.hawker@ibm.com

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

