### PR TITLE
[DOC] Remove backup command from CO upgrade procedure

### DIFF
--- a/documentation/modules/proc-upgrading-the-cluster-operator.adoc
+++ b/documentation/modules/proc-upgrading-the-cluster-operator.adoc
@@ -9,28 +9,24 @@ This procedure describes how to upgrade a Cluster Operator deployment to a later
 
 .Prerequisites
 
-* An existing Cluster Operator deployment is available.
+* An existing Cluster Operator deployment.
 * You have xref:downloads-{context}[downloaded the installation files for the new version].
 
 .Procedure
 
-. Backup the existing Cluster Operator resources:
-+
-[source,shell,subs="+quotes,attributes"]
-----
-kubectl get all -l app=strimzi -o yaml > strimzi-backup.yaml
-----
+. Take note of any configuration changes made to the existing Cluster Operator resources (in the `/install/cluster-operator` directory).
+Any changes will be *overwritten* by the new version of the Cluster Operator.
 
 . Update the Cluster Operator.
-+
-Modify the installation files according to the namespace the Cluster Operator is running in.
+
+.. Modify the installation files for the new version according to the namespace the Cluster Operator is running in.
 +
 include::frag-cluster-operator-namespace-sed.adoc[]
 +
-If you modified one or more environment variables in your existing Cluster Operator `Deployment`, edit the
-`install/cluster-operator/050-Deployment-cluster-operator.yaml` file to reflect the changes that you made in the new version of the Cluster Operator.
+.. If you modified one or more environment variables in your existing Cluster Operator `Deployment`, edit the
+`install/cluster-operator/050-Deployment-cluster-operator.yaml` file to use those environment variables.
 
-. When you have an updated configuration, deploy it along with the rest of the install resources:
+. When you have an updated configuration, deploy it along with the rest of the installation resources:
 +
 [source,shell,subs="+quotes,attributes"]
 ----
@@ -56,4 +52,4 @@ You now have an updated Cluster Operator, but the version of Kafka running in th
 
 .What to do next
 
-Following the Cluster Operator upgrade, you can perform a xref:assembly-upgrading-kafka-versions-str[Kafka upgrade].
+Following the Cluster Operator upgrade, perform a xref:assembly-upgrading-kafka-versions-str[Kafka upgrade].


### PR DESCRIPTION
Signed-off-by: Daniel Laing <dlaing@redhat.com>

### Type of change

- Documentation

### Description

_Edits the procedure for [Upgrading the Cluster Operator](https://strimzi.io/docs/latest/#assembly-upgrade-cluster-operator-str)._

Step one contains a command for backing up your existing Cluster Operator resources before starting the upgrade:

`kubectl get all -l app=strimzi -o yaml > strimzi-backup.yaml`

This command is misleading: it doesn't work everywhere because of missing labels, it doesn't back up everything, and doesn't make it any easier to extract the changes pre-upgrade. Therefore, I've replaced this with a general step advising users to take note of any configuration changes made to their existing CO resources.

I've also made some other changes to improve the readability of the procedure.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging // NO RELEVANT ISSUES FOUND
- [ ] Update CHANGELOG.md

