### PR TITLE
Improve the exception thrown with wrong image configuration

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -194,14 +194,32 @@ public class ClusterOperatorConfig {
                 Util.parseMap(connectS2IImages),
                 Util.parseMap(mirrorMakerImages),
                 Util.parseMap(mirrorMaker2Images));
+
+        String image = "";
+        String envVar = "";
+
         try {
+            image = "Kafka";
+            envVar = STRIMZI_KAFKA_IMAGES;
             lookup.validateKafkaImages(lookup.supportedVersions());
+
+            image = "Kafka Connect";
+            envVar = STRIMZI_KAFKA_CONNECT_IMAGES;
             lookup.validateKafkaConnectImages(lookup.supportedVersions());
+
+            image = "Kafka Connect S2I";
+            envVar = STRIMZI_KAFKA_CONNECT_S2I_IMAGES;
             lookup.validateKafkaConnectS2IImages(lookup.supportedVersions());
+
+            image = "Kafka Mirror Maker";
+            envVar = STRIMZI_KAFKA_MIRROR_MAKER_IMAGES;
             lookup.validateKafkaMirrorMakerImages(lookup.supportedVersions());
+
+            image = "Kafka Mirror Maker 2";
+            envVar = STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES;
             lookup.validateKafkaMirrorMaker2Images(lookup.supportedVersionsForFeature("kafkaMirrorMaker2"));
         } catch (NoImageException e) {
-            throw new InvalidConfigurationException(e);
+            throw new InvalidConfigurationException("Failed to parse default container image configuration for " + image + " from environment variable " + envVar, e);
         }
         return lookup;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
@@ -288,7 +288,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
          */
         public void validateKafkaMirrorMakerImages(Iterable<String> versions) throws NoImageException {
             for (String version : versions) {
-                image(null, version, kafkaConnectImages, ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_IMAGES);
+                image(null, version, kafkaMirrorMakerImages, ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_IMAGES);
             }
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
 import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.common.InvalidConfigurationException;
-import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When users - for example after incorrect upgrade - ends up with CO deployment with missing or misconfigured environment variable for image configuration they currently get this cryptic exception:

```
Exception in thread "main" io.strimzi.operator.common.InvalidConfigurationException: io.strimzi.operator.cluster.model.NoImageException: No image for version 2.4.0
	at io.strimzi.operator.cluster.ClusterOperatorConfig.parseKafkaVersions(ClusterOperatorConfig.java:204)
	at io.strimzi.operator.cluster.ClusterOperatorConfig.fromMap(ClusterOperatorConfig.java:94)
	at io.strimzi.operator.cluster.Main.main(Main.java:59)
Caused by: io.strimzi.operator.cluster.model.NoImageException: No image for version 2.4.0
	at io.strimzi.operator.cluster.model.KafkaVersion$Lookup.image(KafkaVersion.java:163)
	at io.strimzi.operator.cluster.model.KafkaVersion$Lookup.validateKafkaMirrorMaker2Images(KafkaVersion.java:321)
	at io.strimzi.operator.cluster.ClusterOperatorConfig.parseKafkaVersions(ClusterOperatorConfig.java:202)
```

That doesn't really tell them much about the issue. Thsi PR improves the exception to make it more clear where the issue is:

```
Exception in thread "main" io.strimzi.operator.common.InvalidConfigurationException: Failed to parse default container image configuration for Kafka Mirror Maker 2 from environment variable STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
	at io.strimzi.operator.cluster.ClusterOperatorConfig.parseKafkaVersions(ClusterOperatorConfig.java:222)
	at io.strimzi.operator.cluster.ClusterOperatorConfig.fromMap(ClusterOperatorConfig.java:94)
	at io.strimzi.operator.cluster.Main.main(Main.java:59)
Caused by: io.strimzi.operator.cluster.model.NoImageException: No image for version 2.4.0
	at io.strimzi.operator.cluster.model.KafkaVersion$Lookup.image(KafkaVersion.java:163)
	at io.strimzi.operator.cluster.model.KafkaVersion$Lookup.validateKafkaMirrorMaker2Images(KafkaVersion.java:321)
	at io.strimzi.operator.cluster.ClusterOperatorConfig.parseKafkaVersions(ClusterOperatorConfig.java:220)
	... 2 more
```

This should help users better identify the problems.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally