### PR TITLE
[systemtest] Improve logging of CR deployment

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
@@ -417,12 +417,12 @@ public class KubernetesResource {
     }
 
     private static Deployment waitFor(Deployment deployment) {
-        String namespace = ResourceManager.kubeClient().getNamespace();
         String name = deployment.getMetadata().getName();
 
-        LOGGER.info("Waiting for deployment {}", deployment.getMetadata().getName());
-        DeploymentUtils.waitForDeploymentReady(deployment.getMetadata().getName(), deployment.getSpec().getReplicas());
-        LOGGER.info("Deployment {} is ready", deployment.getMetadata().getName());
+        LOGGER.info("Waiting for deployment {}", name);
+        DeploymentUtils.waitForDeploymentReady(name, deployment.getSpec().getReplicas(),
+            () -> DeploymentUtils.logCurrentDeploymentStatus(deployment, kubeClient().getDeployment(name).getStatus()));
+        LOGGER.info("Deployment {} is ready", name);
         return deployment;
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
@@ -417,6 +417,9 @@ public class KubernetesResource {
     }
 
     private static Deployment waitFor(Deployment deployment) {
+        String namespace = ResourceManager.kubeClient().getNamespace();
+        String name = deployment.getMetadata().getName();
+
         LOGGER.info("Waiting for deployment {}", deployment.getMetadata().getName());
         DeploymentUtils.waitForDeploymentReady(deployment.getMetadata().getName(), deployment.getSpec().getReplicas());
         LOGGER.info("Deployment {} is ready", deployment.getMetadata().getName());

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
@@ -417,11 +417,11 @@ public class KubernetesResource {
     }
 
     private static Deployment waitFor(Deployment deployment) {
-        String name = deployment.getMetadata().getName();
+        String deploymentName = deployment.getMetadata().getName();
 
-        LOGGER.info("Waiting for deployment {}", name);
-        DeploymentUtils.waitForDeploymentReady(name, deployment.getSpec().getReplicas());
-        LOGGER.info("Deployment {} is ready", name);
+        LOGGER.info("Waiting for deployment {}", deploymentName);
+        DeploymentUtils.waitForDeploymentReady(deploymentName, deployment.getSpec().getReplicas());
+        LOGGER.info("Deployment {} is ready", deploymentName);
         return deployment;
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
@@ -420,8 +420,7 @@ public class KubernetesResource {
         String name = deployment.getMetadata().getName();
 
         LOGGER.info("Waiting for deployment {}", name);
-        DeploymentUtils.waitForDeploymentReady(name, deployment.getSpec().getReplicas(),
-            () -> DeploymentUtils.logCurrentDeploymentStatus(deployment, kubeClient().getDeployment(name).getStatus()));
+        DeploymentUtils.waitForDeploymentReady(name, deployment.getSpec().getReplicas());
         LOGGER.info("Deployment {} is ready", name);
         return deployment;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
@@ -90,11 +90,11 @@ public class KafkaBridgeResource {
     }
 
     private static KafkaBridge waitFor(KafkaBridge kafkaBridge) {
-        String name = kafkaBridge.getMetadata().getName();
+        String kafkaBridgeCrName = kafkaBridge.getMetadata().getName();
 
-        LOGGER.info("Waiting for Kafka Bridge {}", name);
-        DeploymentUtils.waitForDeploymentReady(KafkaBridgeResources.deploymentName(name), kafkaBridge.getSpec().getReplicas());
-        LOGGER.info("Kafka Bridge {} is ready", name);
+        LOGGER.info("Waiting for Kafka Bridge {}", kafkaBridgeCrName);
+        DeploymentUtils.waitForDeploymentReady(KafkaBridgeResources.deploymentName(kafkaBridgeCrName), kafkaBridge.getSpec().getReplicas());
+        LOGGER.info("Kafka Bridge {} is ready", kafkaBridgeCrName);
 
         return kafkaBridge;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
@@ -14,7 +14,6 @@ import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridgeBuilder;
 import io.strimzi.api.kafka.model.KafkaBridgeResources;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -91,12 +90,10 @@ public class KafkaBridgeResource {
     }
 
     private static KafkaBridge waitFor(KafkaBridge kafkaBridge) {
-        String namespace = ResourceManager.kubeClient().getNamespace();
         String name = kafkaBridge.getMetadata().getName();
 
         LOGGER.info("Waiting for Kafka Bridge {}", name);
-        DeploymentUtils.waitForDeploymentReady(KafkaBridgeResources.deploymentName(name), kafkaBridge.getSpec().getReplicas(),
-            () -> StUtils.logCurrentStatus(kafkaBridge, kafkaBridgeClient().inNamespace(namespace).withName(name).get().getStatus()));
+        DeploymentUtils.waitForDeploymentReady(KafkaBridgeResources.deploymentName(name), kafkaBridge.getSpec().getReplicas());
         LOGGER.info("Kafka Bridge {} is ready", name);
 
         return kafkaBridge;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
@@ -12,7 +12,9 @@ import io.strimzi.api.kafka.KafkaBridgeList;
 import io.strimzi.api.kafka.model.DoneableKafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridgeBuilder;
+import io.strimzi.api.kafka.model.KafkaBridgeResources;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -89,9 +91,14 @@ public class KafkaBridgeResource {
     }
 
     private static KafkaBridge waitFor(KafkaBridge kafkaBridge) {
-        LOGGER.info("Waiting for Kafka Bridge {}", kafkaBridge.getMetadata().getName());
-        DeploymentUtils.waitForDeploymentReady(kafkaBridge.getMetadata().getName() + "-bridge", kafkaBridge.getSpec().getReplicas());
-        LOGGER.info("Kafka Bridge {} is ready", kafkaBridge.getMetadata().getName());
+        String namespace = ResourceManager.kubeClient().getNamespace();
+        String name = kafkaBridge.getMetadata().getName();
+
+        LOGGER.info("Waiting for Kafka Bridge {}", name);
+        DeploymentUtils.waitForDeploymentReady(KafkaBridgeResources.deploymentName(name), kafkaBridge.getSpec().getReplicas(),
+            () -> StUtils.logCurrentStatus(kafkaBridge, kafkaBridgeClient().inNamespace(namespace).withName(name).get().getStatus()));
+        LOGGER.info("Kafka Bridge {} is ready", name);
+
         return kafkaBridge;
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -18,6 +18,7 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.KubernetesResource;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -125,9 +126,14 @@ public class KafkaConnectResource {
     }
 
     private static KafkaConnect waitFor(KafkaConnect kafkaConnect) {
-        LOGGER.info("Waiting for Kafka Connect {}", kafkaConnect.getMetadata().getName());
-        DeploymentUtils.waitForDeploymentReady(kafkaConnect.getMetadata().getName() + "-connect", kafkaConnect.getSpec().getReplicas());
-        LOGGER.info("Kafka Connect {} is ready", kafkaConnect.getMetadata().getName());
+        String namespace = ResourceManager.kubeClient().getNamespace();
+        String name = kafkaConnect.getMetadata().getName();
+
+        LOGGER.info("Waiting for Kafka Connect {}", name);
+        DeploymentUtils.waitForDeploymentReady(KafkaConnectResources.deploymentName(name), kafkaConnect.getSpec().getReplicas(),
+            () -> StUtils.logCurrentStatus(kafkaConnect, kafkaConnectClient().inNamespace(namespace).withName(name).get().getStatus()));
+        LOGGER.info("Kafka Connect {} is ready", name);
+
         return kafkaConnect;
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -125,11 +125,11 @@ public class KafkaConnectResource {
     }
 
     private static KafkaConnect waitFor(KafkaConnect kafkaConnect) {
-        String name = kafkaConnect.getMetadata().getName();
+        String kafkaConnectCrName = kafkaConnect.getMetadata().getName();
 
-        LOGGER.info("Waiting for Kafka Connect {}", name);
-        DeploymentUtils.waitForDeploymentReady(KafkaConnectResources.deploymentName(name), kafkaConnect.getSpec().getReplicas());
-        LOGGER.info("Kafka Connect {} is ready", name);
+        LOGGER.info("Waiting for Kafka Connect {}", kafkaConnectCrName);
+        DeploymentUtils.waitForDeploymentReady(KafkaConnectResources.deploymentName(kafkaConnectCrName), kafkaConnect.getSpec().getReplicas());
+        LOGGER.info("Kafka Connect {} is ready", kafkaConnectCrName);
 
         return kafkaConnect;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -18,7 +18,6 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.KubernetesResource;
-import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -126,12 +125,10 @@ public class KafkaConnectResource {
     }
 
     private static KafkaConnect waitFor(KafkaConnect kafkaConnect) {
-        String namespace = ResourceManager.kubeClient().getNamespace();
         String name = kafkaConnect.getMetadata().getName();
 
         LOGGER.info("Waiting for Kafka Connect {}", name);
-        DeploymentUtils.waitForDeploymentReady(KafkaConnectResources.deploymentName(name), kafkaConnect.getSpec().getReplicas(),
-            () -> StUtils.logCurrentStatus(kafkaConnect, kafkaConnectClient().inNamespace(namespace).withName(name).get().getStatus()));
+        DeploymentUtils.waitForDeploymentReady(KafkaConnectResources.deploymentName(name), kafkaConnect.getSpec().getReplicas());
         LOGGER.info("Kafka Connect {} is ready", name);
 
         return kafkaConnect;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
@@ -18,7 +18,6 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.KubernetesResource;
-import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectS2IUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -106,12 +105,10 @@ public class KafkaConnectS2IResource {
     }
 
     private static KafkaConnectS2I waitFor(KafkaConnectS2I kafkaConnectS2I) {
-        String namespace = ResourceManager.kubeClient().getNamespace();
         String name = kafkaConnectS2I.getMetadata().getName();
 
         LOGGER.info("Waiting for Kafka ConnectS2I {}", name);
-        KafkaConnectS2IUtils.waitForConnectS2IStatus(name, "Ready",
-            () -> StUtils.logCurrentStatus(kafkaConnectS2I, kafkaConnectS2IClient().inNamespace(namespace).withName(name).get().getStatus()));
+        KafkaConnectS2IUtils.waitForConnectS2IStatus(name, "Ready");
         LOGGER.info("Kafka ConnectS2I {} is ready", name);
 
         return kafkaConnectS2I;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
@@ -18,6 +18,7 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.KubernetesResource;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectS2IUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -105,9 +106,14 @@ public class KafkaConnectS2IResource {
     }
 
     private static KafkaConnectS2I waitFor(KafkaConnectS2I kafkaConnectS2I) {
-        LOGGER.info("Waiting for Kafka ConnectS2I {}", kafkaConnectS2I.getMetadata().getName());
-        KafkaConnectS2IUtils.waitForConnectS2IStatus(kafkaConnectS2I.getMetadata().getName(), "Ready");
-        LOGGER.info("Kafka ConnectS2I {} is ready", kafkaConnectS2I.getMetadata().getName());
+        String namespace = ResourceManager.kubeClient().getNamespace();
+        String name = kafkaConnectS2I.getMetadata().getName();
+
+        LOGGER.info("Waiting for Kafka ConnectS2I {}", name);
+        KafkaConnectS2IUtils.waitForConnectS2IStatus(name, "Ready",
+            () -> StUtils.logCurrentStatus(kafkaConnectS2I, kafkaConnectS2IClient().inNamespace(namespace).withName(name).get().getStatus()));
+        LOGGER.info("Kafka ConnectS2I {} is ready", name);
+
         return kafkaConnectS2I;
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
@@ -105,11 +105,11 @@ public class KafkaConnectS2IResource {
     }
 
     private static KafkaConnectS2I waitFor(KafkaConnectS2I kafkaConnectS2I) {
-        String name = kafkaConnectS2I.getMetadata().getName();
+        String kafkaConnectS2ICrName = kafkaConnectS2I.getMetadata().getName();
 
-        LOGGER.info("Waiting for Kafka ConnectS2I {}", name);
-        KafkaConnectS2IUtils.waitForConnectS2IStatus(name, "Ready");
-        LOGGER.info("Kafka ConnectS2I {} is ready", name);
+        LOGGER.info("Waiting for Kafka ConnectS2I {}", kafkaConnectS2ICrName);
+        KafkaConnectS2IUtils.waitForConnectS2IStatus(kafkaConnectS2ICrName, "Ready");
+        LOGGER.info("Kafka ConnectS2I {} is ready", kafkaConnectS2ICrName);
 
         return kafkaConnectS2I;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
@@ -14,7 +14,6 @@ import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -93,12 +92,10 @@ public class KafkaConnectorResource {
     }
 
     private static KafkaConnector waitFor(KafkaConnector kafkaConnector) {
-        String namespace = ResourceManager.kubeClient().getNamespace();
         String name = kafkaConnector.getMetadata().getName();
 
         LOGGER.info("Waiting for Kafka Connector {}", name);
-        KafkaConnectorUtils.waitForConnectorStatus(name, "Ready",
-            () -> StUtils.logCurrentStatus(kafkaConnector, kafkaConnectorClient().inNamespace(namespace).withName(name).get().getStatus()));
+        KafkaConnectorUtils.waitForConnectorStatus(name, "Ready");
         LOGGER.info("Kafka Connector {} is ready", name);
 
         return kafkaConnector;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
@@ -14,6 +14,7 @@ import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -92,9 +93,14 @@ public class KafkaConnectorResource {
     }
 
     private static KafkaConnector waitFor(KafkaConnector kafkaConnector) {
-        LOGGER.info("Waiting for Kafka Connector {}", kafkaConnector.getMetadata().getName());
-        KafkaConnectorUtils.waitForConnectorStatus(kafkaConnector.getMetadata().getName(), "Ready");
-        LOGGER.info("Kafka Connector {} is ready", kafkaConnector.getMetadata().getName());
+        String namespace = ResourceManager.kubeClient().getNamespace();
+        String name = kafkaConnector.getMetadata().getName();
+
+        LOGGER.info("Waiting for Kafka Connector {}", name);
+        KafkaConnectorUtils.waitForConnectorStatus(name, "Ready",
+            () -> StUtils.logCurrentStatus(kafkaConnector, kafkaConnectorClient().inNamespace(namespace).withName(name).get().getStatus()));
+        LOGGER.info("Kafka Connector {} is ready", name);
+
         return kafkaConnector;
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
@@ -92,11 +92,11 @@ public class KafkaConnectorResource {
     }
 
     private static KafkaConnector waitFor(KafkaConnector kafkaConnector) {
-        String name = kafkaConnector.getMetadata().getName();
+        String kafkaConnectorCrName = kafkaConnector.getMetadata().getName();
 
-        LOGGER.info("Waiting for Kafka Connector {}", name);
-        KafkaConnectorUtils.waitForConnectorStatus(name, "Ready");
-        LOGGER.info("Kafka Connector {} is ready", name);
+        LOGGER.info("Waiting for Kafka Connector {}", kafkaConnectorCrName);
+        KafkaConnectorUtils.waitForConnectorStatus(kafkaConnectorCrName, "Ready");
+        LOGGER.info("Kafka Connector {} is ready", kafkaConnectorCrName);
 
         return kafkaConnector;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
@@ -19,7 +19,6 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
-import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -139,12 +138,10 @@ public class KafkaMirrorMaker2Resource {
     }
 
     private static KafkaMirrorMaker2 waitFor(KafkaMirrorMaker2 kafkaMirrorMaker2) {
-        String namespace = ResourceManager.kubeClient().getNamespace();
         String name = kafkaMirrorMaker2.getMetadata().getName();
 
         LOGGER.info("Waiting for Kafka MirrorMaker2 {}", name);
-        DeploymentUtils.waitForDeploymentReady(KafkaMirrorMaker2Resources.deploymentName(name), kafkaMirrorMaker2.getSpec().getReplicas(),
-            () -> StUtils.logCurrentStatus(kafkaMirrorMaker2, kafkaMirrorMaker2Client().inNamespace(namespace).withName(name).get().getStatus()));
+        DeploymentUtils.waitForDeploymentReady(KafkaMirrorMaker2Resources.deploymentName(name), kafkaMirrorMaker2.getSpec().getReplicas());
         LOGGER.info("Kafka MirrorMaker2 {} is ready", name);
 
         return kafkaMirrorMaker2;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
@@ -19,6 +19,7 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -138,9 +139,14 @@ public class KafkaMirrorMaker2Resource {
     }
 
     private static KafkaMirrorMaker2 waitFor(KafkaMirrorMaker2 kafkaMirrorMaker2) {
-        LOGGER.info("Waiting for Kafka MirrorMaker2 {}", kafkaMirrorMaker2.getMetadata().getName());
-        DeploymentUtils.waitForDeploymentReady(KafkaMirrorMaker2Resources.deploymentName(kafkaMirrorMaker2.getMetadata().getName()), kafkaMirrorMaker2.getSpec().getReplicas());
-        LOGGER.info("Kafka MirrorMaker2 {} is ready", kafkaMirrorMaker2.getMetadata().getName());
+        String namespace = ResourceManager.kubeClient().getNamespace();
+        String name = kafkaMirrorMaker2.getMetadata().getName();
+
+        LOGGER.info("Waiting for Kafka MirrorMaker2 {}", name);
+        DeploymentUtils.waitForDeploymentReady(KafkaMirrorMaker2Resources.deploymentName(name), kafkaMirrorMaker2.getSpec().getReplicas(),
+            () -> StUtils.logCurrentStatus(kafkaMirrorMaker2, kafkaMirrorMaker2Client().inNamespace(namespace).withName(name).get().getStatus()));
+        LOGGER.info("Kafka MirrorMaker2 {} is ready", name);
+
         return kafkaMirrorMaker2;
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
@@ -138,11 +138,11 @@ public class KafkaMirrorMaker2Resource {
     }
 
     private static KafkaMirrorMaker2 waitFor(KafkaMirrorMaker2 kafkaMirrorMaker2) {
-        String name = kafkaMirrorMaker2.getMetadata().getName();
+        String kafkaMirrorMaker2CrName = kafkaMirrorMaker2.getMetadata().getName();
 
-        LOGGER.info("Waiting for Kafka MirrorMaker2 {}", name);
-        DeploymentUtils.waitForDeploymentReady(KafkaMirrorMaker2Resources.deploymentName(name), kafkaMirrorMaker2.getSpec().getReplicas());
-        LOGGER.info("Kafka MirrorMaker2 {} is ready", name);
+        LOGGER.info("Waiting for Kafka MirrorMaker2 {}", kafkaMirrorMaker2CrName);
+        DeploymentUtils.waitForDeploymentReady(KafkaMirrorMaker2Resources.deploymentName(kafkaMirrorMaker2CrName), kafkaMirrorMaker2.getSpec().getReplicas());
+        LOGGER.info("Kafka MirrorMaker2 {} is ready", kafkaMirrorMaker2CrName);
 
         return kafkaMirrorMaker2;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
@@ -12,9 +12,11 @@ import io.strimzi.api.kafka.KafkaMirrorMakerList;
 import io.strimzi.api.kafka.model.DoneableKafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerBuilder;
+import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -114,9 +116,14 @@ public class KafkaMirrorMakerResource {
     }
 
     private static KafkaMirrorMaker waitFor(KafkaMirrorMaker kafkaMirrorMaker) {
-        LOGGER.info("Waiting for Kafka MirrorMaker {}", kafkaMirrorMaker.getMetadata().getName());
-        DeploymentUtils.waitForDeploymentReady(kafkaMirrorMaker.getMetadata().getName() + "-mirror-maker", kafkaMirrorMaker.getSpec().getReplicas());
-        LOGGER.info("Kafka MirrorMaker {} is ready", kafkaMirrorMaker.getMetadata().getName());
+        String namespace = ResourceManager.kubeClient().getNamespace();
+        String name = kafkaMirrorMaker.getMetadata().getName();
+
+        LOGGER.info("Waiting for Kafka MirrorMaker {}", name);
+        DeploymentUtils.waitForDeploymentReady(KafkaMirrorMakerResources.deploymentName(name), kafkaMirrorMaker.getSpec().getReplicas(),
+            () -> StUtils.logCurrentStatus(kafkaMirrorMaker, kafkaMirrorMakerClient().inNamespace(namespace).withName(name).get().getStatus()));
+        LOGGER.info("Kafka MirrorMaker {} is ready", name);
+
         return kafkaMirrorMaker;
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
@@ -16,7 +16,6 @@ import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
-import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -116,12 +115,10 @@ public class KafkaMirrorMakerResource {
     }
 
     private static KafkaMirrorMaker waitFor(KafkaMirrorMaker kafkaMirrorMaker) {
-        String namespace = ResourceManager.kubeClient().getNamespace();
         String name = kafkaMirrorMaker.getMetadata().getName();
 
         LOGGER.info("Waiting for Kafka MirrorMaker {}", name);
-        DeploymentUtils.waitForDeploymentReady(KafkaMirrorMakerResources.deploymentName(name), kafkaMirrorMaker.getSpec().getReplicas(),
-            () -> StUtils.logCurrentStatus(kafkaMirrorMaker, kafkaMirrorMakerClient().inNamespace(namespace).withName(name).get().getStatus()));
+        DeploymentUtils.waitForDeploymentReady(KafkaMirrorMakerResources.deploymentName(name), kafkaMirrorMaker.getSpec().getReplicas());
         LOGGER.info("Kafka MirrorMaker {} is ready", name);
 
         return kafkaMirrorMaker;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
@@ -115,11 +115,11 @@ public class KafkaMirrorMakerResource {
     }
 
     private static KafkaMirrorMaker waitFor(KafkaMirrorMaker kafkaMirrorMaker) {
-        String name = kafkaMirrorMaker.getMetadata().getName();
+        String kafkaMirrorMakerCrName = kafkaMirrorMaker.getMetadata().getName();
 
-        LOGGER.info("Waiting for Kafka MirrorMaker {}", name);
-        DeploymentUtils.waitForDeploymentReady(KafkaMirrorMakerResources.deploymentName(name), kafkaMirrorMaker.getSpec().getReplicas());
-        LOGGER.info("Kafka MirrorMaker {} is ready", name);
+        LOGGER.info("Waiting for Kafka MirrorMaker {}", kafkaMirrorMakerCrName);
+        DeploymentUtils.waitForDeploymentReady(KafkaMirrorMakerResources.deploymentName(kafkaMirrorMakerCrName), kafkaMirrorMaker.getSpec().getReplicas());
+        LOGGER.info("Kafka MirrorMaker {} is ready", kafkaMirrorMakerCrName);
 
         return kafkaMirrorMaker;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -212,29 +212,23 @@ public class KafkaResource {
         LOGGER.info("Waiting for Kafka {} in namespace {}", name, namespace);
 
         LOGGER.info("Waiting for Zookeeper pods");
-        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(name),
-                kafka.getSpec().getZookeeper().getReplicas(),
-            () -> StUtils.logCurrentStatus(kafka, kafkaClient().inNamespace(namespace).withName(name).get().getStatus()));
+        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(name), kafka.getSpec().getZookeeper().getReplicas());
         LOGGER.info("Zookeeper pods are ready");
 
         LOGGER.info("Waiting for Kafka pods");
-        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(name),
-                kafka.getSpec().getKafka().getReplicas(),
-            () -> StUtils.logCurrentStatus(kafka, kafkaClient().inNamespace(namespace).withName(name).get().getStatus()));
+        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(name), kafka.getSpec().getKafka().getReplicas());
         LOGGER.info("Kafka pods are ready");
 
         // EO should not be deployed if it does not contain UO and TO
         if (kafka.getSpec().getEntityOperator().getTopicOperator() != null || kafka.getSpec().getEntityOperator().getUserOperator() != null) {
             LOGGER.info("Waiting for Entity Operator pods");
-            DeploymentUtils.waitForDeploymentReady(KafkaResources.entityOperatorDeploymentName(name),
-                () -> StUtils.logCurrentStatus(kafka, kafkaClient().inNamespace(namespace).withName(name).get().getStatus()));
+            DeploymentUtils.waitForDeploymentReady(KafkaResources.entityOperatorDeploymentName(name));
             LOGGER.info("Entity Operator pods are ready");
         }
         // Kafka Exporter is not setup everytime
         if (kafka.getSpec().getKafkaExporter() != null) {
             LOGGER.info("Waiting for Kafka Exporter pods");
-            DeploymentUtils.waitForDeploymentReady(KafkaExporterResources.deploymentName(name),
-                () -> StUtils.logCurrentStatus(kafka, kafkaClient().inNamespace(namespace).withName(name).get().getStatus()));
+            DeploymentUtils.waitForDeploymentReady(KafkaExporterResources.deploymentName(name));
             LOGGER.info("Kafka Exporter pods are ready");
         }
         return kafka;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -207,28 +207,29 @@ public class KafkaResource {
      * Wait until the ZK, Kafka and EO are all ready
      */
     private static Kafka waitFor(Kafka kafka) {
-        String name = kafka.getMetadata().getName();
+        String kafkaCrName = kafka.getMetadata().getName();
         String namespace = kafka.getMetadata().getNamespace();
-        LOGGER.info("Waiting for Kafka {} in namespace {}", name, namespace);
+
+        LOGGER.info("Waiting for Kafka {} in namespace {}", kafkaCrName, namespace);
 
         LOGGER.info("Waiting for Zookeeper pods");
-        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(name), kafka.getSpec().getZookeeper().getReplicas());
+        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(kafkaCrName), kafka.getSpec().getZookeeper().getReplicas());
         LOGGER.info("Zookeeper pods are ready");
 
         LOGGER.info("Waiting for Kafka pods");
-        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(name), kafka.getSpec().getKafka().getReplicas());
+        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(kafkaCrName), kafka.getSpec().getKafka().getReplicas());
         LOGGER.info("Kafka pods are ready");
 
         // EO should not be deployed if it does not contain UO and TO
         if (kafka.getSpec().getEntityOperator().getTopicOperator() != null || kafka.getSpec().getEntityOperator().getUserOperator() != null) {
             LOGGER.info("Waiting for Entity Operator pods");
-            DeploymentUtils.waitForDeploymentReady(KafkaResources.entityOperatorDeploymentName(name));
+            DeploymentUtils.waitForDeploymentReady(KafkaResources.entityOperatorDeploymentName(kafkaCrName));
             LOGGER.info("Entity Operator pods are ready");
         }
         // Kafka Exporter is not setup everytime
         if (kafka.getSpec().getKafkaExporter() != null) {
             LOGGER.info("Waiting for Kafka Exporter pods");
-            DeploymentUtils.waitForDeploymentReady(KafkaExporterResources.deploymentName(name));
+            DeploymentUtils.waitForDeploymentReady(KafkaExporterResources.deploymentName(kafkaCrName));
             LOGGER.info("Kafka Exporter pods are ready");
         }
         return kafka;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -174,8 +174,7 @@ public class KafkaResource {
                             throw e;
                         }
                     }
-                }
-            );
+                });
             return waitFor(deleteLater(k));
         });
     }
@@ -211,22 +210,31 @@ public class KafkaResource {
         String name = kafka.getMetadata().getName();
         String namespace = kafka.getMetadata().getNamespace();
         LOGGER.info("Waiting for Kafka {} in namespace {}", name, namespace);
+
         LOGGER.info("Waiting for Zookeeper pods");
-        StatefulSetUtils.waitForAllStatefulSetPodsReady(io.strimzi.api.kafka.model.KafkaResources.zookeeperStatefulSetName(name), kafka.getSpec().getZookeeper().getReplicas());
+        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(name),
+                kafka.getSpec().getZookeeper().getReplicas(),
+            () -> StUtils.logCurrentStatus(kafka, kafkaClient().inNamespace(namespace).withName(name).get().getStatus()));
         LOGGER.info("Zookeeper pods are ready");
+
         LOGGER.info("Waiting for Kafka pods");
-        StatefulSetUtils.waitForAllStatefulSetPodsReady(io.strimzi.api.kafka.model.KafkaResources.kafkaStatefulSetName(name), kafka.getSpec().getKafka().getReplicas());
+        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(name),
+                kafka.getSpec().getKafka().getReplicas(),
+            () -> StUtils.logCurrentStatus(kafka, kafkaClient().inNamespace(namespace).withName(name).get().getStatus()));
         LOGGER.info("Kafka pods are ready");
+
         // EO should not be deployed if it does not contain UO and TO
         if (kafka.getSpec().getEntityOperator().getTopicOperator() != null || kafka.getSpec().getEntityOperator().getUserOperator() != null) {
             LOGGER.info("Waiting for Entity Operator pods");
-            DeploymentUtils.waitForDeploymentReady(io.strimzi.api.kafka.model.KafkaResources.entityOperatorDeploymentName(name));
+            DeploymentUtils.waitForDeploymentReady(KafkaResources.entityOperatorDeploymentName(name),
+                () -> StUtils.logCurrentStatus(kafka, kafkaClient().inNamespace(namespace).withName(name).get().getStatus()));
             LOGGER.info("Entity Operator pods are ready");
         }
         // Kafka Exporter is not setup everytime
         if (kafka.getSpec().getKafkaExporter() != null) {
             LOGGER.info("Waiting for Kafka Exporter pods");
-            DeploymentUtils.waitForDeploymentReady(KafkaExporterResources.deploymentName(name));
+            DeploymentUtils.waitForDeploymentReady(KafkaExporterResources.deploymentName(name),
+                () -> StUtils.logCurrentStatus(kafka, kafkaClient().inNamespace(namespace).withName(name).get().getStatus()));
             LOGGER.info("Kafka Exporter pods are ready");
         }
         return kafka;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
@@ -12,7 +12,6 @@ import io.strimzi.api.kafka.model.DoneableKafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -79,12 +78,11 @@ public class KafkaTopicResource {
     }
 
     private static KafkaTopic waitFor(KafkaTopic kafkaTopic) {
-        String namespace = ResourceManager.kubeClient().getNamespace();
         String name = kafkaTopic.getMetadata().getName();
 
         LOGGER.info("Waiting for Kafka Topic {}", name);
         KafkaTopicUtils.waitForKafkaTopicCreation(name,
-            () -> StUtils.logCurrentStatus(kafkaTopic, kafkaTopicClient().inNamespace(namespace).withName(name).get().getStatus()));
+            () -> LOGGER.info(kafkaTopic));
         LOGGER.info("Kafka Topic {} is ready", name);
 
         return kafkaTopic;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
@@ -78,11 +78,11 @@ public class KafkaTopicResource {
     }
 
     private static KafkaTopic waitFor(KafkaTopic kafkaTopic) {
-        String name = kafkaTopic.getMetadata().getName();
+        String kafkaTopicCrName = kafkaTopic.getMetadata().getName();
 
-        LOGGER.info("Waiting for Kafka Topic {}", name);
-        KafkaTopicUtils.waitForKafkaTopicCreation(name);
-        LOGGER.info("Kafka Topic {} is ready", name);
+        LOGGER.info("Waiting for Kafka Topic {}", kafkaTopicCrName);
+        KafkaTopicUtils.waitForKafkaTopicCreation(kafkaTopicCrName);
+        LOGGER.info("Kafka Topic {} is ready", kafkaTopicCrName);
 
         return kafkaTopic;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
@@ -81,8 +81,7 @@ public class KafkaTopicResource {
         String name = kafkaTopic.getMetadata().getName();
 
         LOGGER.info("Waiting for Kafka Topic {}", name);
-        KafkaTopicUtils.waitForKafkaTopicCreation(name,
-            () -> LOGGER.info(kafkaTopic));
+        KafkaTopicUtils.waitForKafkaTopicCreation(name);
         LOGGER.info("Kafka Topic {} is ready", name);
 
         return kafkaTopic;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.DoneableKafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -78,9 +79,14 @@ public class KafkaTopicResource {
     }
 
     private static KafkaTopic waitFor(KafkaTopic kafkaTopic) {
-        LOGGER.info("Waiting for Kafka Topic {}", kafkaTopic.getMetadata().getName());
-        KafkaTopicUtils.waitForKafkaTopicCreation(kafkaTopic.getMetadata().getName());
-        LOGGER.info("Kafka Topic {} is ready", kafkaTopic.getMetadata().getName());
+        String namespace = ResourceManager.kubeClient().getNamespace();
+        String name = kafkaTopic.getMetadata().getName();
+
+        LOGGER.info("Waiting for Kafka Topic {}", name);
+        KafkaTopicUtils.waitForKafkaTopicCreation(name,
+            () -> StUtils.logCurrentStatus(kafkaTopic, kafkaTopicClient().inNamespace(namespace).withName(name).get().getStatus()));
+        LOGGER.info("Kafka Topic {} is ready", name);
+
         return kafkaTopic;
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
@@ -76,11 +76,11 @@ public class KafkaUserResource {
     }
 
     private static KafkaUser waitFor(KafkaUser kafkaUser) {
-        String name = kafkaUser.getMetadata().getName();
+        String kafkaUserCrName = kafkaUser.getMetadata().getName();
 
-        LOGGER.info("Waiting for Kafka User {}", name);
-        KafkaUserUtils.waitForKafkaUserCreation(name);
-        LOGGER.info("Kafka User {} is ready", name);
+        LOGGER.info("Waiting for Kafka User {}", kafkaUserCrName);
+        KafkaUserUtils.waitForKafkaUserCreation(kafkaUserCrName);
+        LOGGER.info("Kafka User {} is ready", kafkaUserCrName);
 
         return kafkaUser;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
@@ -12,8 +12,8 @@ import io.strimzi.api.kafka.model.DoneableKafkaUser;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserBuilder;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
-import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -77,10 +77,14 @@ public class KafkaUserResource {
     }
 
     private static KafkaUser waitFor(KafkaUser kafkaUser) {
-        LOGGER.info("Waiting for Kafka User {}", kafkaUser.getMetadata().getName());
-        SecretUtils.waitForSecretReady(kafkaUser.getMetadata().getName());
-        KafkaUserUtils.waitForKafkaUserCreation(kafkaUser.getMetadata().getName());
-        LOGGER.info("Kafka User {} is ready", kafkaUser.getMetadata().getName());
+        String namespace = ResourceManager.kubeClient().getNamespace();
+        String name = kafkaUser.getMetadata().getName();
+
+        LOGGER.info("Waiting for Kafka User {}", name);
+        KafkaUserUtils.waitForKafkaUserCreation(name,
+            () -> StUtils.logCurrentStatus(kafkaUser, kafkaUserClient().inNamespace(namespace).withName(name).get().getStatus()));
+        LOGGER.info("Kafka User {} is ready", name);
+
         return kafkaUser;
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
@@ -79,8 +79,7 @@ public class KafkaUserResource {
         String name = kafkaUser.getMetadata().getName();
 
         LOGGER.info("Waiting for Kafka User {}", name);
-        KafkaUserUtils.waitForKafkaUserCreation(name,
-            () -> LOGGER.info(kafkaUser));
+        KafkaUserUtils.waitForKafkaUserCreation(name);
         LOGGER.info("Kafka User {} is ready", name);
 
         return kafkaUser;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
@@ -12,7 +12,6 @@ import io.strimzi.api.kafka.model.DoneableKafkaUser;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserBuilder;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -77,12 +76,11 @@ public class KafkaUserResource {
     }
 
     private static KafkaUser waitFor(KafkaUser kafkaUser) {
-        String namespace = ResourceManager.kubeClient().getNamespace();
         String name = kafkaUser.getMetadata().getName();
 
         LOGGER.info("Waiting for Kafka User {}", name);
         KafkaUserUtils.waitForKafkaUserCreation(name,
-            () -> StUtils.logCurrentStatus(kafkaUser, kafkaUserClient().inNamespace(namespace).withName(name).get().getStatus()));
+            () -> LOGGER.info(kafkaUser));
         LOGGER.info("Kafka User {} is ready", name);
 
         return kafkaUser;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -234,7 +234,10 @@ public class StUtils {
         }
         return isJSON;
     }
-
+    /**
+     * Log actual status of custom resource with pods.
+     * @param customResource - Kafka, KafkaConnect etc. - every resource that HasMetadata and HasStatus (Strimzi status)
+     */
     public static <T extends CustomResource & HasStatus> void logCurrentStatus(T customResource) {
         String kind = customResource.getKind();
         String name = customResource.getMetadata().getName();

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -10,7 +10,7 @@ import io.fabric8.kubernetes.client.CustomResource;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.ContainerEnvVarBuilder;
 import io.strimzi.api.kafka.model.status.Condition;
-import io.strimzi.api.kafka.model.status.Status;
+import io.strimzi.api.kafka.model.status.HasStatus;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
@@ -235,13 +235,13 @@ public class StUtils {
         return isJSON;
     }
 
-    public static <T extends CustomResource, L extends Status> void logCurrentStatus(T customResource, L status) {
+    public static <T extends CustomResource & HasStatus> void logCurrentStatus(T customResource) {
         String kind = customResource.getKind();
         String name = customResource.getMetadata().getName();
 
         List<String> log = new ArrayList<>(asList("\n", kind, " status:\n", "\nConditions:\n"));
 
-        for (Condition condition : status.getConditions()) {
+        for (Condition condition : customResource.getStatus().getConditions()) {
             log.add("\tType: " + condition.getType() + "\n");
             log.add("\tMessage: " + condition.getMessage() + "\n");
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
-import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.crd.KafkaConnectS2IResource;
 import io.strimzi.systemtest.utils.StUtils;
@@ -26,11 +25,11 @@ public class KafkaConnectS2IUtils {
      * @param status desired status value
      */
     public static void waitForConnectS2IStatus(String name, String status) {
-        KafkaConnectS2I kafkaConnectS2I = KafkaConnectS2IResource.kafkaConnectS2IClient().inNamespace(kubeClient().getNamespace()).withName(name).get();
         LOGGER.info("Waiting for Kafka Connect S2I {} state: {}", name, status);
         TestUtils.waitFor("Kafka Connect S2I " + name + " state: " + status, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> kafkaConnectS2I.getStatus().getConditions().get(0).getType().equals(status),
-            () -> StUtils.logCurrentStatus(kafkaConnectS2I));
+            () -> KafkaConnectS2IResource.kafkaConnectS2IClient().inNamespace(kubeClient().getNamespace())
+                    .withName(name).get().getStatus().getConditions().get(0).getType().equals(status),
+            () -> StUtils.logCurrentStatus(KafkaConnectS2IResource.kafkaConnectS2IClient().inNamespace(kubeClient().getNamespace()).withName(name).get()));
         LOGGER.info("Kafka Connect S2I {} is in desired state: {}", name, status);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
@@ -24,9 +24,14 @@ public class KafkaConnectS2IUtils {
      * @param status desired status value
      */
     public static void waitForConnectS2IStatus(String name, String status) {
+        waitForConnectS2IStatus(name, status, () -> { });
+    }
+
+    public static void waitForConnectS2IStatus(String name, String status, Runnable onTimeout) {
         LOGGER.info("Waiting for Kafka Connect S2I {} state: {}", name, status);
         TestUtils.waitFor("Kafka Connect S2I " + name + " state: " + status, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> Crds.kafkaConnectS2iOperation(kubeClient().getClient()).inNamespace(kubeClient().getNamespace()).withName(name).get().getStatus().getConditions().get(0).getType().equals(status));
+            () -> Crds.kafkaConnectS2iOperation(kubeClient().getClient()).inNamespace(kubeClient().getNamespace()).withName(name).get().getStatus().getConditions().get(0).getType().equals(status),
+                onTimeout);
         LOGGER.info("Kafka Connect S2I {} is in desired state: {}", name, status);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
@@ -4,8 +4,10 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
-import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.resources.crd.KafkaConnectS2IResource;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -24,14 +26,11 @@ public class KafkaConnectS2IUtils {
      * @param status desired status value
      */
     public static void waitForConnectS2IStatus(String name, String status) {
-        waitForConnectS2IStatus(name, status, () -> { });
-    }
-
-    public static void waitForConnectS2IStatus(String name, String status, Runnable onTimeout) {
+        KafkaConnectS2I kafkaConnectS2I = KafkaConnectS2IResource.kafkaConnectS2IClient().inNamespace(kubeClient().getNamespace()).withName(name).get();
         LOGGER.info("Waiting for Kafka Connect S2I {} state: {}", name, status);
         TestUtils.waitFor("Kafka Connect S2I " + name + " state: " + status, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> Crds.kafkaConnectS2iOperation(kubeClient().getClient()).inNamespace(kubeClient().getNamespace()).withName(name).get().getStatus().getConditions().get(0).getType().equals(status),
-                onTimeout);
+            () -> kafkaConnectS2I.getStatus().getConditions().get(0).getType().equals(status),
+            () -> StUtils.logCurrentStatus(kafkaConnectS2I));
         LOGGER.info("Kafka Connect S2I {} is in desired state: {}", name, status);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectorUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectorUtils.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
-import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.crd.KafkaConnectorResource;
 import io.strimzi.systemtest.utils.StUtils;
@@ -46,12 +45,11 @@ public class KafkaConnectorUtils {
     }
 
     public static void waitForConnectorStatus(String name, String state) {
-        KafkaConnector kafkaConnector = KafkaConnectorResource.kafkaConnectorClient().inNamespace(kubeClient().getNamespace()).withName(name).get();
-
         LOGGER.info("Waiting for Kafka Connector {}", name);
         TestUtils.waitFor(" Kafka Connector " + name + " is ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> kafkaConnector.getStatus().getConditions().get(0).getType().equals(state),
-            () -> StUtils.logCurrentStatus(kafkaConnector));
+            () -> KafkaConnectorResource.kafkaConnectorClient().inNamespace(kubeClient().getNamespace())
+                    .withName(name).get().getStatus().getConditions().get(0).getType().equals(state),
+            () -> StUtils.logCurrentStatus(KafkaConnectorResource.kafkaConnectorClient().inNamespace(kubeClient().getNamespace()).withName(name).get()));
         LOGGER.info("Kafka Connector {} is ready", name);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectorUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectorUtils.java
@@ -44,9 +44,14 @@ public class KafkaConnectorUtils {
     }
 
     public static void waitForConnectorStatus(String name, String state) {
+        waitForConnectorStatus(name, state, () -> { });
+    }
+
+    public static void waitForConnectorStatus(String name, String state, Runnable onTimeout) {
         LOGGER.info("Waiting for Kafka Connector {}", name);
         TestUtils.waitFor(" Kafka Connector " + name + " is ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> Crds.kafkaConnectorOperation(kubeClient().getClient()).inNamespace(kubeClient().getNamespace()).withName(name).get().getStatus().getConditions().get(0).getType().equals(state));
+            () -> Crds.kafkaConnectorOperation(kubeClient().getClient()).inNamespace(kubeClient().getNamespace()).withName(name).get().getStatus().getConditions().get(0).getType().equals(state),
+                onTimeout);
         LOGGER.info("Kafka Connector {} is ready", name);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.utils.kafkaUtils;
 
 import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
@@ -42,13 +43,11 @@ public class KafkaTopicUtils {
     }
 
     public static void waitForKafkaTopicCreation(String topicName) {
-        waitForKafkaTopicCreation(topicName, () -> { });
-    }
-    public static void waitForKafkaTopicCreation(String topicName, Runnable onTimeout) {
+        KafkaTopic kafkaTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(topicName).get();
         LOGGER.info("Waiting for Kafka topic creation {}", topicName);
         TestUtils.waitFor("Waits for Kafka topic creation " + topicName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS, () ->
-            Crds.topicOperation(kubeClient().getClient()).inNamespace(kubeClient().getNamespace()).withName(topicName).get().getStatus().getConditions().get(0).getType().equals("Ready"),
-            onTimeout
+            kafkaTopic.getStatus().getConditions().get(0).getType().equals("Ready"),
+            () -> LOGGER.info(kafkaTopic)
         );
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -42,9 +42,13 @@ public class KafkaTopicUtils {
     }
 
     public static void waitForKafkaTopicCreation(String topicName) {
+        waitForKafkaTopicCreation(topicName, () -> { });
+    }
+    public static void waitForKafkaTopicCreation(String topicName, Runnable onTimeout) {
         LOGGER.info("Waiting for Kafka topic creation {}", topicName);
         TestUtils.waitFor("Waits for Kafka topic creation " + topicName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS, () ->
-            Crds.topicOperation(kubeClient().getClient()).inNamespace(kubeClient().getNamespace()).withName(topicName).get().getStatus().getConditions().get(0).getType().equals("Ready")
+            Crds.topicOperation(kubeClient().getClient()).inNamespace(kubeClient().getNamespace()).withName(topicName).get().getStatus().getConditions().get(0).getType().equals("Ready"),
+            onTimeout
         );
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -5,7 +5,6 @@
 package io.strimzi.systemtest.utils.kafkaUtils;
 
 import io.strimzi.api.kafka.Crds;
-import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
@@ -43,11 +42,11 @@ public class KafkaTopicUtils {
     }
 
     public static void waitForKafkaTopicCreation(String topicName) {
-        KafkaTopic kafkaTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(topicName).get();
         LOGGER.info("Waiting for Kafka topic creation {}", topicName);
-        TestUtils.waitFor("Waits for Kafka topic creation " + topicName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS, () ->
-            kafkaTopic.getStatus().getConditions().get(0).getType().equals("Ready"),
-            () -> LOGGER.info(kafkaTopic)
+        TestUtils.waitFor("Waits for Kafka topic creation " + topicName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+            () -> KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace())
+                    .withName(topicName).get().getStatus().getConditions().get(0).getType().equals("Ready"),
+            () -> LOGGER.info(KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(topicName).get())
         );
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
@@ -26,7 +26,7 @@ public class KafkaUserUtils {
 
     public static void waitForKafkaUserCreation(String userName, Runnable onTimeout) {
         LOGGER.info("Waiting for Kafka user creation {}", userName);
-        SecretUtils.waitForSecretReady(userName);
+        SecretUtils.waitForSecretReady(userName, onTimeout);
         TestUtils.waitFor("Waits for Kafka user creation " + userName,
             Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
             () -> KafkaUserResource.kafkaUserClient()

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
@@ -5,7 +5,6 @@
 package io.strimzi.systemtest.utils.kafkaUtils;
 
 import io.strimzi.api.kafka.Crds;
-import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
@@ -22,15 +21,15 @@ public class KafkaUserUtils {
     private KafkaUserUtils() {}
 
     public static void waitForKafkaUserCreation(String userName) {
-        KafkaUser kafkaUser = KafkaUserResource.kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName).get();
-
         LOGGER.info("Waiting for Kafka user creation {}", userName);
-        SecretUtils.waitForSecretReady(userName, () -> LOGGER.info(kafkaUser));
+        SecretUtils.waitForSecretReady(userName,
+            () -> LOGGER.info(KafkaUserResource.kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName).get()));
 
         TestUtils.waitFor("Waits for Kafka user creation " + userName,
             Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> kafkaUser.getStatus().getConditions().get(0).getType().equals("Ready"),
-            () -> LOGGER.info(kafkaUser)
+            () -> KafkaUserResource.kafkaUserClient().inNamespace(kubeClient().getNamespace())
+                    .withName(userName).get().getStatus().getConditions().get(0).getType().equals("Ready"),
+            () -> LOGGER.info(KafkaUserResource.kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName).get())
         );
 
         LOGGER.info("Kafka user {} created", userName);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
@@ -21,13 +21,18 @@ public class KafkaUserUtils {
     private KafkaUserUtils() {}
 
     public static void waitForKafkaUserCreation(String userName) {
+        waitForKafkaUserCreation(userName, () -> { });
+    }
+
+    public static void waitForKafkaUserCreation(String userName, Runnable onTimeout) {
         LOGGER.info("Waiting for Kafka user creation {}", userName);
         SecretUtils.waitForSecretReady(userName);
         TestUtils.waitFor("Waits for Kafka user creation " + userName,
             Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
             () -> KafkaUserResource.kafkaUserClient()
                 .inNamespace(kubeClient().getNamespace())
-                .withName(userName).get().getStatus().getConditions().get(0).getType().equals("Ready")
+                .withName(userName).get().getStatus().getConditions().get(0).getType().equals("Ready"),
+            onTimeout
         );
         LOGGER.info("Kafka user {} created", userName);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
@@ -146,9 +146,13 @@ public class DeploymentUtils {
      * @param name The name of the Deployment.
      */
     public static void waitForDeploymentReady(String name) {
+        waitForDeploymentReady(name, () -> { });
+    }
+
+    public static void waitForDeploymentReady(String name, Runnable onTimeout) {
         LOGGER.debug("Waiting for Deployment {}", name);
         TestUtils.waitFor("deployment " + name, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> kubeClient().getDeploymentStatus(name));
+            () -> kubeClient().getDeploymentStatus(name), onTimeout);
         LOGGER.debug("Deployment {} is ready", name);
     }
 
@@ -158,12 +162,16 @@ public class DeploymentUtils {
      * @param expectPods The expected number of pods.
      */
     public static void waitForDeploymentReady(String name, int expectPods) {
+        waitForDeploymentReady(name, expectPods, () -> { });
+    }
+
+    public static void waitForDeploymentReady(String name, int expectPods, Runnable onTimeout) {
         LOGGER.debug("Waiting for Deployment {}", name);
         TestUtils.waitFor("deployment " + name + " pods to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> kubeClient().getDeploymentStatus(name));
+            () -> kubeClient().getDeploymentStatus(name), onTimeout);
         LOGGER.debug("Deployment {} is ready", name);
         LOGGER.debug("Waiting for Pods of Deployment {} to be ready", name);
-        PodUtils.waitForPodsReady(kubeClient().getDeploymentSelectors(name), expectPods, true);
+        PodUtils.waitForPodsReady(kubeClient().getDeploymentSelectors(name), expectPods, true, onTimeout);
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
@@ -252,7 +252,7 @@ public class DeploymentUtils {
      * Log actual status of deployment with pods
      * @param deployment - every DoneableDeployment, that HasMetadata and has status (fabric8 status)
      **/
-    public static <T extends Deployment> void logCurrentDeploymentStatus(T deployment) {
+    public static void logCurrentDeploymentStatus(Deployment deployment) {
         String kind = deployment.getKind();
         String name = deployment.getMetadata().getName();
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
@@ -248,6 +248,10 @@ public class DeploymentUtils {
         return depConfigSnapshot(name);
     }
 
+    /**
+     * Log actual status of deployment with pods
+     * @param deployment - every DoneableDeployment, that HasMetadata and has status (fabric8 status)
+     **/
     public static <T extends Deployment> void logCurrentDeploymentStatus(T deployment) {
         String kind = deployment.getKind();
         String name = deployment.getMetadata().getName();

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
@@ -8,6 +8,8 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -130,16 +132,14 @@ public class StatefulSetUtils {
      * @param expectPods The number of pods expected.
      */
     public static void waitForAllStatefulSetPodsReady(String name, int expectPods) {
-        waitForAllStatefulSetPodsReady(name, expectPods, () -> { });
-    }
-
-    public static void waitForAllStatefulSetPodsReady(String name, int expectPods, Runnable onTimeout) {
         LOGGER.debug("Waiting for StatefulSet {} to be ready", name);
         TestUtils.waitFor("statefulset " + name + " to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> kubeClient().getStatefulSetStatus(name), onTimeout);
+            () -> kubeClient().getStatefulSetStatus(name),
+            () -> StUtils.logCurrentStatus(KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(name).get()));
         LOGGER.debug("StatefulSet {} is ready", name);
         LOGGER.debug("Waiting for Pods of StatefulSet {} to be ready", name);
-        PodUtils.waitForPodsReady(kubeClient().getStatefulSetSelectors(name), expectPods, true, onTimeout);
+        PodUtils.waitForPodsReady(kubeClient().getStatefulSetSelectors(name), expectPods, true,
+            () -> StUtils.logCurrentStatus(KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(name).get()));
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
@@ -130,12 +130,16 @@ public class StatefulSetUtils {
      * @param expectPods The number of pods expected.
      */
     public static void waitForAllStatefulSetPodsReady(String name, int expectPods) {
+        waitForAllStatefulSetPodsReady(name, expectPods, () -> { });
+    }
+
+    public static void waitForAllStatefulSetPodsReady(String name, int expectPods, Runnable onTimeout) {
         LOGGER.debug("Waiting for StatefulSet {} to be ready", name);
         TestUtils.waitFor("statefulset " + name + " to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> kubeClient().getStatefulSetStatus(name));
+            () -> kubeClient().getStatefulSetStatus(name), onTimeout);
         LOGGER.debug("StatefulSet {} is ready", name);
         LOGGER.debug("Waiting for Pods of StatefulSet {} to be ready", name);
-        PodUtils.waitForPodsReady(kubeClient().getStatefulSetSelectors(name), expectPods, true);
+        PodUtils.waitForPodsReady(kubeClient().getStatefulSetSelectors(name), expectPods, true, onTimeout);
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
@@ -128,18 +128,21 @@ public class StatefulSetUtils {
     /**
      *
      * Wait until the STS is ready and all of its Pods are also ready.
-     * @param name The name of the StatefulSet
+     * @param statefulSetName The name of the StatefulSet
      * @param expectPods The number of pods expected.
      */
-    public static void waitForAllStatefulSetPodsReady(String name, int expectPods) {
-        LOGGER.debug("Waiting for StatefulSet {} to be ready", name);
-        TestUtils.waitFor("statefulset " + name + " to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> kubeClient().getStatefulSetStatus(name),
-            () -> StUtils.logCurrentStatus(KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(name).get()));
-        LOGGER.debug("StatefulSet {} is ready", name);
-        LOGGER.debug("Waiting for Pods of StatefulSet {} to be ready", name);
-        PodUtils.waitForPodsReady(kubeClient().getStatefulSetSelectors(name), expectPods, true,
-            () -> StUtils.logCurrentStatus(KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(name).get()));
+    public static void waitForAllStatefulSetPodsReady(String statefulSetName, int expectPods) {
+        String resourceName = statefulSetName.contains("-kafka") ? statefulSetName.replace("-kafka", "") : statefulSetName.replace("-zookeeper", "");
+
+        LOGGER.debug("Waiting for StatefulSet {} to be ready", statefulSetName);
+        TestUtils.waitFor("statefulset " + statefulSetName + " to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+            () -> kubeClient().getStatefulSetStatus(statefulSetName),
+            () -> StUtils.logCurrentStatus(KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get()));
+        LOGGER.debug("StatefulSet {} is ready", statefulSetName);
+        LOGGER.debug("Waiting for Pods of StatefulSet {} to be ready", statefulSetName);
+
+        PodUtils.waitForPodsReady(kubeClient().getStatefulSetSelectors(statefulSetName), expectPods, true,
+            () -> StUtils.logCurrentStatus(KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get()));
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -254,6 +254,12 @@ public class PodUtils {
             });
     }
 
+    /**
+     * Log actual pod statuses list by prefix name
+     * @param kind - custom resource / deployment kind - Kafka, KafkaBridge etc.
+     * @param name - custom resource / deployment name - used for prefix
+     * @param log - ArrayList - add statuses, pods and conditions for future display
+     */
     public static void logCurrentPodStatus(String kind, String name, List<String> log) {
         if (!(kind.equals("KafkaConnector"))) {
             log.add("\nPods with conditions and messages:\n\n");

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.utils.kubeUtils.objects;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodCondition;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
@@ -251,5 +252,21 @@ public class PodUtils {
                 }
                 return false;
             });
+    }
+
+    public static void logCurrentPodStatus(String kind, String name, List<String> log) {
+        if (!(kind.equals("KafkaConnector"))) {
+            log.add("\nPods with conditions and messages:\n\n");
+            for (Pod pod : kubeClient().listPodsByPrefixInName(name)) {
+                log.add(pod.getMetadata().getName() + ":");
+                for (PodCondition podCondition : pod.getStatus().getConditions()) {
+                    if (podCondition.getMessage() != null) {
+                        log.add("\n\tType: " + podCondition.getType() + "\n");
+                        log.add("\tMessage: " + podCondition.getMessage() + "\n");
+                    }
+                }
+                log.add("\n\n");
+            }
+        }
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -56,6 +56,10 @@ public class PodUtils {
     }
 
     public static void waitForPodsReady(LabelSelector selector, int expectPods, boolean containers) {
+        waitForPodsReady(selector, expectPods, containers, () -> { });
+    }
+
+    public static void waitForPodsReady(LabelSelector selector, int expectPods, boolean containers, Runnable onTimeout) {
         AtomicInteger count = new AtomicInteger();
         TestUtils.waitFor("All pods matching " + selector + "to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS, () -> {
             List<Pod> pods = kubeClient().listPods(selector);
@@ -88,7 +92,7 @@ public class PodUtils {
             int c = count.getAndIncrement();
             // When pod is up, it will check that are rolled pods are stable for next 10 polls and then it return true
             return c > 10;
-        });
+        }, onTimeout);
     }
 
     public static void waitForPodUpdate(String podName, Date startTime) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -33,9 +33,14 @@ public class SecretUtils {
     private SecretUtils() { }
 
     public static void waitForSecretReady(String secretName) {
+        waitForSecretReady(secretName, () -> { });
+    }
+
+    public static void waitForSecretReady(String secretName, Runnable onTimeout) {
         LOGGER.info("Waiting for Kafka user secret {}", secretName);
         TestUtils.waitFor("Expected secret " + secretName + " exists", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_SECRET_CREATION,
-            () -> kubeClient().getSecret(secretName) != null);
+            () -> kubeClient().getSecret(secretName) != null,
+            onTimeout);
         LOGGER.info("Kafka user secret {} created", secretName);
     }
 


### PR DESCRIPTION
### Type of change

- Enhancement 

### Description

When the deployment of custom resource fail on timeout in creation, we don't know what is going on. In this PR I'm trying to improve our logging with displaying status after timeout exception - conditions and messages of deployments and pods are displayed.

This will help us investigate a problem in deployment.

### Checklist

- [x] Make sure all tests pass
- [X] Create logging method in StUtils
- [X] Add logCurrentStatus() method to all resources classes


