### PR TITLE
Update example for kafka and kafka-connect metric rules

### DIFF
--- a/examples/metrics/grafana-dashboards/strimzi-kafka-connect.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kafka-connect.json
@@ -120,7 +120,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kafka_connect_connect_worker_metrics_connector_count{strimzi_io_kind=~\"KafkaConnect.*\",strimzi_io_cluster=\"$strimzi_connect_cluster_name\"})",
+          "expr": "sum(kafka_connect_worker_connector_count{strimzi_io_kind=~\"KafkaConnect.*\",strimzi_io_cluster=\"$strimzi_connect_cluster_name\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -202,7 +202,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kafka_connect_connect_worker_metrics_task_count{strimzi_io_kind=~\"KafkaConnect.*\",strimzi_io_cluster=\"$strimzi_connect_cluster_name\"})",
+          "expr": "sum(kafka_connect_worker_task_count{strimzi_io_kind=~\"KafkaConnect.*\",strimzi_io_cluster=\"$strimzi_connect_cluster_name\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -260,7 +260,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kafka_connect_connect_metrics_connect_1_incoming_byte_rate{strimzi_io_kind=~\"KafkaConnect.*\",strimzi_io_cluster=\"$strimzi_connect_cluster_name\"})",
+          "expr": "sum(kafka_connect_incoming_byte_total{strimzi_io_kind=~\"KafkaConnect.*\",strimzi_io_cluster=\"$strimzi_connect_cluster_name\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -348,7 +348,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kafka_connect_connect_metrics_connect_1_outgoing_byte_rate{strimzi_io_kind=~\"KafkaConnect.*\",strimzi_io_cluster=\"$strimzi_connect_cluster_name\"})",
+          "expr": "sum(kafka_connect_outgoing_byte_total{strimzi_io_kind=~\"KafkaConnect.*\",strimzi_io_cluster=\"$strimzi_connect_cluster_name\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -686,7 +686,7 @@
         "multi": false,
         "name": "kubernetes_namespace",
         "options": [],
-        "query": "query_result(kafka_connect_connect_worker_metrics_connector_count)",
+        "query": "query_result(kafka_connect_worker_connector_count)",
         "refresh": 1,
         "regex": "/.*namespace=\"([^\"]*).*/",
         "sort": 0,
@@ -709,7 +709,7 @@
         "multi": false,
         "name": "strimzi_connect_cluster_name",
         "options": [],
-        "query": "query_result(kafka_connect_connect_worker_metrics_connector_count{namespace=\"$kubernetes_namespace\"})",
+        "query": "query_result(kafka_connect_worker_connector_count{namespace=\"$kubernetes_namespace\"})",
         "refresh": 1,
         "regex": "/.*strimzi_io_cluster=\"([^\"]*).*/",
         "sort": 0,

--- a/examples/metrics/grafana-dashboards/strimzi-kafka-mirror-maker-2.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kafka-mirror-maker-2.json
@@ -120,7 +120,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kafka_connect_connect_worker_metrics_connector_count{strimzi_io_kind=~\"KafkaMirrorMaker2\",strimzi_io_cluster=\"$strimzi_mirror_maker_cluster_name\"})",
+          "expr": "sum(kafka_connect_worker_connector_count{strimzi_io_kind=~\"KafkaMirrorMaker2\",strimzi_io_cluster=\"$strimzi_mirror_maker_cluster_name\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -202,7 +202,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kafka_connect_connect_worker_metrics_task_count{strimzi_io_kind=~\"KafkaMirrorMaker2\",strimzi_io_cluster=\"$strimzi_mirror_maker_cluster_name\"})",
+          "expr": "sum(kafka_connect_worker_task_count{strimzi_io_kind=~\"KafkaMirrorMaker2\",strimzi_io_cluster=\"$strimzi_mirror_maker_cluster_name\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -260,7 +260,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kafka_connect_connect_metrics_connect_1_incoming_byte_rate{strimzi_io_kind=~\"KafkaMirrorMaker2\",strimzi_io_cluster=\"$strimzi_mirror_maker_cluster_name\"})",
+          "expr": "sum(kafka_connect_incoming_byte_total{strimzi_io_kind=~\"KafkaMirrorMaker2\",strimzi_io_cluster=\"$strimzi_mirror_maker_cluster_name\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -348,7 +348,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kafka_connect_connect_metrics_connect_1_outgoing_byte_rate{strimzi_io_kind=~\"KafkaMirrorMaker2\",strimzi_io_cluster=\"$strimzi_mirror_maker_cluster_name\"})",
+          "expr": "sum(kafka_connect_outgoing_byte_total{strimzi_io_kind=~\"KafkaMirrorMaker2\",strimzi_io_cluster=\"$strimzi_mirror_maker_cluster_name\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -686,7 +686,7 @@
         "multi": false,
         "name": "kubernetes_namespace",
         "options": [],
-        "query": "query_result(kafka_connect_connect_worker_metrics_connector_count)",
+        "query": "query_result(kafka_connect_worker_connector_count)",
         "refresh": 1,
         "regex": "/.*namespace=\"([^\"]*).*/",
         "sort": 0,
@@ -709,7 +709,7 @@
         "multi": false,
         "name": "strimzi_mirror_maker_cluster_name",
         "options": [],
-        "query": "query_result(kafka_connect_connect_worker_metrics_connector_count{namespace=\"$kubernetes_namespace\"})",
+        "query": "query_result(kafka_connect_worker_connector_count{namespace=\"$kubernetes_namespace\"})",
         "refresh": 1,
         "regex": "/.*strimzi_io_cluster=\"([^\"]*).*/",
         "sort": 0,

--- a/examples/metrics/kafka-connect-metrics.yaml
+++ b/examples/metrics/kafka-connect-metrics.yaml
@@ -9,10 +9,112 @@ spec:
   replicas: 1
   bootstrapServers: my-cluster-kafka-bootstrap:9092
   metrics:
+    # Inspired by kafka-connect rules
+    # https://github.com/prometheus/jmx_exporter/blob/master/example_configs/kafka-connect.yml
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     rules:
-    - pattern : "kafka.connect<type=connect-worker-metrics>([^:]+):"
-      name: "kafka_connect_connect_worker_metrics_$1"
-    - pattern : "kafka.connect<type=connect-metrics, client-id=([^:]+)><>([^:]+)"
-      name: "kafka_connect_connect_metrics_$1_$2"
+      #kafka.connect:type=app-info,client-id="{clientid}"
+      #kafka.consumer:type=app-info,client-id="{clientid}"
+      #kafka.producer:type=app-info,client-id="{clientid}"
+      - pattern: 'kafka.(.+)<type=app-info, client-id=(.+)><>start-time-ms'
+        name: kafka_$1_start_time_seconds
+        labels:
+          clientId: "$2"
+        help: "Kafka $1 JMX metric start time seconds"
+        type: GAUGE
+        valueFactor: 0.001
+      - pattern: 'kafka.(.+)<type=app-info, client-id=(.+)><>(commit-id|version): (.+)'
+        name: kafka_$1_$3_info
+        value: 1
+        labels:
+          clientId: "$2"
+          $3: "$4"
+        help: "Kafka $1 JMX metric info version and commit-id"
+        type: GAUGE
+
+      #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
+      #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
+      - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+), partition=(.+)><>(.+-total|compression-rate|.+-avg|.+-replica|.+-lag|.+-lead)
+        name: kafka_$2_$6
+        labels:
+          clientId: "$3"
+          topic: "$4"
+          partition: "$5"
+        help: "Kafka $1 JMX metric type $2"
+        type: GAUGE
+
+      #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"
+      #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
+      - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+)><>(.+-total|compression-rate|.+-avg)
+        name: kafka_$2_$5
+        labels:
+          clientId: "$3"
+          topic: "$4"
+        help: "Kafka $1 JMX metric type $2"
+        type: GAUGE
+
+      #kafka.connect:type=connect-node-metrics,client-id="{clientid}",node-id="{nodeid}"
+      #kafka.consumer:type=consumer-node-metrics,client-id=consumer-1,node-id="{nodeid}"
+      - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), node-id=(.+)><>(.+-total|.+-avg)
+        name: kafka_$2_$5
+        labels:
+          clientId: "$3"
+          nodeId: "$4"
+        help: "Kafka $1 JMX metric type $2"
+        type: UNTYPED
+
+      #kafka.connect:type=kafka-metrics-count,client-id="{clientid}"
+      #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}"
+      #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
+      #kafka.consumer:type=consumer-metrics,client-id="{clientid}"
+      - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.+-total|.+-avg|.+-bytes|.+-count|.+-ratio|.+-age|.+-flight|.+-threads|.+-connectors|.+-tasks|.+-ago)
+        name: kafka_$2_$4
+        labels:
+          clientId: "$3"
+        help: "Kafka $1 JMX metric type $2"
+        type: GAUGE
+
+      #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}<> status"
+      - pattern: 'kafka.connect<type=connector-task-metrics, connector=(.+), task=(.+)><>status: ([a-z-]+)'
+        name: kafka_connect_connector_status
+        value: 1
+        labels:
+          connector: "$1"
+          task: "$2"
+          status: "$3"
+        help: "Kafka Connect JMX Connector status"
+        type: GAUGE
+
+      #kafka.connect:type=task-error-metrics,connector="{connector}",task="{task}"
+      #kafka.connect:type=source-task-metrics,connector="{connector}",task="{task}"
+      #kafka.connect:type=sink-task-metrics,connector="{connector}",task="{task}"
+      #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}"
+      - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-ms|.+-ratio|.+-avg|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)
+        name: kafka_connect_$1_$4
+        labels:
+          connector: "$2"
+          task: "$3"
+        help: "Kafka Connect JMX metric type $1"
+        type: GAUGE
+
+      #kafka.connect:type=connector-metrics,connector="{connector}"
+      #kafka.connect:type=connect-worker-metrics,connector="{connector}"
+      - pattern: kafka.connect<type=connect-worker-metrics, connector=(.+)><>([a-z-]+)
+        name: kafka_connect_worker_$2
+        labels:
+          connector: "$1"
+        help: "Kafka Connect JMX metric $1"
+        type: GAUGE
+
+      #kafka.connect:type=connect-worker-metrics
+      - pattern: kafka.connect<type=connect-worker-metrics><>([a-z-]+)
+        name: kafka_connect_worker_$1
+        help: "Kafka Connect JMX metric worker"
+        type: GAUGE
+
+      #kafka.connect:type=connect-worker-rebalance-metrics
+      - pattern: kafka.connect<type=connect-worker-rebalance-metrics><>([a-z-]+)
+        name: kafka_connect_worker_rebalance_$1
+        help: "Kafka Connect JMX metric rebalance information"
+        type: GAUGE

--- a/examples/metrics/kafka-metrics.yaml
+++ b/examples/metrics/kafka-metrics.yaml
@@ -144,25 +144,37 @@ spec:
       # replicated Zookeeper
       - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+)><>(\\w+)"
         name: "zookeeper_$2"
+        type: GAUGE
       - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+)><>(\\w+)"
         name: "zookeeper_$3"
+        type: GAUGE
         labels:
           replicaId: "$2"
+      - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+)><>(Packets.*)"
+        name: "zookeeper_$4"
+        type: COUNTER
+        labels:
+          replicaId: "$2"
+          memberType: "$3"
       - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+)><>(\\w+)"
         name: "zookeeper_$4"
+        type: GAUGE
         labels:
           replicaId: "$2"
           memberType: "$3"
       - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+), name3=(\\w+)><>(\\w+)"
         name: "zookeeper_$4_$5"
+        type: GAUGE
         labels:
           replicaId: "$2"
           memberType: "$3"
       # standalone Zookeeper
       - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+)><>(\\w+)"
+        type: GAUGE
         name: "zookeeper_$2"
-      - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+), name1=(InMemoryDataTree)><>(\\w+)"
-        name: "zookeeper_$2_$3"
+      - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+), name1=InMemoryDataTree><>(\\w+)"
+        type: GAUGE
+        name: "zookeeper_$2"
   entityOperator:
     topicOperator: {}
     userOperator: {}


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Examples for kafka and kafka-connect metrics rules are not up to date.
In this PR updated prometheus rules according to recent changes: https://github.com/prometheus/jmx_exporter/pull/464
https://github.com/prometheus/jmx_exporter/pull/473

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

