### PR TITLE
feat: Context succeeding - Part 6 - topic-operator mockkube kafka-init api

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
@@ -13,14 +13,13 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionSpec;
-import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -55,7 +54,7 @@ public class ExamplesTest {
         validateRecursively(new File("../examples"));
     }
 
-    private void validateRecursively(File directory) throws IOException {
+    private void validateRecursively(File directory) {
         for (File f : directory.listFiles()) {
             if (f.isDirectory()) {
                 if (f.getAbsolutePath().contains("examples/metrics/grafana") || f.getAbsolutePath().contains("examples/metrics/prometheus"))  {

--- a/api/src/test/java/io/strimzi/api/kafka/model/JmxTransTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/JmxTransTest.java
@@ -10,30 +10,39 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 
 public class JmxTransTest {
     @Test
     public void testQueries() {
         JmxTransSpec opts = TestUtils.fromJson("{" +
                 "\"kafkaQueries\": [{" +
-                        "\"targetMBean\": \"targetMBean\"," +
+                        "\"targetMBean\": \"targetMBean1\"," +
                         "\"attributes\": [\"attribute0\", \"attribute1\"]," +
                         "\"outputs\": [\"output0\", \"output1\"]" +
                     "}, {" +
-                        "\"targetMBean\": \"targetMBean\"," +
-                        "\"attributes\": [\"attribute1\", \"attribute2\"]," +
-                        "\"outputs\": [\"output0\", \"output1\"]" +
+                        "\"targetMBean\": \"targetMBean2\"," +
+                        "\"attributes\": [\"attribute2\", \"attribute3\"]," +
+                        "\"outputs\": [\"output2\", \"output3\"]" +
                     "}]" +
                 "}", JmxTransSpec.class);
 
         assertThat(opts, is(notNullValue()));
-        assertThat(opts.getKafkaQueries().size(),  is(2));
-        assertThat(opts.getKafkaQueries().get(0).getTargetMBean(),  is("targetMBean"));
+        assertThat(opts.getKafkaQueries(), hasSize(2));
+
+        assertThat(opts.getKafkaQueries().get(0).getTargetMBean(),  is("targetMBean1"));
         assertThat(opts.getKafkaQueries().get(0).getAttributes().size(),  is(2));
         assertThat(opts.getKafkaQueries().get(0).getAttributes().get(0),  is("attribute0"));
         assertThat(opts.getKafkaQueries().get(0).getAttributes().get(1),  is("attribute1"));
         assertThat(opts.getKafkaQueries().get(0).getOutputs().get(0),  is("output0"));
         assertThat(opts.getKafkaQueries().get(0).getOutputs().get(1),  is("output1"));
+
+        assertThat(opts.getKafkaQueries().get(1).getTargetMBean(),  is("targetMBean2"));
+        assertThat(opts.getKafkaQueries().get(1).getAttributes().size(),  is(2));
+        assertThat(opts.getKafkaQueries().get(1).getAttributes().get(0),  is("attribute2"));
+        assertThat(opts.getKafkaQueries().get(1).getAttributes().get(1),  is("attribute3"));
+        assertThat(opts.getKafkaQueries().get(1).getOutputs().get(0),  is("output2"));
+        assertThat(opts.getKafkaQueries().get(1).getOutputs().get(1),  is("output3"));
     }
 
     @Test
@@ -53,17 +62,22 @@ public class JmxTransTest {
                 "}", JmxTransSpec.class);
 
         assertThat(opts, is(notNullValue()));
-        assertThat(opts.getOutputDefinitions().size(),  is(2));
-        assertThat(opts.getOutputDefinitions().get(0).getHost(),  is("targetHost"));
-        assertThat(opts.getOutputDefinitions().get(0).getOutputType(),  is("targetOutputType"));
-        assertThat(opts.getOutputDefinitions().get(0).getFlushDelayInSeconds(),  is(1));
-        assertThat(opts.getOutputDefinitions().get(0).getTypeNames().get(0),  is("typeName0"));
-        assertThat(opts.getOutputDefinitions().get(0).getTypeNames().get(1),  is("typeName1"));
-        assertThat(opts.getOutputDefinitions().get(0).getName(),  is("targetName"));
+        assertThat(opts.getOutputDefinitions(), hasSize(2));
+
+        assertThat(opts.getOutputDefinitions().get(0).getHost(), is("targetHost"));
+        assertThat(opts.getOutputDefinitions().get(0).getOutputType(), is("targetOutputType"));
+        assertThat(opts.getOutputDefinitions().get(0).getFlushDelayInSeconds(), is(1));
+        assertThat(opts.getOutputDefinitions().get(0).getTypeNames().get(0), is("typeName0"));
+        assertThat(opts.getOutputDefinitions().get(0).getTypeNames().get(1), is("typeName1"));
+        assertThat(opts.getOutputDefinitions().get(0).getName(), is("targetName"));
+
+
+        assertThat(opts.getOutputDefinitions().get(1).getOutputType(), is("targetOutputType"));
+        assertThat(opts.getOutputDefinitions().get(1).getName(), is("name1"));
     }
 
     @Test
-    public void getCustomImage() {
+    public void testUseCustomImage() {
         JmxTransSpec opts = TestUtils.fromJson("{" +
                 "\"image\": \"testImage\"" +
                 "}", JmxTransSpec.class);

--- a/api/src/test/java/io/strimzi/api/kafka/model/JvmOptionsTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/JvmOptionsTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 public class JvmOptionsTest {
     @Test
-    public void testXmxXms() {
+    public void testSetXmxXms() {
         JvmOptions opts = TestUtils.fromJson("{" +
                 "  \"-Xmx\": \"2g\"," +
                 "  \"-Xms\": \"1g\"" +
@@ -37,7 +37,6 @@ public class JvmOptionsTest {
 
         assertThat(opts.isServer(), is(true));
 
-
         opts = TestUtils.fromJson("{" +
                 "  \"-server\": true" +
                 "}", JvmOptions.class);
@@ -46,6 +45,12 @@ public class JvmOptionsTest {
 
         opts = TestUtils.fromJson("{" +
                 "  \"-server\": \"false\"" +
+                "}", JvmOptions.class);
+
+        assertThat(opts.isServer(), is(false));
+
+        opts = TestUtils.fromJson("{" +
+                "  \"-server\": false" +
                 "}", JvmOptions.class);
 
         assertThat(opts.isServer(), is(false));
@@ -67,6 +72,10 @@ public class JvmOptionsTest {
                 "}", JvmOptions.class);
 
         assertThat(opts.getXx(), is(TestUtils.map("key1", "value1", "key2", "value2", "key3", "true", "key4", "true", "key5", "10")));
+
+        opts = TestUtils.fromJson("{}", JvmOptions.class);
+
+        assertThat(opts.getXx(), is(nullValue()));
     }
 }
 

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
@@ -45,9 +45,7 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
     void testKafkaBridgeWithMissingRequired() {
         Throwable exception = assertThrows(
             KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(KafkaBridge.class, "KafkaBridge-with-missing-required-property.yaml");
-            });
+            () -> createDelete(KafkaBridge.class, "KafkaBridge-with-missing-required-property.yaml"));
 
         assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.bootstrapServers");
     }
@@ -66,9 +64,7 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
     void testKafkaBridgeWithTlsAuthWithMissingRequired() {
         Throwable exception = assertThrows(
             KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(KafkaBridge.class, "KafkaBridge-with-tls-auth-with-missing-required.yaml");
-            });
+            () -> createDelete(KafkaBridge.class, "KafkaBridge-with-tls-auth-with-missing-required.yaml"));
 
         assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.authentication.certificateAndKey.certificate",
                 "spec.authentication.certificateAndKey.key");
@@ -93,9 +89,7 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
     void testKafkaBridgeWithWrongTracingType() {
         Throwable exception = assertThrows(
             KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(KafkaBridge.class, "KafkaBridge-with-wrong-tracing-type.yaml");
-            });
+            () -> createDelete(KafkaBridge.class, "KafkaBridge-with-wrong-tracing-type.yaml"));
 
         assertThat(exception.getMessage(), anyOf(
                 containsStringIgnoringCase("spec.tracing.type in body should be one of [jaeger]"),
@@ -106,9 +100,7 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
     void testKafkaBridgeWithMissingTracingType() {
         Throwable exception = assertThrows(
             KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(KafkaBridge.class, "KafkaBridge-with-missing-tracing-type.yaml");
-            });
+            () -> createDelete(KafkaBridge.class, "KafkaBridge-with-missing-tracing-type.yaml"));
 
         assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.tracing.type");
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
@@ -48,9 +48,7 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
     void testKafkaConnectWithMissingRequired() {
         Throwable exception = assertThrows(
             KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(KafkaConnect.class, "KafkaConnect-with-missing-required-property.yaml");
-            });
+            () -> createDelete(KafkaConnect.class, "KafkaConnect-with-missing-required-property.yaml"));
 
         assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.bootstrapServers");
     }
@@ -59,9 +57,7 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
     void testKafkaConnectWithInvalidReplicas() {
         Throwable exception = assertThrows(
             KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(KafkaConnect.class, "KafkaConnect-with-invalid-replicas.yaml");
-            });
+            () -> createDelete(KafkaConnect.class, "KafkaConnect-with-invalid-replicas.yaml"));
 
         assertThat(exception.getMessage(),
                 containsStringIgnoringCase("spec.replicas in body must be of type integer: \"string\""));
@@ -81,9 +77,7 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
     void testKafkaConnectWithTlsAuthWithMissingRequired() {
         Throwable exception = assertThrows(
             KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(KafkaConnect.class, "KafkaConnect-with-tls-auth-with-missing-required.yaml");
-            });
+            () -> createDelete(KafkaConnect.class, "KafkaConnect-with-tls-auth-with-missing-required.yaml"));
 
         assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.authentication.certificateAndKey.certificate", "spec.authentication.certificateAndKey.key");
     }
@@ -107,9 +101,7 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
     public void testKafkaConnectWithInvalidExternalConfiguration() {
         Throwable exception = assertThrows(
             KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(KafkaConnect.class, "KafkaConnect-with-invalid-external-configuration.yaml");
-            });
+            () -> createDelete(KafkaConnect.class, "KafkaConnect-with-invalid-external-configuration.yaml"));
 
         assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.externalConfiguration.env.valueFrom");
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -51,9 +51,7 @@ public class KafkaCrdIT extends AbstractCrdIT {
     void testKafkaWithMissingRequired() {
         Throwable exception = assertThrows(
             KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(Kafka.class, "Kafka-with-missing-required-property.yaml");
-            });
+            () -> createDelete(Kafka.class, "Kafka-with-missing-required-property.yaml"));
 
         assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.zookeeper", "spec.kafka");
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2CrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2CrdIT.java
@@ -44,9 +44,7 @@ public class KafkaMirrorMaker2CrdIT extends AbstractCrdIT {
     void testKafkaMirrorMaker2WithMissingRequired() {
         Throwable exception = assertThrows(
             KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(KafkaMirrorMaker2.class, "KafkaMirrorMaker2-with-missing-required-property.yaml");
-            });
+            () -> createDelete(KafkaMirrorMaker2.class, "KafkaMirrorMaker2-with-missing-required-property.yaml"));
 
         assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.connectCluster", "spec.clusters.alias", "spec.mirrors.sourceCluster", "spec.mirrors.targetCluster");
     }
@@ -55,9 +53,7 @@ public class KafkaMirrorMaker2CrdIT extends AbstractCrdIT {
     void testKafkaMirrorMaker2WithInvalidReplicas() {
         Throwable exception = assertThrows(
             KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(KafkaMirrorMaker2.class, "KafkaMirrorMaker2-with-invalid-replicas.yaml");
-            });
+            () -> createDelete(KafkaMirrorMaker2.class, "KafkaMirrorMaker2-with-invalid-replicas.yaml"));
 
         assertThat(exception.getMessage(),
                 containsStringIgnoringCase("spec.replicas in body must be of type integer: \"string\""));
@@ -77,9 +73,7 @@ public class KafkaMirrorMaker2CrdIT extends AbstractCrdIT {
     void testKafkaMirrorMaker2WithTlsAuthWithMissingRequired() {
         Throwable exception = assertThrows(
             KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(KafkaMirrorMaker2.class, "KafkaMirrorMaker2-with-tls-auth-with-missing-required.yaml");
-            });
+            () -> createDelete(KafkaMirrorMaker2.class, "KafkaMirrorMaker2-with-tls-auth-with-missing-required.yaml"));
         
         assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.clusters.authentication.certificateAndKey.certificate", "spec.clusters.authentication.certificateAndKey.key");
     }
@@ -103,9 +97,7 @@ public class KafkaMirrorMaker2CrdIT extends AbstractCrdIT {
     public void testKafkaMirrorMaker2WithInvalidExternalConfiguration() {
         Throwable exception = assertThrows(
             KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(KafkaMirrorMaker2.class, "KafkaMirrorMaker2-with-invalid-external-configuration.yaml");
-            });
+            () -> createDelete(KafkaMirrorMaker2.class, "KafkaMirrorMaker2-with-invalid-external-configuration.yaml"));
 
         assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.externalConfiguration.env.valueFrom");
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
@@ -71,9 +71,7 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
     void testKafkaMirrorMakerWithTlsAuthWithMissingRequired() {
         Throwable exception = assertThrows(
             KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-tls-auth-with-missing-required.yaml");
-            });
+            () -> createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-tls-auth-with-missing-required.yaml"));
 
         assertMissingRequiredPropertiesMessage(exception.getMessage(),
                 "spec.producer.authentication.certificateAndKey.certificate",

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
@@ -46,9 +46,7 @@ public class KafkaTopicCrdIT extends AbstractCrdIT {
     void testKafkaTopicWithMissingProperty() {
         Throwable exception = assertThrows(
             KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(KafkaTopic.class, "KafkaTopic-with-missing-required-property.yaml");
-            });
+            () -> createDelete(KafkaTopic.class, "KafkaTopic-with-missing-required-property.yaml"));
 
         assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.partitions", "spec.replicas");
     }

--- a/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterConfigTest.java
+++ b/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterConfigTest.java
@@ -6,19 +6,18 @@ package io.strimzi.kafka.init;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 public class InitWriterConfigTest {
 
     private static Map<String, String> envVars = new HashMap<>(3);
-
     static {
         envVars.put(InitWriterConfig.NODE_NAME, "localhost");
         envVars.put(InitWriterConfig.RACK_TOPOLOGY_KEY, "failure-domain.beta.kubernetes.io/zone");
@@ -26,7 +25,7 @@ public class InitWriterConfigTest {
     }
 
     @Test
-    public void testEnvVars() {
+    public void testFromMap() {
         InitWriterConfig config = InitWriterConfig.fromMap(envVars);
 
         assertThat(config.getNodeName(), is("localhost"));
@@ -36,7 +35,7 @@ public class InitWriterConfigTest {
     }
 
     @Test
-    public void testEnvVarsWithAddressType() {
+    public void testFromMapWithAddressTypeEnvVar() {
         Map<String, String> envs = new HashMap<>(envVars);
         envs.put(InitWriterConfig.EXTERNAL_ADDRESS_TYPE, "InternalDNS");
 
@@ -45,19 +44,15 @@ public class InitWriterConfigTest {
     }
 
     @Test
-    public void testEmptyEnvVars() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            InitWriterConfig.fromMap(Collections.emptyMap());
-        });
+    public void testFromMapEmptyEnvVarsThrows() {
+        assertThrows(IllegalArgumentException.class, () -> InitWriterConfig.fromMap(Collections.emptyMap()));
     }
 
     @Test
-    public void testNoNodeName() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            Map<String, String> envVars = new HashMap<>(InitWriterConfigTest.envVars);
-            envVars.remove(InitWriterConfig.NODE_NAME);
+    public void testFromMapMissingNodeNameThrows() {
+        Map<String, String> envVars = new HashMap<>(InitWriterConfigTest.envVars);
+        envVars.remove(InitWriterConfig.NODE_NAME);
 
-            InitWriterConfig.fromMap(envVars);
-        });
+        assertThrows(IllegalArgumentException.class, () -> InitWriterConfig.fromMap(envVars));
     }
 }

--- a/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeRegressionTest.java
+++ b/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeRegressionTest.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class MockKubeRegressionTest {
@@ -30,7 +31,7 @@ public class MockKubeRegressionTest {
     }
 
     @Test
-    public void test1() {
+    public void testStatefulSetCreationAndDeletion() {
         client.apps().statefulSets().inNamespace("ns").withName("foo").createNew()
                 .withNewMetadata()
                     .withName("foo")
@@ -43,10 +44,10 @@ public class MockKubeRegressionTest {
                         .withNewSpec().endSpec()
                     .endTemplate()
                 .endSpec()
-            .done();
+                .done();
 
         List<Pod> ns = client.pods().inNamespace("ns").list().getItems();
-        assertThat(ns.size(), is(3));
+        assertThat(ns, hasSize(3));
 
         AtomicBoolean deleted = new AtomicBoolean(false);
         AtomicBoolean recreated = new AtomicBoolean(false);
@@ -79,7 +80,7 @@ public class MockKubeRegressionTest {
         watch.close();
 
         ns = client.pods().inNamespace("ns").list().getItems();
-        assertThat(ns.size(), is(3));
+        assertThat(ns, hasSize(3));
 
         client.apps().statefulSets().inNamespace("ns").withName("foo").cascading(true).delete();
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ConfigTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ConfigTest.java
@@ -12,8 +12,8 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class ConfigTest {
 
@@ -26,28 +26,28 @@ public class ConfigTest {
     }
 
     @Test
-    public void unknownKey() {
+    public void testUnknownKeyThrows() {
         assertThrows(IllegalArgumentException.class, () -> {
             new Config(Collections.singletonMap("foo", "bar"));
         });
     }
 
     @Test
-    public void empty() {
+    public void testEmptyMapThrows() {
         assertThrows(IllegalArgumentException.class, () -> {
             Config c = new Config(Collections.emptyMap());
         });
     }
 
     @Test
-    public void defaults() {
+    public void testDefaultInput() {
         Map<String, String> map = new HashMap<>(MANDATORY);
         Config c = new Config(map);
         assertThat(c.get(Config.ZOOKEEPER_SESSION_TIMEOUT_MS).intValue(), is(20_000));
     }
 
     @Test
-    public void override() {
+    public void testOverrideZookeeperSessionTimeout() {
         Map<String, String> map = new HashMap<>(MANDATORY);
         map.put(Config.ZOOKEEPER_SESSION_TIMEOUT_MS.key, "13000");
 
@@ -56,24 +56,18 @@ public class ConfigTest {
     }
 
     @Test
-    public void intervals() {
+    public void testNewInvalidTimeout() {
         Map<String, String> map = new HashMap<>(MANDATORY);
-
         map.put(Config.ZOOKEEPER_SESSION_TIMEOUT_MS.key, "13000");
-        new Config(map);
 
+        assertDoesNotThrow(() -> new Config(map));
 
-        try {
-            map.put(Config.ZOOKEEPER_SESSION_TIMEOUT_MS.key, "foos");
-            new Config(map);
-            fail();
-        } catch (IllegalArgumentException e) {
-
-        }
+        map.put(Config.ZOOKEEPER_SESSION_TIMEOUT_MS.key, "foos");
+        assertThrows(IllegalArgumentException.class, () -> new Config(map));
     }
 
     @Test
-    public void topicMetadataMaxAttempts() {
+    public void testTopicMetadataMaxAttemptsIsSetCorrectly() {
 
         Map<String, String> map = new HashMap<>(MANDATORY);
         map.put(Config.TC_TOPIC_METADATA_MAX_ATTEMPTS, "3");

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/LabelsTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/LabelsTest.java
@@ -11,25 +11,15 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LabelsTest {
 
     @Test
-    public void testCtorError() {
-        try {
-            new Labels("foo");
-            fail();
-        } catch (IllegalArgumentException e) {
-
-        }
-
-        try {
-            new Labels("foo", "1", "bar");
-            fail();
-        } catch (IllegalArgumentException e) {
-
-        }
+    public void testOddNumberOfArgumentsThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new Labels("foo"));
+        assertThrows(IllegalArgumentException.class, () -> new Labels("foo", "1", "bar"));
     }
 
     /**
@@ -38,43 +28,41 @@ public class LabelsTest {
      */
     @Test
     public void testParser() {
-        asserParseFails("foo");
+        assertParseThrows("foo");
 
-        asserParseFails("foo=bar,");
+        assertParseThrows("foo=bar,");
 
         // Disallow these for now
-        asserParseFails("foo==bar");
-        asserParseFails("foo!=bar");
-        asserParseFails("foo=bar,");
-        asserParseFails("foo=bar,,");
-        asserParseFails(",foo=bar");
-        asserParseFails(",,foo=bar");
-        asserParseFails("8/foo=bar");
-        asserParseFails("//foo=bar");
-        asserParseFails("a/b/foo=bar");
-        asserParseFails("foo=bar/");
+        assertParseThrows("foo==bar");
+        assertParseThrows("foo!=bar");
+        assertParseThrows("foo=bar,");
+        assertParseThrows("foo=bar,,");
+        assertParseThrows(",foo=bar");
+        assertParseThrows(",,foo=bar");
+        assertParseThrows("8/foo=bar");
+        assertParseThrows("//foo=bar");
+        assertParseThrows("a/b/foo=bar");
+        assertParseThrows("foo=bar/");
 
-        // label values can be empty
-        Labels.fromString("foo=");
+        assertDoesNotThrow(() -> {
+            // label values can be empty
+            Labels.fromString("foo=");
 
-        // single selector
-        Labels.fromString("foo=bar");
-        Labels.fromString("foo/bar=baz");
-        Labels.fromString("foo.io/bar=baz");
+            // single selector
+            Labels.fromString("foo=bar");
+            Labels.fromString("foo/bar=baz");
+            Labels.fromString("foo.io/bar=baz");
 
-        // multiple selectors
-        Labels.fromString("foo=bar,name=gee");
-        Labels.fromString("foo=bar,name=");
-        Labels.fromString("foo=bar,lala/name=");
+            // multiple selectors
+            Labels.fromString("foo=bar,name=gee");
+            Labels.fromString("foo=bar,name=");
+            Labels.fromString("foo=bar,lala/name=");
+        });
+
     }
 
-    private void asserParseFails(String foo) {
-        try {
-            Labels.fromString(foo);
-            fail();
-        } catch (IllegalArgumentException e) {
-
-        }
+    private void assertParseThrows(String unparsable) {
+        assertThrows(IllegalArgumentException.class, () -> Labels.fromString(unparsable));
     }
 
     @Test
@@ -83,6 +71,7 @@ public class LabelsTest {
         Map<String, String> m = new HashMap<>(2);
         m.put("foo", "1");
         m.put("bar", "2");
+
         assertThat(p.labels(), is(m));
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
@@ -6,7 +6,7 @@ package io.strimzi.operator.topic;
 
 import io.strimzi.operator.topic.zk.Zk;
 import io.strimzi.test.EmbeddedZooKeeper;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
@@ -19,8 +19,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.concurrent.ExecutionException;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -37,8 +37,7 @@ public class ZkTopicStoreTest {
     private Zk zk;
 
     @BeforeEach
-    public void setup()
-            throws IOException, InterruptedException {
+    public void setup() throws IOException, InterruptedException {
         this.zkServer = new EmbeddedZooKeeper();
         zk = Zk.createSync(vertx, zkServer.getZkConnectString(), 60_000, 10_000);
         this.store = new ZkTopicStore(zk, "/strimzi/topics");
@@ -55,91 +54,73 @@ public class ZkTopicStoreTest {
     }
 
     @Test
-    public void testCrud(VertxTestContext context) throws ExecutionException, InterruptedException {
+    public void testCrud(VertxTestContext context) {
+        Checkpoint async = context.checkpoint();
+
         Topic topic = new Topic.Builder("my_topic", 2,
                 (short) 3, Collections.singletonMap("foo", "bar")).build();
 
+        Promise<Void> failedCreateCompleted = Promise.promise();
+
         // Create the topic
-        Checkpoint async0 = context.checkpoint();
-        store.create(topic).setHandler(ar -> {
-            async0.flag();
-        });
+        store.create(topic)
+            .setHandler(context.succeeding())
 
-        // Read the topic
-        Checkpoint async1 = context.checkpoint();
-        Future<Topic> topicFuture = Future.future();
-        store.read(new TopicName("my_topic")).setHandler(ar -> {
-            topicFuture.complete(ar.result());
-            async1.flag();
-        });
-        Topic readTopic = topicFuture.result();
+            // Read the topic
+            .compose(v -> store.read(new TopicName("my_topic")))
+            .setHandler(context.succeeding(readTopic -> context.verify(() -> {
+                // assert topics equal
+                assertThat(readTopic.getTopicName(), is(topic.getTopicName()));
+                assertThat(readTopic.getNumPartitions(), is(topic.getNumPartitions()));
+                assertThat(readTopic.getNumReplicas(), is(topic.getNumReplicas()));
+                assertThat(readTopic.getConfig(), is(topic.getConfig()));
+            })))
 
-        // assert topics equal
-        assertThat(readTopic.getTopicName(), is(topic.getTopicName()));
-        assertThat(readTopic.getNumPartitions(), is(topic.getNumPartitions()));
-        assertThat(readTopic.getNumReplicas(), is(topic.getNumReplicas()));
-        assertThat(readTopic.getConfig(), is(topic.getConfig()));
+            // try to create it again: assert an error
+            .compose(v -> store.create(topic))
+            .setHandler(context.failing(e -> context.verify(() -> {
+                assertThat(e, instanceOf(TopicStore.EntityExistsException.class));
+                failedCreateCompleted.complete();
+            })));
 
-        // try to create it again: assert an error
-        store.create(topic).setHandler(ar -> {
-            if (ar.succeeded()) {
-                context.failNow(new Throwable("Should throw"));
-            } else {
-                if (!(ar.cause() instanceof TopicStore.EntityExistsException)) {
-                    context.failNow(ar.cause());
-                }
-            }
-        });
-
-        // update my_topic
-        Checkpoint async2 = context.checkpoint();
-        Topic updated = new Topic.Builder(topic)
+        Topic updatedTopic = new Topic.Builder(topic)
                 .withNumPartitions(3)
-                .withConfigEntry("fruit", "apple").build();
-        store.update(updated).setHandler(ar -> async2.flag());
+                .withConfigEntry("fruit", "apple")
+                .build();
 
-        // re-read it and assert equal
-        Checkpoint async3 = context.checkpoint();
-        Future<Topic> fut = Future.future();
-        store.read(new TopicName("my_topic")).setHandler(ar -> {
-            fut.complete(ar.result());
-            async3.flag();
-        });
-        Topic rereadTopic = fut.result();
+        failedCreateCompleted.future()
+            .compose(v -> {
+                // update my_topic
+                return store.update(updatedTopic);
+            })
+            .setHandler(context.succeeding())
 
-        // assert topics equal
-        assertThat(rereadTopic.getTopicName(), is(updated.getTopicName()));
-        assertThat(rereadTopic.getNumPartitions(), is(updated.getNumPartitions()));
-        assertThat(rereadTopic.getNumReplicas(), is(updated.getNumReplicas()));
-        assertThat(rereadTopic.getConfig(), is(updated.getConfig()));
+            // re-read it and assert equal
+            .compose(v -> store.read(new TopicName("my_topic")))
+            .setHandler(context.succeeding(rereadTopic -> context.verify(() -> {
+                // assert topics equal
+                assertThat(rereadTopic.getTopicName(), is(updatedTopic.getTopicName()));
+                assertThat(rereadTopic.getNumPartitions(), is(updatedTopic.getNumPartitions()));
+                assertThat(rereadTopic.getNumReplicas(), is(updatedTopic.getNumReplicas()));
+                assertThat(rereadTopic.getConfig(), is(updatedTopic.getConfig()));
+            })))
 
-        // delete it
-        Checkpoint async4 = context.checkpoint();
-        store.delete(updated.getTopicName()).setHandler(ar -> async4.flag());
+            // delete it
+            .compose(v -> store.delete(updatedTopic.getTopicName()))
+            .setHandler(context.succeeding())
 
-        // assert we can't read it again
-        Checkpoint async5 = context.checkpoint();
-        store.read(new TopicName("my_topic")).setHandler(ar -> {
-            async5.flag();
-            if (ar.succeeded()) {
-                context.verify(() -> assertThat(ar.result(), is(nullValue())));
-            } else {
-                context.failNow(new Throwable("read() on a non-existent topic should return null"));
-            }
-        });
+            // assert we can't read it again
+            .compose(v -> store.read(new TopicName("my_topic")))
+            .setHandler(context.succeeding(deletedTopic -> context.verify(() -> {
+                assertThat(deletedTopic, is(nullValue()));
+            })))
 
-        // delete it again: assert an error
-        Checkpoint async6 = context.checkpoint();
-        store.delete(updated.getTopicName()).setHandler(ar -> {
-            async6.flag();
-            if (ar.succeeded()) {
-                context.failNow(new Throwable("Should throw"));
-            } else {
-                if (!(ar.cause() instanceof TopicStore.NoSuchEntityExistsException)) {
-                    context.failNow(new Throwable("Unexpected exception " + ar.cause()));
-                }
-            }
-        });
+            // delete it again: assert an error
+            .compose(v -> store.delete(updatedTopic.getTopicName()))
+            .setHandler(context.failing(e -> context.verify(() -> {
+                assertThat(e, instanceOf(TopicStore.NoSuchEntityExistsException.class));
+                async.flag();
+            })));
     }
 
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicsWatcherTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicsWatcherTest.java
@@ -33,18 +33,18 @@ public class ZkTopicsWatcherTest {
     }
 
     private void addTopic() {
-        operator = new MockTopicOperator();
         operator.topicCreatedResult = Future.succeededFuture();
-        mockZk = new MockZk();
         mockZk.childrenResult = Future.succeededFuture(asList("foo", "bar"));
         mockZk.dataResult = Future.succeededFuture(new byte[0]);
+
         TopicConfigsWatcher topicConfigsWatcher = new TopicConfigsWatcher(operator);
         ZkTopicWatcher topicWatcher = new ZkTopicWatcher(operator);
         ZkTopicsWatcher topicsWatcher = new ZkTopicsWatcher(operator, topicConfigsWatcher, topicWatcher);
         topicsWatcher.start(mockZk);
         mockZk.triggerChildren(Future.succeededFuture(asList("foo", "bar", "baz")));
-        assertThat(operator.getMockOperatorEvents(), is(asList(new MockTopicOperator.MockOperatorEvent(
-                Type.CREATE, new TopicName("baz")))));
+
+        assertThat(operator.getMockOperatorEvents(),
+                is(asList(new MockTopicOperator.MockOperatorEvent(Type.CREATE, new TopicName("baz")))));
         assertThat(topicConfigsWatcher.watching("baz"), is(true));
         assertThat(topicWatcher.watching("baz"), is(true));
     }
@@ -53,29 +53,30 @@ public class ZkTopicsWatcherTest {
     public void testTopicConfigChange() {
         // First add a topic
         addTopic();
+
         // Now change the config
         operator.clearEvents();
         mockZk.triggerData("/config/topics/baz", Future.succeededFuture(new byte[0]));
-        assertThat(operator.getMockOperatorEvents(), is(singletonList(
-                new MockTopicOperator.MockOperatorEvent(Type.MODIFY_CONFIG, new TopicName("baz")))));
+        assertThat(operator.getMockOperatorEvents(),
+                is(singletonList(new MockTopicOperator.MockOperatorEvent(Type.MODIFY_CONFIG, new TopicName("baz")))));
 
         operator.clearEvents();
         mockZk.triggerData("/brokers/topics/baz", Future.succeededFuture(new byte[0]));
-        assertThat(operator.getMockOperatorEvents(), is(singletonList(
-                new MockTopicOperator.MockOperatorEvent(Type.MODIFY_PARTITIONS, new TopicName("baz")))));
+        assertThat(operator.getMockOperatorEvents(),
+                is(singletonList(new MockTopicOperator.MockOperatorEvent(Type.MODIFY_PARTITIONS, new TopicName("baz")))));
     }
 
     @Test
     public void testTopicDelete() {
-        operator = new MockTopicOperator();
         operator.topicDeletedResult = Future.succeededFuture();
-        mockZk = new MockZk();
         mockZk.childrenResult = Future.succeededFuture(asList("foo", "bar"));
+
         TopicConfigsWatcher topicConfigsWatcher = new TopicConfigsWatcher(operator);
         ZkTopicWatcher topicWatcher = new ZkTopicWatcher(operator);
         ZkTopicsWatcher topicsWatcher = new ZkTopicsWatcher(operator, topicConfigsWatcher, topicWatcher);
         topicsWatcher.start(mockZk);
         mockZk.triggerChildren(Future.succeededFuture(asList("foo")));
+
         assertThat(operator.getMockOperatorEvents(), is(asList(new MockTopicOperator.MockOperatorEvent(
                 Type.DELETE, new TopicName("bar")))));
         assertThat(topicConfigsWatcher.watching("baz"), is(false));

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/zk/ZkImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/zk/ZkImplTest.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.topic.zk;
 
 import io.strimzi.test.EmbeddedZooKeeper;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
@@ -18,8 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -35,113 +34,109 @@ public class ZkImplTest {
     private Zk zk;
 
     @BeforeEach
-    public void setup()
-            throws IOException, InterruptedException {
+    public void setup() throws IOException, InterruptedException {
         this.zkServer = new EmbeddedZooKeeper();
         zk = Zk.createSync(vertx, zkServer.getZkConnectString(), 60_000, 10_000);
     }
 
     @AfterEach
-    public void teardown(VertxTestContext context) throws InterruptedException {
-        CountDownLatch async = new CountDownLatch(1);
-        zk.disconnect(result -> async.countDown());
-        if (!async.await(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Teardown timeout"));
-        }
-        if (this.zkServer != null) {
-            this.zkServer.close();
-        }
-        context.completeNow();
-        vertx.close();
+    public void teardown(VertxTestContext context) {
+        Checkpoint async = context.checkpoint();
+
+        Promise<Void> zkDisconnected = Promise.promise();
+        zk.disconnect(result -> zkDisconnected.complete());
+
+        zkDisconnected.future().compose(v -> {
+            if (this.zkServer != null) {
+                this.zkServer.close();
+            }
+            vertx.close();
+            async.flag();
+            return Future.succeededFuture();
+        });
+
     }
 
     @Disabled
     @Test
     public void testReconnectOnBounce(VertxTestContext context) throws IOException, InterruptedException {
+        Checkpoint async = context.checkpoint();
+
         Zk zkImpl = Zk.createSync(vertx, zkServer.getZkConnectString(), 60_000, 10_000);
         zkServer.restart();
-        CountDownLatch async = new CountDownLatch(1);
-        zkImpl.create("/foo", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar -> {
-            context.verify(() -> assertThat(ar.succeeded(), is(true)));
-            async.countDown();
-        });
-        if (!async.await(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
-        zkServer.restart();
-        // TODO Without the sleep this test fails, because there's a race between the creation of /bar
-        // and the reconnection within ZkImpl. We probably need to fix ZkImpl to retry if things fail due to
-        // connection loss, possibly with some limit on the number of retries.
-        // TODO We also need to reset the watches on reconnection.
-        Thread.sleep(2000);
-        Checkpoint async2 = context.checkpoint();
-        zkImpl.create("/bar", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar -> {
-            //ar.cause().printStackTrace();
-            context.verify(() -> assertThat(ar.toString(), ar.succeeded(), is(true)));
-            async2.flag();
-        });
-    }
 
-    @Test
-    public void testWatchUnwatchChildren(VertxTestContext context) throws InterruptedException {
-        // Create a node
-        CountDownLatch fooFuture = new CountDownLatch(1);
-        zk.create("/foo", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar -> {
-            fooFuture.countDown();
-        });
-        if (!fooFuture.await(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
+        Promise fooCreated = Promise.promise();
 
-        // Now watch its children
-        CountDownLatch barFuture = new CountDownLatch(1);
-        zk.watchChildren("/foo", watchResult -> {
-            if (singletonList("bar").equals(watchResult.result())) {
-                zk.unwatchChildren("/foo");
-                zk.delete("/foo/bar", -1, deleteResult -> {
-                    barFuture.countDown();
-                });
+        zkImpl.create("/foo", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, context.succeeding(v -> fooCreated.complete()));
+
+        fooCreated.future().compose(v -> {
+            try {
+                zkServer.restart();
+                // TODO Without the sleep this test fails, because there's a race between the creation of /bar
+                // and the reconnection within ZkImpl. We probably need to fix ZkImpl to retry if things fail due to
+                // connection loss, possibly with some limit on the number of retries.
+                // TODO We also need to reset the watches on reconnection.
+                Thread.sleep(2000);
+                zkImpl.create("/bar", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, context.succeeding(vv -> async.flag()));
+            } catch (Exception e) {
+                context.failNow(e);
             }
-        }).<Void>compose(ignored -> {
-            zk.children("/foo", lsResult -> {
-                context.verify(() -> assertThat(lsResult.result(), is(emptyList())));
-                zk.create("/foo/bar", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ig -> { });
-            });
             return Future.succeededFuture();
         });
-        if (!barFuture.await(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
-        context.completeNow();
+
     }
 
     @Test
-    public void testWatchUnwatchData(VertxTestContext context) throws InterruptedException {
+    public void testWatchThenUnwatchChildren(VertxTestContext context) {
+        Checkpoint async = context.checkpoint(2);
+
+        Promise fooCreated = Promise.promise();
+
         // Create a node
-        CountDownLatch fooFuture = new CountDownLatch(1);
-        byte[] data1 = new byte[]{1};
-        zk.create("/foo", data1, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar -> {
-            fooFuture.countDown();
-        });
-        if (!fooFuture.await(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
+        zk.create("/foo", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, context.succeeding(v -> fooCreated.complete()));
 
-        Checkpoint done = context.checkpoint();
-        byte[] data2 = {2};
-        zk.watchData("/foo", dataWatch -> {
-            context.verify(() -> assertThat(dataWatch.result(), is(data2)));
-        }).compose(zk2 -> {
-            zk.getData("/foo", dataResult -> {
-                context.verify(() -> assertThat(dataResult.result(), is(data1)));
-
-                zk.setData("/foo", data2, -1, setResult -> {
-                    done.flag();
+        fooCreated.future().compose(v -> {
+            // Now watch its children
+            zk.watchChildren("/foo", context.succeeding(watchResult -> {
+                if (watchResult.equals(singletonList("bar"))) {
+                    zk.unwatchChildren("/foo");
+                    zk.delete("/foo/bar", -1, deleteResult -> async.flag());
+                }
+            }))
+                .compose(ignored -> {
+                    zk.children("/foo",  context.succeeding(lsResult -> {
+                        context.verify(() -> assertThat(lsResult, is(emptyList())));
+                        zk.create("/foo/bar", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ig -> async.flag());
+                    }));
+                    return Future.succeededFuture();
                 });
-            });
             return Future.succeededFuture();
         });
-        context.completeNow();
     }
 
+    @Test
+    public void testWatchThenUnwatchData(VertxTestContext context) {
+        Checkpoint async = context.checkpoint();
+
+        Promise fooCreated = Promise.promise();
+
+        // Create a node
+        byte[] data1 = new byte[]{1};
+        zk.create("/foo", data1, AclBuilder.PUBLIC, CreateMode.PERSISTENT, context.succeeding(v -> fooCreated.complete()));
+
+        fooCreated.future().compose(v -> {
+            byte[] data2 = {2};
+            return zk.watchData("/foo", context.succeeding(dataWatch -> {
+                context.verify(() -> assertThat(dataWatch, is(data2)));
+            }))
+            .compose(zk -> {
+                zk.getData("/foo", context.succeeding(dataResult -> {
+                    context.verify(() -> assertThat(dataResult, is(data1)));
+
+                    zk.setData("/foo", data2, -1, context.succeeding(setResult -> async.flag()));
+                }));
+                return Future.succeededFuture();
+            });
+        });
+    }
 }

--- a/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
@@ -114,9 +114,9 @@ public class ResourceUtils {
 
     public static KafkaUser createKafkaUserQuotas(Integer consumerByteRate, Integer producerByteRate, Integer requestPercentage) {
         KafkaUserQuotas kuq = new KafkaUserQuotasBuilder()
-                    .withConsumerByteRate(consumerByteRate)
-                    .withProducerByteRate(producerByteRate)
-                    .withRequestPercentage(requestPercentage)
+                .withConsumerByteRate(consumerByteRate)
+                .withProducerByteRate(producerByteRate)
+                .withRequestPercentage(requestPercentage)
                 .build();
 
         return createKafkaUser(kuq);
@@ -135,8 +135,8 @@ public class ResourceUtils {
     public static Secret createClientsCaKeySecret()  {
         return new SecretBuilder()
                 .withNewMetadata()
-                .withName(ResourceUtils.CA_KEY_NAME)
-                .withNamespace(NAMESPACE)
+                    .withName(ResourceUtils.CA_KEY_NAME)
+                    .withNamespace(NAMESPACE)
                 .endMetadata()
                 .addToData("ca.key", Base64.getEncoder().encodeToString("clients-ca-key".getBytes()))
                 .build();

--- a/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
@@ -37,7 +37,7 @@ public class UserOperatorConfigTest {
     }
 
     @Test
-    public void testConfig()    {
+    public void testFromMap()    {
         UserOperatorConfig config = UserOperatorConfig.fromMap(envVars);
 
         assertThat(config.getNamespace(), is(envVars.get(UserOperatorConfig.STRIMZI_NAMESPACE)));
@@ -50,27 +50,23 @@ public class UserOperatorConfigTest {
     }
 
     @Test
-    public void testNamespaceEnvVarMissingThrows()  {
+    public void testFromMapNamespaceEnvVarMissingThrows()  {
         Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.envVars);
         envVars.remove(UserOperatorConfig.STRIMZI_NAMESPACE);
 
-        assertThrows(InvalidConfigurationException.class, () -> {
-            UserOperatorConfig.fromMap(envVars);
-        });
+        assertThrows(InvalidConfigurationException.class, () -> UserOperatorConfig.fromMap(envVars));
     }
 
     @Test
-    public void testMissingCaName()  {
+    public void testFromMapCaNameEnvVarMissingThrows()  {
         Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.envVars);
         envVars.remove(UserOperatorConfig.STRIMZI_CA_CERT_SECRET_NAME);
 
-        assertThrows(InvalidConfigurationException.class, () -> {
-            UserOperatorConfig.fromMap(envVars);
-        });
+        assertThrows(InvalidConfigurationException.class, () -> UserOperatorConfig.fromMap(envVars));
     }
 
     @Test
-    public void testMissingReconciliationInterval()  {
+    public void testFromMapReconciliationIntervalEnvVarMissingSetsDefault()  {
         Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.envVars);
         envVars.remove(UserOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS);
 
@@ -79,7 +75,7 @@ public class UserOperatorConfigTest {
     }
 
     @Test
-    public void testMissingLabels()  {
+    public void testFromMapStrimziLabelsEnvVarMissingSetsEmptyLabels()  {
         Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.envVars);
         envVars.remove(UserOperatorConfig.STRIMZI_LABELS);
 
@@ -88,7 +84,7 @@ public class UserOperatorConfigTest {
     }
 
     @Test
-    public void testMissingCaNamespace()  {
+    public void testFromMapCaNamespaceMissingUsesNamespaceInstead()  {
         Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.envVars);
         envVars.remove(UserOperatorConfig.STRIMZI_CA_NAMESPACE);
 
@@ -97,22 +93,18 @@ public class UserOperatorConfigTest {
     }
 
     @Test
-    public void testInvalidReconciliationInterval()  {
-        assertThrows(NumberFormatException.class, () -> {
-            Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.envVars);
-            envVars.put(UserOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, "not_an_long");
+    public void testFromMapInvalidReconciliationIntervalThrows()  {
+        Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.envVars);
+        envVars.put(UserOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, "not_an_long");
 
-            UserOperatorConfig config = UserOperatorConfig.fromMap(envVars);
-        });
+        assertThrows(NumberFormatException.class, () -> UserOperatorConfig.fromMap(envVars));
     }
 
     @Test
-    public void testInvalidLabels()  {
-        assertThrows(InvalidConfigurationException.class, () -> {
-            Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.envVars);
-            envVars.put(UserOperatorConfig.STRIMZI_LABELS, ",label1=");
+    public void testFromMapInvalidLabelsStringThrows()  {
+        Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.envVars);
+        envVars.put(UserOperatorConfig.STRIMZI_LABELS, ",label1=");
 
-            UserOperatorConfig config = UserOperatorConfig.fromMap(envVars);
-        });
+        assertThrows(InvalidConfigurationException.class, () -> UserOperatorConfig.fromMap(envVars));
     }
 }


### PR DESCRIPTION
For this Pull request I have continued the context
succeeding work, and taken the opportunity to remove
unneeded concurrency based dependencies.
minor test renames, hamcrest additions and variable
renames to improve clarity.

This contains improvements to the topic-operator,
mockkube, kafka-init and api sub-modules.
I put some work into removing the passing of Exceptions
in test code and instead to error immediately out of tests
on fatal throws.

Contributes to: #2647

Signed-off-by: Samuel Hawker samuel.hawker@ibm.com

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

