### PR TITLE
Wait for CRD creation before api ITs

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
@@ -109,6 +109,7 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
     void setupEnvironment() {
         cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA_BRIDGE);
+        cluster.cmdClient().waitForResourceCreation("crd", "kafkabridges.kafka.strimzi.io");
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
@@ -110,6 +110,7 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
     void setupEnvironment() {
         cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA_CONNECT);
+        cluster.cmdClient().waitForResourceCreation("crd", "kafkaconnects.kafka.strimzi.io");
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -174,6 +174,7 @@ public class KafkaCrdIT extends AbstractCrdIT {
     void setupEnvironment() {
         cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA);
+        cluster.cmdClient().waitForResourceCreation("crd", "kafkas.kafka.strimzi.io");
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2CrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2CrdIT.java
@@ -106,6 +106,7 @@ public class KafkaMirrorMaker2CrdIT extends AbstractCrdIT {
     void setupEnvironment() {
         cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA_MIRROR_MAKER_2);
+        cluster.cmdClient().waitForResourceCreation("crd", "kafkamirrormaker2s.kafka.strimzi.io");
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
@@ -98,6 +98,7 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
     void setupEnvironment() {
         cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA_MIRROR_MAKER);
+        cluster.cmdClient().waitForResourceCreation("crd", "kafkamirrormakers.kafka.strimzi.io");
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
@@ -55,6 +55,7 @@ public class KafkaTopicCrdIT extends AbstractCrdIT {
     void setupEnvironment() {
         cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_TOPIC);
+        cluster.cmdClient().waitForResourceCreation("crd", "kafkatopics.kafka.strimzi.io");
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
@@ -43,6 +43,7 @@ public class KafkaUserCrdIT extends AbstractCrdIT {
     void setupEnvironment() {
         cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA_USER);
+        cluster.cmdClient().waitForResourceCreation("crd", "kafkausers.kafka.strimzi.io");
     }
 
     @AfterAll


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes the race-condition, when ITs were trying to apply specific CRs, but CRD wasn't ready yet. I hit that every time on Azure DevOps.

### Checklist

- [x] Make sure all tests pass


