### PR TITLE
Make sure volume names are valid

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -7,8 +7,6 @@ package io.strimzi.operator.cluster.model;
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
-import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
-import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
@@ -37,7 +35,6 @@ import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
-import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentStrategy;
@@ -624,20 +621,6 @@ public abstract class AbstractModel {
         }
 
         return pvc;
-    }
-
-    protected Volume createConfigMapVolume(String name, String configMapName) {
-
-        ConfigMapVolumeSource configMapVolumeSource = new ConfigMapVolumeSourceBuilder()
-                .withName(configMapName)
-                .build();
-
-        Volume volume = new VolumeBuilder()
-                .withName(name)
-                .withConfigMap(configMapVolumeSource)
-                .build();
-        log.trace("Created configMap Volume named '{}' with source configMap '{}'", name, configMapName);
-        return volume;
     }
 
     protected ConfigMap createConfigMap(String name, Map<String, String> data) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -267,7 +267,7 @@ public class EntityTopicOperator extends AbstractModel {
     }
 
     public List<Volume> getVolumes() {
-        return singletonList(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
+        return singletonList(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
     }
 
     private List<VolumeMount> getVolumeMounts() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -265,7 +265,7 @@ public class EntityUserOperator extends AbstractModel {
     }
 
     public List<Volume> getVolumes() {
-        return singletonList(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
+        return singletonList(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
     }
 
     private List<VolumeMount> getVolumeMounts() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
@@ -194,8 +194,8 @@ public class JmxTrans extends AbstractModel {
 
     public List<Volume> getVolumes() {
         List<Volume> volumes = new ArrayList<>();
-        volumes.add(createConfigMapVolume(JMXTRANS_VOLUME_NAME, configMapName));
-        volumes.add(createConfigMapVolume(logAndMetricsConfigVolumeName, KafkaCluster.metricAndLogConfigsName(clusterName)));
+        volumes.add(VolumeUtils.createConfigMapVolume(JMXTRANS_VOLUME_NAME, configMapName));
+        volumes.add(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, KafkaCluster.metricAndLogConfigsName(clusterName)));
         return volumes;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -265,7 +265,7 @@ public class KafkaBridgeCluster extends AbstractModel {
 
     protected List<Volume> getVolumes(boolean isOpenShift) {
         List<Volume> volumeList = new ArrayList<>(1);
-        volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
+        volumeList.add(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
 
         if (tls != null) {
             List<CertSecretSource> trustedCertificates = tls.getTrustedCertificates();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1439,7 +1439,7 @@ public class KafkaCluster extends AbstractModel {
 
             volumeList.add(VolumeUtils.createSecretVolume("custom-tls-9093-certs", this.secretSourceTls.getSecretName(), items, isOpenShift));
         }
-        volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
+        volumeList.add(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
         volumeList.add(new VolumeBuilder().withName("ready-files").withNewEmptyDir().withMedium("Memory").endEmptyDir().build());
 
         if (listeners != null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -295,7 +295,7 @@ public class KafkaConnectCluster extends AbstractModel {
 
     protected List<Volume> getVolumes(boolean isOpenShift) {
         List<Volume> volumeList = new ArrayList<>(1);
-        volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
+        volumeList.add(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
 
         if (tls != null) {
             List<CertSecretSource> trustedCertificates = tls.getTrustedCertificates();
@@ -337,7 +337,7 @@ public class KafkaConnectCluster extends AbstractModel {
                         source.setDefaultMode(mode);
 
                         Volume newVol = new VolumeBuilder()
-                                .withName(EXTERNAL_CONFIGURATION_VOLUME_NAME_PREFIX + name)
+                                .withName(VolumeUtils.getValidVolumeName(EXTERNAL_CONFIGURATION_VOLUME_NAME_PREFIX + name))
                                 .withConfigMap(source)
                                 .build();
 
@@ -347,7 +347,7 @@ public class KafkaConnectCluster extends AbstractModel {
                         source.setDefaultMode(mode);
 
                         Volume newVol = new VolumeBuilder()
-                                .withName(EXTERNAL_CONFIGURATION_VOLUME_NAME_PREFIX + name)
+                                .withName(VolumeUtils.getValidVolumeName(EXTERNAL_CONFIGURATION_VOLUME_NAME_PREFIX + name))
                                 .withSecret(source)
                                 .build();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -233,7 +233,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
 
     protected List<Volume> getVolumes(boolean isOpenShift) {
         List<Volume> volumeList = new ArrayList<>(1);
-        volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
+        volumeList.add(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
 
         createClientSecretVolume(producer, volumeList, "producer-oauth-certs", isOpenShift);
         createClientSecretVolume(consumer, volumeList, "consumer-oauth-certs", isOpenShift);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -378,7 +378,7 @@ public class TopicOperator extends AbstractModel {
 
     private List<Volume> getVolumes(boolean isOpenShift) {
         List<Volume> volumeList = new ArrayList<>();
-        volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
+        volumeList.add(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
         volumeList.add(VolumeUtils.createSecretVolume(TLS_SIDECAR_EO_CERTS_VOLUME_NAME, TopicOperator.secretName(cluster), isOpenShift));
         volumeList.add(VolumeUtils.createSecretVolume(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, AbstractModel.clusterCaCertSecretName(cluster), isOpenShift));
         return volumeList;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
@@ -348,7 +348,7 @@ public class VolumeUtils {
      * Gets the first 8 characters from a SHA-1 hash of a volume name
      *
      * @param name  Volume name
-     * @return      First 8 characters of the sHA-1 hash
+     * @return      First 8 characters of the SHA-1 hash
      */
     private static String getVolumeNameHashStub(String name)   {
         try {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
@@ -62,7 +62,7 @@ public class VolumeUtils {
                 .withName(getValidVolumeName(name))
                 .withConfigMap(configMapVolumeSource)
                 .build();
-        AbstractModel.log.trace("Created configMap Volume named '{}' with source configMap '{}'", name, configMapName);
+        log.trace("Created configMap Volume named '{}' with source configMap '{}'", name, configMapName);
         return volume;
     }
 
@@ -327,7 +327,7 @@ public class VolumeUtils {
                 .replace(".", "-")
                 .replace("_", "-");
 
-        // The name with the hash should be only up to63 characters long
+        // The name with the hash should be only up to 63 characters long
         int i = Math.min(newName.length(), 54);
 
         while (i > 0) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
@@ -4,13 +4,20 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import io.fabric8.kubernetes.api.model.EmptyDirVolumeSource;
 import io.fabric8.kubernetes.api.model.EmptyDirVolumeSourceBuilder;
@@ -36,8 +43,28 @@ import io.strimzi.api.kafka.model.storage.Storage;
  * Shared methods for working with Volume
  */
 public class VolumeUtils {
-
     protected static final Logger log = LogManager.getLogger(VolumeUtils.class.getName());
+    private static Pattern volumeNamePattern = Pattern.compile("^([a-z0-9]{1}[a-z0-9-]{0,61}[a-z0-9]{1})$");
+
+    /**
+     * Creates a Kubernetes volume which will map to ConfigMap
+     *
+     * @param name              Name of the Volume
+     * @param configMapName     Name of the ConfigMap
+     * @return                  The newly created Volume
+     */
+    public static Volume createConfigMapVolume(String name, String configMapName) {
+        ConfigMapVolumeSource configMapVolumeSource = new ConfigMapVolumeSourceBuilder()
+                .withName(configMapName)
+                .build();
+
+        Volume volume = new VolumeBuilder()
+                .withName(getValidVolumeName(name))
+                .withConfigMap(configMapVolumeSource)
+                .build();
+        AbstractModel.log.trace("Created configMap Volume named '{}' with source configMap '{}'", name, configMapName);
+        return volume;
+    }
 
     /**
      * Creates a secret volume with given items
@@ -72,7 +99,7 @@ public class VolumeUtils {
                 .build();
 
         Volume volume = new VolumeBuilder()
-                .withName(name)
+                .withName(getValidVolumeName(name))
                 .withSecret(secretVolumeSource)
                 .build();
         log.trace("Created secret Volume named '{}' with source secret '{}'", name, secretName);
@@ -99,7 +126,7 @@ public class VolumeUtils {
                 .build();
 
         Volume volume = new VolumeBuilder()
-                .withName(name)
+                .withName(getValidVolumeName(name))
                 .withSecret(secretVolumeSource)
                 .build();
         log.trace("Created secret Volume named '{}' with source secret '{}'", name, secretName);
@@ -120,7 +147,7 @@ public class VolumeUtils {
         }
 
         Volume volume = new VolumeBuilder()
-                .withName(name)
+                .withName(getValidVolumeName(name))
                 .withEmptyDir(emptyDirVolumeSource)
                 .build();
         log.trace("Created emptyDir Volume named '{}' with sizeLimit '{}'", name, sizeLimit);
@@ -145,15 +172,15 @@ public class VolumeUtils {
 
         return new PersistentVolumeClaimBuilder()
                 .withNewMetadata()
-                .withName(name)
+                    .withName(name)
                 .endMetadata()
                 .withNewSpec()
-                .withAccessModes("ReadWriteOnce")
-                .withNewResources()
-                .withRequests(requests)
-                .endResources()
-                .withStorageClassName(storage.getStorageClass())
-                .withSelector(selector)
+                    .withAccessModes("ReadWriteOnce")
+                    .withNewResources()
+                        .withRequests(requests)
+                    .endResources()
+                    .withStorageClassName(storage.getStorageClass())
+                    .withSelector(selector)
                 .endSpec()
                 .build();
     }
@@ -167,7 +194,7 @@ public class VolumeUtils {
      */
     public static VolumeMount createVolumeMount(String name, String path) {
         VolumeMount volumeMount = new VolumeMountBuilder()
-                .withName(name)
+                .withName(getValidVolumeName(name))
                 .withMountPath(path)
                 .build();
         log.trace("Created volume mount {}", volumeMount);
@@ -256,5 +283,81 @@ public class VolumeUtils {
      */
     public static String getVolumePrefix(Integer id) {
         return id == null ? AbstractModel.VOLUME_NAME : AbstractModel.VOLUME_NAME + "-" + id;
+    }
+
+    /**
+     * Volume names have to follow DNS label standard form RFC1123:
+     *     - contain at most 63 characters
+     *     - contain only lowercase alphanumeric characters or ‘-’
+     *     - start with an alphanumeric character
+     *     - end with an alphanumeric character
+     *
+     *  This method checkes if the volume name is a valid name and if not it will modify it to make it valid.
+     *
+     * @param originalName  The original name of the volume
+     * @return              Either the original volume name or a modified version to match volume name criteria
+     */
+    public static String getValidVolumeName(String originalName) {
+        if (originalName == null) {
+            throw new RuntimeException("Volume name cannot be null");
+        }
+
+        if (volumeNamePattern.matcher(originalName).matches()) {
+            return originalName;
+        } else {
+            return makeValidVolumeName(originalName);
+        }
+    }
+
+    /**
+     * Makes a valid volume name out of an invalid name. To do so it:
+     *     - Replaces . and _ characters with -
+     *     - Shortens the name if needed
+     *     - Uses SHA1 hash for uniqueness of the new name
+     *
+     * @param originalName  Original invalid volume name
+     * @return              New valid volume name
+     */
+    /*test*/ static String makeValidVolumeName(String originalName) {
+        // SHA-1 hash is used for uniqueness
+        String digestStub = getVolumeNameHashStub(originalName);
+
+        // Special characters need to be replaced
+        String newName = originalName
+                .replace(".", "-")
+                .replace("_", "-");
+
+        // The name with the hash should be only up to63 characters long
+        int i = Math.min(newName.length(), 54);
+
+        while (i > 0) {
+            char lastChar = newName.charAt(i - 1);
+
+            if (lastChar == '-') {
+                i--;
+            } else {
+                break;
+            }
+        }
+
+        // Returned new fixed name with the hash at the end
+        return newName.substring(0, i) + "-" + digestStub;
+    }
+
+    /**
+     * Gets the first 8 characters from a SHA-1 hash of a volume name
+     *
+     * @param name  Volume name
+     * @return      First 8 characters of the sHA-1 hash
+     */
+    private static String getVolumeNameHashStub(String name)   {
+        try {
+            MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
+            byte[] digest = sha1.digest(name.getBytes(StandardCharsets.US_ASCII));
+
+            return String.format("%040x", new BigInteger(1, digest)).substring(0, 8);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Failed to get volume name SHA-1 hash", e);
+        }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
@@ -54,15 +54,19 @@ public class VolumeUtils {
      * @return                  The newly created Volume
      */
     public static Volume createConfigMapVolume(String name, String configMapName) {
+        String validName = getValidVolumeName(name);
+
         ConfigMapVolumeSource configMapVolumeSource = new ConfigMapVolumeSourceBuilder()
                 .withName(configMapName)
                 .build();
 
         Volume volume = new VolumeBuilder()
-                .withName(getValidVolumeName(name))
+                .withName(validName)
                 .withConfigMap(configMapVolumeSource)
                 .build();
-        log.trace("Created configMap Volume named '{}' with source configMap '{}'", name, configMapName);
+
+        log.trace("Created configMap Volume named '{}' with source configMap '{}'", validName, configMapName);
+
         return volume;
     }
 
@@ -76,6 +80,8 @@ public class VolumeUtils {
      * @return The Volume created
      */
     public static Volume createSecretVolume(String name, String secretName, Map<String, String> items, boolean isOpenshift) {
+        String validName = getValidVolumeName(name);
+
         int mode = 0444;
         if (isOpenshift) {
             mode = 0440;
@@ -99,10 +105,10 @@ public class VolumeUtils {
                 .build();
 
         Volume volume = new VolumeBuilder()
-                .withName(getValidVolumeName(name))
+                .withName(validName)
                 .withSecret(secretVolumeSource)
                 .build();
-        log.trace("Created secret Volume named '{}' with source secret '{}'", name, secretName);
+        log.trace("Created secret Volume named '{}' with source secret '{}'", validName, secretName);
         return volume;
     }
 
@@ -115,6 +121,8 @@ public class VolumeUtils {
      * @return The Volume created
      */
     public static Volume createSecretVolume(String name, String secretName, boolean isOpenshift) {
+        String validName = getValidVolumeName(name);
+
         int mode = 0444;
         if (isOpenshift) {
             mode = 0440;
@@ -126,10 +134,10 @@ public class VolumeUtils {
                 .build();
 
         Volume volume = new VolumeBuilder()
-                .withName(getValidVolumeName(name))
+                .withName(validName)
                 .withSecret(secretVolumeSource)
                 .build();
-        log.trace("Created secret Volume named '{}' with source secret '{}'", name, secretName);
+        log.trace("Created secret Volume named '{}' with source secret '{}'", validName, secretName);
         return volume;
     }
 
@@ -141,16 +149,18 @@ public class VolumeUtils {
      * @return The Volume created
      */
     public static Volume createEmptyDirVolume(String name, String sizeLimit) {
+        String validName = getValidVolumeName(name);
+
         EmptyDirVolumeSource emptyDirVolumeSource = new EmptyDirVolumeSourceBuilder().build();
         if (sizeLimit != null && !sizeLimit.isEmpty()) {
             emptyDirVolumeSource.setSizeLimit(new Quantity(sizeLimit));
         }
 
         Volume volume = new VolumeBuilder()
-                .withName(getValidVolumeName(name))
+                .withName(validName)
                 .withEmptyDir(emptyDirVolumeSource)
                 .build();
-        log.trace("Created emptyDir Volume named '{}' with sizeLimit '{}'", name, sizeLimit);
+        log.trace("Created emptyDir Volume named '{}' with sizeLimit '{}'", validName, sizeLimit);
         return volume;
     }
 
@@ -193,11 +203,13 @@ public class VolumeUtils {
      * @return The Volume mount created
      */
     public static VolumeMount createVolumeMount(String name, String path) {
+        String validName = getValidVolumeName(name);
+
         VolumeMount volumeMount = new VolumeMountBuilder()
-                .withName(getValidVolumeName(name))
+                .withName(validName)
                 .withMountPath(path)
                 .build();
-        log.trace("Created volume mount {}", volumeMount);
+        log.trace("Created volume mount {} for volume {}", volumeMount, validName);
         return volumeMount;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -628,7 +628,7 @@ public class ZookeeperCluster extends AbstractModel {
             String sizeLimit = ((EphemeralStorage) storage).getSizeLimit();
             volumeList.add(VolumeUtils.createEmptyDirVolume(VOLUME_NAME, sizeLimit));
         }
-        volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
+        volumeList.add(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
         volumeList.add(VolumeUtils.createSecretVolume(TLS_SIDECAR_NODES_VOLUME_NAME, ZookeeperCluster.nodesSecretName(cluster), isOpenShift));
         volumeList.add(VolumeUtils.createSecretVolume(TLS_SIDECAR_CLUSTER_CA_VOLUME_NAME, AbstractModel.clusterCaCertSecretName(cluster), isOpenShift));
         return volumeList;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/VolumeUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/VolumeUtilsTest.java
@@ -31,4 +31,49 @@ public class VolumeUtilsTest {
         Volume volume = VolumeUtils.createEmptyDirVolume("bar", "");
         assertThat(volume.getEmptyDir().getSizeLimit(), is(nullValue()));
     }
+
+    @Test
+    public void testValidVolumeNames() {
+        assertThat(VolumeUtils.getValidVolumeName("my-user"), is("my-user"));
+        assertThat(VolumeUtils.getValidVolumeName("my-0123456789012345678901234567890123456789012345678901234-user"),
+                is("my-0123456789012345678901234567890123456789012345678901234-user"));
+    }
+
+    @Test
+    public void testInvalidVolumeNames() {
+        assertThat(VolumeUtils.getValidVolumeName("my.user"), is("my-user-4dbf077e"));
+        assertThat(VolumeUtils.getValidVolumeName("my_user"), is("my-user-e10dbc61"));
+        assertThat(VolumeUtils.getValidVolumeName("my-very-long-012345678901234567890123456789012345678901234567890123456789-user"),
+                is("my-very-long-01234567890123456789012345678901234567890-12a964dc"));
+        assertThat(VolumeUtils.getValidVolumeName("my-very-long-0123456789012345678901234567890123456789-1234567890123456789-user"),
+                is("my-very-long-0123456789012345678901234567890123456789-348f6fec"));
+        assertThat(VolumeUtils.getValidVolumeName("my.bridge.012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"),
+                is("my-bridge-01234567890123456789012345678901234567890123-30a4fce1"));
+        assertThat(VolumeUtils.getValidVolumeName("a.a"), is("a-a-5bd24583"));
+        assertThat(VolumeUtils.getValidVolumeName("a"), is("a-86f7e437"));
+    }
+
+    @Test
+    public void testCreateSecretVolumeWithValidName() {
+        Volume volume = VolumeUtils.createSecretVolume("oauth-my-secret", "my-secret", true);
+        assertThat(volume.getName(), is("oauth-my-secret"));
+    }
+
+    @Test
+    public void testCreateSecretVolumeWithInvalidName() {
+        Volume volume = VolumeUtils.createSecretVolume("oauth-my.secret", "my.secret", true);
+        assertThat(volume.getName(), is("oauth-my-secret-b744ae5a"));
+    }
+
+    @Test
+    public void testCreateConfigMapVolumeWithValidName() {
+        Volume volume = VolumeUtils.createConfigMapVolume("oauth-my-cm", "my-cm");
+        assertThat(volume.getName(), is("oauth-my-cm"));
+    }
+
+    @Test
+    public void testCreateConfigMapVolumeWithInvalidName() {
+        Volume volume = VolumeUtils.createConfigMapVolume("oauth-my.cm", "my.cm");
+        assertThat(volume.getName(), is("oauth-my-cm-62fdd747"));
+    }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -286,7 +286,7 @@ public class Labels {
         while (i > 0) {
             char lastChar = instance.charAt(i - 1);
 
-            if (lastChar == '.' || lastChar == '-') {
+            if (lastChar == '.' || lastChar == '-' || lastChar == '_') {
                 i--;
             } else {
                 break;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Strimzi usually uses volumes to mount different secrets with passwords or certificates. Quite often we seem to name volumes after the secrets names. However, the volume names follow the DNS label standard as defined in RFC 1123. This means the name must:
* contain at most 63 characters
* contain only lowercase alphanumeric characters or ‘-’
* start with an alphanumeric character
* end with an alphanumeric character

Teh rules for resources such as secrets are much more relaxed. So this does not work in some cases - for example when the user secret mounted is for a user with a `.` in the name.

This PR should fix this by doing the following:
* Check if the desired volume name is valid and if it is, just use it as it is
* If it is not valid
    * Fix all the invalid characters (such as the `.` mentioned above)
    * Create SHA-1 has of the original name
    * Shorten the original name (when needed) and attach the first 8 characters form the has to the end of the volume name

That should give us a reasonable certainty that we will not have duplicate volumes names when using volumes with similar names (such as for `my-user` and `my.user`).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally