### PR TITLE
feat: BeforeAll AfterAll vertx start consistency

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -67,11 +67,11 @@ public class ClusterOperatorTest {
 
     @BeforeAll
     public static void before() {
-        vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
+        VertxOptions options = new VertxOptions().setMetricsOptions(
                 new MicrometerMetricsOptions()
                         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
-                        .setEnabled(true)
-        ));
+                        .setEnabled(true));
+        vertx = Vertx.vertx(options);
     }
 
     @AfterAll

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/MainIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/MainIT.java
@@ -13,6 +13,7 @@ import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,18 +28,26 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @ExtendWith(VertxExtension.class)
 public class MainIT {
-    private Vertx vertx;
+    private static Vertx vertx;
     private KubernetesClient client;
 
-    @BeforeEach
-    public void createClient() {
+    @BeforeAll
+    public static void before() {
         vertx = Vertx.vertx();
+    }
+
+    @AfterEach
+    public static void after() {
+        vertx.close();
+    }
+
+    @BeforeEach
+    private void createClient() {
         client = new DefaultKubernetesClient();
     }
 
     @AfterEach
-    public void closeClient() {
-        vertx.close();
+    private void closeClient() {
         client.close();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/MainIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/MainIT.java
@@ -12,6 +12,7 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +37,7 @@ public class MainIT {
         vertx = Vertx.vertx();
     }
 
-    @AfterEach
+    @AfterAll
     public static void after() {
         vertx.close();
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -116,9 +116,7 @@ public class CertificateRenewalTest {
 
     @AfterAll
     public static void after() {
-        if (vertx != null) {
-            vertx.close();
-        }
+        vertx.close();
     }
 
     private Future<ArgumentCaptor<Secret>> reconcileCa(VertxTestContext context, CertificateAuthority clusterCa, CertificateAuthority clientsCa) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -136,9 +136,7 @@ public class ConnectorMockTest {
 
     @AfterAll
     public static void after() {
-        if (vertx != null) {
-            vertx.close();
-        }
+        vertx.close();
     }
 
     @BeforeEach

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -209,12 +209,12 @@ public class KafkaAssemblyOperatorMockTest {
     private Kafka cluster;
 
     @BeforeAll
-    static void before() {
+    public static void before() {
         vertx = Vertx.vertx();
     }
 
     @AfterAll
-    static void after() {
+    public static void after() {
         vertx.close();
         ResourceUtils.cleanUpTemporaryTLSFiles();
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -63,12 +63,12 @@ public class KafkaRollerTest {
     private List<String> restarted;
 
     @BeforeAll
-    public static void startVertx() {
+    public static void before() {
         vertx = Vertx.vertx();
     }
 
     @AfterAll
-    public static void stopVertx() {
+    public static void after() {
         vertx.close();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
@@ -73,12 +73,12 @@ public class ZookeeperLeaderFinderTest {
     private static final int MAX_ATTEMPTS = 4;
 
     @BeforeAll
-    public static void initVertx() {
+    public static void before() {
         vertx = Vertx.vertx();
     }
 
     @AfterAll
-    public static void closeVertx() {
+    public static void after() {
         vertx.close();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalerTest.java
@@ -60,12 +60,12 @@ public class ZookeeperScalerTest {
             .build();
 
     @BeforeAll
-    public static void initVertx() {
+    public static void before() {
         vertx = Vertx.vertx();
     }
 
     @AfterAll
-    public static void closeVertx() {
+    public static void after() {
         vertx.close();
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
@@ -14,8 +14,8 @@ import io.vertx.core.http.HttpServer;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -31,15 +31,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @ExtendWith(VertxExtension.class)
 public class PlatformFeaturesAvailabilityTest {
-    protected Vertx vertx;
+    protected static Vertx vertx;
 
-    @BeforeEach
-    public void before() {
+    @BeforeAll
+    public static void before() {
         vertx = Vertx.vertx();
     }
 
-    @AfterEach
-    public void after() {
+    @AfterAll
+    public static void after() {
         vertx.close();
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractCustomResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractCustomResourceOperatorIT.java
@@ -101,9 +101,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
 
     @AfterAll
     public void after() {
-        if (vertx != null) {
-            vertx.close();
-        }
+        vertx.close();
 
         String namespace = getNamespace();
         if (kubeClient().getNamespace(namespace) != null && System.getenv("SKIP_TEARDOWN") == null) {

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorIT.java
@@ -46,9 +46,7 @@ public abstract class AbstractNonNamespacedResourceOperatorIT<C extends Kubernet
 
     @AfterAll
     public static void after() {
-        if (vertx != null) {
-            vertx.close();
-        }
+        vertx.close();
     }
 
     abstract AbstractNonNamespacedResourceOperator<C, T, L, D, R> operator();

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorIT.java
@@ -68,9 +68,7 @@ public abstract class AbstractResourceOperatorIT<C extends KubernetesClient, T e
 
     @AfterAll
     public static void after() {
-        if (vertx != null) {
-            vertx.close();
-        }
+        vertx.close();
         if (kubeClient().getNamespace(namespace) != null && System.getenv("SKIP_TEARDOWN") == null) {
             log.warn("Deleting namespace {} after tests run", namespace);
             kubeClient().deleteNamespace(namespace);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
@@ -36,15 +36,14 @@ public class K8sImplTest {
     private static Vertx vertx;
 
     @BeforeAll
-    public static void initVertx() {
+    public static void before() {
         vertx = Vertx.vertx();
     }
 
     @AfterAll
-    public static void closeVertx() {
+    public static void after() {
         vertx.close();
     }
-
 
     @Test
     public void testList(VertxTestContext context) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -16,9 +16,12 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.VertxPrometheusOptions;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.Config;
@@ -27,6 +30,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,9 +49,6 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import io.vertx.core.VertxOptions;
-import io.vertx.micrometer.MicrometerMetricsOptions;
-import io.vertx.micrometer.VertxPrometheusOptions;
 
 @ExtendWith(VertxExtension.class)
 public class TopicOperatorMockTest {
@@ -66,34 +67,23 @@ public class TopicOperatorMockTest {
 
     // TODO this is all in common with TOIT, so factor out a common base class
 
-    @AfterEach
-    public void tearDown() {
-        if (vertx != null && deploymentId != null) {
-            vertx.undeploy(deploymentId);
-        }
-        if (adminClient != null) {
-            adminClient.close();
-        }
-        if (kafkaCluster != null) {
-            kafkaCluster.shutdown();
-        }
-    }
-
-    @AfterAll
-    public static void closeVertx() {
-        if (vertx != null) {
-            vertx.close();
-        }
-    }
-
-    @BeforeEach
-    public void createMockKube(VertxTestContext context) throws Exception {
-        assumeTrue(System.getenv("TRAVIS") == null, "This test is flaky on Travis, for unknown reasons");
+    @BeforeAll
+    public static void before() {
         VertxOptions options = new VertxOptions().setMetricsOptions(
                 new MicrometerMetricsOptions()
                         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
                         .setEnabled(true));
         vertx = Vertx.vertx(options);
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
+    }
+
+    @BeforeEach
+    public void createMockKube(VertxTestContext context) throws Exception {
+        assumeTrue(System.getenv("TRAVIS") == null, "This test is flaky on Travis, for unknown reasons");
         MockKube mockKube = new MockKube();
         mockKube.withCustomResourceDefinition(Crds.topic(),
                         KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
@@ -145,6 +135,19 @@ public class TopicOperatorMockTest {
             () -> this.topicsWatcher.started());
         //waitFor(context, () -> this.topicsConfigWatcher.started(), timeout, "Topic configs watcher not started");
         //waitFor(context, () -> this.topicWatcher.started(), timeout, "Topic watcher not started");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (vertx != null && deploymentId != null) {
+            vertx.undeploy(deploymentId);
+        }
+        if (adminClient != null) {
+            adminClient.close();
+        }
+        if (kafkaCluster != null) {
+            kafkaCluster.shutdown();
+        }
     }
 
     private static int zkPort(KafkaCluster cluster) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -22,7 +22,9 @@ import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.TopicDeletionDisabledException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,7 +57,7 @@ public class TopicOperatorTest {
 
     private final TopicName topicName = new TopicName("my-topic");
     private final ResourceName resourceName = topicName.asKubeName();
-    private Vertx vertx = Vertx.vertx();
+    private static Vertx vertx;
     private MockKafka mockKafka;
     private MockTopicStore mockTopicStore = new MockTopicStore();
     private MockK8s mockK8s = new MockK8s();
@@ -73,6 +75,16 @@ public class TopicOperatorTest {
         MANDATORY_CONFIG.put(Config.TOPIC_METADATA_MAX_ATTEMPTS.key, "3");
     }
 
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
+    }
+
     @BeforeEach
     public void setup() {
         mockKafka = new MockKafka();
@@ -88,7 +100,6 @@ public class TopicOperatorTest {
 
     @AfterEach
     public void teardown() {
-        vertx.close();
         mockKafka = null;
         mockTopicStore = null;
         mockK8s = null;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
@@ -11,7 +11,9 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -31,10 +33,20 @@ public class ZkTopicStoreTest {
 
     private EmbeddedZooKeeper zkServer;
 
-    private Vertx vertx = Vertx.vertx();
+    private static Vertx vertx;
 
     private ZkTopicStore store;
     private Zk zk;
+
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
+    }
 
     @BeforeEach
     public void setup() throws IOException, InterruptedException {
@@ -50,7 +62,6 @@ public class ZkTopicStoreTest {
         if (this.zkServer != null) {
             this.zkServer.close();
         }
-        vertx.close();
     }
 
     @Test

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/zk/ZkImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/zk/ZkImplTest.java
@@ -12,7 +12,9 @@ import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.zookeeper.CreateMode;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -30,8 +32,18 @@ public class ZkImplTest {
 
     private EmbeddedZooKeeper zkServer;
 
-    private Vertx vertx = Vertx.vertx();
+    private static Vertx vertx;
     private Zk zk;
+
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
+    }
 
     @BeforeEach
     public void setup() throws IOException, InterruptedException {
@@ -50,7 +62,6 @@ public class ZkImplTest {
             if (this.zkServer != null) {
                 this.zkServer.close();
             }
-            vertx.close();
             async.flag();
             return Future.succeededFuture();
         });

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
@@ -59,11 +59,12 @@ public class KafkaUserOperatorTest {
 
     @BeforeAll
     public static void before() {
-        vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
+        //Setup Micrometer metrics options
+        VertxOptions options = new VertxOptions().setMetricsOptions(
                 new MicrometerMetricsOptions()
                         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
-                        .setEnabled(true)
-        ));
+                        .setEnabled(true));
+        vertx = Vertx.vertx(options);
     }
 
     @AfterAll

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserQuotasIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserQuotasIT.java
@@ -39,15 +39,17 @@ public class KafkaUserQuotasIT {
 
 
     @BeforeAll
-    public static void startZk() throws IOException, InterruptedException {
+    public static void before() throws IOException, InterruptedException {
         vertx = Vertx.vertx();
+        // Start ZookKeeper Server
         zkServer = new EmbeddedZooKeeper();
         kuq = new KafkaUserQuotasOperator(vertx, zkServer.getZkConnectString(), 6_000);
     }
 
     @AfterAll
-    public static void stopZk() {
+    public static void after() {
         vertx.close();
+        // Teardown ZooKeeper Server
         zkServer.close();
     }
 


### PR DESCRIPTION
To match the precedent set by #2737
BeforeAll before AfterAll after methods for
vertx for all test classes

Signed-off-by: Samuel Hawker <samuel.hawker@ibm.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

