### PR TITLE
Increase spotbugs version to 4.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <maven.dependency.version>3.1.1</maven.dependency.version>
         <maven.gpg.version>1.6</maven.gpg.version>
         <maven.checkstyle.version>3.1.0</maven.checkstyle.version>
-        <spotbugs.version>3.1.12</spotbugs.version>
+        <spotbugs.version>4.0.1</spotbugs.version>
         <sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
         <jacoco.version>0.7.9</jacoco.version>
         <license.maven.version>2.11</license.maven.version>


### PR DESCRIPTION
_Select the type of your PR_

- Enhancement / new feature

### Description

Spotbugs 3.1.12 is not working properly on Azure DevOps. Spotbugs marks two occurences of `UPM_UNCALLED_PRIVATE_METHOD` as false-positive with Azure's Java 11 JDK. This PR solve the problem.

### Checklist

- [x] Make sure all tests pass

