### PR TITLE
[DOC] Upgrade procedure for cooperative rebalancing in Kafka 2.4.0

### DIFF
--- a/documentation/assemblies/assembly-upgrading-kafka-versions.adoc
+++ b/documentation/assemblies/assembly-upgrading-kafka-versions.adoc
@@ -19,8 +19,6 @@ When the versions are the same for the current and target Kafka version, as is t
 
 When one or more of these versions differ, the Cluster Operator requires two or three rolling updates of the Kafka brokers to perform the upgrade.
 
-
-
 .Additional resources
 
 * xref:assembly-upgrade-cluster-operator-str[]
@@ -30,3 +28,6 @@ include::../modules/con-versions-and-images.adoc[leveloffset=+1]
 include::../modules/con-strategies-for-upgrading-clients.adoc[leveloffset=+1]
 
 include::../modules/proc-upgrading-brokers-newer-kafka.adoc[leveloffset=+1]
+
+//upgrade clients and kafka streams to incremental cooperative rebalance protocol added in kafka 2.4
+include::../modules/proc-upgrading-consumers-streams-cooperative-rebalancing.adoc[leveloffset=+1]

--- a/documentation/modules/proc-upgrading-consumers-streams-cooperative-rebalancing.adoc
+++ b/documentation/modules/proc-upgrading-consumers-streams-cooperative-rebalancing.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// assembly-upgrading-kafka-versions.adoc
+
+[id="proc-upgrading-consumers-streams-cooperative-rebalancing_{context}"]
+
+= Upgrading Kafka consumers and Kafka Streams applications to use incremental cooperative rebalancing
+
+This procedure describes how to upgrade Kafka consumers and Kafka Streams applications to use _incremental cooperative rebalancing_. This is a new strategy for implementing partition rebalances that was added in Kafka 2.4.0.
+
+Incremental cooperative rebalancing is more efficient than the default  `range` strategy because consumers keep their assigned partitions and only revoke them at the end of the process, if needed to achieve a balanced cluster.
+
+Upgrading to cooperative rebalancing is optional and the `range` strategy is still supported.
+
+.Prerequisites
+
+* You have xref:proc-upgrading-brokers-newer-kafka-{context}[upgraded Kafka brokers and client applications] to Kafka {DefaultKafkaVersion}.
+
+.Procedure
+
+*To upgrade a Kafka consumer to use incremental cooperative rebalancing:*
+
+. Replace the Kafka clients `.jar` file with the new version.
+
+. In the consumer configuration, append `cooperative-sticky` to the `partition.assignment.strategy`. For example, if the `range` strategy is set, change the configuration to `range, cooperative-sticky`.
+
+. Restart each consumer in the group in turn, waiting for the consumer to rejoin the group after each restart.
+
+. Reconfigure each consumer in the group by removing the earlier `partition.assignment.strategy` from the consumer configuration, leaving only the `cooperative-sticky` strategy.
+
+. Restart each consumer in the group in turn, waiting for the consumer to rejoin the group after each restart.
+
+*To upgrade a Kafka Streams application to use incremental cooperative rebalancing:*
+
+. Replace the Kafka Streams `.jar` file with the new version.
+
+. In the Kafka Streams configuration, set the `upgrade.from` configuration parameter to the Kafka version you are upgrading from (for example, 2.3).
+
+. Restart each of the stream processors (nodes) in turn.
+
+. Remove the `upgrade.from` configuration parameter from the Kafka Streams configuration.
+
+. Restart each consumer in the group in turn. 
+
+.Additional resources
+
+* ???

--- a/documentation/modules/proc-upgrading-consumers-streams-cooperative-rebalancing.adoc
+++ b/documentation/modules/proc-upgrading-consumers-streams-cooperative-rebalancing.adoc
@@ -4,13 +4,13 @@
 
 [id="proc-upgrading-consumers-streams-cooperative-rebalancing_{context}"]
 
-= Upgrading Kafka consumers and Kafka Streams applications to use incremental cooperative rebalancing
+= Upgrading consumers and Kafka Streams applications to cooperative rebalancing
 
-This procedure describes how to upgrade Kafka consumers and Kafka Streams applications to use _incremental cooperative rebalancing_. This is a new strategy for implementing partition rebalances that was added in Kafka 2.4.0.
+You can upgrade Kafka consumers and Kafka Streams applications to use the _incremental cooperative rebalance_ protocol for partition rebalances instead of the default _eager rebalance_ protocol. The new protocol was added in Kafka 2.4.0.
 
-Incremental cooperative rebalancing is more efficient than the default  `range` strategy because consumers keep their assigned partitions and only revoke them at the end of the process, if needed to achieve a balanced cluster.
+Consumers keep their partition assignments in a cooperative rebalance and only revoke them at the end of the process, if needed to achieve a balanced cluster. This reduces the unavailability of the consumer group or Kafka Streams application.
 
-Upgrading to cooperative rebalancing is optional and the `range` strategy is still supported.
+NOTE: Upgrading to the incremental cooperative rebalance protocol is optional. The eager rebalance protocol is still supported.
 
 .Prerequisites
 
@@ -18,7 +18,7 @@ Upgrading to cooperative rebalancing is optional and the `range` strategy is sti
 
 .Procedure
 
-*To upgrade a Kafka consumer to use incremental cooperative rebalancing:*
+*To upgrade a Kafka consumer to use the incremental cooperative rebalance protocol:*
 
 . Replace the Kafka clients `.jar` file with the new version.
 
@@ -30,7 +30,7 @@ Upgrading to cooperative rebalancing is optional and the `range` strategy is sti
 
 . Restart each consumer in the group in turn, waiting for the consumer to rejoin the group after each restart.
 
-*To upgrade a Kafka Streams application to use incremental cooperative rebalancing:*
+*To upgrade a Kafka Streams application to use the incremental cooperative rebalance protocol:*
 
 . Replace the Kafka Streams `.jar` file with the new version.
 
@@ -44,4 +44,4 @@ Upgrading to cooperative rebalancing is optional and the `range` strategy is sti
 
 .Additional resources
 
-* ???
+* link:https://kafka.apache.org/documentation/#upgrade_240_notable[Notable changes in 2.4.0^] in the Apache Kafka documentation.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Adds a new procedure for "Upgrading consumers and Kafka Streams applications to cooperative rebalancing" to the "Upgrading Kafka" assembly.

Upgrading consumers and Streams apps to the new _incremental cooperative rebalance_ protocol is an optional step in upgrades to Kafka 2.4.0, which is supported in Strimzi 0.17.0.

Once merged, this PR should be cherry-picked to Strimzi 0.17.0.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging // NO ISSUES FOUND
- [ ] Update CHANGELOG.md

