### PR TITLE
Remove call to deleted dynamic_resources.sh script

### DIFF
--- a/docker-images/operator/scripts/launch_java.sh
+++ b/docker-images/operator/scripts/launch_java.sh
@@ -2,8 +2,6 @@
 set -x
 shift
 
-. ${STRIMZI_HOME}/bin/dynamic_resources.sh
-
 # expand gc options based upon java version
 function get_gc_opts {
   if [ "${STRIMZI_GC_LOG_ENABLED}" == "true" ]; then


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The PR #2689 removed the scirpt `dynamic_resources.sh` from the operator images. However, the script is still called from `launch_java.sh` and causing an error:

```
+ . /opt/strimzi/bin/dynamic_resources.sh
/opt/strimzi/bin/launch_java.sh: line 5: /opt/strimzi/bin/dynamic_resources.sh: No such file or directory
```