### PR TITLE
[MO] - [clients] -> removing future + solving issue with vertx

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/AbstractKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/AbstractKafkaClient.java
@@ -9,6 +9,8 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.security.InvalidParameterException;
 
@@ -16,6 +18,8 @@ import static io.strimzi.api.kafka.model.KafkaResources.externalBootstrapService
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public abstract class AbstractKafkaClient {
+
+    private static final Logger LOGGER = LogManager.getLogger(AbstractKafkaClient.class);
 
     protected String topicName;
     protected String namespaceName;
@@ -113,8 +117,12 @@ public abstract class AbstractKafkaClient {
         this.messageCount = messageCount;
     }
 
-    protected boolean verifyProducedAndConsumedMessages(int producedMessages, int consumedMessages) {
-        return producedMessages == consumedMessages;
+    public void verifyProducedAndConsumedMessages(int producedMessages, int consumedMessages) {
+        if (producedMessages != consumedMessages) {
+            LOGGER.info("Producer produced {} messages", producedMessages);
+            LOGGER.info("Consumer consumed {} messages", consumedMessages);
+            throw new RuntimeException("Producer or consumer does not produce or consume required message");
+        }
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/KafkaClientOperations.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/KafkaClientOperations.java
@@ -11,40 +11,39 @@ package io.strimzi.systemtest.kafkaclients;
  * @see io.strimzi.systemtest.kafkaclients.externalClients.OauthExternalKafkaClient
  * @see io.strimzi.systemtest.kafkaclients.externalClients.TracingExternalKafkaClient
  * @see io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient
- * @param <T> returned type of each operation
  */
-public interface KafkaClientOperations<T> {
+public interface KafkaClientOperations {
 
     /**
      * Sending plain messages with the selected client
      * @param timeoutMs timeout in milliseconds
-     * @return <T> type
+     * @return count of messages
      * @throws Exception exception
      */
-    T sendMessagesPlain(long timeoutMs) throws Exception;
+    int sendMessagesPlain(long timeoutMs) throws Exception;
 
     /**
      * Sending encrypted messages using Tls technology with the selected client
      * @param timeoutMs timeout in milliseconds
-     * @return <T> type
+     * @return count of messages
      * @throws Exception exception
      */
-    T sendMessagesTls(long timeoutMs) throws Exception;
+    int sendMessagesTls(long timeoutMs) throws Exception;
 
     /**
      * Receiving plain messages with the selected client
      * @param timeoutMs timeout in milliseconds
-     * @return <T> type
+     * @return count of messages
      * @throws Exception exception
      */
 
-    T receiveMessagesPlain(long timeoutMs) throws Exception;
+    int receiveMessagesPlain(long timeoutMs) throws Exception;
 
     /**
      * Sending encrypted messages using Tls technology with the selected client
      * @param timeoutMs timeout in milliseconds
-     * @return <T> type
+     * @return count of messages
      * @throws Exception exception
      */
-    T receiveMessagesTls(long timeoutMs) throws Exception;
+    int receiveMessagesTls(long timeoutMs) throws Exception;
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/BasicExternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/BasicExternalKafkaClient.java
@@ -9,7 +9,6 @@ import io.strimzi.systemtest.kafkaclients.AbstractKafkaClient;
 import io.strimzi.systemtest.kafkaclients.KafkaClientOperations;
 import io.strimzi.systemtest.kafkaclients.KafkaClientProperties;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
-import io.strimzi.test.TestUtils;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -19,6 +18,8 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.IntPredicate;
 
 /**
@@ -74,11 +75,8 @@ public class BasicExternalKafkaClient extends AbstractKafkaClient implements Kaf
 
             plainProducer.getVertx().deployVerticle(plainProducer);
 
-            TestUtils.waitFor("Waiting until producer async call is done {}", Constants.GLOBAL_POLL_INTERVAL, timeoutMs,
-                () -> plainProducer.getResultPromise().isDone());
-
-            return plainProducer.getResultPromise().get();
-        } catch (InterruptedException | ExecutionException e) {
+            return plainProducer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
             throw new RuntimeException(e);
         }
@@ -120,17 +118,14 @@ public class BasicExternalKafkaClient extends AbstractKafkaClient implements Kaf
 
             tlsProducer.getVertx().deployVerticle(tlsProducer);
 
-            TestUtils.waitFor("Waiting until producer async call is done {}", Constants.GLOBAL_POLL_INTERVAL, timeoutMs,
-                () -> tlsProducer.getResultPromise().isDone());
-
-            return tlsProducer.getResultPromise().get();
-        } catch (InterruptedException | ExecutionException e) {
+            return tlsProducer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
             throw new RuntimeException(e);
         }
     }
 
-    public int receiveMessagesPlain() throws InterruptedException, ExecutionException {
+    public int receiveMessagesPlain() {
         return receiveMessagesPlain(Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 
@@ -138,7 +133,7 @@ public class BasicExternalKafkaClient extends AbstractKafkaClient implements Kaf
      * Receive messages to external entrypoint of the cluster with PLAINTEXT security protocol setting
      * @return
      */
-    public int receiveMessagesPlain(long timeoutMs) throws InterruptedException, ExecutionException {
+    public int receiveMessagesPlain(long timeoutMs) {
 
         String clientName = "receiver-plain-" + clusterName;
         CompletableFuture<Integer> resultPromise = new CompletableFuture<>();
@@ -161,10 +156,10 @@ public class BasicExternalKafkaClient extends AbstractKafkaClient implements Kaf
 
             plainConsumer.getVertx().deployVerticle(plainConsumer);
 
-            TestUtils.waitFor("Waiting until consumer async call is done {}", Constants.GLOBAL_POLL_INTERVAL, timeoutMs,
-                () -> plainConsumer.getResultPromise().isDone());
-
-            return plainConsumer.getResultPromise().get();
+            return plainConsumer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
@@ -206,11 +201,8 @@ public class BasicExternalKafkaClient extends AbstractKafkaClient implements Kaf
 
             tlsConsumer.getVertx().deployVerticle(tlsConsumer);
 
-            TestUtils.waitFor("Waiting until consumer async call is done {}", Constants.GLOBAL_POLL_INTERVAL, timeoutMs,
-                () -> tlsConsumer.getResultPromise().isDone());
-
-            return tlsConsumer.getResultPromise().get();
-        } catch (InterruptedException | ExecutionException e) {
+            return tlsConsumer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
             throw new RuntimeException(e);
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/BasicExternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/BasicExternalKafkaClient.java
@@ -45,7 +45,7 @@ public class BasicExternalKafkaClient extends AbstractKafkaClient implements Kaf
         super(builder);
     }
 
-    public Integer sendMessagesPlain() {
+    public int sendMessagesPlain() {
         return sendMessagesPlain(Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/BasicExternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/BasicExternalKafkaClient.java
@@ -9,7 +9,7 @@ import io.strimzi.systemtest.kafkaclients.AbstractKafkaClient;
 import io.strimzi.systemtest.kafkaclients.KafkaClientOperations;
 import io.strimzi.systemtest.kafkaclients.KafkaClientProperties;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
-import io.vertx.core.Vertx;
+import io.strimzi.test.TestUtils;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -18,17 +18,15 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ExecutionException;
 import java.util.function.IntPredicate;
 
 /**
  * The BasicExternalKafkaClient for sending and receiving messages with basic properties. The client is using an external listeners.
  */
-public class BasicExternalKafkaClient extends AbstractKafkaClient implements AutoCloseable, KafkaClientOperations<Future<Integer>> {
+public class BasicExternalKafkaClient extends AbstractKafkaClient implements KafkaClientOperations {
 
     private static final Logger LOGGER = LogManager.getLogger(BasicExternalKafkaClient.class);
-    private Vertx vertx = Vertx.vertx();
 
     public static class Builder extends AbstractKafkaClient.Builder<Builder> {
 
@@ -47,7 +45,7 @@ public class BasicExternalKafkaClient extends AbstractKafkaClient implements Aut
         super(builder);
     }
 
-    public Future<Integer> sendMessagesPlain() {
+    public Integer sendMessagesPlain() {
         return sendMessagesPlain(Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 
@@ -55,36 +53,38 @@ public class BasicExternalKafkaClient extends AbstractKafkaClient implements Aut
      * Send messages to external entrypoint of the cluster with PLAINTEXT security protocol setting
      * @return future with sent message count
      */
-    @Override
-    public Future<Integer> sendMessagesPlain(long timeoutMs) {
+    public int sendMessagesPlain(long timeoutMs) {
 
         String clientName = "sender-plain-" + this.clusterName;
         CompletableFuture<Integer> resultPromise = new CompletableFuture<>();
-
         IntPredicate msgCntPredicate = x -> x == messageCount;
 
-        vertx.deployVerticle(new Producer(
-            new KafkaClientProperties.KafkaClientPropertiesBuilder()
-                .withNamespaceName(namespaceName)
-                .withClusterName(clusterName)
-                .withBootstrapServerConfig(getExternalBootstrapConnect(namespaceName, clusterName))
-                .withKeySerializerConfig(StringSerializer.class)
-                .withValueSerializerConfig(StringSerializer.class)
-                .withClientIdConfig(kafkaUsername + "-producer")
-                .withSecurityProtocol(SecurityProtocol.PLAINTEXT)
-                .withSharedProperties()
-                .build(), resultPromise, msgCntPredicate, this.topicName, clientName));
+        KafkaClientProperties properties = new KafkaClientProperties.KafkaClientPropertiesBuilder()
+            .withNamespaceName(namespaceName)
+            .withClusterName(clusterName)
+            .withBootstrapServerConfig(getExternalBootstrapConnect(namespaceName, clusterName))
+            .withKeySerializerConfig(StringSerializer.class)
+            .withValueSerializerConfig(StringSerializer.class)
+            .withClientIdConfig(kafkaUsername + "-producer")
+            .withSecurityProtocol(SecurityProtocol.PLAINTEXT)
+            .withSharedProperties()
+            .build();
 
-        try {
-            resultPromise.get(timeoutMs, TimeUnit.MILLISECONDS);
-        } catch (Exception e) {
-            resultPromise.completeExceptionally(e);
+        try (Producer plainProducer = new Producer(properties, resultPromise, msgCntPredicate, this.topicName, clientName)) {
+
+            plainProducer.getVertx().deployVerticle(plainProducer);
+
+            TestUtils.waitFor("Waiting until producer async call is done {}", Constants.GLOBAL_POLL_INTERVAL, timeoutMs,
+                () -> plainProducer.getResultPromise().isDone());
+
+            return plainProducer.getResultPromise().get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-        vertx.close();
-        return resultPromise;
     }
 
-    public Future<Integer> sendMessagesTls() {
+    public int sendMessagesTls() {
         return sendMessagesTls(Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 
@@ -92,45 +92,45 @@ public class BasicExternalKafkaClient extends AbstractKafkaClient implements Aut
      * Send messages to external entrypoint of the cluster with SSL security protocol setting
      * @return future with sent message count
      */
-    @Override
-    public Future<Integer> sendMessagesTls(long timeoutMs) {
+    public int sendMessagesTls(long timeoutMs) {
 
         String clientName = "sender-ssl" + this.clusterName;
-        vertx = Vertx.vertx();
         CompletableFuture<Integer> resultPromise = new CompletableFuture<>();
-
         IntPredicate msgCntPredicate = x -> x == messageCount;
 
         String caCertName = this.caCertName == null ?
                 KafkaResource.getKafkaExternalListenerCaCertName(this.namespaceName, clusterName) : this.caCertName;
         LOGGER.info("Going to use the following CA certificate: {}", caCertName);
 
-        vertx.deployVerticle(new Producer(
-            new KafkaClientProperties.KafkaClientPropertiesBuilder()
-                .withNamespaceName(namespaceName)
-                .withClusterName(clusterName)
-                .withBootstrapServerConfig(getExternalBootstrapConnect(namespaceName, clusterName))
-                .withKeySerializerConfig(StringSerializer.class)
-                .withValueSerializerConfig(StringSerializer.class)
-                .withClientIdConfig(kafkaUsername + "-producer")
-                .withCaSecretName(caCertName)
-                .withKafkaUsername(kafkaUsername)
-                .withSecurityProtocol(securityProtocol)
-                .withSaslMechanism("")
-                .withSharedProperties()
-                .build(),
-            resultPromise, msgCntPredicate, this.topicName, clientName));
+        KafkaClientProperties properties = new KafkaClientProperties.KafkaClientPropertiesBuilder()
+            .withNamespaceName(namespaceName)
+            .withClusterName(clusterName)
+            .withBootstrapServerConfig(getExternalBootstrapConnect(namespaceName, clusterName))
+            .withKeySerializerConfig(StringSerializer.class)
+            .withValueSerializerConfig(StringSerializer.class)
+            .withClientIdConfig(kafkaUsername + "-producer")
+            .withCaSecretName(caCertName)
+            .withKafkaUsername(kafkaUsername)
+            .withSecurityProtocol(securityProtocol)
+            .withSaslMechanism("")
+            .withSharedProperties()
+            .build();
 
-        try {
-            resultPromise.get(timeoutMs, TimeUnit.MILLISECONDS);
-        } catch (Exception e) {
-            resultPromise.completeExceptionally(e);
+        try (Producer tlsProducer = new Producer(properties, resultPromise, msgCntPredicate, this.topicName, clientName)) {
+
+            tlsProducer.getVertx().deployVerticle(tlsProducer);
+
+            TestUtils.waitFor("Waiting until producer async call is done {}", Constants.GLOBAL_POLL_INTERVAL, timeoutMs,
+                () -> tlsProducer.getResultPromise().isDone());
+
+            return tlsProducer.getResultPromise().get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-        vertx.close();
-        return resultPromise;
     }
 
-    public Future<Integer> receiveMessagesPlain() {
+    public int receiveMessagesPlain() throws InterruptedException, ExecutionException {
         return receiveMessagesPlain(Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 
@@ -138,39 +138,37 @@ public class BasicExternalKafkaClient extends AbstractKafkaClient implements Aut
      * Receive messages to external entrypoint of the cluster with PLAINTEXT security protocol setting
      * @return
      */
-    @Override
-    public Future<Integer> receiveMessagesPlain(long timeoutMs) {
+    public int receiveMessagesPlain(long timeoutMs) throws InterruptedException, ExecutionException {
 
         String clientName = "receiver-plain-" + clusterName;
-        vertx = Vertx.vertx();
         CompletableFuture<Integer> resultPromise = new CompletableFuture<>();
-
         IntPredicate msgCntPredicate = x -> x == messageCount;
 
-        vertx.deployVerticle(new Consumer(
-            new KafkaClientProperties.KafkaClientPropertiesBuilder()
-                .withNamespaceName(namespaceName)
-                .withClusterName(clusterName)
-                .withBootstrapServerConfig(getExternalBootstrapConnect(namespaceName, clusterName))
-                .withKeyDeserializerConfig(StringDeserializer.class)
-                .withValueDeserializerConfig(StringDeserializer.class)
-                .withClientIdConfig(kafkaUsername + "-consumer")
-                .withAutoOffsetResetConfig(OffsetResetStrategy.EARLIEST)
-                .withGroupIdConfig(consumerGroup)
-                .withSecurityProtocol(SecurityProtocol.PLAINTEXT)
-                .withSharedProperties()
-                .build(), resultPromise, msgCntPredicate, this.topicName, clientName));
+        KafkaClientProperties properties = new KafkaClientProperties.KafkaClientPropertiesBuilder()
+            .withNamespaceName(namespaceName)
+            .withClusterName(clusterName)
+            .withBootstrapServerConfig(getExternalBootstrapConnect(namespaceName, clusterName))
+            .withKeyDeserializerConfig(StringDeserializer.class)
+            .withValueDeserializerConfig(StringDeserializer.class)
+            .withClientIdConfig(kafkaUsername + "-consumer")
+            .withAutoOffsetResetConfig(OffsetResetStrategy.EARLIEST)
+            .withGroupIdConfig(consumerGroup)
+            .withSecurityProtocol(SecurityProtocol.PLAINTEXT)
+            .withSharedProperties()
+            .build();
 
-        try {
-            resultPromise.get(timeoutMs, TimeUnit.MILLISECONDS);
-        } catch (Exception e) {
-            resultPromise.completeExceptionally(e);
+        try (Consumer plainConsumer = new Consumer(properties, resultPromise, msgCntPredicate, this.topicName, clientName)) {
+
+            plainConsumer.getVertx().deployVerticle(plainConsumer);
+
+            TestUtils.waitFor("Waiting until consumer async call is done {}", Constants.GLOBAL_POLL_INTERVAL, timeoutMs,
+                () -> plainConsumer.getResultPromise().isDone());
+
+            return plainConsumer.getResultPromise().get();
         }
-        vertx.close();
-        return resultPromise;
     }
 
-    public Future<Integer> receiveMessagesTls() {
+    public int receiveMessagesTls() {
         return receiveMessagesTls(Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 
@@ -178,47 +176,44 @@ public class BasicExternalKafkaClient extends AbstractKafkaClient implements Aut
      * Receive messages to external entrypoint of the cluster with SSL security protocol setting
      * @return future with received message count
      */
-    public Future<Integer> receiveMessagesTls(long timeoutMs) {
+    public int receiveMessagesTls(long timeoutMs) {
 
         String clientName = "receiver-ssl-" + clusterName;
-        vertx = Vertx.vertx();
         CompletableFuture<Integer> resultPromise = new CompletableFuture<>();
-
         IntPredicate msgCntPredicate = x -> x == messageCount;
 
         String caCertName = this.caCertName == null ?
                 KafkaResource.getKafkaExternalListenerCaCertName(this.namespaceName, this.clusterName) : this.caCertName;
         LOGGER.info("Going to use the following CA certificate: {}", caCertName);
 
-        vertx.deployVerticle(new Consumer(
-            new KafkaClientProperties.KafkaClientPropertiesBuilder()
-                .withNamespaceName(namespaceName)
-                .withClusterName(clusterName)
-                .withBootstrapServerConfig(getExternalBootstrapConnect(namespaceName, clusterName))
-                .withKeyDeserializerConfig(StringDeserializer.class)
-                .withValueDeserializerConfig(StringDeserializer.class)
-                .withClientIdConfig(kafkaUsername + "-consumer")
-                .withAutoOffsetResetConfig(OffsetResetStrategy.EARLIEST)
-                .withGroupIdConfig(consumerGroup)
-                .withSecurityProtocol(securityProtocol)
-                .withCaSecretName(caCertName)
-                .withKafkaUsername(kafkaUsername)
-                .withSaslMechanism("")
-                .withSharedProperties()
-                .build(), resultPromise, msgCntPredicate, this.topicName, clientName));
+        KafkaClientProperties properties = new KafkaClientProperties.KafkaClientPropertiesBuilder()
+            .withNamespaceName(namespaceName)
+            .withClusterName(clusterName)
+            .withBootstrapServerConfig(getExternalBootstrapConnect(namespaceName, clusterName))
+            .withKeyDeserializerConfig(StringDeserializer.class)
+            .withValueDeserializerConfig(StringDeserializer.class)
+            .withClientIdConfig(kafkaUsername + "-consumer")
+            .withAutoOffsetResetConfig(OffsetResetStrategy.EARLIEST)
+            .withGroupIdConfig(consumerGroup)
+            .withSecurityProtocol(securityProtocol)
+            .withCaSecretName(caCertName)
+            .withKafkaUsername(kafkaUsername)
+            .withSaslMechanism("")
+            .withSharedProperties()
+            .build();
 
-        try {
-            resultPromise.get(timeoutMs, TimeUnit.MILLISECONDS);
-        } catch (Exception e) {
-            resultPromise.completeExceptionally(e);
+        try (Consumer tlsConsumer = new Consumer(properties, resultPromise, msgCntPredicate, this.topicName, clientName)) {
+
+            tlsConsumer.getVertx().deployVerticle(tlsConsumer);
+
+            TestUtils.waitFor("Waiting until consumer async call is done {}", Constants.GLOBAL_POLL_INTERVAL, timeoutMs,
+                () -> tlsConsumer.getResultPromise().isDone());
+
+            return tlsConsumer.getResultPromise().get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-        vertx.close();
-        return resultPromise;
-    }
-
-    @Override
-    public void close() {
-        vertx.close();
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/ClientHandlerBase.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/ClientHandlerBase.java
@@ -29,4 +29,7 @@ public abstract class ClientHandlerBase<T> extends AbstractVerticle {
 
     protected abstract void handleClient();
 
+    public CompletableFuture<T> getResultPromise() {
+        return resultPromise;
+    }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/Consumer.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/Consumer.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.kafkaclients.externalClients;
 
 import io.strimzi.systemtest.kafkaclients.KafkaClientProperties;
+import io.vertx.core.Vertx;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -13,8 +14,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntPredicate;
 
-
-public class Consumer extends ClientHandlerBase<Integer> {
+// TODO: autocloseable to close vertx always...
+public class Consumer extends ClientHandlerBase<Integer> implements AutoCloseable {
     private static final Logger LOGGER = LogManager.getLogger(Consumer.class);
     private KafkaClientProperties properties;
     private final AtomicInteger numReceived = new AtomicInteger(0);
@@ -26,6 +27,7 @@ public class Consumer extends ClientHandlerBase<Integer> {
         this.properties = properties;
         this.topic = topic;
         this.clientName = clientName;
+        this.vertx = Vertx.vertx();
     }
 
     @Override
@@ -60,6 +62,13 @@ public class Consumer extends ClientHandlerBase<Integer> {
                 resultPromise.completeExceptionally(ar.cause());
             }
         });
+    }
 
+    @Override
+    public void close() {
+        LOGGER.info("Closing Vert.x instance for the client {}", this.getClass().getName());
+        if (vertx != null) {
+            vertx.close();
+        }
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/Consumer.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/Consumer.java
@@ -14,7 +14,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntPredicate;
 
-// TODO: autocloseable to close vertx always...
 public class Consumer extends ClientHandlerBase<Integer> implements AutoCloseable {
     private static final Logger LOGGER = LogManager.getLogger(Consumer.class);
     private KafkaClientProperties properties;

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/OauthExternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/OauthExternalKafkaClient.java
@@ -9,7 +9,6 @@ import io.strimzi.systemtest.kafkaclients.AbstractKafkaClient;
 import io.strimzi.systemtest.kafkaclients.KafkaClientOperations;
 import io.strimzi.systemtest.kafkaclients.KafkaClientProperties;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
-import io.strimzi.test.TestUtils;
 import io.vertx.core.Vertx;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -21,6 +20,8 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.IntPredicate;
 
 /**
@@ -118,11 +119,8 @@ public class OauthExternalKafkaClient extends AbstractKafkaClient implements Kaf
 
             plainProducer.getVertx().deployVerticle(plainProducer);
 
-            TestUtils.waitFor("Waiting until producer async call is done {}", Constants.GLOBAL_POLL_INTERVAL, timeoutMs,
-                () -> plainProducer.getResultPromise().isDone());
-
-            return plainProducer.getResultPromise().get();
-        } catch (InterruptedException | ExecutionException e) {
+            return plainProducer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
             throw new RuntimeException(e);
         }
@@ -158,15 +156,12 @@ public class OauthExternalKafkaClient extends AbstractKafkaClient implements Kaf
             .withSaslJassConfigAndTls(clientId, clientSecretName, oauthTokenEndpointUri)
             .build();
 
-        try (Producer plainProducer = new Producer(clientProperties, resultPromise, msgCntPredicate, topicName, clientName)) {
+        try (Producer tlsProducer = new Producer(clientProperties, resultPromise, msgCntPredicate, topicName, clientName)) {
 
-            plainProducer.getVertx().deployVerticle(plainProducer);
+            tlsProducer.getVertx().deployVerticle(tlsProducer);
 
-            TestUtils.waitFor("Waiting until producer async call is done {}", Constants.GLOBAL_POLL_INTERVAL, timeoutMs,
-                () -> plainProducer.getResultPromise().isDone());
-
-            return plainProducer.getResultPromise().get();
-        } catch (InterruptedException | ExecutionException e) {
+            return tlsProducer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
             throw new RuntimeException(e);
         }
@@ -202,11 +197,8 @@ public class OauthExternalKafkaClient extends AbstractKafkaClient implements Kaf
 
             plainConsumer.getVertx().deployVerticle(plainConsumer);
 
-            TestUtils.waitFor("Waiting until producer async call is done {}", Constants.GLOBAL_POLL_INTERVAL, timeoutMs,
-                () -> plainConsumer.getResultPromise().isDone());
-
-            return plainConsumer.getResultPromise().get();
-        } catch (InterruptedException | ExecutionException e) {
+            return plainConsumer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
             throw new RuntimeException(e);
         }
@@ -249,11 +241,8 @@ public class OauthExternalKafkaClient extends AbstractKafkaClient implements Kaf
 
             tlsConsumer.getVertx().deployVerticle(tlsConsumer);
 
-            TestUtils.waitFor("Waiting until producer async call is done {}", Constants.GLOBAL_POLL_INTERVAL, timeoutMs,
-                () -> tlsConsumer.getResultPromise().isDone());
-
-            return tlsConsumer.getResultPromise().get();
-        } catch (InterruptedException | ExecutionException e) {
+            return tlsConsumer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
             throw new RuntimeException(e);
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/OauthExternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/OauthExternalKafkaClient.java
@@ -9,6 +9,7 @@ import io.strimzi.systemtest.kafkaclients.AbstractKafkaClient;
 import io.strimzi.systemtest.kafkaclients.KafkaClientOperations;
 import io.strimzi.systemtest.kafkaclients.KafkaClientProperties;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.test.TestUtils;
 import io.vertx.core.Vertx;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -19,15 +20,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ExecutionException;
 import java.util.function.IntPredicate;
 
 /**
  * The OauthExternalKafkaClient for sending and receiving messages using access token provided by authorization server.
  * The client is using an external listeners.
  */
-public class OauthExternalKafkaClient extends AbstractKafkaClient implements KafkaClientOperations<Future<Integer>> {
+public class OauthExternalKafkaClient extends AbstractKafkaClient implements KafkaClientOperations {
 
     private static final Logger LOGGER = LogManager.getLogger(OauthExternalKafkaClient.class);
     private Vertx vertx = Vertx.vertx();
@@ -90,19 +90,17 @@ public class OauthExternalKafkaClient extends AbstractKafkaClient implements Kaf
         introspectionEndpointUri = builder.introspectionEndpointUri;
     }
 
-    public Future<Integer> sendMessagesPlain() {
+    public int sendMessagesPlain() {
         return sendMessagesPlain(Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 
     @Override
-    public Future<Integer> sendMessagesPlain(long timeoutMs) {
+    public int sendMessagesPlain(long timeoutMs) {
         String clientName = "sender-plain-" + clusterName;
-        vertx = Vertx.vertx();
         CompletableFuture<Integer> resultPromise = new CompletableFuture<>();
-
         IntPredicate msgCntPredicate = x -> x == messageCount;
 
-        KafkaClientProperties kafkaClientProperties = new KafkaClientProperties.KafkaClientPropertiesBuilder()
+        clientProperties = new KafkaClientProperties.KafkaClientPropertiesBuilder()
             .withNamespaceName(namespaceName)
             .withClusterName(clusterName)
             .withSecurityProtocol(SecurityProtocol.SASL_PLAINTEXT)
@@ -116,35 +114,35 @@ public class OauthExternalKafkaClient extends AbstractKafkaClient implements Kaf
             .withSaslJassConfig(this.clientId, this.clientSecretName, this.oauthTokenEndpointUri)
             .build();
 
-        vertx.deployVerticle(new Producer(kafkaClientProperties, resultPromise, msgCntPredicate, topicName, clientName));
+        try (Producer plainProducer = new Producer(clientProperties, resultPromise, msgCntPredicate, topicName, clientName)) {
 
-        try {
-            resultPromise.get(timeoutMs, TimeUnit.MILLISECONDS);
-        } catch (Exception e) {
-            resultPromise.completeExceptionally(e);
+            plainProducer.getVertx().deployVerticle(plainProducer);
+
+            TestUtils.waitFor("Waiting until producer async call is done {}", Constants.GLOBAL_POLL_INTERVAL, timeoutMs,
+                () -> plainProducer.getResultPromise().isDone());
+
+            return plainProducer.getResultPromise().get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-        vertx.close();
-        return resultPromise;
     }
 
-    public Future<Integer> sendMessagesTls() {
+    public int sendMessagesTls() {
         return sendMessagesTls(Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 
     @Override
-    public Future<Integer> sendMessagesTls(long timeoutMs) {
+    public int sendMessagesTls(long timeoutMs) {
         String clientName = "sender-ssl" + clusterName;
-        vertx = Vertx.vertx();
         CompletableFuture<Integer> resultPromise = new CompletableFuture<>();
-
         IntPredicate msgCntPredicate = x -> x == messageCount;
 
         String caCertName = this.caCertName == null ?
                 KafkaResource.getKafkaExternalListenerCaCertName(namespaceName, clusterName) : this.caCertName;
         LOGGER.info("Going to use the following CA certificate: {}", caCertName);
 
-
-        KafkaClientProperties kafkaClientProperties = new KafkaClientProperties.KafkaClientPropertiesBuilder()
+        clientProperties = new KafkaClientProperties.KafkaClientPropertiesBuilder()
             .withNamespaceName(namespaceName)
             .withClusterName(clusterName)
             .withBootstrapServerConfig(getExternalBootstrapConnect(namespaceName, clusterName))
@@ -160,30 +158,31 @@ public class OauthExternalKafkaClient extends AbstractKafkaClient implements Kaf
             .withSaslJassConfigAndTls(clientId, clientSecretName, oauthTokenEndpointUri)
             .build();
 
-        vertx.deployVerticle(new Producer(kafkaClientProperties, resultPromise, msgCntPredicate, topicName, clientName));
+        try (Producer plainProducer = new Producer(clientProperties, resultPromise, msgCntPredicate, topicName, clientName)) {
 
-        try {
-            resultPromise.get(timeoutMs, TimeUnit.MILLISECONDS);
-        } catch (Exception e) {
-            resultPromise.completeExceptionally(e);
+            plainProducer.getVertx().deployVerticle(plainProducer);
+
+            TestUtils.waitFor("Waiting until producer async call is done {}", Constants.GLOBAL_POLL_INTERVAL, timeoutMs,
+                () -> plainProducer.getResultPromise().isDone());
+
+            return plainProducer.getResultPromise().get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-        vertx.close();
-        return resultPromise;
     }
 
-    public Future<Integer> receiveMessagesPlain() {
+    public int receiveMessagesPlain() {
         return receiveMessagesPlain(Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 
     @Override
-    public Future<Integer> receiveMessagesPlain(long timeoutMs) {
+    public int receiveMessagesPlain(long timeoutMs) {
         String clientName = "receiver-plain-" + clusterName;
-        vertx = Vertx.vertx();
         CompletableFuture<Integer> resultPromise = new CompletableFuture<>();
-
         IntPredicate msgCntPredicate = x -> x == messageCount;
 
-        KafkaClientProperties kafkaClientProperties = new KafkaClientProperties.KafkaClientPropertiesBuilder()
+        clientProperties = new KafkaClientProperties.KafkaClientPropertiesBuilder()
             .withNamespaceName(namespaceName)
             .withClusterName(clusterName)
             .withGroupIdConfig(consumerGroup)
@@ -199,35 +198,36 @@ public class OauthExternalKafkaClient extends AbstractKafkaClient implements Kaf
             .withSaslJassConfig(this.clientId, this.clientSecretName, this.oauthTokenEndpointUri)
             .build();
 
-        vertx.deployVerticle(new Consumer(kafkaClientProperties, resultPromise, msgCntPredicate, topicName, clientName));
+        try (Consumer plainConsumer = new Consumer(clientProperties, resultPromise, msgCntPredicate, topicName, clientName)) {
 
-        try {
-            resultPromise.get(timeoutMs, TimeUnit.MILLISECONDS);
-        } catch (Exception e) {
-            resultPromise.completeExceptionally(e);
+            plainConsumer.getVertx().deployVerticle(plainConsumer);
+
+            TestUtils.waitFor("Waiting until producer async call is done {}", Constants.GLOBAL_POLL_INTERVAL, timeoutMs,
+                () -> plainConsumer.getResultPromise().isDone());
+
+            return plainConsumer.getResultPromise().get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-        vertx.close();
-        return resultPromise;
     }
 
-    public Future<Integer> receiveMessagesTls() {
+    public int receiveMessagesTls() {
         return sendMessagesTls(Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 
     @Override
-    public Future<Integer> receiveMessagesTls(long timeoutMs) {
+    public int receiveMessagesTls(long timeoutMs) {
 
         String clientName = "receiver-ssl-" + clusterName;
-        vertx = Vertx.vertx();
         CompletableFuture<Integer> resultPromise = new CompletableFuture<>();
-
         IntPredicate msgCntPredicate = x -> x == messageCount;
 
         String caCertName = this.caCertName == null ?
                 KafkaResource.getKafkaExternalListenerCaCertName(namespaceName, clusterName) : this.caCertName;
         LOGGER.info("Going to use the following CA certificate: {}", caCertName);
 
-        KafkaClientProperties kafkaClientProperties = new KafkaClientProperties.KafkaClientPropertiesBuilder()
+        clientProperties = new KafkaClientProperties.KafkaClientPropertiesBuilder()
             .withNamespaceName(namespaceName)
             .withClusterName(clusterName)
             .withCaSecretName(caCertName)
@@ -245,15 +245,18 @@ public class OauthExternalKafkaClient extends AbstractKafkaClient implements Kaf
             .withSaslJassConfigAndTls(this.clientId, this.clientSecretName, this.oauthTokenEndpointUri)
             .build();
 
-        vertx.deployVerticle(new Consumer(kafkaClientProperties, resultPromise, msgCntPredicate, topicName, clientName));
+        try (Consumer tlsConsumer = new Consumer(clientProperties, resultPromise, msgCntPredicate, topicName, clientName)) {
 
-        try {
-            resultPromise.get(timeoutMs, TimeUnit.MILLISECONDS);
-        } catch (Exception e) {
-            resultPromise.completeExceptionally(e);
+            tlsConsumer.getVertx().deployVerticle(tlsConsumer);
+
+            TestUtils.waitFor("Waiting until producer async call is done {}", Constants.GLOBAL_POLL_INTERVAL, timeoutMs,
+                () -> tlsConsumer.getResultPromise().isDone());
+
+            return tlsConsumer.getResultPromise().get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-        vertx.close();
-        return resultPromise;
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/OauthExternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/OauthExternalKafkaClient.java
@@ -9,7 +9,6 @@ import io.strimzi.systemtest.kafkaclients.AbstractKafkaClient;
 import io.strimzi.systemtest.kafkaclients.KafkaClientOperations;
 import io.strimzi.systemtest.kafkaclients.KafkaClientProperties;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
-import io.vertx.core.Vertx;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/OauthExternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/OauthExternalKafkaClient.java
@@ -31,7 +31,6 @@ import java.util.function.IntPredicate;
 public class OauthExternalKafkaClient extends AbstractKafkaClient implements KafkaClientOperations {
 
     private static final Logger LOGGER = LogManager.getLogger(OauthExternalKafkaClient.class);
-    private Vertx vertx = Vertx.vertx();
 
     private String clientId;
     private String clientSecretName;

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/Producer.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/Producer.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.kafkaclients.externalClients;
 
 import io.strimzi.systemtest.kafkaclients.KafkaClientProperties;
+import io.vertx.core.Vertx;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import io.vertx.kafka.client.producer.RecordMetadata;
@@ -15,7 +16,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntPredicate;
 
-public class Producer extends ClientHandlerBase<Integer> {
+public class Producer extends ClientHandlerBase<Integer> implements AutoCloseable {
     private static final Logger LOGGER = LogManager.getLogger(Producer.class);
     private KafkaClientProperties properties;
     private final AtomicInteger numSent = new AtomicInteger(0);
@@ -27,10 +28,13 @@ public class Producer extends ClientHandlerBase<Integer> {
         this.properties = properties;
         this.topic = topic;
         this.clientName = clientName;
+        this.vertx = Vertx.vertx();
     }
 
     @Override
     protected void handleClient() {
+        LOGGER.info("Creating instance of Vert.x for the client {}", this.getClass().getName());
+
         LOGGER.info("Producer is starting with following properties: {}", properties.getProperties().toString());
 
         KafkaProducer<String, String> producer = KafkaProducer.create(vertx, properties.getProperties());
@@ -48,11 +52,19 @@ public class Producer extends ClientHandlerBase<Integer> {
         }
     }
 
+    @Override
+    public void close() {
+        LOGGER.info("Closing Vert.x instance for the client {}", this.getClass().getName());
+        if (vertx != null) {
+            vertx.close();
+        }
+    }
+
     private void sendNext(KafkaProducer<String, String> producer, String topic) {
         if (msgCntPredicate.negate().test(numSent.get())) {
 
             KafkaProducerRecord<String, String> record =
-                    KafkaProducerRecord.create(topic, String.valueOf("\"Sending messages\": \"Hello-world - " + numSent.get() + "\""));
+                    KafkaProducerRecord.create(topic, "\"Sending messages\": \"Hello-world - " + numSent.get() + "\"");
 
             producer.send(record, done -> {
                 if (done.succeeded()) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/TracingExternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/TracingExternalKafkaClient.java
@@ -9,13 +9,11 @@ import io.strimzi.systemtest.kafkaclients.KafkaClientOperations;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.concurrent.Future;
-
 /**
  * The TracingKafkaClient for sending and receiving messages using tracing properties.
  * The client is using an external listeners.
  */
-public class TracingExternalKafkaClient extends AbstractKafkaClient implements KafkaClientOperations<Future<Integer>> {
+public class TracingExternalKafkaClient extends AbstractKafkaClient implements KafkaClientOperations {
 
     private static final Logger LOGGER = LogManager.getLogger(TracingExternalKafkaClient.class);
     private String serviceName;
@@ -50,22 +48,22 @@ public class TracingExternalKafkaClient extends AbstractKafkaClient implements K
 
     // TODO: these methods will be implemented in the following PR for the clients with support of tracing
     @Override
-    public Future<Integer> sendMessagesPlain(long timeoutMs) {
+    public int sendMessagesPlain(long timeoutMs) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Future<Integer> sendMessagesTls(long timeoutMs) {
+    public int sendMessagesTls(long timeoutMs) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Future<Integer> receiveMessagesPlain(long timeoutMs) {
+    public int receiveMessagesPlain(long timeoutMs) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Future<Integer> receiveMessagesTls(long timeoutMs) {
+    public int receiveMessagesTls(long timeoutMs) {
         throw new UnsupportedOperationException();
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/InternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/InternalKafkaClient.java
@@ -24,7 +24,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * The InternalKafkaClient for sending and receiving messages using basic properties.
  * The client is using an internal listeners and communicate from the pod.
  */
-public class InternalKafkaClient extends AbstractKafkaClient implements KafkaClientOperations<Integer> {
+public class InternalKafkaClient extends AbstractKafkaClient implements KafkaClientOperations {
 
     private static final Logger LOGGER = LogManager.getLogger(InternalKafkaClient.class);
 
@@ -55,7 +55,7 @@ public class InternalKafkaClient extends AbstractKafkaClient implements KafkaCli
         podName = builder.podName;
     }
 
-    public Integer sendMessagesPlain() {
+    public int sendMessagesPlain() {
         return sendMessagesPlain(Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 
@@ -64,7 +64,7 @@ public class InternalKafkaClient extends AbstractKafkaClient implements KafkaCli
      * @return count of send and acknowledged messages
      */
     @Override
-    public Integer sendMessagesPlain(long timeout) {
+    public int sendMessagesPlain(long timeout) {
 
         VerifiableClient producer = new VerifiableClient.VerifiableClientBuilder()
             .withClientType(CLI_KAFKA_VERIFIABLE_PRODUCER)
@@ -93,12 +93,12 @@ public class InternalKafkaClient extends AbstractKafkaClient implements KafkaCli
         return sent;
     }
 
-    public Integer sendMessagesTls() {
+    public int sendMessagesTls() {
         return sendMessagesTls(Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 
     @Override
-    public Integer sendMessagesTls(long timeout) {
+    public int sendMessagesTls(long timeout) {
 
         VerifiableClient producerTls = new VerifiableClient.VerifiableClientBuilder()
             .withClientType(CLI_KAFKA_VERIFIABLE_PRODUCER)
@@ -123,12 +123,12 @@ public class InternalKafkaClient extends AbstractKafkaClient implements KafkaCli
         return sent;
     }
 
-    public Integer receiveMessagesPlain() {
+    public int receiveMessagesPlain() {
         return receiveMessagesPlain(Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 
     @Override
-    public Integer receiveMessagesPlain(long timeout) {
+    public int receiveMessagesPlain(long timeout) {
 
         VerifiableClient consumer = new VerifiableClient.VerifiableClientBuilder()
             .withClientType(CLI_KAFKA_VERIFIABLE_CONSUMER)
@@ -155,7 +155,7 @@ public class InternalKafkaClient extends AbstractKafkaClient implements KafkaCli
         return received;
     }
 
-    public Integer receiveMessagesTls() {
+    public int receiveMessagesTls() {
         return receiveMessagesTls(Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 
@@ -164,7 +164,7 @@ public class InternalKafkaClient extends AbstractKafkaClient implements KafkaCli
        * @return count of received messages
      */
     @Override
-    public Integer receiveMessagesTls(long timeoutMs) {
+    public int receiveMessagesTls(long timeoutMs) {
 
         VerifiableClient consumerTls = new VerifiableClient.VerifiableClientBuilder()
             .withClientType(CLI_KAFKA_VERIFIABLE_CONSUMER)

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -24,7 +24,7 @@ public class ClientUtils {
     // ensuring that object can not be created outside of class
     private ClientUtils() {}
 
-    public static void waitUntilClientReceivedMessagesTls(KafkaClientOperations<Integer> kafkaClient, int exceptedMessages) {
+    public static void waitUntilClientReceivedMessagesTls(KafkaClientOperations kafkaClient, int exceptedMessages) {
         TestUtils.waitFor("Kafka " + kafkaClient.toString() + " client received messages", Constants.GLOBAL_CLIENTS_POLL, Constants.GLOBAL_TIMEOUT,
             () -> {
                 int receivedMessages = 0;

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -60,8 +60,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static io.strimzi.api.kafka.model.KafkaResources.externalBootstrapServiceName;
@@ -104,11 +102,10 @@ class CustomResourceStatusST extends BaseST {
             .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
             .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesPlain();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesPlain();
-
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesPlain(),
+            basicExternalKafkaClient.receiveMessagesPlain()
+        );
 
         assertKafkaStatus(1, "my-cluster-kafka-bootstrap.status-cluster-test.svc");
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -81,8 +81,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Random;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -1160,7 +1158,6 @@ class KafkaST extends BaseST {
                 .editKafka()
                     .editListeners()
                         .withNewKafkaListenerExternalNodePort()
-                            .withTls(false)
                         .endKafkaListenerExternalNodePort()
                     .endListeners()
                     .withConfig(singletonMap("default.replication.factor", 3))
@@ -1176,11 +1173,10 @@ class KafkaST extends BaseST {
             .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
             .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesPlain();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesPlain();
-
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MINUTES), is(MESSAGE_COUNT));
-        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MINUTES), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesPlain(),
+            basicExternalKafkaClient.receiveMessagesPlain()
+        );
 
         // Check that Kafka status has correct addresses in NodePort external listener part
         for (ListenerStatus listenerStatus : KafkaResource.getKafkaStatus(CLUSTER_NAME, NAMESPACE).getListeners()) {
@@ -1250,11 +1246,11 @@ class KafkaST extends BaseST {
             .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
             .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesPlain();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesPlain();
-
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+//        Future<Integer> producer = basicExternalKafkaClient.sendMessagesPlain();
+//        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesPlain();
+//
+//        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+//        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
     }
 
     @Test
@@ -1290,11 +1286,11 @@ class KafkaST extends BaseST {
                 .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
                 .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesTls();
-
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+//        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
+//        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesTls();
+//
+//        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+//        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
     }
 
     @Test
@@ -1324,11 +1320,11 @@ class KafkaST extends BaseST {
                 .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
                 .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesPlain();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesPlain();
-
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+//        Future<Integer> producer = basicExternalKafkaClient.sendMessagesPlain();
+//        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesPlain();
+//
+//        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+//        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
     }
 
     @Test
@@ -1366,11 +1362,10 @@ class KafkaST extends BaseST {
                 .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
                 .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesTls();
-
-        assertThat(producer.get(1, TimeUnit.MINUTES), is(MESSAGE_COUNT));
-        assertThat(consumer.get(1, TimeUnit.MINUTES), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -527,7 +527,6 @@ class KafkaST extends BaseST {
     @Test
     @Tag(INTERNAL_CLIENTS_USED)
     void testSendMessagesPlainAnonymous() {
-        int messagesCount = 200;
         String topicName = TOPIC_NAME + "-" + rng.nextInt(Integer.MAX_VALUE);
 
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
@@ -543,7 +542,7 @@ class KafkaST extends BaseST {
             .withTopicName(topicName)
             .withNamespaceName(NAMESPACE)
             .withClusterName(CLUSTER_NAME)
-            .withMessageCount(messagesCount)
+            .withMessageCount(MESSAGE_COUNT)
             .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
             .build();
 
@@ -621,7 +620,7 @@ class KafkaST extends BaseST {
     @Test
     @Tag(ACCEPTANCE)
     @Tag(INTERNAL_CLIENTS_USED)
-    void testSendMessagesPlainScramSha() throws InterruptedException {
+    void testSendMessagesPlainScramSha() {
         String kafkaUsername = "my-user";
         String topicName = TOPIC_NAME + "-" + rng.nextInt(Integer.MAX_VALUE);
 
@@ -1152,12 +1151,13 @@ class KafkaST extends BaseST {
     @Test
     @Tag(NODEPORT_SUPPORTED)
     @Tag(EXTERNAL_CLIENTS_USED)
-    void testNodePort() throws Exception {
+    void testNodePort() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
             .editSpec()
                 .editKafka()
                     .editListeners()
                         .withNewKafkaListenerExternalNodePort()
+                            .withTls(false)
                         .endKafkaListenerExternalNodePort()
                     .endListeners()
                     .withConfig(singletonMap("default.replication.factor", 3))
@@ -1200,7 +1200,7 @@ class KafkaST extends BaseST {
 
     @Test
     @Tag(NODEPORT_SUPPORTED)
-    void testOverrideNodePortConfiguration() throws Exception {
+    void testOverrideNodePortConfiguration() {
         int brokerNodePort = 32000;
         int brokerId = 0;
 
@@ -1246,18 +1246,17 @@ class KafkaST extends BaseST {
             .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
             .build();
 
-//        Future<Integer> producer = basicExternalKafkaClient.sendMessagesPlain();
-//        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesPlain();
-//
-//        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-//        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesPlain(),
+            basicExternalKafkaClient.receiveMessagesPlain()
+        );
     }
 
     @Test
     @Tag(ACCEPTANCE)
     @Tag(NODEPORT_SUPPORTED)
     @Tag(EXTERNAL_CLIENTS_USED)
-    void testNodePortTls() throws Exception {
+    void testNodePortTls() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
             .editSpec()
                 .editKafka()
@@ -1286,17 +1285,16 @@ class KafkaST extends BaseST {
                 .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
                 .build();
 
-//        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
-//        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesTls();
-//
-//        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-//        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
     }
 
     @Test
     @Tag(LOADBALANCER_SUPPORTED)
     @Tag(EXTERNAL_CLIENTS_USED)
-    void testLoadBalancer() throws Exception {
+    void testLoadBalancer() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3)
             .editSpec()
                 .editKafka()
@@ -1320,18 +1318,17 @@ class KafkaST extends BaseST {
                 .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
                 .build();
 
-//        Future<Integer> producer = basicExternalKafkaClient.sendMessagesPlain();
-//        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesPlain();
-//
-//        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-//        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesPlain(),
+            basicExternalKafkaClient.receiveMessagesPlain()
+        );
     }
 
     @Test
     @Tag(ACCEPTANCE)
     @Tag(LOADBALANCER_SUPPORTED)
     @Tag(EXTERNAL_CLIENTS_USED)
-    void testLoadBalancerTls() throws Exception {
+    void testLoadBalancerTls() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3)
             .editSpec()
                 .editKafka()
@@ -1595,7 +1592,7 @@ class KafkaST extends BaseST {
 
     @Test
     @Tag(INTERNAL_CLIENTS_USED)
-    void testLabelModificationDoesNotBreakCluster() throws Exception {
+    void testLabelModificationDoesNotBreakCluster() {
         Map<String, String> labels = new HashMap<>();
         String[] labelKeys = {"label-name-1", "label-name-2", ""};
         String[] labelValues = {"name-of-the-label-1", "name-of-the-label-2", ""};

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
@@ -33,8 +33,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Random;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
@@ -76,9 +74,7 @@ class HttpBridgeST extends HttpBridgeBaseST {
                 .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
                 .build();
 
-        Future<Integer> consumer = basicKafkaClient.receiveMessagesPlain();
-
-        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(messageCount));
+        assertThat(basicKafkaClient.receiveMessagesPlain(), is(messageCount));
 
         // Checking labels for Kafka Bridge
         verifyLabelsOnPods(CLUSTER_NAME, "my-bridge", null, "KafkaBridge");
@@ -117,9 +113,7 @@ class HttpBridgeST extends HttpBridgeBaseST {
                 .build();
 
         // Send messages to Kafka
-        Future<Integer> producer = basicKafkaClient.sendMessagesPlain();
-
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MINUTES), is(MESSAGE_COUNT));
+        assertThat(basicKafkaClient.sendMessagesPlain(), is(MESSAGE_COUNT));
 
         // Try to consume messages
         JsonArray bridgeResponse = HttpUtils.receiveMessagesHttpRequest(bridgeHost, bridgePort, groupId, name, client);

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
@@ -35,8 +35,6 @@ import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 
 import java.util.Random;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
@@ -80,8 +78,7 @@ class HttpBridgeScramShaST extends HttpBridgeBaseST {
                 .withSecurityProtocol(SecurityProtocol.SASL_SSL)
                 .build();
 
-        Future<Integer> consumer = kafkaClient.receiveMessagesTls();
-        assertThat(consumer.get(2, TimeUnit.MINUTES), is(messageCount));
+        assertThat(kafkaClient.receiveMessagesTls(), is(messageCount));
     }
 
     @Test
@@ -101,8 +98,7 @@ class HttpBridgeScramShaST extends HttpBridgeBaseST {
                 .build();
 
         // Send messages to Kafka
-        Future<Integer> producer = kafkaClient.sendMessagesTls();
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        assertThat(kafkaClient.sendMessagesTls(), is(MESSAGE_COUNT));
 
         String name = "kafka-consumer-simple-receive";
         String groupId = "my-group-" + new Random().nextInt(Integer.MAX_VALUE);

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
@@ -32,8 +32,6 @@ import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 
 import java.util.Random;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.BRIDGE;
@@ -77,8 +75,7 @@ class HttpBridgeTlsST extends HttpBridgeBaseST {
             .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
             .build();
 
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesTls();
-        assertThat(consumer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
+        assertThat(basicExternalKafkaClient.receiveMessagesTls(), is(MESSAGE_COUNT));
     }
 
     @Test
@@ -116,8 +113,7 @@ class HttpBridgeTlsST extends HttpBridgeBaseST {
             .build();
 
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        assertThat(basicExternalKafkaClient.sendMessagesTls(), is(MESSAGE_COUNT));
         // Try to consume messages
         JsonArray bridgeResponse = HttpUtils.receiveMessagesHttpRequest(bridgeHost, bridgePort, groupId, USER_NAME, client);
         if (bridgeResponse.size() == 0) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
@@ -38,8 +38,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
@@ -112,11 +110,10 @@ public class ListenersST extends BaseST {
             .withSecurityProtocol(SecurityProtocol.SSL)
             .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesTls();
-
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
         KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
@@ -196,11 +193,11 @@ public class ListenersST extends BaseST {
 
         LOGGER.info("This is client configuration {}", basicExternalKafkaClient.getClientProperties());
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesTls();
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
 // Deploy client pod with custom certificates and collect messages from internal TLS listener
         KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
 
@@ -267,11 +264,11 @@ public class ListenersST extends BaseST {
             .withSecurityProtocol(SecurityProtocol.SSL)
             .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesTls();
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
 // Deploy client pod with custom certificates and collect messages from internal TLS listener
         KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
 
@@ -342,11 +339,10 @@ public class ListenersST extends BaseST {
             .withSecurityProtocol(SecurityProtocol.SSL)
             .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesTls();
-
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
         KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
@@ -415,11 +411,11 @@ public class ListenersST extends BaseST {
             .withSecurityProtocol(SecurityProtocol.SSL)
             .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesTls();
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
 // Deploy client pod with custom certificates and collect messages from internal TLS listener
         KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
 
@@ -486,11 +482,11 @@ public class ListenersST extends BaseST {
             .withSecurityProtocol(SecurityProtocol.SSL)
             .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesTls();
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
 // Deploy client pod with custom certificates and collect messages from internal TLS listener
         KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
 
@@ -554,11 +550,11 @@ public class ListenersST extends BaseST {
             .withCertificateAuthorityCertificateName(null)
             .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesTls();
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
         Map<String, String> kafkaSnapshot = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
 
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka -> {
@@ -607,11 +603,10 @@ public class ListenersST extends BaseST {
             .withCertificateAuthorityCertificateName(customCertServer1)
             .build();
 
-        producer = basicExternalKafkaClient.sendMessagesTls();
-        consumer = basicExternalKafkaClient.receiveMessagesTls();
-
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
         KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
@@ -656,11 +651,10 @@ public class ListenersST extends BaseST {
         LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
         assertThat(internalSecretCerts, is(internalCerts));
 
-        producer = basicExternalKafkaClient.sendMessagesTls();
-        consumer = basicExternalKafkaClient.receiveMessagesTls();
-
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
         internalKafkaClient.setConsumerGroup("consumer-group-certs-71");
         internalKafkaClient.setMessageCount(MESSAGE_COUNT * 3);
@@ -701,11 +695,10 @@ public class ListenersST extends BaseST {
             .withCertificateAuthorityCertificateName(null)
             .build();
 
-        producer = basicExternalKafkaClient.sendMessagesTls();
-        consumer = basicExternalKafkaClient.receiveMessagesTls();
-
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
         internalKafkaClient.setConsumerGroup("consumer-group-certs-83");
 
@@ -752,11 +745,10 @@ public class ListenersST extends BaseST {
             .withSecurityProtocol(SecurityProtocol.SSL)
             .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesTls();
-
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
         Map<String, String> kafkaSnapshot = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
 
@@ -807,11 +799,10 @@ public class ListenersST extends BaseST {
             .withCertificateAuthorityCertificateName(customCertServer1)
             .build();
 
-        producer = basicExternalKafkaClient.sendMessagesTls();
-        consumer = basicExternalKafkaClient.receiveMessagesTls();
-
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
         KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
@@ -856,12 +847,10 @@ public class ListenersST extends BaseST {
         LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
         assertThat(internalSecretCerts, is(internalCerts));
 
-        producer = basicExternalKafkaClient.sendMessagesTls();
-        // TODO: make sure that passing...need to change in `IntPredicate msgCntPredicate = x -> x == messageCount;` to x >= messageCount probably...
-        consumer = basicExternalKafkaClient.receiveMessagesTls();
-
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
         internalKafkaClient.setConsumerGroup("consumer-group-certs-72");
         internalKafkaClient.setMessageCount(MESSAGE_COUNT * 5);
@@ -902,11 +891,10 @@ public class ListenersST extends BaseST {
             .withCertificateAuthorityCertificateName(null)
             .build();
 
-        producer = basicExternalKafkaClient.sendMessagesTls();
-        consumer = basicExternalKafkaClient.receiveMessagesTls();
-
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
         internalKafkaClient.setConsumerGroup("consumer-group-certs-73");
 
@@ -954,11 +942,10 @@ public class ListenersST extends BaseST {
             .withCertificateAuthorityCertificateName(null)
             .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesTls();
-
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
         Map<String, String> kafkaSnapshot = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
 
@@ -1000,11 +987,10 @@ public class ListenersST extends BaseST {
         basicExternalKafkaClient.setCaCertName(null);
         basicExternalKafkaClient.setConsumerGroup(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
 
-        producer = basicExternalKafkaClient.sendMessagesTls();
-        consumer = basicExternalKafkaClient.receiveMessagesTls();
-
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
         KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
@@ -1049,11 +1035,10 @@ public class ListenersST extends BaseST {
         LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
         assertThat(internalSecretCerts, is(internalCerts));
 
-        producer = basicExternalKafkaClient.sendMessagesTls();
-        consumer = basicExternalKafkaClient.receiveMessagesTls();
-
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
         internalKafkaClient.setConsumerGroup("consumer-group-certs-92");
         internalKafkaClient.setMessageCount(MESSAGE_COUNT * 5);
@@ -1084,11 +1069,10 @@ public class ListenersST extends BaseST {
         basicExternalKafkaClient.setCaCertName(null);
         basicExternalKafkaClient.setConsumerGroup(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
 
-        producer = basicExternalKafkaClient.sendMessagesTls();
-        consumer = basicExternalKafkaClient.receiveMessagesTls();
-
-        assertThat("Producer didn't produce all messages", producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat("Consumer didn't consume all messages", consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesTls(),
+            basicExternalKafkaClient.receiveMessagesTls()
+        );
 
         internalKafkaClient.setMessageCount(5 * MESSAGE_COUNT);
         internalKafkaClient.setConsumerGroup("consumer-group-certs-93");

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthAuthorizationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthAuthorizationST.java
@@ -16,6 +16,7 @@ import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
+import io.strimzi.test.TimeoutException;
 import io.vertx.core.cli.annotations.Description;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.junit.jupiter.api.BeforeAll;
@@ -29,7 +30,6 @@ import org.junit.jupiter.api.TestMethodOrder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeoutException;
 
 import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthTlsST.java
@@ -42,8 +42,6 @@ import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
 
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
@@ -73,12 +71,11 @@ public class OauthTlsST extends OauthBaseST {
             "As an oauth producer, i am able to produce messages to the kafka broker\n" +
             "As an oauth consumer, i am able to consumer messages from the kafka broker using encrypted communication")
     @Test
-    void testProducerConsumer() throws InterruptedException, ExecutionException, java.util.concurrent.TimeoutException {
-        Future<Integer> producer = oauthExternalKafkaClientTls.sendMessagesTls();
-        Future<Integer> consumer = oauthExternalKafkaClientTls.receiveMessagesTls();
-
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+    void testProducerConsumer() {
+        oauthExternalKafkaClientTls.verifyProducedAndConsumedMessages(
+            oauthExternalKafkaClientTls.sendMessagesTls(),
+            oauthExternalKafkaClientTls.receiveMessagesTls()
+        );
     }
 
     @Description("As an oauth kafka connect, i am able to sink messages from kafka broker topic using encrypted communication.")
@@ -86,11 +83,10 @@ public class OauthTlsST extends OauthBaseST {
     @Tag(CONNECT)
     @Tag(CONNECT_COMPONENTS)
     void testProducerConsumerConnect() throws InterruptedException, ExecutionException, java.util.concurrent.TimeoutException {
-        Future<Integer> producer = oauthExternalKafkaClientTls.sendMessagesTls();
-        Future<Integer> consumer = oauthExternalKafkaClientTls.receiveMessagesTls();
-
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        oauthExternalKafkaClientTls.verifyProducedAndConsumedMessages(
+            oauthExternalKafkaClientTls.sendMessagesTls(),
+            oauthExternalKafkaClientTls.receiveMessagesTls()
+        );
 
         KafkaClientsResource.deployKafkaClients(false, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).done();
 
@@ -142,11 +138,10 @@ public class OauthTlsST extends OauthBaseST {
     @Description("As a oauth bridge, i am able to send messages to bridge endpoint using encrypted communication")
     @Test
     void testProducerConsumerBridge(Vertx vertx) throws InterruptedException, TimeoutException, ExecutionException, java.util.concurrent.TimeoutException {
-        Future<Integer> producer = oauthExternalKafkaClientTls.sendMessagesTls();
-        Future<Integer> consumer = oauthExternalKafkaClientTls.receiveMessagesTls();
-
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        oauthExternalKafkaClientTls.verifyProducedAndConsumedMessages(
+            oauthExternalKafkaClientTls.sendMessagesTls(),
+            oauthExternalKafkaClientTls.receiveMessagesTls()
+        );
 
         KafkaBridgeResource.kafkaBridge(CLUSTER_NAME, KafkaResources.tlsBootstrapAddress(CLUSTER_NAME), 1)
                 .editSpec()
@@ -217,12 +212,11 @@ public class OauthTlsST extends OauthBaseST {
     @Description("As a oauth mirror maker, i am able to replicate topic data using using encrypted communication")
     @Test
     @Tag(MIRROR_MAKER)
-    void testMirrorMaker() throws InterruptedException, ExecutionException, java.util.concurrent.TimeoutException {
-        Future<Integer> producer = oauthExternalKafkaClientTls.sendMessagesTls();
-        Future<Integer> consumer = oauthExternalKafkaClientTls.receiveMessagesTls();
-
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+    void testMirrorMaker() {
+        oauthExternalKafkaClientTls.verifyProducedAndConsumedMessages(
+            oauthExternalKafkaClientTls.sendMessagesTls(),
+            oauthExternalKafkaClientTls.receiveMessagesTls()
+        );
 
         String targetKafkaCluster = CLUSTER_NAME + "-target";
 
@@ -334,9 +328,7 @@ public class OauthTlsST extends OauthBaseST {
         oauthExternalKafkaClientTls.setClusterName(targetKafkaCluster);
         oauthExternalKafkaClientTls.setConsumerGroup(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
 
-        consumer = oauthExternalKafkaClientTls.receiveMessagesTls();
-
-        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        assertThat(oauthExternalKafkaClientTls.receiveMessagesTls(), is(MESSAGE_COUNT));
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -14,7 +14,6 @@ import io.strimzi.api.kafka.model.listener.LoadBalancerListenerBootstrapOverride
 import io.strimzi.api.kafka.model.listener.LoadBalancerListenerBrokerOverride;
 import io.strimzi.api.kafka.model.listener.LoadBalancerListenerBrokerOverrideBuilder;
 import io.strimzi.systemtest.BaseST;
-import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -31,8 +30,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import java.util.List;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -107,12 +104,10 @@ public class SpecificST extends BaseST {
             .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
             .build();
 
-
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesPlain();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesPlain();
-
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesPlain(),
+            basicExternalKafkaClient.receiveMessagesPlain()
+        );
     }
 
 
@@ -158,11 +153,10 @@ public class SpecificST extends BaseST {
             .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
             .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesPlain();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesPlain();
-
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesPlain(),
+            basicExternalKafkaClient.receiveMessagesPlain()
+        );
     }
 
     @Test
@@ -230,11 +224,10 @@ public class SpecificST extends BaseST {
             .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
             .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesPlain();
-        Future<Integer> consumer = basicExternalKafkaClient.receiveMessagesPlain();
-
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+            basicExternalKafkaClient.sendMessagesPlain(),
+            basicExternalKafkaClient.receiveMessagesPlain()
+        );
 
         String invalidNetworkAddress = "255.255.255.111/30";
 
@@ -249,10 +242,11 @@ public class SpecificST extends BaseST {
         basicExternalKafkaClient.setConsumerGroup(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
         basicExternalKafkaClient.setMessageCount(2 * MESSAGE_COUNT);
 
-        assertThrows(ExecutionException.class, () -> {
-            Future<Integer> invalidProducer = basicExternalKafkaClient.sendMessagesPlain();
-            Future<Integer> invalidConsumer = basicExternalKafkaClient.receiveMessagesPlain();
-        });
+        assertThrows(TimeoutException.class, () ->
+            basicExternalKafkaClient.verifyProducedAndConsumedMessages(
+                basicExternalKafkaClient.sendMessagesPlain(),
+                basicExternalKafkaClient.receiveMessagesPlain()
+            ));
     }
 
     @BeforeAll


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR adding ability that clients only returning int type, which is sent or receive messages and encapsulate all the async calls inside the methods. 

Additionally, I have done some refactoring which was needed for instance:
 -  use instance attribute of `Vert.x` from the class AbstractVerticle
 -  auto-closeable interfaces, which ensures that the client will always close the `Vert.x` instance

### Checklist

- [x] Make sure all tests pass


