### PR TITLE
Refactor `SimpleAclOperator` to make use of Admin Client API

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityUserOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityUserOperatorSpec.java
@@ -36,6 +36,7 @@ public class EntityUserOperatorSpec implements UnknownPropertyPreserving, Serial
     public static final int DEFAULT_HEALTHCHECK_DELAY = 10;
     public static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
     public static final int DEFAULT_ZOOKEEPER_PORT = 2181;
+    public static final int DEFAULT_BOOTSTRAP_SERVERS_PORT = 9091;
     public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS = 120;
     public static final long DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS = 6;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -102,6 +102,7 @@ public class EntityUserOperatorTest {
     private List<EnvVar> getExpectedEnvVars() {
         List<EnvVar> expected = new ArrayList<>();
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_ZOOKEEPER_CONNECT).withValue(String.format("%s:%d", "localhost", EntityUserOperatorSpec.DEFAULT_ZOOKEEPER_PORT)).build());
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_KAFKA_BOOTSTRAP_SERVERS).withValue(String.format("%s:%d", "foo-kafka-bootstrap", EntityUserOperatorSpec.DEFAULT_BOOTSTRAP_SERVERS_PORT)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_WATCHED_NAMESPACE).withValue(uoWatchedNamespace).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_RESOURCE_LABELS).withValue(ModelUtils.defaultResourceLabels(cluster)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS).withValue(String.valueOf(uoReconciliationInterval * 1000)).build());
@@ -109,6 +110,8 @@ public class EntityUserOperatorTest {
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME).withValue(KafkaCluster.clientsCaKeySecretName(cluster)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME).withValue(KafkaCluster.clientsCaCertSecretName(cluster)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_NAMESPACE).withValue(namespace).build());
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLUSTER_CA_CERT_SECRET_NAME).withValue(KafkaCluster.clusterCaCertSecretName(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_EO_KEY_SECRET_NAME).withValue(EntityOperator.secretName(cluster)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_STRIMZI_GC_LOG_ENABLED).withValue(Boolean.toString(AbstractModel.DEFAULT_JVM_GC_LOGGING_ENABLED)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_VALIDITY).withValue(Integer.toString(CertificateAuthority.DEFAULT_CERTS_VALIDITY_DAYS)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_RENEWAL).withValue(Integer.toString(CertificateAuthority.DEFAULT_CERTS_RENEWAL_DAYS)).build());
@@ -150,6 +153,7 @@ public class EntityUserOperatorTest {
         assertThat(entityUserOperator.getReconciliationIntervalMs(), is(uoReconciliationInterval * 1000L));
         assertThat(entityUserOperator.getZookeeperSessionTimeoutMs(), is(uoZookeeperSessionTimeout * 1000L));
         assertThat(entityUserOperator.getZookeeperConnect(), is(EntityUserOperator.defaultZookeeperConnect(cluster)));
+        assertThat(entityUserOperator.getKafkaBootstrapServers(), is(String.format("%s:%d", KafkaCluster.serviceName(cluster), EntityUserOperatorSpec.DEFAULT_BOOTSTRAP_SERVERS_PORT)));
         assertThat(entityUserOperator.getLogging().getType(), is(userOperatorLogging.getType()));
         assertThat(((InlineLogging) entityUserOperator.getLogging()).getLoggers(), is(userOperatorLogging.getLoggers()));
     }
@@ -178,6 +182,7 @@ public class EntityUserOperatorTest {
         assertThat(entityUserOperator.livenessProbeOptions.getInitialDelaySeconds(), is(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_DELAY));
         assertThat(entityUserOperator.livenessProbeOptions.getTimeoutSeconds(), is(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT));
         assertThat(entityUserOperator.getZookeeperConnect(), is(EntityUserOperator.defaultZookeeperConnect(cluster)));
+        assertThat(entityUserOperator.getKafkaBootstrapServers(), is(EntityUserOperator.defaultBootstrapServers(cluster)));
         assertThat(entityUserOperator.getLogging(), is(nullValue()));
     }
 

--- a/documentation/modules/proc-deploying-the-user-operator-standalone.adoc
+++ b/documentation/modules/proc-deploying-the-user-operator-standalone.adoc
@@ -24,6 +24,13 @@ The `Secret` should contain the private key of the Certificate Authority under t
 .. The `STRIMZI_NAMESPACE` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to the Kubernetes namespace in which you want the operator to watch for  `KafkaUser` resources.
 .. The `STRIMZI_JAVA_OPTS` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to the Java options used for the JVM running User Operator. An example is `-Xmx=512M -Xms=256M`.
 .. The `STRIMZI_JAVA_SYSTEM_PROPERTIES` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to the list of `-D` options which are set to the User Operator. An example is `-Djavax.net.debug=verbose -DpropertyName=value`.
+.. The `STRIMZI_KAFKA_BOOTSTRAP_SERVERS` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to a list of the Kafka brokers, given as a comma-separated list of `_hostname_:‍_port_` pairs.
+.. The `STRIMZI_CLUSTER_CA_CERT_SECRET_NAME` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to point to a Kubernetes `Secret` which should contain the public key of the Certificate Authority used for signing Kafka brokers certificates for enabling TLS based communication.
+The `Secret` should contain the public key of the Certificate Authority under the key `ca.crt`.
+This environment variable is optional and should be set only if the communication with the Kafka cluster is TLS based.
+.. The `STRIMZI_EO_KEY_SECRET_NAME` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to point to a Kubernetes `Secret` which should contain the private key and related certificate for TLS Client Authentication against the Kafka cluster.
+The `Secret` should contain the keystore with the private key and certificate under the key `entity-operator.p12` and the related password under the key `entity-operator.password`.
+This environment variable is optional and should be set if the TLS Client Authentication is needed when the communication with the Kafka cluster is TLS based.
 
 . Deploy the User Operator.
 +

--- a/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
@@ -20,37 +20,78 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
 
     private static final Logger LOGGER = LogManager.getLogger(DefaultAdminClientProvider.class);
 
+    /**
+     * Create a Kafka Admin interface instance handling the following different scenarios:
+     *
+     * 1. No TLS connection, no TLS client authentication:
+     *
+     * If {@code clusterCaCertSecret}, {@code keyCertSecret} and {@code keyCertName} are null, the returned Admin Client instance
+     * is configured to connect to the Apache Kafka bootstrap (defined via {@code hostname}) on plain connection with no
+     * TLS encryption and no TLS client authentication.
+     *
+     * 2. TLS connection, no TLS client authentication
+     *
+     * If only {@code clusterCaCertSecret} is provided as not null, the returned Admin Client instance is configured to
+     * connect to the Apache Kafka bootstrap (defined via {@code hostname}) on TLS encrypted connection but with no
+     * TLS authentication.
+     *
+     * 3. TLS connection and TLS client authentication
+     *
+     * If {@code clusterCaCertSecret}, {@code keyCertSecret} and {@code keyCertName} are provided as not null, the returned
+     * Admin Client instance is configured to connect to the Apache Kafka bootstrap (defined via {@code hostname}) on
+     * TLS encrypted connection and with TLS client authentication.
+     */
     @Override
     public Admin createAdminClient(String hostname, Secret clusterCaCertSecret, Secret keyCertSecret, String keyCertName) {
         Admin ac;
-        PasswordGenerator pg = new PasswordGenerator(12);
-        String trustStorePassword = pg.generate();
-        File truststoreFile = Util.createFileTrustStore(getClass().getName(), "ts", Ca.cert(clusterCaCertSecret, Ca.CA_CRT), trustStorePassword.toCharArray());
+        String trustStorePassword = null;
+        File truststoreFile = null;
+        // provided Secret with cluster CA certificate for TLS encryption
+        if (clusterCaCertSecret != null) {
+            PasswordGenerator pg = new PasswordGenerator(12);
+            trustStorePassword = pg.generate();
+            truststoreFile = Util.createFileTrustStore(getClass().getName(), "ts", Ca.cert(clusterCaCertSecret, Ca.CA_CRT), trustStorePassword.toCharArray());
+        }
+
         try {
-            String keyStorePassword = new String(Util.decodeFromSecret(keyCertSecret, keyCertName + ".password"), StandardCharsets.US_ASCII);
-            File keystoreFile = Util.createFileStore(getClass().getName(), "ts", Util.decodeFromSecret(keyCertSecret, keyCertName + ".p12"));
+            String keyStorePassword = null;
+            File keystoreFile = null;
+            // provided Secret and related key for getting the private key for TLS client authentication
+            if (keyCertSecret != null && keyCertName != null && !keyCertName.isEmpty()) {
+                keyStorePassword = new String(Util.decodeFromSecret(keyCertSecret, keyCertName + ".password"), StandardCharsets.US_ASCII);
+                keystoreFile = Util.createFileStore(getClass().getName(), "ts", Util.decodeFromSecret(keyCertSecret, keyCertName + ".p12"));
+            }
+
             try {
                 Properties p = new Properties();
                 p.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, hostname);
-                p.setProperty(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, "SSL");
 
-                p.setProperty(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, truststoreFile.getAbsolutePath());
-                p.setProperty(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PKCS12");
-                p.setProperty(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, trustStorePassword);
+                // configuring TLS encryption if requested
+                if (truststoreFile != null && trustStorePassword != null) {
+                    p.setProperty(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, "SSL");
 
-                p.setProperty(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, keystoreFile.getAbsolutePath());
-                p.setProperty(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PKCS12");
-                p.setProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, keyStorePassword);
+                    p.setProperty(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, truststoreFile.getAbsolutePath());
+                    p.setProperty(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PKCS12");
+                    p.setProperty(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, trustStorePassword);
+                }
+
+                // configuring TLS client authentication
+                if (keystoreFile != null && keyStorePassword != null) {
+                    p.setProperty(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, keystoreFile.getAbsolutePath());
+                    p.setProperty(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PKCS12");
+                    p.setProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, keyStorePassword);
+                }
+
                 p.setProperty(AdminClientConfig.METADATA_MAX_AGE_CONFIG, "30000");
 
                 ac = Admin.create(p);
             } finally {
-                if (!keystoreFile.delete()) {
+                if (keystoreFile != null && !keystoreFile.delete()) {
                     LOGGER.warn("Unable to delete keystore file {}", keystoreFile);
                 }
             }
         } finally {
-            if (!truststoreFile.delete()) {
+            if (truststoreFile != null && !truststoreFile.delete()) {
                 LOGGER.warn("Unable to delete truststore file {}", truststoreFile);
             }
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/BasicExternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/BasicExternalKafkaClient.java
@@ -9,6 +9,7 @@ import io.strimzi.systemtest.kafkaclients.AbstractKafkaClient;
 import io.strimzi.systemtest.kafkaclients.KafkaClientOperations;
 import io.strimzi.systemtest.kafkaclients.KafkaClientProperties;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.test.WaitException;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -78,7 +79,7 @@ public class BasicExternalKafkaClient extends AbstractKafkaClient implements Kaf
             return plainProducer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
-            throw new RuntimeException(e);
+            throw new WaitException(e);
         }
     }
 
@@ -121,7 +122,7 @@ public class BasicExternalKafkaClient extends AbstractKafkaClient implements Kaf
             return tlsProducer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
-            throw new RuntimeException(e);
+            throw new WaitException(e);
         }
     }
 
@@ -159,7 +160,7 @@ public class BasicExternalKafkaClient extends AbstractKafkaClient implements Kaf
             return plainConsumer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
-            throw new RuntimeException(e);
+            throw new WaitException(e);
         }
     }
 
@@ -204,7 +205,7 @@ public class BasicExternalKafkaClient extends AbstractKafkaClient implements Kaf
             return tlsConsumer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
-            throw new RuntimeException(e);
+            throw new WaitException(e);
         }
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/OauthExternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/OauthExternalKafkaClient.java
@@ -9,6 +9,7 @@ import io.strimzi.systemtest.kafkaclients.AbstractKafkaClient;
 import io.strimzi.systemtest.kafkaclients.KafkaClientOperations;
 import io.strimzi.systemtest.kafkaclients.KafkaClientProperties;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.test.WaitException;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
@@ -120,7 +121,7 @@ public class OauthExternalKafkaClient extends AbstractKafkaClient implements Kaf
             return plainProducer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
-            throw new RuntimeException(e);
+            throw new WaitException(e);
         }
     }
 
@@ -161,7 +162,7 @@ public class OauthExternalKafkaClient extends AbstractKafkaClient implements Kaf
             return tlsProducer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
-            throw new RuntimeException(e);
+            throw new WaitException(e);
         }
     }
 
@@ -198,7 +199,7 @@ public class OauthExternalKafkaClient extends AbstractKafkaClient implements Kaf
             return plainConsumer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
-            throw new RuntimeException(e);
+            throw new WaitException(e);
         }
     }
 
@@ -242,7 +243,7 @@ public class OauthExternalKafkaClient extends AbstractKafkaClient implements Kaf
             return tlsConsumer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
-            throw new RuntimeException(e);
+            throw new WaitException(e);
         }
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
@@ -13,7 +13,6 @@ import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserBuilder;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
-import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -23,15 +22,13 @@ import java.util.function.Consumer;
 public class KafkaUserResource {
     private static final Logger LOGGER = LogManager.getLogger(KafkaUserResource.class);
 
-    public static final String PATH_TO_KAFKA_USER_CONFIG = "../examples/user/kafka-user.yaml";
-
     public static MixedOperation<KafkaUser, KafkaUserList, DoneableKafkaUser, Resource<KafkaUser, DoneableKafkaUser>> kafkaUserClient() {
         return Crds.kafkaUserOperation(ResourceManager.kubeClient().getClient());
     }
 
     public static DoneableKafkaUser tlsUser(String clusterName, String name) {
         return user(defaultUser(clusterName, name)
-            .editSpec()
+            .withNewSpec()
                 .withNewKafkaUserTlsClientAuthentication()
                 .endKafkaUserTlsClientAuthentication()
             .endSpec()
@@ -40,7 +37,7 @@ public class KafkaUserResource {
 
     public static DoneableKafkaUser scramShaUser(String clusterName, String name) {
         return user(defaultUser(clusterName, name)
-            .editSpec()
+            .withNewSpec()
                 .withNewKafkaUserScramSha512ClientAuthentication()
                 .endKafkaUserScramSha512ClientAuthentication()
             .endSpec()
@@ -48,8 +45,7 @@ public class KafkaUserResource {
     }
 
     public static KafkaUserBuilder defaultUser(String clusterName, String name) {
-        KafkaUser kafkaUser = getKafkaUserFromYaml(PATH_TO_KAFKA_USER_CONFIG);
-        return new KafkaUserBuilder(kafkaUser)
+        return new KafkaUserBuilder()
             .withNewMetadata()
                 .withClusterName(clusterName)
                 .withName(name)
@@ -69,10 +65,6 @@ public class KafkaUserResource {
     public static KafkaUser kafkaUserWithoutWait(KafkaUser user) {
         kafkaUserClient().inNamespace(ResourceManager.kubeClient().getNamespace()).createOrReplace(user);
         return user;
-    }
-
-    private static KafkaUser getKafkaUserFromYaml(String yamlPath) {
-        return TestUtils.configFromYaml(yamlPath, KafkaUser.class);
     }
 
     private static KafkaUser waitFor(KafkaUser kafkaUser) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -97,7 +97,6 @@ import static io.strimzi.systemtest.utils.StUtils.configMap2Properties;
 import static io.strimzi.systemtest.utils.StUtils.stringToProperties;
 import static io.strimzi.test.TestUtils.fromYamlString;
 import static io.strimzi.test.TestUtils.map;
-import static io.strimzi.test.TestUtils.waitFor;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static java.util.Collections.singletonMap;
@@ -1269,18 +1268,14 @@ class KafkaST extends BaseST {
             .endSpec()
             .done();
 
-        String userName = "alice";
-        KafkaUserResource.tlsUser(CLUSTER_NAME, userName).done();
-        waitFor("Wait for secrets became available", Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_GET_SECRETS,
-            () -> kubeClient().getSecret("alice") != null,
-            () -> LOGGER.error("Couldn't find user secret {}", kubeClient().listSecrets()));
+        KafkaUserResource.tlsUser(CLUSTER_NAME, USER_NAME).done();
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
                 .withTopicName(TOPIC_NAME)
                 .withNamespaceName(NAMESPACE)
                 .withClusterName(CLUSTER_NAME)
                 .withMessageCount(MESSAGE_COUNT)
-                .withKafkaUsername(userName)
+                .withKafkaUsername(USER_NAME)
                 .withSecurityProtocol(SecurityProtocol.SSL)
                 .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
                 .build();
@@ -1341,11 +1336,7 @@ class KafkaST extends BaseST {
             .endSpec()
             .done();
 
-        String userName = "alice";
-        KafkaUserResource.tlsUser(CLUSTER_NAME, userName).done();
-        waitFor("Wait for secrets became available", Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_GET_SECRETS,
-            () -> kubeClient().getSecret("alice") != null,
-            () -> LOGGER.error("Couldn't find user secret {}", kubeClient().listSecrets()));
+        KafkaUserResource.tlsUser(CLUSTER_NAME, USER_NAME).done();
 
         ServiceUtils.waitUntilAddressIsReachable(kubeClient().getService(KafkaResources.externalBootstrapServiceName(CLUSTER_NAME)).getStatus().getLoadBalancer().getIngress().get(0).getHostname());
 
@@ -1354,7 +1345,7 @@ class KafkaST extends BaseST {
                 .withNamespaceName(NAMESPACE)
                 .withClusterName(CLUSTER_NAME)
                 .withMessageCount(MESSAGE_COUNT)
-                .withKafkaUsername(userName)
+                .withKafkaUsername(USER_NAME)
                 .withSecurityProtocol(SecurityProtocol.SSL)
                 .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
                 .build();

--- a/systemtest/src/test/java/io/strimzi/systemtest/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MirrorMaker2ST.java
@@ -225,10 +225,8 @@ class MirrorMaker2ST extends BaseST {
 
         // Create Kafka user
         KafkaUser userSource = KafkaUserResource.tlsUser(kafkaClusterSourceName, kafkaUserSourceName).done();
-        SecretUtils.waitForSecretReady(kafkaUserSourceName);
 
         KafkaUser userTarget = KafkaUserResource.tlsUser(kafkaClusterTargetName, kafkaUserTargetName).done();
-        SecretUtils.waitForSecretReady(kafkaUserTargetName);
 
         KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, userSource, userTarget).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MirrorMakerST.java
@@ -197,10 +197,8 @@ public class MirrorMakerST extends BaseST {
 
         // Create Kafka user
         KafkaUser userSource = KafkaUserResource.tlsUser(kafkaClusterSourceName, kafkaSourceUserName).done();
-        SecretUtils.waitForSecretReady(kafkaSourceUserName);
 
         KafkaUser userTarget = KafkaUserResource.tlsUser(kafkaClusterTargetName, kafkaTargetUserName).done();
-        SecretUtils.waitForSecretReady(kafkaTargetUserName);
 
         // Initialize CertSecretSource with certificate and secret names for consumer
         CertSecretSource certSecretSource = new CertSecretSource();

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -279,8 +279,7 @@ class RollingUpdateST extends BaseST {
                 .endKafka()
             .endSpec().done();
 
-        String userName = "alice";
-        KafkaUser user = KafkaUserResource.tlsUser(CLUSTER_NAME, userName).done();
+        KafkaUser user = KafkaUserResource.tlsUser(CLUSTER_NAME, USER_NAME).done();
 
         testDockerImagesForKafkaCluster(CLUSTER_NAME, NAMESPACE, 3, 1, false);
         // kafka cluster already deployed
@@ -304,7 +303,7 @@ class RollingUpdateST extends BaseST {
             .withNamespaceName(NAMESPACE)
             .withClusterName(CLUSTER_NAME)
             .withMessageCount(MESSAGE_COUNT)
-            .withKafkaUsername(userName)
+            .withKafkaUsername(USER_NAME)
             .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
             .build();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -158,16 +158,13 @@ class SecurityST extends BaseST {
             boolean zkShouldRoll,
             boolean kafkaShouldRoll,
             boolean eoShouldRoll) {
-        String userName = "alice";
         String topicName = TOPIC_NAME + "-" + rng.nextInt(Integer.MAX_VALUE);
 
         createKafkaCluster();
 
-        KafkaUser user = KafkaUserResource.tlsUser(CLUSTER_NAME, userName).done();
+        KafkaUser user = KafkaUserResource.tlsUser(CLUSTER_NAME, USER_NAME).done();
         KafkaTopicResource.topic(CLUSTER_NAME, topicName).done();
         KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, user).done();
-
-        SecretUtils.waitForSecretReady(userName);
 
         String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
@@ -12,7 +12,6 @@ import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClie
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaBridgeUtils;
 import io.strimzi.systemtest.utils.HttpUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
-import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.ServiceUtils;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -144,7 +143,6 @@ class HttpBridgeTlsST extends HttpBridgeBaseST {
 
         // Create Kafka user
         KafkaUserResource.tlsUser(CLUSTER_NAME, USER_NAME).done();
-        SecretUtils.waitForSecretReady(USER_NAME);
 
         // Initialize CertSecretSource with certificate and secret names for consumer
         CertSecretSource certSecret = new CertSecretSource();

--- a/test/src/main/java/io/strimzi/test/WaitException.java
+++ b/test/src/main/java/io/strimzi/test/WaitException.java
@@ -8,4 +8,8 @@ public class WaitException extends RuntimeException {
     public WaitException(String message) {
         super(message);
     }
+
+    public WaitException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -58,16 +58,8 @@
             <artifactId>kafka-clients</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.101tec</groupId>
             <artifactId>zkclient</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -106,6 +98,16 @@
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
@@ -20,23 +20,30 @@ public class UserOperatorConfig {
     public static final String STRIMZI_LABELS = "STRIMZI_LABELS";
     public static final String STRIMZI_CA_CERT_SECRET_NAME = "STRIMZI_CA_CERT_NAME";
     public static final String STRIMZI_CA_KEY_SECRET_NAME = "STRIMZI_CA_KEY_NAME";
+    public static final String STRIMZI_CLUSTER_CA_CERT_SECRET_NAME = "STRIMZI_CLUSTER_CA_CERT_SECRET_NAME";
+    public static final String STRIMZI_EO_KEY_SECRET_NAME = "STRIMZI_EO_KEY_SECRET_NAME";
     public static final String STRIMZI_CA_NAMESPACE = "STRIMZI_CA_NAMESPACE";
+    public static final String STRIMZI_KAFKA_BOOTSTRAP_SERVERS = "STRIMZI_KAFKA_BOOTSTRAP_SERVERS";
     public static final String STRIMZI_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
     public static final String STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
     public static final String STRIMZI_CLIENTS_CA_VALIDITY = "STRIMZI_CA_VALIDITY";
     public static final String STRIMZI_CLIENTS_CA_RENEWAL = "STRIMZI_CA_RENEWAL";
 
     public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_MS = 120_000;
+    public static final String DEFAULT_KAFKA_BOOTSTRAP_SERVERS = "localhost:9091";
     public static final String DEFAULT_ZOOKEEPER_CONNECT = "localhost:2181";
     public static final long DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_MS = 6_000;
 
     private final String namespace;
     private final long reconciliationIntervalMs;
+    private final String kafkaBootstrapServers;
     private final String zookeperConnect;
     private final long zookeeperSessionTimeoutMs;
     private Labels labels;
     private final String caCertSecretName;
     private final String caKeySecretName;
+    private final String clusterCaCertSecretName;
+    private final String eoKeySecretName;
     private final String caNamespace;
 
     /**
@@ -44,27 +51,37 @@ public class UserOperatorConfig {
      *
      * @param namespace namespace in which the operator will run and create resources.
      * @param reconciliationIntervalMs How many milliseconds between reconciliation runs.
+     * @param kafkaBootstrapServers Kafka bootstrap servers list
      * @param zookeperConnect Connecton URL for Zookeeper.
      * @param zookeeperSessionTimeoutMs Session timeout for Zookeeper connections.
      * @param labels Map with labels which should be used to find the KafkaUser resources.
-     * @param caCertSecretName Name of the secret containing the Certification Authority certificate.
-     * @param caKeySecretName The name of the secret containing the Certification Authority key.
+     * @param caCertSecretName Name of the secret containing the clients Certification Authority certificate.
+     * @param caKeySecretName The name of the secret containing the clients Certification Authority key.
+     * @param clusterCaCertSecretName Name of the secret containing the cluster Certification Authority certificate.
+     * @param eoKeySecretName The name of the secret containing the Entity Operator key and certificate
      * @param caNamespace Namespace with the CA secret.
      */
+    @SuppressWarnings({"checkstyle:ParameterNumber"}) //TODO: to remove when removing the zookeeper related parameters
     public UserOperatorConfig(String namespace,
                               long reconciliationIntervalMs,
+                              String kafkaBootstrapServers,
                               String zookeperConnect,
                               long zookeeperSessionTimeoutMs,
                               Labels labels, String caCertSecretName,
                               String caKeySecretName,
+                              String clusterCaCertSecretName,
+                              String eoKeySecretName,
                               String caNamespace) {
         this.namespace = namespace;
         this.reconciliationIntervalMs = reconciliationIntervalMs;
+        this.kafkaBootstrapServers = kafkaBootstrapServers;
         this.zookeperConnect = zookeperConnect;
         this.zookeeperSessionTimeoutMs = zookeeperSessionTimeoutMs;
         this.labels = labels;
         this.caCertSecretName = caCertSecretName;
         this.caKeySecretName = caKeySecretName;
+        this.clusterCaCertSecretName = clusterCaCertSecretName;
+        this.eoKeySecretName = eoKeySecretName;
         this.caNamespace = caNamespace;
     }
 
@@ -74,6 +91,7 @@ public class UserOperatorConfig {
      * @param map   map from which loading configuration parameters
      * @return  Cluster Operator configuration instance
      */
+    @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity"})
     public static UserOperatorConfig fromMap(Map<String, String> map) {
 
         String namespace = map.get(UserOperatorConfig.STRIMZI_NAMESPACE);
@@ -86,6 +104,12 @@ public class UserOperatorConfig {
         String reconciliationIntervalEnvVar = map.get(UserOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS);
         if (reconciliationIntervalEnvVar != null) {
             reconciliationInterval = Long.parseLong(reconciliationIntervalEnvVar);
+        }
+
+        String kafkaBootstrapServers = DEFAULT_KAFKA_BOOTSTRAP_SERVERS;
+        String kafkaBootstrapServersEnvVar = map.get(UserOperatorConfig.STRIMZI_KAFKA_BOOTSTRAP_SERVERS);
+        if (kafkaBootstrapServersEnvVar != null && !kafkaBootstrapServersEnvVar.isEmpty()) {
+            kafkaBootstrapServers = kafkaBootstrapServersEnvVar;
         }
 
         String zookeeperConnect = DEFAULT_ZOOKEEPER_CONNECT;
@@ -117,12 +141,17 @@ public class UserOperatorConfig {
             throw new InvalidConfigurationException(UserOperatorConfig.STRIMZI_CA_KEY_SECRET_NAME + " cannot be null");
         }
 
+        String clusterCaCertSecretName = map.get(UserOperatorConfig.STRIMZI_CLUSTER_CA_CERT_SECRET_NAME);
+
+        String eoKeySecretName = map.get(UserOperatorConfig.STRIMZI_EO_KEY_SECRET_NAME);
+
         String caNamespace = map.get(UserOperatorConfig.STRIMZI_CA_NAMESPACE);
         if (caNamespace == null || caNamespace.isEmpty()) {
             caNamespace = namespace;
         }
 
-        return new UserOperatorConfig(namespace, reconciliationInterval, zookeeperConnect, zookeeperSessionTimeoutMs, labels, caCertSecretName, caKeySecretName, caNamespace);
+        return new UserOperatorConfig(namespace, reconciliationInterval, kafkaBootstrapServers, zookeeperConnect, zookeeperSessionTimeoutMs, labels,
+                caCertSecretName, caKeySecretName, clusterCaCertSecretName, eoKeySecretName, caNamespace);
     }
 
     public static int getClientsCaValidityDays() {
@@ -178,10 +207,31 @@ public class UserOperatorConfig {
     }
 
     /**
+     * @return  The name of the secret with the Cluster CA
+     */
+    public String getClusterCaCertSecretName() {
+        return clusterCaCertSecretName;
+    }
+
+    /**
+     * @return  The name of the secret with Entity Operator key and certificate
+     */
+    public String getEoKeySecretName() {
+        return eoKeySecretName;
+    }
+
+    /**
      * @return  The namespace of the Client CA
      */
     public String getCaNamespace() {
         return caNamespace;
+    }
+
+    /**
+     * @return  Kafka bootstrap servers list
+     */
+    public String getKafkaBootstrapServers() {
+        return kafkaBootstrapServers;
     }
 
     /**
@@ -203,10 +253,13 @@ public class UserOperatorConfig {
         return "ClusterOperatorConfig(" +
                 "namespace=" + namespace +
                 ",reconciliationIntervalMs=" + reconciliationIntervalMs +
+                ",kafkaBootstrapServers=" + kafkaBootstrapServers +
                 ",zookeperConnect=" + zookeperConnect +
                 ",zookeeperSessionTimeoutMs=" + zookeeperSessionTimeoutMs +
                 ",labels=" + labels +
                 ",caName=" + caCertSecretName +
+                ",clusterCaCertSecretName=" + clusterCaCertSecretName +
+                ",eoKeySecretName=" + eoKeySecretName +
                 ",caNamespace=" + caNamespace +
                 ")";
     }

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResource.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResource.java
@@ -11,13 +11,8 @@ import io.strimzi.api.kafka.model.AclRuleResource;
 import io.strimzi.api.kafka.model.AclRuleTopicResource;
 import io.strimzi.api.kafka.model.AclRuleTransactionalIdResource;
 
-import kafka.security.auth.Cluster$;
-import kafka.security.auth.Group$;
-import kafka.security.auth.Resource;
-import kafka.security.auth.ResourceType;
-import kafka.security.auth.Topic$;
-import kafka.security.auth.TransactionalId$;
 import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePattern;
 
 /**
  * This class represents Kafka resource and is used in the SimpleAclRule objects.
@@ -97,18 +92,18 @@ public class SimpleAclRuleResource {
     }
 
     /**
-     * Creates Kafka's Resource class from the current object
+     * Creates Kafka's ResourcePattern instance from the current SimpleAclRuleResource instance
      *
-     * @return The resource.
+     * @return the ResourcePattern instance
      */
-    public Resource toKafkaResource()   {
-        ResourceType kafkaType;
+    public ResourcePattern toKafkaResourcePattern() {
+        org.apache.kafka.common.resource.ResourceType kafkaType;
         String kafkaName;
         PatternType kafkaPattern = PatternType.LITERAL;
 
         switch (type) {
             case TOPIC:
-                kafkaType = Topic$.MODULE$;
+                kafkaType = org.apache.kafka.common.resource.ResourceType.TOPIC;
                 kafkaName = name;
 
                 if (AclResourcePatternType.PREFIX.equals(pattern))   {
@@ -117,7 +112,7 @@ public class SimpleAclRuleResource {
 
                 break;
             case GROUP:
-                kafkaType = Group$.MODULE$;
+                kafkaType = org.apache.kafka.common.resource.ResourceType.GROUP;
                 kafkaName = name;
 
                 if (AclResourcePatternType.PREFIX.equals(pattern))   {
@@ -126,11 +121,11 @@ public class SimpleAclRuleResource {
 
                 break;
             case CLUSTER:
-                kafkaType = Cluster$.MODULE$;
+                kafkaType = org.apache.kafka.common.resource.ResourceType.CLUSTER;
                 kafkaName = "kafka-cluster";
                 break;
             case TRANSACTIONAL_ID:
-                kafkaType = TransactionalId$.MODULE$;
+                kafkaType = org.apache.kafka.common.resource.ResourceType.TRANSACTIONAL_ID;
                 kafkaName = name;
 
                 if (AclResourcePatternType.PREFIX.equals(pattern))   {
@@ -142,26 +137,26 @@ public class SimpleAclRuleResource {
                 throw new IllegalArgumentException("Invalid Acl resource type: " + type);
         }
 
-        return new Resource(kafkaType, kafkaName, kafkaPattern);
+        return new ResourcePattern(kafkaType, kafkaName, kafkaPattern);
     }
 
     /**
-     * Creates SimpleAclRuleResource object based on Kafka's Resource object
+     * Creates SimpleAclRuleResource instance based on Kafka's ResourcePattern instance
      *
-     * @param kafkaResource Kafka's Resource object
-     * @return The resource.
+     * @param kafkaResourcePattern Kafka's ResourcePattern instance
+     * @return the SimpleAclRuleResource instance
      */
-    public static SimpleAclRuleResource fromKafkaResource(Resource kafkaResource)   {
+    public static SimpleAclRuleResource fromKafkaResourcePattern(ResourcePattern kafkaResourcePattern) {
         String resourceName;
         SimpleAclRuleResourceType resourceType;
         AclResourcePatternType resourcePattern = null;
 
-        switch (kafkaResource.resourceType().toJava()) {
+        switch (kafkaResourcePattern.resourceType()) {
             case TOPIC:
-                resourceName = kafkaResource.name();
+                resourceName = kafkaResourcePattern.name();
                 resourceType = SimpleAclRuleResourceType.TOPIC;
 
-                switch (kafkaResource.patternType()) {
+                switch (kafkaResourcePattern.patternType()) {
                     case LITERAL:
                         resourcePattern = AclResourcePatternType.LITERAL;
                         break;
@@ -169,15 +164,15 @@ public class SimpleAclRuleResource {
                         resourcePattern = AclResourcePatternType.PREFIX;
                         break;
                     default:
-                        throw new IllegalArgumentException("Invalid Resource type: " + kafkaResource.resourceType());
+                        throw new IllegalArgumentException("Invalid Resource type: " + kafkaResourcePattern.resourceType());
                 }
 
                 break;
             case GROUP:
                 resourceType = SimpleAclRuleResourceType.GROUP;
-                resourceName = kafkaResource.name();
+                resourceName = kafkaResourcePattern.name();
 
-                switch (kafkaResource.patternType()) {
+                switch (kafkaResourcePattern.patternType()) {
                     case LITERAL:
                         resourcePattern = AclResourcePatternType.LITERAL;
                         break;
@@ -185,7 +180,7 @@ public class SimpleAclRuleResource {
                         resourcePattern = AclResourcePatternType.PREFIX;
                         break;
                     default:
-                        throw new IllegalArgumentException("Invalid Resource type: " + kafkaResource.resourceType());
+                        throw new IllegalArgumentException("Invalid Resource type: " + kafkaResourcePattern.resourceType());
                 }
 
                 break;
@@ -196,8 +191,8 @@ public class SimpleAclRuleResource {
                 break;
             case TRANSACTIONAL_ID:
                 resourceType = SimpleAclRuleResourceType.TRANSACTIONAL_ID;
-                resourceName = kafkaResource.name();
-                switch (kafkaResource.patternType()) {
+                resourceName = kafkaResourcePattern.name();
+                switch (kafkaResourcePattern.patternType()) {
                     case LITERAL:
                         resourcePattern = AclResourcePatternType.LITERAL;
                         break;
@@ -205,12 +200,12 @@ public class SimpleAclRuleResource {
                         resourcePattern = AclResourcePatternType.PREFIX;
                         break;
                     default:
-                        throw new IllegalArgumentException("Invalid Resource type: " + kafkaResource.resourceType());
+                        throw new IllegalArgumentException("Invalid Resource type: " + kafkaResourcePattern.resourceType());
                 }
 
                 break;
             default:
-                throw new IllegalArgumentException("Invalid Resource type: " + kafkaResource.resourceType());
+                throw new IllegalArgumentException("Invalid Resource type: " + kafkaResourcePattern.resourceType());
         }
 
         return new SimpleAclRuleResource(resourceName, resourceType, resourcePattern);

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
@@ -4,30 +4,35 @@
  */
 package io.strimzi.operator.user.operator;
 
+import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.user.model.KafkaUserModel;
 import io.strimzi.operator.user.model.acl.SimpleAclRule;
-import io.strimzi.operator.user.model.acl.SimpleAclRuleResource;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import kafka.security.auth.Acl;
-import kafka.security.auth.Resource;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.common.acl.AccessControlEntryFilter;
+import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.errors.SecurityDisabledException;
+import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.utils.SecurityUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import scala.Tuple2;
-import scala.collection.Iterator;
-import scala.collection.JavaConverters;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 /**
  * SimlpeAclOperator is responsible for managing the authorization rules in Apache Kafka / Apache Zookeeper.
@@ -43,17 +48,17 @@ public class SimpleAclOperator {
     private static final List<String> IGNORED_USERS = Arrays.asList("*", "ANONYMOUS");
 
     private final Vertx vertx;
-    private final kafka.security.auth.SimpleAclAuthorizer authorizer;
+    private final Admin adminClient;
 
     /**
      * Constructor
      *
-     * @param vertx     Vertx instance
-     * @param authorizer    SimpleAcAuthorizer instance
+     * @param vertx Vertx instance
+     * @param adminClient Kafka Admin client instance
      */
-    public SimpleAclOperator(Vertx vertx, kafka.security.auth.SimpleAclAuthorizer authorizer)  {
+    public SimpleAclOperator(Vertx vertx, Admin adminClient)  {
         this.vertx = vertx;
-        this.authorizer = authorizer;
+        this.adminClient = adminClient;
     }
 
     /**
@@ -61,9 +66,9 @@ public class SimpleAclOperator {
      *
      * @param username  User name of the reconciled user. When using TLS client auth, the username should be already in the Kafka format, e.g. CN=my-user
      * @param desired   The list of desired Acl rules
-     * @return
+     * @return the Future with reconcile result
      */
-    Future<ReconcileResult<Set<SimpleAclRule>>> reconcile(String username, Set<SimpleAclRule> desired) {
+    public Future<ReconcileResult<Set<SimpleAclRule>>> reconcile(String username, Set<SimpleAclRule> desired) {
         Promise<ReconcileResult<Set<SimpleAclRule>>> promise = Promise.promise();
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
             future -> {
@@ -72,9 +77,16 @@ public class SimpleAclOperator {
                 try {
                     current = getAcls(username);
                 } catch (Exception e)   {
-                    log.error("Reconciliation failed for user {}", username, e);
-                    future.fail(e);
-                    return;
+                    // if authorization is not enabled in the Kafka resource, but the KafkaUser resource doesn't
+                    // have ACLs, the UO can just ignore the corresponding exception
+                    if (e instanceof InvalidResourceException && (desired == null || desired.isEmpty())) {
+                        future.complete();
+                        return;
+                    } else {
+                        log.error("Reconciliation failed for user {}", username, e);
+                        future.fail(e);
+                        return;
+                    }
                 }
 
                 if (desired == null || desired.isEmpty()) {
@@ -106,11 +118,8 @@ public class SimpleAclOperator {
      */
     protected Future<ReconcileResult<Set<SimpleAclRule>>> internalCreate(String username, Set<SimpleAclRule> desired) {
         try {
-            HashMap<Resource, Set<Acl>> map = getResourceAclsMap(username, desired);
-            for (Map.Entry<Resource, Set<Acl>> entry: map.entrySet()) {
-                scala.collection.mutable.Set<Acl> add = JavaConverters.asScalaSet(entry.getValue());
-                authorizer.addAcls(add.toSet(), entry.getKey());
-            }
+            Collection<AclBinding> aclBindings = getAclBindings(username, desired);
+            adminClient.createAcls(aclBindings).all().get();
         } catch (Exception e) {
             log.error("Adding Acl rules for user {} failed", username, e);
             return Future.failedFuture(e);
@@ -126,10 +135,10 @@ public class SimpleAclOperator {
      * It delagates to {@link #internalCreate internalCreate} and {@link #internalDelete internalDelete} methods for the actual addition or deletion.
      */
     protected Future<ReconcileResult<Set<SimpleAclRule>>> internalUpdate(String username, Set<SimpleAclRule> desired, Set<SimpleAclRule> current) {
-        Set<SimpleAclRule> toBeDeleted = new HashSet<SimpleAclRule>(current);
+        Set<SimpleAclRule> toBeDeleted = new HashSet<>(current);
         toBeDeleted.removeAll(desired);
 
-        Set<SimpleAclRule> toBeAdded = new HashSet<SimpleAclRule>(desired);
+        Set<SimpleAclRule> toBeAdded = new HashSet<>(desired);
         toBeAdded.removeAll(current);
 
         List<Future> updates = new ArrayList<>(2);
@@ -150,31 +159,32 @@ public class SimpleAclOperator {
         return promise.future();
     }
 
-    protected HashMap<Resource, Set<Acl>> getResourceAclsMap(String username, Set<SimpleAclRule> aclRules) {
+    private Collection<AclBindingFilter> getAclBindingFilters(String username, Set<SimpleAclRule> aclRules) {
         KafkaPrincipal principal = new KafkaPrincipal("User", username);
-        HashMap<Resource, Set<Acl>> map = new HashMap<>();
+        Collection<AclBindingFilter> aclBindingFilters = new ArrayList<>();
         for (SimpleAclRule rule: aclRules) {
-            Resource resource = rule.getResource().toKafkaResource();
-            Set<Acl> aclSet = map.get(resource);
-            if (aclSet == null) {
-                aclSet = new HashSet<>();
-            }
-            aclSet.add(rule.toKafkaAcl(principal));
-            map.put(resource, aclSet);
+            aclBindingFilters.add(rule.toKafkaAclBinding(principal).toFilter());
         }
-        return map;
+        return aclBindingFilters;
     }
+
+    private Collection<AclBinding> getAclBindings(String username, Set<SimpleAclRule> aclRules) {
+        KafkaPrincipal principal = new KafkaPrincipal("User", username);
+        Collection<AclBinding> aclBindings = new ArrayList<>();
+        for (SimpleAclRule rule: aclRules) {
+            aclBindings.add(rule.toKafkaAclBinding(principal));
+        }
+        return aclBindings;
+    }
+
     /**
      * Deletes all ACLs for given user
      */
     protected Future<ReconcileResult<Set<SimpleAclRule>>> internalDelete(String username, Set<SimpleAclRule> current) {
 
         try {
-            HashMap<Resource, Set<Acl>> map =  getResourceAclsMap(username, current);
-            for (Map.Entry<Resource, Set<Acl>> entry: map.entrySet()) {
-                scala.collection.mutable.Set<Acl> remove = JavaConverters.asScalaSet(entry.getValue());
-                authorizer.removeAcls(remove.toSet(), entry.getKey());
-            }
+            Collection<AclBindingFilter> aclBindingFilters = getAclBindingFilters(username, current);
+            adminClient.deleteAcls(aclBindingFilters).all().get();
         } catch (Exception e) {
             log.error("Deleting Acl rules for user {} failed", username, e);
             return Future.failedFuture(e);
@@ -190,37 +200,33 @@ public class SimpleAclOperator {
      */
     public Set<SimpleAclRule> getAcls(String username)   {
         log.debug("Searching for ACL rules of user {}", username);
-        Set<SimpleAclRule> result = new HashSet<SimpleAclRule>();
+        Set<SimpleAclRule> result = new HashSet<>();
         KafkaPrincipal principal = new KafkaPrincipal("User", username);
 
-        scala.collection.immutable.Map<Resource, scala.collection.immutable.Set<Acl>> rules;
+        AclBindingFilter aclBindingFilter = new AclBindingFilter(ResourcePatternFilter.ANY,
+            new AccessControlEntryFilter(principal.toString(), null, AclOperation.ANY, AclPermissionType.ANY));
 
+        Collection<AclBinding> aclBindings = null;
         try {
-            rules = authorizer.getAcls(principal);
-        } catch (Exception e)   {
-            log.error("Failed to get existing Acls rules for user {}", username, e);
-            throw e;
+            aclBindings = adminClient.describeAcls(aclBindingFilter).values().get();
+        } catch (InterruptedException | ExecutionException e) {
+            // Admin Client API needs authorizer enabled on the Kafka brokers
+            if (e.getCause() instanceof SecurityDisabledException) {
+                throw new InvalidResourceException("Authorization needs to be enabled in the Kafka custom resource", e.getCause());
+            } else if (e.getCause() instanceof UnknownServerException && e.getMessage().contains("Simple ACL delegation not enabled")) {
+                throw new InvalidResourceException("Simple ACL delegation needs to be enabled in the Kafka custom resource", e.getCause());
+            }
         }
 
-        Iterator<Tuple2<Resource, scala.collection.immutable.Set<Acl>>> iter = resourceAclsIterator(rules);
-        while (iter.hasNext())  {
-            Tuple2<Resource, scala.collection.immutable.Set<Acl>> tuple = iter.next();
-            SimpleAclRuleResource resource = SimpleAclRuleResource.fromKafkaResource(tuple._1());
-            scala.collection.immutable.Set<Acl> acls = tuple._2();
-
-            Iterator<Acl> iter2 = acls.iterator();
-            while (iter2.hasNext()) {
-                result.add(SimpleAclRule.fromKafkaAcl(resource, iter2.next()));
+        if (aclBindings != null) {
+            log.debug("ACL rules for user {}", username);
+            for (AclBinding aclBinding : aclBindings) {
+                log.debug("{}", aclBinding);
+                result.add(SimpleAclRule.fromAclBinding(aclBinding));
             }
         }
 
         return result;
-    }
-
-    private Iterator<Tuple2<Resource, scala.collection.immutable.Set<Acl>>> resourceAclsIterator(scala.collection.immutable.Map<Resource, scala.collection.immutable.Set<Acl>> rules) {
-        // this cast fixes an error with VSCode compiler (using the Eclipse JDT Language Server)
-        // error details: The method iterator() is ambiguous for the type Map<Resource,Set<Acl>>
-        return ((scala.collection.GenIterableLike<Tuple2<Resource, scala.collection.immutable.Set<Acl>>, ?>) rules).iterator();
     }
 
     /**
@@ -229,45 +235,37 @@ public class SimpleAclOperator {
      * @return The set with all usernames which have some ACLs.
      */
     public Set<String> getUsersWithAcls()   {
-        Set<String> result = new HashSet<String>();
-        Set<String> ignored = new HashSet<String>(IGNORED_USERS.size());
+        Set<String> result = new HashSet<>();
+        Set<String> ignored = new HashSet<>(IGNORED_USERS.size());
 
         log.debug("Searching for Users with any ACL rules");
 
-        scala.collection.immutable.Map<Resource, scala.collection.immutable.Set<Acl>> rules;
-
+        Collection<AclBinding> aclBindings;
         try {
-            rules =  authorizer.getAcls();
-        } catch (Exception e)   {
-            log.error("Failed to get existing Acls rules all users", e);
+            aclBindings = adminClient.describeAcls(AclBindingFilter.ANY).values().get();
+        } catch (InterruptedException | ExecutionException e) {
             return result;
         }
 
-        Iterator<Tuple2<Resource, scala.collection.immutable.Set<Acl>>> iter = resourceAclsIterator(rules);
-        while (iter.hasNext())  {
-            scala.collection.immutable.Set<Acl> acls = iter.next()._2();
+        for (AclBinding aclBinding : aclBindings) {
+            KafkaPrincipal principal = SecurityUtils.parseKafkaPrincipal(aclBinding.entry().principal());
 
-            Iterator<Acl> iter2 = acls.iterator();
-            while (iter2.hasNext()) {
-                KafkaPrincipal principal = iter2.next().principal();
+            if (KafkaPrincipal.USER_TYPE.equals(principal.getPrincipalType()))  {
+                // Username in ACL might keep different format (for example based on user's subject) and need to be decoded
+                String username = KafkaUserModel.decodeUsername(principal.getName());
 
-                if (KafkaPrincipal.USER_TYPE.equals(principal.getPrincipalType()))  {
-                    // Username in ACL might keep different format (for example based on user's subject) and need to be decoded
-                    String username = KafkaUserModel.decodeUsername(principal.getName());
-
-                    if (IGNORED_USERS.contains(username))   {
-                        if (!ignored.contains(username)) {
-                            // This info message is loged only once per reocnciliation even if there are multiple rules
-                            log.info("Existing ACLs for user '{}' will be ignored.", username);
-                            ignored.add(username);
-                        }
-                    } else {
-                        if (log.isTraceEnabled()) {
-                            log.trace("Adding user {} to Set of users with ACLs", username);
-                        }
-
-                        result.add(username);
+                if (IGNORED_USERS.contains(username))   {
+                    if (!ignored.contains(username)) {
+                        // This info message is loged only once per reocnciliation even if there are multiple rules
+                        log.info("Existing ACLs for user '{}' will be ignored.", username);
+                        ignored.add(username);
                     }
+                } else {
+                    if (log.isTraceEnabled()) {
+                        log.trace("Adding user {} to Set of users with ACLs", username);
+                    }
+
+                    result.add(username);
                 }
             }
         }

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResourceTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResourceTest.java
@@ -10,12 +10,9 @@ import io.strimzi.api.kafka.model.AclRuleGroupResourceBuilder;
 import io.strimzi.api.kafka.model.AclRuleResource;
 import io.strimzi.api.kafka.model.AclRuleTopicResourceBuilder;
 import io.strimzi.api.kafka.model.AclRuleTransactionalIdResourceBuilder;
-import kafka.security.auth.Cluster$;
-import kafka.security.auth.Group$;
-import kafka.security.auth.Resource;
-import kafka.security.auth.Topic$;
-import kafka.security.auth.TransactionalId$;
 import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourceType;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -98,192 +95,192 @@ public class SimpleAclRuleResourceTest {
     }
 
     @Test
-    public void testToKafkaResourceForTopicResource()  {
+    public void testToKafkaResourcePatternForTopicResource()  {
         // Regular topic
         SimpleAclRuleResource topicResourceRules = new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL);
-        Resource expectedKafkaResource = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
-        assertThat(topicResourceRules.toKafkaResource(), is(expectedKafkaResource));
+        ResourcePattern expectedKafkaResourcePattern = new ResourcePattern(ResourceType.TOPIC, "my-topic", PatternType.LITERAL);
+        assertThat(topicResourceRules.toKafkaResourcePattern(), is(expectedKafkaResourcePattern));
 
         // Prefixed topic
         topicResourceRules = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.PREFIX);
-        expectedKafkaResource = new Resource(Topic$.MODULE$, "my-", PatternType.PREFIXED);
-        assertThat(topicResourceRules.toKafkaResource(), is(expectedKafkaResource));
+        expectedKafkaResourcePattern = new ResourcePattern(ResourceType.TOPIC, "my-", PatternType.PREFIXED);
+        assertThat(topicResourceRules.toKafkaResourcePattern(), is(expectedKafkaResourcePattern));
     }
 
     @Test
-    public void testToKafkaResourceForGroupResource()  {
+    public void testToKafkaResourcePatternForGroupResource()  {
         // Regular group
         SimpleAclRuleResource groupResourceRules = new SimpleAclRuleResource("my-group", SimpleAclRuleResourceType.GROUP, AclResourcePatternType.LITERAL);
-        Resource expectedKafkaResource = new Resource(Group$.MODULE$, "my-group", PatternType.LITERAL);
-        assertThat(groupResourceRules.toKafkaResource(), is(expectedKafkaResource));
+        ResourcePattern expectedKafkaResourcePattern = new ResourcePattern(ResourceType.GROUP, "my-group", PatternType.LITERAL);
+        assertThat(groupResourceRules.toKafkaResourcePattern(), is(expectedKafkaResourcePattern));
 
         // Prefixed group
         groupResourceRules = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.GROUP, AclResourcePatternType.PREFIX);
-        expectedKafkaResource = new Resource(Group$.MODULE$, "my-", PatternType.PREFIXED);
-        assertThat(groupResourceRules.toKafkaResource(), is(expectedKafkaResource));
+        expectedKafkaResourcePattern = new ResourcePattern(ResourceType.GROUP, "my-", PatternType.PREFIXED);
+        assertThat(groupResourceRules.toKafkaResourcePattern(), is(expectedKafkaResourcePattern));
     }
 
     @Test
-    public void testToKafkaResourceForClusterResource()  {
+    public void testToKafkaResourcePatternForClusterResource()  {
         // Regular cluster
         SimpleAclRuleResource clusterResourceRules = new SimpleAclRuleResource(null, SimpleAclRuleResourceType.CLUSTER, null);
-        Resource expectedKafkaResource = new Resource(Cluster$.MODULE$, "kafka-cluster", PatternType.LITERAL);
-        assertThat(clusterResourceRules.toKafkaResource(), is(expectedKafkaResource));
+        ResourcePattern expectedKafkaResourcePattern = new ResourcePattern(ResourceType.CLUSTER, "kafka-cluster", PatternType.LITERAL);
+        assertThat(clusterResourceRules.toKafkaResourcePattern(), is(expectedKafkaResourcePattern));
     }
 
     @Test
-    public void testToKafkaResourceForTransactionalIdResource()  {
+    public void testToKafkaResourcePatternForTransactionalIdResource()  {
         // Regular transactionalId
         SimpleAclRuleResource transactionalIdResourceRules = new SimpleAclRuleResource("my-transactionalId", SimpleAclRuleResourceType.TRANSACTIONAL_ID, null);
-        Resource expectedKafkaResource = new Resource(TransactionalId$.MODULE$, "my-transactionalId", PatternType.LITERAL);
-        assertThat(transactionalIdResourceRules.toKafkaResource(), is(expectedKafkaResource));
+        ResourcePattern expectedKafkaResourcePattern = new ResourcePattern(ResourceType.TRANSACTIONAL_ID, "my-transactionalId", PatternType.LITERAL);
+        assertThat(transactionalIdResourceRules.toKafkaResourcePattern(), is(expectedKafkaResourcePattern));
 
         // Prefixed transactionalId
         transactionalIdResourceRules = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.TRANSACTIONAL_ID, AclResourcePatternType.PREFIX);
-        expectedKafkaResource = new Resource(TransactionalId$.MODULE$, "my-", PatternType.PREFIXED);
-        assertThat(transactionalIdResourceRules.toKafkaResource(), is(expectedKafkaResource));
+        expectedKafkaResourcePattern = new ResourcePattern(ResourceType.TRANSACTIONAL_ID, "my-", PatternType.PREFIXED);
+        assertThat(transactionalIdResourceRules.toKafkaResourcePattern(), is(expectedKafkaResourcePattern));
     }
 
     @Test
-    public void testFromKafkaResourceWithTopicResource()  {
+    public void testFromKafkaResourcePatternWithTopicResource()  {
         // Regular topic
-        Resource kafkaTopicResource = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
+        ResourcePattern kafkaTopicResourcePattern = new ResourcePattern(ResourceType.TOPIC, "my-topic", PatternType.LITERAL);
         SimpleAclRuleResource expectedTopicResourceRules = new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafkaTopicResource), is(expectedTopicResourceRules));
+        assertThat(SimpleAclRuleResource.fromKafkaResourcePattern(kafkaTopicResourcePattern), is(expectedTopicResourceRules));
 
         // Prefixed topic
-        kafkaTopicResource = new Resource(Topic$.MODULE$, "my-", PatternType.PREFIXED);
+        kafkaTopicResourcePattern = new ResourcePattern(ResourceType.TOPIC, "my-", PatternType.PREFIXED);
         expectedTopicResourceRules = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.PREFIX);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafkaTopicResource), is(expectedTopicResourceRules));
+        assertThat(SimpleAclRuleResource.fromKafkaResourcePattern(kafkaTopicResourcePattern), is(expectedTopicResourceRules));
     }
 
     @Test
-    public void testFromKafkaResourceWithGroupResource()  {
+    public void testFromKafkaResourcePatternWithGroupResource()  {
         // Regular group
-        Resource kafkaGroupResource = new Resource(Group$.MODULE$, "my-group", PatternType.LITERAL);
+        ResourcePattern kafkaGroupResourcePattern = new ResourcePattern(ResourceType.GROUP, "my-group", PatternType.LITERAL);
         SimpleAclRuleResource expectedGroupResourceRules = new SimpleAclRuleResource("my-group", SimpleAclRuleResourceType.GROUP, AclResourcePatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafkaGroupResource), is(expectedGroupResourceRules));
+        assertThat(SimpleAclRuleResource.fromKafkaResourcePattern(kafkaGroupResourcePattern), is(expectedGroupResourceRules));
 
         // Prefixed group
-        kafkaGroupResource = new Resource(Group$.MODULE$, "my-", PatternType.PREFIXED);
+        kafkaGroupResourcePattern = new ResourcePattern(ResourceType.GROUP, "my-", PatternType.PREFIXED);
         expectedGroupResourceRules = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.GROUP, AclResourcePatternType.PREFIX);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafkaGroupResource), is(expectedGroupResourceRules));
+        assertThat(SimpleAclRuleResource.fromKafkaResourcePattern(kafkaGroupResourcePattern), is(expectedGroupResourceRules));
     }
 
     @Test
-    public void testFromKafkaResourceWithClusterResource()  {
+    public void testFromKafkaResourcePatternWithClusterResource()  {
         // Regular cluster
-        Resource kafkaClusterResource = new Resource(Cluster$.MODULE$, "kafka-cluster", PatternType.LITERAL);
+        ResourcePattern kafkaClusterResourcePattern = new ResourcePattern(ResourceType.CLUSTER, "kafka-cluster", PatternType.LITERAL);
         SimpleAclRuleResource expectedClusterResourceRules = new SimpleAclRuleResource("kafka-cluster", SimpleAclRuleResourceType.CLUSTER, AclResourcePatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafkaClusterResource), is(expectedClusterResourceRules));
+        assertThat(SimpleAclRuleResource.fromKafkaResourcePattern(kafkaClusterResourcePattern), is(expectedClusterResourceRules));
     }
 
     @Test
-    public void testFromKafkaResourceWithTransactionalIdResource()  {
+    public void testFromKafkaResourcePatternWithTransactionalIdResource()  {
         // Regular transactionalId
-        Resource kafkaTransactionalIdResource = new Resource(TransactionalId$.MODULE$, "my-transactionalId", PatternType.LITERAL);
+        ResourcePattern kafkaTransactionalIdResourcePattern = new ResourcePattern(ResourceType.TRANSACTIONAL_ID, "my-transactionalId", PatternType.LITERAL);
         SimpleAclRuleResource expectedTransactionalIdResourceRules = new SimpleAclRuleResource("my-transactionalId", SimpleAclRuleResourceType.TRANSACTIONAL_ID, AclResourcePatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafkaTransactionalIdResource), is(expectedTransactionalIdResourceRules));
+        assertThat(SimpleAclRuleResource.fromKafkaResourcePattern(kafkaTransactionalIdResourcePattern), is(expectedTransactionalIdResourceRules));
 
         // Prefixed transactionalId
-        kafkaTransactionalIdResource = new Resource(TransactionalId$.MODULE$, "my-", PatternType.PREFIXED);
+        kafkaTransactionalIdResourcePattern = new ResourcePattern(ResourceType.TRANSACTIONAL_ID, "my-", PatternType.PREFIXED);
         expectedTransactionalIdResourceRules = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.TRANSACTIONAL_ID, AclResourcePatternType.PREFIX);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafkaTransactionalIdResource), is(expectedTransactionalIdResourceRules));
+        assertThat(SimpleAclRuleResource.fromKafkaResourcePattern(kafkaTransactionalIdResourcePattern), is(expectedTransactionalIdResourceRules));
     }
 
     @Test
-    public void testFromKafkaResourceToKafkaResourceRoundTripForTopicResource()    {
-        // Regular group
-        Resource kafka = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafka).toKafkaResource(), is(kafka));
+    public void testFromKafkaResourcePatternToKafkaResourcePatternRoundTripForTopicResource()    {
+        // Regular topic
+        ResourcePattern kafka = new ResourcePattern(ResourceType.TOPIC, "my-topic", PatternType.LITERAL);
+        assertThat(SimpleAclRuleResource.fromKafkaResourcePattern(kafka).toKafkaResourcePattern(), is(kafka));
 
         // Prefixed topic
-        kafka = new Resource(Topic$.MODULE$, "my-", PatternType.PREFIXED);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafka).toKafkaResource(), is(kafka));
+        kafka = new ResourcePattern(ResourceType.TOPIC, "my-", PatternType.PREFIXED);
+        assertThat(SimpleAclRuleResource.fromKafkaResourcePattern(kafka).toKafkaResourcePattern(), is(kafka));
     }
 
     @Test
-    public void testFromKafkaResourceToKafkaResourceRoundTripForGroupResource()  {
+    public void testFromKafkaResourcePatternToKafkaResourcePatternRoundTripForGroupResource()  {
         // Regular group
-        Resource kafka = new Resource(Group$.MODULE$, "my-group", PatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafka).toKafkaResource(), is(kafka));
+        ResourcePattern kafka = new ResourcePattern(ResourceType.GROUP, "my-group", PatternType.LITERAL);
+        assertThat(SimpleAclRuleResource.fromKafkaResourcePattern(kafka).toKafkaResourcePattern(), is(kafka));
 
         // Prefixed group
-        kafka = new Resource(Group$.MODULE$, "my-", PatternType.PREFIXED);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafka).toKafkaResource(), is(kafka));
+        kafka = new ResourcePattern(ResourceType.GROUP, "my-", PatternType.PREFIXED);
+        assertThat(SimpleAclRuleResource.fromKafkaResourcePattern(kafka).toKafkaResourcePattern(), is(kafka));
     }
 
     @Test
-    public void testFromKafkaResourceToKafkaResourceRoundTripForClusterResource()  {
+    public void testFromKafkaResourcePatternToKafkaResourcePatternRoundTripForClusterResource()  {
         // Regular cluster
-        Resource kafka = new Resource(Cluster$.MODULE$, "kafka-cluster", PatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafka).toKafkaResource(), is(kafka));
+        ResourcePattern kafka = new ResourcePattern(ResourceType.CLUSTER, "kafka-cluster", PatternType.LITERAL);
+        assertThat(SimpleAclRuleResource.fromKafkaResourcePattern(kafka).toKafkaResourcePattern(), is(kafka));
     }
 
     @Test
-    public void testFromKafkaResourceToKafkaResourceRoundTripForTransactionalIdResource()  {
+    public void testFromKafkaResourcePatternToKafkaResourcePatternRoundTripForTransactionalIdResource()  {
         // Regular transactionID
-        Resource kafka = new Resource(TransactionalId$.MODULE$, "my-transactionID", PatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafka).toKafkaResource(), is(kafka));
+        ResourcePattern kafka = new ResourcePattern(ResourceType.TRANSACTIONAL_ID, "my-transactionID", PatternType.LITERAL);
+        assertThat(SimpleAclRuleResource.fromKafkaResourcePattern(kafka).toKafkaResourcePattern(), is(kafka));
 
         // Prefixed transactionID
-        kafka = new Resource(TransactionalId$.MODULE$, "my-", PatternType.PREFIXED);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafka).toKafkaResource(), is(kafka));
+        kafka = new ResourcePattern(ResourceType.TRANSACTIONAL_ID, "my-", PatternType.PREFIXED);
+        assertThat(SimpleAclRuleResource.fromKafkaResourcePattern(kafka).toKafkaResourcePattern(), is(kafka));
     }
 
     @Test
-    public void testFromCrdToKafkaResourceForTopicResource()    {
+    public void testFromCrdToKafkaResourcePatternForTopicResource()    {
         // Regular group
         AclRuleResource resource = new AclRuleTopicResourceBuilder()
-            .withName("my-topic")
-            .withPatternType(AclResourcePatternType.LITERAL)
-            .build();
-        Resource expectedKafkaTopicResource = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(expectedKafkaTopicResource));
+                .withName("my-topic")
+                .withPatternType(AclResourcePatternType.LITERAL)
+                .build();
+        ResourcePattern expectedKafkaTopicResourcePattern = new ResourcePattern(ResourceType.TOPIC, "my-topic", PatternType.LITERAL);
+        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResourcePattern(), is(expectedKafkaTopicResourcePattern));
 
         // Prefixed topic
         resource = new AclRuleTopicResourceBuilder()
-            .withName("my-")
-            .withPatternType(AclResourcePatternType.PREFIX)
-            .build();
-        expectedKafkaTopicResource = new Resource(Topic$.MODULE$, "my-", PatternType.PREFIXED);
-        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(expectedKafkaTopicResource));
+                .withName("my-")
+                .withPatternType(AclResourcePatternType.PREFIX)
+                .build();
+        expectedKafkaTopicResourcePattern = new ResourcePattern(ResourceType.TOPIC, "my-", PatternType.PREFIXED);
+        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResourcePattern(), is(expectedKafkaTopicResourcePattern));
     }
 
     @Test
-    public void testFromCrdToKafkaResourceForGroupResource()  {
+    public void testFromCrdToKafkaResourcePatternForGroupResource()  {
         // Regular group
         AclRuleResource resource = new AclRuleGroupResourceBuilder()
-            .withName("my-group")
-            .withPatternType(AclResourcePatternType.LITERAL)
-            .build();
-        Resource expectedKafkaGroupResource = new Resource(Group$.MODULE$, "my-group", PatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(expectedKafkaGroupResource));
+                .withName("my-group")
+                .withPatternType(AclResourcePatternType.LITERAL)
+                .build();
+        ResourcePattern expectedKafkaGroupResourcePattern = new ResourcePattern(ResourceType.GROUP, "my-group", PatternType.LITERAL);
+        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResourcePattern(), is(expectedKafkaGroupResourcePattern));
 
         // Prefixed group
         resource = new AclRuleGroupResourceBuilder()
-            .withName("my-")
-            .withPatternType(AclResourcePatternType.PREFIX)
-            .build();
-        expectedKafkaGroupResource = new Resource(Group$.MODULE$, "my-", PatternType.PREFIXED);
-        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(expectedKafkaGroupResource));
+                .withName("my-")
+                .withPatternType(AclResourcePatternType.PREFIX)
+                .build();
+        expectedKafkaGroupResourcePattern = new ResourcePattern(ResourceType.GROUP, "my-", PatternType.PREFIXED);
+        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResourcePattern(), is(expectedKafkaGroupResourcePattern));
     }
 
     @Test
-    public void testFromCrdToKafkaResourceForClusterResource()  {
+    public void testFromCrdToKafkaResourcePatternForClusterResource()  {
         // Regular cluster
         AclRuleResource resource = new AclRuleClusterResource();
-        Resource expectedKafkaClusterResource = new Resource(Cluster$.MODULE$, "kafka-cluster", PatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(expectedKafkaClusterResource));
+        ResourcePattern expectedKafkaClusterResourcePattern = new ResourcePattern(ResourceType.CLUSTER, "kafka-cluster", PatternType.LITERAL);
+        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResourcePattern(), is(expectedKafkaClusterResourcePattern));
     }
 
     @Test
-    public void testFromCrdToKafkaResourceForTransactionalIdResource()  {
+    public void testFromCrdToKafkaResourcePatternForTransactionalIdResource()  {
         // Regular transactionalId
         AclRuleResource resource = new AclRuleTransactionalIdResourceBuilder()
-            .withName("my-transactionalId")
-            .build();
-        Resource expectedKafkaTransactionalIdResource = new Resource(TransactionalId$.MODULE$, "my-transactionalId", PatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(expectedKafkaTransactionalIdResource));
+                .withName("my-transactionalId")
+                .build();
+        ResourcePattern expectedKafkaTransactionalIdResourcePattern = new ResourcePattern(ResourceType.TRANSACTIONAL_ID, "my-transactionalId", PatternType.LITERAL);
+        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResourcePattern(), is(expectedKafkaTransactionalIdResourcePattern));
     }
 }

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorIT.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.user.operator;
+
+import io.debezium.kafka.KafkaCluster;
+import io.debezium.util.Testing;
+import io.strimzi.api.kafka.model.AclOperation;
+import io.strimzi.api.kafka.model.AclResourcePatternType;
+import io.strimzi.api.kafka.model.AclRuleType;
+import io.strimzi.operator.common.DefaultAdminClientProvider;
+import io.strimzi.operator.user.model.acl.SimpleAclRule;
+import io.strimzi.operator.user.model.acl.SimpleAclRuleResource;
+import io.strimzi.operator.user.model.acl.SimpleAclRuleResourceType;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hamcrest.collection.IsEmptyCollection;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+@ExtendWith(VertxExtension.class)
+public class SimpleAclOperatorIT {
+
+    private static final Logger log = LogManager.getLogger(SimpleAclOperatorIT.class);
+    private static final int TEST_TIMEOUT = 60;
+
+    private static Vertx vertx;
+
+    private static KafkaCluster kafkaCluster;
+
+    private static SimpleAclOperator simpleAclOperator;
+
+    private static Properties kafkaClusterConfig() {
+        Properties config = new Properties();
+        config.setProperty("authorizer.class.name", "kafka.security.auth.SimpleAclAuthorizer");
+        config.setProperty("super.users", "User:ANONYMOUS");
+        return config;
+    }
+
+    @BeforeAll
+    public static void beforeAll() {
+        vertx = Vertx.vertx();
+
+        try {
+            kafkaCluster =
+                    new KafkaCluster()
+                            .usingDirectory(Testing.Files.createTestingDirectory("simple-acl-operator-integration-test"))
+                            .deleteDataPriorToStartup(true)
+                            .deleteDataUponShutdown(true)
+                            .addBrokers(1)
+                            .withKafkaConfiguration(kafkaClusterConfig())
+                            .startup();
+        } catch (IOException e) {
+            assertThat(false, is(true));
+        }
+
+        simpleAclOperator = new SimpleAclOperator(vertx,
+                new DefaultAdminClientProvider().createAdminClient(kafkaCluster.brokerList(), null, null, null));
+    }
+
+    @Test
+    public void testNoAclRules(VertxTestContext context) {
+        Set<SimpleAclRule> acls = simpleAclOperator.getAcls("no-acls-user");
+        context.verify(() -> {
+            assertThat(acls, IsEmptyCollection.empty());
+        });
+        context.completeNow();
+    }
+
+    @Test
+    public void testCreateAclRule(VertxTestContext context) throws InterruptedException {
+        SimpleAclRule rule = new SimpleAclRule(
+                AclRuleType.ALLOW,
+                new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL),
+                "*",
+                AclOperation.READ);
+
+        CountDownLatch async = new CountDownLatch(1);
+        simpleAclOperator.reconcile("my-user", Collections.singleton(rule))
+                .setHandler(ignore -> context.verify(() -> {
+                    Set<SimpleAclRule> acls = simpleAclOperator.getAcls("my-user");
+                    assertThat(acls, hasSize(1));
+                    assertThat(acls, hasItem(rule));
+                    async.countDown();
+                }));
+
+        async.await(TEST_TIMEOUT, TimeUnit.SECONDS);
+        context.completeNow();
+    }
+
+    @Test
+    public void testCreateAndUpdateAclRule(VertxTestContext context) throws InterruptedException {
+        SimpleAclRule rule1 = new SimpleAclRule(
+                AclRuleType.ALLOW,
+                new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL),
+                "*",
+                AclOperation.READ);
+
+        CountDownLatch async1 = new CountDownLatch(1);
+        simpleAclOperator.reconcile("my-user", Collections.singleton(rule1))
+                .setHandler(ignore -> context.verify(() -> {
+                    Set<SimpleAclRule> acls = simpleAclOperator.getAcls("my-user");
+                    assertThat(acls, hasSize(1));
+                    assertThat(acls, hasItem(rule1));
+                    async1.countDown();
+                }));
+
+        async1.await(TEST_TIMEOUT, TimeUnit.SECONDS);
+
+        SimpleAclRule rule2 = new SimpleAclRule(
+                AclRuleType.ALLOW,
+                new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL),
+                "*",
+                AclOperation.WRITE);
+
+        CountDownLatch async2 = new CountDownLatch(1);
+        simpleAclOperator.reconcile("my-user", new HashSet<>(asList(rule1, rule2)))
+                .setHandler(ignore -> context.verify(() -> {
+                    Set<SimpleAclRule> acls = simpleAclOperator.getAcls("my-user");
+                    assertThat(acls, hasSize(2));
+                    assertThat(acls, hasItems(rule1, rule2));
+                    async2.countDown();
+                }));
+
+        async2.await(TEST_TIMEOUT, TimeUnit.SECONDS);
+        context.completeNow();
+    }
+
+    @Test
+    public void testCreateAndDeleteAclRule(VertxTestContext context) throws InterruptedException {
+        SimpleAclRule rule1 = new SimpleAclRule(
+                AclRuleType.ALLOW,
+                new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL),
+                "*",
+                AclOperation.READ);
+
+        CountDownLatch async1 = new CountDownLatch(1);
+        simpleAclOperator.reconcile("my-user", Collections.singleton(rule1))
+                .setHandler(ignore -> context.verify(() -> {
+                    Set<SimpleAclRule> acls = simpleAclOperator.getAcls("my-user");
+                    assertThat(acls, hasSize(1));
+                    assertThat(acls, hasItem(rule1));
+                    async1.countDown();
+                }));
+
+        async1.await(TEST_TIMEOUT, TimeUnit.SECONDS);
+
+        CountDownLatch async2 = new CountDownLatch(1);
+        simpleAclOperator.reconcile("my-user", null)
+                .setHandler(ignore -> context.verify(() -> {
+                    Set<SimpleAclRule> acls = simpleAclOperator.getAcls("my-user");
+                    assertThat(acls, IsEmptyCollection.empty());
+                    async2.countDown();
+                }));
+
+        async2.await(TEST_TIMEOUT, TimeUnit.SECONDS);
+        context.completeNow();
+    }
+
+    @Test
+    public void testUsersWithAcls(VertxTestContext context) throws InterruptedException {
+        SimpleAclRule rule1 = new SimpleAclRule(
+                AclRuleType.ALLOW,
+                new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL),
+                "*",
+                AclOperation.READ);
+
+        CountDownLatch async1 = new CountDownLatch(1);
+        simpleAclOperator.reconcile("my-user", Collections.singleton(rule1))
+                .setHandler(ignore -> context.verify(() -> {
+                    Set<SimpleAclRule> acls = simpleAclOperator.getAcls("my-user");
+                    assertThat(acls, hasSize(1));
+                    assertThat(acls, hasItem(rule1));
+                    async1.countDown();
+                }));
+
+        async1.await(TEST_TIMEOUT, TimeUnit.SECONDS);
+
+        SimpleAclRule rule2 = new SimpleAclRule(
+                AclRuleType.ALLOW,
+                new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL),
+                "*",
+                AclOperation.WRITE);
+
+        CountDownLatch async2 = new CountDownLatch(1);
+        simpleAclOperator.reconcile("my-user-2", Collections.singleton(rule2))
+                .setHandler(ignore -> context.verify(() -> {
+                    Set<SimpleAclRule> acls = simpleAclOperator.getAcls("my-user-2");
+                    assertThat(acls, hasSize(1));
+                    assertThat(acls, hasItem(rule2));
+                    async2.countDown();
+                }));
+
+        async2.await(TEST_TIMEOUT, TimeUnit.SECONDS);
+
+        Set<String> usersWithAcls = simpleAclOperator.getUsersWithAcls();
+        context.verify(() -> {
+            assertThat(usersWithAcls, hasItems("my-user", "my-user-2"));
+        });
+        context.completeNow();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        if (kafkaCluster != null) {
+            kafkaCluster.shutdown();
+        }
+        if (vertx != null) {
+            vertx.close();
+        }
+    }
+}

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
@@ -14,17 +14,20 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import kafka.security.auth.Acl;
-import kafka.security.auth.Allow$;
-import kafka.security.auth.Cluster$;
-import kafka.security.auth.Describe$;
-import kafka.security.auth.Group$;
-import kafka.security.auth.Read$;
-import kafka.security.auth.Resource;
-import kafka.security.auth.SimpleAclAuthorizer;
-import kafka.security.auth.Topic$;
-import kafka.security.auth.Write$;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.CreateAclsResult;
+import org.apache.kafka.clients.admin.DeleteAclsResult;
+import org.apache.kafka.clients.admin.DescribeAclsResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.acl.AccessControlEntry;
+import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourcePatternFilter;
+import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -32,17 +35,23 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.Mockito.doNothing;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -62,162 +71,187 @@ public class SimpleAclOperatorTest {
 
     @Test
     public void testGetUsersFromAcls(VertxTestContext context)  {
-        SimpleAclAuthorizer mockAuthorizer = mock(SimpleAclAuthorizer.class);
-        SimpleAclOperator aclOp = new SimpleAclOperator(vertx, mockAuthorizer);
+        Admin mockAdminClient = mock(AdminClient.class);
+        SimpleAclOperator aclOp = new SimpleAclOperator(vertx, mockAdminClient);
 
-        KafkaPrincipal foo = new KafkaPrincipal("User", "CN=foo");
-        Acl fooAcl = new Acl(foo, Allow$.MODULE$, "*", Read$.MODULE$);
-        KafkaPrincipal bar = new KafkaPrincipal("User", "CN=bar");
-        Acl barAcl = new Acl(bar, Allow$.MODULE$, "*", Read$.MODULE$);
-        KafkaPrincipal baz = new KafkaPrincipal("User", "baz");
-        Acl bazAcl = new Acl(baz, Allow$.MODULE$, "*", Read$.MODULE$);
-        KafkaPrincipal all = new KafkaPrincipal("User", "*");
-        Acl allAcl = new Acl(all, Allow$.MODULE$, "*", Read$.MODULE$);
-        KafkaPrincipal anonymous = new KafkaPrincipal("User", "ANONYMOUS");
-        Acl anonymousAcl = new Acl(anonymous, Allow$.MODULE$, "*", Read$.MODULE$);
-        Resource res1 = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
-        Resource res2 = new Resource(Group$.MODULE$, "my-group", PatternType.LITERAL);
-        scala.collection.immutable.Set<Acl> set1 = new scala.collection.immutable.Set.Set3<>(fooAcl, barAcl, allAcl);
-        scala.collection.immutable.Set<Acl> set2 = new scala.collection.immutable.Set.Set2<>(bazAcl, anonymousAcl);
-        scala.collection.immutable.Map<Resource, scala.collection.immutable.Set<Acl>> map = new scala.collection.immutable.Map.Map2<>(res1, set1, res2, set2);
-        when(mockAuthorizer.getAcls()).thenReturn(map);
+        ResourcePattern res1 = new ResourcePattern(ResourceType.TOPIC, "my-topic", PatternType.LITERAL);
+        ResourcePattern res2 = new ResourcePattern(ResourceType.GROUP, "my-group", PatternType.LITERAL);
 
-        ArgumentCaptor<KafkaPrincipal> principalCaptor = ArgumentCaptor.forClass(KafkaPrincipal.class);
-        when(mockAuthorizer.getAcls(principalCaptor.capture())).thenReturn(map);
+        KafkaPrincipal foo = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "CN=foo");
+        AclBinding fooAclBinding = new AclBinding(res1, new AccessControlEntry(foo.toString(), "*",
+                org.apache.kafka.common.acl.AclOperation.READ, AclPermissionType.ALLOW));
+        KafkaPrincipal bar = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "CN=bar");
+        AclBinding barAclBinding = new AclBinding(res1, new AccessControlEntry(bar.toString(), "*",
+                org.apache.kafka.common.acl.AclOperation.READ, AclPermissionType.ALLOW));
+        KafkaPrincipal baz = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "baz");
+        AclBinding bazAclBinding = new AclBinding(res2, new AccessControlEntry(baz.toString(), "*",
+                org.apache.kafka.common.acl.AclOperation.READ, AclPermissionType.ALLOW));
+        KafkaPrincipal all = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "*");
+        AclBinding allAclBinding = new AclBinding(res1, new AccessControlEntry(all.toString(), "*",
+                org.apache.kafka.common.acl.AclOperation.READ, AclPermissionType.ALLOW));
+        KafkaPrincipal anonymous = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "ANONYMOUS");
+        AclBinding anonymousAclBinding = new AclBinding(res2, new AccessControlEntry(anonymous.toString(), "*",
+                org.apache.kafka.common.acl.AclOperation.READ, AclPermissionType.ALLOW));
 
-        assertThat(aclOp.getUsersWithAcls(), is(new HashSet(asList("foo", "bar", "baz"))));
+        Collection<AclBinding> aclBindings =
+                asList(fooAclBinding, barAclBinding, bazAclBinding, allAclBinding, anonymousAclBinding);
+
+        assertDoesNotThrow(() -> mockDescribeAcls(mockAdminClient, AclBindingFilter.ANY, aclBindings));
+        assertThat(aclOp.getUsersWithAcls(), is(new HashSet<>(asList("foo", "bar", "baz"))));
         context.completeNow();
     }
 
     @Test
     public void testReconcileInternalCreateAddsAclsToAuthorizer(VertxTestContext context) {
-        SimpleAclAuthorizer mockAuthorizer = mock(SimpleAclAuthorizer.class);
-        SimpleAclOperator aclOp = new SimpleAclOperator(vertx, mockAuthorizer);
+        Admin mockAdminClient = mock(AdminClient.class);
+        SimpleAclOperator aclOp = new SimpleAclOperator(vertx, mockAdminClient);
 
-        scala.collection.immutable.Map<Resource, scala.collection.immutable.Set<Acl>> map = new scala.collection.immutable.HashMap<Resource, scala.collection.immutable.Set<Acl>>();
-        ArgumentCaptor<KafkaPrincipal> principalCaptor = ArgumentCaptor.forClass(KafkaPrincipal.class);
-        when(mockAuthorizer.getAcls(principalCaptor.capture())).thenReturn(map);
+        ResourcePattern resource1 = new ResourcePattern(ResourceType.CLUSTER, "kafka-cluster", PatternType.LITERAL);
+        ResourcePattern resource2 = new ResourcePattern(ResourceType.TOPIC, "my-topic", PatternType.LITERAL);
 
-        ArgumentCaptor<scala.collection.immutable.Set<Acl>> aclCaptor = ArgumentCaptor.forClass(scala.collection.immutable.Set.class);
-        ArgumentCaptor<Resource> resourceCaptor = ArgumentCaptor.forClass(Resource.class);
-        doNothing().when(mockAuthorizer).addAcls(aclCaptor.capture(), resourceCaptor.capture());
+        KafkaPrincipal foo = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "CN=foo");
+        AclBinding describeAclBinding = new AclBinding(resource1, new AccessControlEntry(foo.toString(), "*",
+                org.apache.kafka.common.acl.AclOperation.DESCRIBE, AclPermissionType.ALLOW));
+        AclBinding readAclBinding = new AclBinding(resource2, new AccessControlEntry(foo.toString(), "*",
+                org.apache.kafka.common.acl.AclOperation.READ, AclPermissionType.ALLOW));
+        AclBinding writeAclBinding = new AclBinding(resource2, new AccessControlEntry(foo.toString(), "*",
+                org.apache.kafka.common.acl.AclOperation.WRITE, AclPermissionType.ALLOW));
 
-        SimpleAclRuleResource ruleResource1 = new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.CLUSTER, AclResourcePatternType.LITERAL);
+        SimpleAclRuleResource ruleResource1 = new SimpleAclRuleResource("kafka-cluster", SimpleAclRuleResourceType.CLUSTER, AclResourcePatternType.LITERAL);
         SimpleAclRuleResource ruleResource2 = new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL);
         SimpleAclRule resource1DescribeRule = new SimpleAclRule(AclRuleType.ALLOW, ruleResource1, "*", AclOperation.DESCRIBE);
         SimpleAclRule resource2ReadRule = new SimpleAclRule(AclRuleType.ALLOW, ruleResource2, "*", AclOperation.READ);
         SimpleAclRule resource2WriteRule = new SimpleAclRule(AclRuleType.ALLOW, ruleResource2, "*", AclOperation.WRITE);
 
-        KafkaPrincipal foo = new KafkaPrincipal("User", "CN=foo");
-        Acl readAcl = new Acl(foo, Allow$.MODULE$, "*", Read$.MODULE$);
-        Acl writeAcl = new Acl(foo, Allow$.MODULE$, "*", Write$.MODULE$);
-        Acl describeAcl = new Acl(foo, Allow$.MODULE$, "*", Describe$.MODULE$);
-        scala.collection.immutable.Set<Acl> expectedResource1RuleSet = new scala.collection.immutable.Set.Set1<>(describeAcl);
-        scala.collection.immutable.Set<Acl> expectedResource2RuleSet = new scala.collection.immutable.Set.Set2<>(readAcl, writeAcl);
-
-        Resource resource1 = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
-        Resource resource2 = new Resource(Cluster$.MODULE$, "kafka-cluster", PatternType.LITERAL);
+        ArgumentCaptor<Collection<AclBinding>> aclBindingsCaptor = ArgumentCaptor.forClass(Collection.class);
+        assertDoesNotThrow(() -> {
+            mockDescribeAcls(mockAdminClient, null, emptyList());
+            mockCreateAcls(mockAdminClient, aclBindingsCaptor);
+        });
 
         Checkpoint async = context.checkpoint();
         aclOp.reconcile("CN=foo", new LinkedHashSet<>(asList(resource2ReadRule, resource2WriteRule, resource1DescribeRule)))
-            .setHandler(context.succeeding(rr -> context.verify(() -> {
-                List<scala.collection.immutable.Set<Acl>> capturedAcls = aclCaptor.getAllValues();
-                List<Resource> capturedResource = resourceCaptor.getAllValues();
+                .setHandler(context.succeeding(rr -> context.verify(() -> {
+                    Collection<AclBinding> capturedAclBindings = aclBindingsCaptor.getValue();
+                    assertThat(capturedAclBindings, hasSize(3));
+                    assertThat(capturedAclBindings, hasItems(describeAclBinding, readAclBinding, writeAclBinding));
 
-                assertThat(capturedAcls, hasSize(2));
-                assertThat(capturedResource, hasSize(2));
+                    Set<ResourcePattern> capturedResourcePatterns =
+                            capturedAclBindings.stream().map(AclBinding::pattern).collect(Collectors.toSet());
+                    assertThat(capturedResourcePatterns, hasSize(2));
+                    assertThat(capturedResourcePatterns, hasItems(resource1, resource2));
 
-                assertThat(capturedResource, hasItems(resource1, resource2));
-                assertThat(capturedAcls, hasItems(expectedResource1RuleSet, expectedResource2RuleSet));
-
-                async.flag();
-            })));
+                    async.flag();
+                })));
     }
 
     @Test
     public void testReconcileInternalUpdateCreatesNewAclsAndDeletesOldAcls(VertxTestContext context) {
-        SimpleAclAuthorizer mockAuthorizer = mock(SimpleAclAuthorizer.class);
-        SimpleAclOperator aclOp = new SimpleAclOperator(vertx, mockAuthorizer);
+        Admin mockAdminClient = mock(AdminClient.class);
+        SimpleAclOperator aclOp = new SimpleAclOperator(vertx, mockAdminClient);
+
+        ResourcePattern resource1 = new ResourcePattern(ResourceType.TOPIC, "my-topic", PatternType.LITERAL);
+        ResourcePattern resource2 = new ResourcePattern(ResourceType.TOPIC, "my-topic2", PatternType.LITERAL);
+
+        KafkaPrincipal foo = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "CN=foo");
+        AclBinding readAclBinding = new AclBinding(resource1, new AccessControlEntry(foo.toString(), "*", org.apache.kafka.common.acl.AclOperation.READ, AclPermissionType.ALLOW));
+        AclBinding writeAclBinding = new AclBinding(resource2, new AccessControlEntry(foo.toString(), "*", org.apache.kafka.common.acl.AclOperation.WRITE, AclPermissionType.ALLOW));
 
         SimpleAclRuleResource resource = new SimpleAclRuleResource("my-topic2", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL);
         SimpleAclRule rule1 = new SimpleAclRule(AclRuleType.ALLOW, resource, "*", AclOperation.WRITE);
 
-        KafkaPrincipal foo = new KafkaPrincipal("User", "CN=foo");
-        Acl readAcl = new Acl(foo, Allow$.MODULE$, "*", Read$.MODULE$);
-        scala.collection.immutable.Set<Acl> readAclSet = new scala.collection.immutable.Set.Set1<>(readAcl);
-        Acl writeAcl = new Acl(foo, Allow$.MODULE$, "*", Write$.MODULE$);
-        scala.collection.immutable.Set<Acl> writeAclSet = new scala.collection.immutable.Set.Set1<>(writeAcl);
-
-        Resource resource1 = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
-        Resource resource2 = new Resource(Topic$.MODULE$, "my-topic2", PatternType.LITERAL);
-
-        scala.collection.immutable.Map<Resource, scala.collection.immutable.Set<Acl>> map = new scala.collection.immutable.Map.Map1<>(resource1, readAclSet);
-        ArgumentCaptor<KafkaPrincipal> principalCaptor = ArgumentCaptor.forClass(KafkaPrincipal.class);
-        when(mockAuthorizer.getAcls(principalCaptor.capture())).thenReturn(map);
-
-        ArgumentCaptor<scala.collection.immutable.Set<Acl>> aclCaptor = ArgumentCaptor.forClass(scala.collection.immutable.Set.class);
-        ArgumentCaptor<Resource> resourceCaptor = ArgumentCaptor.forClass(Resource.class);
-        doNothing().when(mockAuthorizer).addAcls(aclCaptor.capture(), resourceCaptor.capture());
-
-        ArgumentCaptor<scala.collection.immutable.Set<Acl>> deleteAclCaptor = ArgumentCaptor.forClass(scala.collection.immutable.Set.class);
-        ArgumentCaptor<Resource> deleterResourceCaptor = ArgumentCaptor.forClass(Resource.class);
-        when(mockAuthorizer.removeAcls(deleteAclCaptor.capture(), deleterResourceCaptor.capture())).thenReturn(true);
+        ArgumentCaptor<Collection<AclBinding>> aclBindingsCaptor = ArgumentCaptor.forClass(Collection.class);
+        ArgumentCaptor<Collection<AclBindingFilter>> aclBindingFiltersCaptor = ArgumentCaptor.forClass(Collection.class);
+        assertDoesNotThrow(() -> {
+            mockDescribeAcls(mockAdminClient, null, Collections.singleton(readAclBinding));
+            mockCreateAcls(mockAdminClient, aclBindingsCaptor);
+            mockDeleteAcls(mockAdminClient, Collections.singleton(readAclBinding), aclBindingFiltersCaptor);
+        });
 
         Checkpoint async = context.checkpoint();
         aclOp.reconcile("CN=foo", new LinkedHashSet(asList(rule1)))
-            .setHandler(context.succeeding(rr -> context.verify(() -> {
-                List<scala.collection.immutable.Set<Acl>> capturedAcls = aclCaptor.getAllValues();
-                List<Resource> capturedResource = resourceCaptor.getAllValues();
-                List<scala.collection.immutable.Set<Acl>> deleteCapturedAcls = deleteAclCaptor.getAllValues();
-                List<Resource> deleteCapturedResource = deleterResourceCaptor.getAllValues();
+                .setHandler(context.succeeding(rr -> context.verify(() -> {
 
-                // Create Write rule for resource 2
-                assertThat(capturedAcls, hasSize(1));
-                assertThat(capturedAcls, hasItem(writeAclSet));
-                assertThat(capturedResource, hasSize(1));
-                assertThat(capturedResource, hasItem(resource2));
+                    // Create Write rule for resource 2
+                    Collection<AclBinding> capturedAclBindings = aclBindingsCaptor.getValue();
+                    assertThat(capturedAclBindings, hasSize(1));
+                    assertThat(capturedAclBindings, hasItem(writeAclBinding));
+                    Set<ResourcePattern> capturedResourcePatterns =
+                            capturedAclBindings.stream().map(AclBinding::pattern).collect(Collectors.toSet());
+                    assertThat(capturedResourcePatterns, hasSize(1));
+                    assertThat(capturedResourcePatterns, hasItem(resource2));
 
-                // Delete read rule for resource 1
-                assertThat(deleteCapturedAcls, hasSize(1));
-                assertThat(deleteCapturedAcls, hasItem(readAclSet));
-                assertThat(deleteCapturedResource, hasSize(1));
-                assertThat(deleteCapturedResource, hasItem(resource1));
+                    // Delete read rule for resource 1
+                    Collection<AclBindingFilter> capturedAclBindingFilters = aclBindingFiltersCaptor.getValue();
+                    assertThat(capturedAclBindingFilters, hasSize(1));
+                    assertThat(capturedAclBindingFilters, hasItem(readAclBinding.toFilter()));
 
-                async.flag();
-            })));
+                    Set<ResourcePatternFilter> capturedResourcePatternFilters =
+                            capturedAclBindingFilters.stream().map(AclBindingFilter::patternFilter).collect(Collectors.toSet());
+                    assertThat(capturedResourcePatternFilters, hasSize(1));
+                    assertThat(capturedResourcePatternFilters, hasItem(resource1.toFilter()));
+
+                    async.flag();
+                })));
     }
 
     @Test
     public void testReconcileInternalDelete(VertxTestContext context) {
-        SimpleAclAuthorizer mockAuthorizer = mock(SimpleAclAuthorizer.class);
-        SimpleAclOperator aclOp = new SimpleAclOperator(vertx, mockAuthorizer);
+        Admin mockAdminClient = mock(AdminClient.class);
+        SimpleAclOperator aclOp = new SimpleAclOperator(vertx, mockAdminClient);
+
+        ResourcePattern resource = new ResourcePattern(ResourceType.TOPIC, "my-topic", PatternType.LITERAL);
 
         KafkaPrincipal foo = new KafkaPrincipal("User", "CN=foo");
-        Acl readAcl = new Acl(foo, Allow$.MODULE$, "*", Read$.MODULE$);
-        scala.collection.immutable.Set<Acl> readAclSet = new scala.collection.immutable.Set.Set1<>(readAcl);
-        Resource resource1 = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
+        AclBinding readAclBinding = new AclBinding(resource, new AccessControlEntry(foo.toString(), "*", org.apache.kafka.common.acl.AclOperation.READ, AclPermissionType.ALLOW));
 
-        scala.collection.immutable.Map<Resource, scala.collection.immutable.Set<Acl>> map = new scala.collection.immutable.Map.Map1<>(resource1, readAclSet);
-        ArgumentCaptor<KafkaPrincipal> principalCaptor = ArgumentCaptor.forClass(KafkaPrincipal.class);
-        when(mockAuthorizer.getAcls(principalCaptor.capture())).thenReturn(map);
-
-        ArgumentCaptor<scala.collection.immutable.Set<Acl>> deleteAclCaptor = ArgumentCaptor.forClass(scala.collection.immutable.Set.class);
-        ArgumentCaptor<Resource> deleterResourceCaptor = ArgumentCaptor.forClass(Resource.class);
-        when(mockAuthorizer.removeAcls(deleteAclCaptor.capture(), deleterResourceCaptor.capture())).thenReturn(true);
+        ArgumentCaptor<Collection<AclBindingFilter>> aclBindingFiltersCaptor = ArgumentCaptor.forClass(Collection.class);
+        assertDoesNotThrow(() -> {
+            mockDescribeAcls(mockAdminClient, null, Collections.singleton(readAclBinding));
+            mockDeleteAcls(mockAdminClient, Collections.singleton(readAclBinding), aclBindingFiltersCaptor);
+        });
 
         Checkpoint async = context.checkpoint();
         aclOp.reconcile("CN=foo", null)
-            .setHandler(context.succeeding(rr -> context.verify(() -> {
-                List<scala.collection.immutable.Set<Acl>> deleteCapturedAcls = deleteAclCaptor.getAllValues();
-                List<Resource> deleteCapturedResource = deleterResourceCaptor.getAllValues();
+                .setHandler(context.succeeding(rr -> context.verify(() -> {
 
-                // Delete correct read rule for resource 1
-                assertThat(deleteCapturedAcls, hasSize(1));
-                assertThat(deleteCapturedAcls, hasItem(readAclSet));
-                assertThat(deleteCapturedResource, hasSize(1));
-                assertThat(deleteCapturedResource, hasItem(resource1));
+                    Collection<AclBindingFilter> capturedAclBindingFilters = aclBindingFiltersCaptor.getValue();
+                    assertThat(capturedAclBindingFilters, hasSize(1));
+                    assertThat(capturedAclBindingFilters, hasItem(readAclBinding.toFilter()));
 
-                async.flag();
-            })));
+                    Set<ResourcePatternFilter> capturedResourcePatternFilters =
+                            capturedAclBindingFilters.stream().map(AclBindingFilter::patternFilter).collect(Collectors.toSet());
+                    assertThat(capturedResourcePatternFilters, hasSize(1));
+                    assertThat(capturedResourcePatternFilters, hasItem(resource.toFilter()));
+
+                    async.flag();
+                })));
+    }
+
+    private void mockDescribeAcls(Admin mockAdminClient, AclBindingFilter aclBindingFilter, Collection<AclBinding> aclBindings)
+            throws InterruptedException, ExecutionException {
+        DescribeAclsResult result = mock(DescribeAclsResult.class);
+        KafkaFuture<Collection<AclBinding>> future = mock(KafkaFuture.class);
+        when(future.get()).thenReturn(aclBindings);
+        when(result.values()).thenReturn(future);
+        when(mockAdminClient.describeAcls(aclBindingFilter != null ? aclBindingFilter : any())).thenReturn(result);
+    }
+
+    private void mockCreateAcls(Admin mockAdminClient, ArgumentCaptor<Collection<AclBinding>> aclBindingsCaptor)
+            throws InterruptedException, ExecutionException {
+        CreateAclsResult result = mock(CreateAclsResult.class);
+        KafkaFuture<Void> future = mock(KafkaFuture.class);
+        when(future.get()).thenReturn(null);
+        when(result.all()).thenReturn(future);
+        when(mockAdminClient.createAcls(aclBindingsCaptor.capture())).thenReturn(result);
+    }
+
+    private void mockDeleteAcls(Admin mockAdminClient, Collection<AclBinding> aclBindings, ArgumentCaptor<Collection<AclBindingFilter>> aclBindingFiltersCaptor)
+            throws InterruptedException, ExecutionException {
+        DeleteAclsResult result = mock(DeleteAclsResult.class);
+        KafkaFuture<Collection<AclBinding>> future = mock(KafkaFuture.class);
+        when(future.get()).thenReturn(aclBindings);
+        when(result.all()).thenReturn(future);
+        when(mockAdminClient.deleteAcls(aclBindingFiltersCaptor.capture())).thenReturn(result);
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR fixes #1106. It removes the `SimpleAclAuthorizer` usage in the `SimpleAclOperator` for handling the ACLs and uses the new Admin Client API for doing that.
It also adds the way to provide through the Cluster Operator, the Kafka bootstrap address, the Secret for the cluster CA certificate and EO key and certificate to be used by the Admin Client.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

