### PR TITLE
Added Kubernetes part-of label and its propagation from user template

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -192,6 +192,7 @@ public abstract class AbstractModel {
         this.labels = labels.withCluster(cluster)
                             .withKubernetesName()
                             .withKubernetesInstance(cluster)
+                            .withKubernetesPartOf(cluster)
                             .withKubernetesManagedBy(STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -542,6 +542,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     .withCluster(reconciliation.name())
                     .withKubernetesName()
                     .withKubernetesInstance(reconciliation.name())
+                    .withKubernetesPartOf(reconciliation.name())
                     .withKubernetesManagedBy(AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
             Promise<ReconciliationState> resultPromise = Promise.promise();
             vertx.createSharedWorkerExecutor("kubernetes-ops-pool").<ReconciliationState>executeBlocking(
@@ -3173,6 +3174,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     .withCluster(reconciliation.name())
                     .withKubernetesName()
                     .withKubernetesInstance(reconciliation.name())
+                    .withKubernetesPartOf(reconciliation.name())
                     .withKubernetesManagedBy(AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
 
             OwnerReference ownerRef = new OwnerReferenceBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -93,6 +93,7 @@ public class KafkaBridgeClusterTest {
                 Labels.STRIMZI_KIND_LABEL, KafkaBridge.RESOURCE_KIND,
                 Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
                 Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+                Labels.KUBERNETES_PART_OF_LABEL, Labels.KUBERNETES_NAME + "-" + this.cluster,
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -171,6 +171,7 @@ public class KafkaClusterTest {
             Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND,
             Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
             Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+            Labels.KUBERNETES_PART_OF_LABEL, Labels.KUBERNETES_NAME + "-" + this.cluster,
             Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -117,6 +117,7 @@ public class KafkaConnectClusterTest {
                 Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND,
                 Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
                 Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+                Labels.KUBERNETES_PART_OF_LABEL, Labels.KUBERNETES_NAME + "-" + this.cluster,
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -122,6 +122,7 @@ public class KafkaConnectS2IClusterTest {
             Labels.STRIMZI_KIND_LABEL, KafkaConnectS2I.RESOURCE_KIND,
             Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
             Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+            Labels.KUBERNETES_PART_OF_LABEL, Labels.KUBERNETES_NAME + "-" + this.cluster,
             Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -98,6 +98,7 @@ public class KafkaExporterTest {
                 Labels.STRIMZI_NAME_LABEL, name,
                 Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
                 Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+                Labels.KUBERNETES_PART_OF_LABEL, Labels.KUBERNETES_NAME + "-" + this.cluster,
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -127,6 +127,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND,
                 Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
                 Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+                Labels.KUBERNETES_PART_OF_LABEL, Labels.KUBERNETES_NAME + "-" + this.cluster,
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -119,6 +119,7 @@ public class KafkaMirrorMakerClusterTest {
                 Labels.STRIMZI_NAME_LABEL, name,
                 Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
                 Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+                Labels.KUBERNETES_PART_OF_LABEL, Labels.KUBERNETES_NAME + "-" + this.cluster,
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -133,6 +133,7 @@ public class ZookeeperClusterTest {
             Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND,
             Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
             Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+            Labels.KUBERNETES_PART_OF_LABEL, Labels.KUBERNETES_NAME + "-" + this.cluster,
             Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -65,6 +65,7 @@ public class Labels {
     public static final String KUBERNETES_NAME_LABEL = KUBERNETES_DOMAIN + "name";
     public static final String KUBERNETES_INSTANCE_LABEL = KUBERNETES_DOMAIN + "instance";
     public static final String KUBERNETES_MANAGED_BY_LABEL = KUBERNETES_DOMAIN + "managed-by";
+    public static final String KUBERNETES_PART_OF_LABEL = KUBERNETES_DOMAIN + "part-of";
 
     public static final String KUBERNETES_NAME = "strimzi";
 
@@ -116,10 +117,12 @@ public class Labels {
         }
 
         // Remove Kubernetes Domain specific labels
+        // Exceptions app.kubernetes.io/part-of
         Map<String, String> filteredLabels = userLabels
                 .entrySet()
                 .stream()
-                .filter(entryset -> !entryset.getKey().startsWith(Labels.KUBERNETES_DOMAIN))
+                .filter(entryset ->
+                        !entryset.getKey().startsWith(Labels.KUBERNETES_DOMAIN) || entryset.getKey().equals(KUBERNETES_PART_OF_LABEL))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         return new Labels(filteredLabels);
@@ -227,6 +230,15 @@ public class Labels {
      */
     public Labels withKubernetesInstance(String instance) {
         return with(Labels.KUBERNETES_INSTANCE_LABEL, getOrValidInstanceLabelValue(instance));
+    }
+
+    /**
+     * The same labels as this instance, but with the given {@code part-of} for the {@code app.kubernetes.io/part-of} key.
+     * @param instance The instance to add.
+     * @return A new instance with the given kubernetes application part-of added.
+     */
+    public Labels withKubernetesPartOf(String instance) {
+        return with(Labels.KUBERNETES_PART_OF_LABEL, getOrValidInstanceLabelValue(KUBERNETES_NAME + "-" + instance));
     }
 
     /**

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
@@ -128,6 +128,7 @@ public class LabelsTest {
         userLabels.put(Labels.KUBERNETES_INSTANCE_LABEL, "my-cluster");
         userLabels.put("key2", "value2");
         userLabels.put(Labels.KUBERNETES_MANAGED_BY_LABEL, "my-operator");
+        userLabels.put(Labels.KUBERNETES_PART_OF_LABEL, "strimzi-my-cluster");
         String validLabelContainingKubernetesDomainSubstring = "foo/" + Labels.KUBERNETES_DOMAIN;
         userLabels.put(validLabelContainingKubernetesDomainSubstring, "bar");
 
@@ -136,6 +137,8 @@ public class LabelsTest {
         Map expectedUserLabels = new HashMap<String, String>(2);
         expectedUserLabels.put("key1", "value1");
         expectedUserLabels.put("key2", "value2");
+        // Kubernetes part-of is not filtered and allowed to be set by user
+        expectedUserLabels.put(Labels.KUBERNETES_PART_OF_LABEL, "strimzi-my-cluster");
         expectedUserLabels.put(validLabelContainingKubernetesDomainSubstring, "bar");
 
 
@@ -188,6 +191,7 @@ public class LabelsTest {
         Map<String, String> userLabels = new HashMap<String, String>(5);
         userLabels.put(Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME);
         userLabels.put(Labels.KUBERNETES_INSTANCE_LABEL, "my-cluster");
+        userLabels.put(Labels.KUBERNETES_PART_OF_LABEL, "strimzi-my-cluster");
         userLabels.put(Labels.KUBERNETES_MANAGED_BY_LABEL, "my-operator");
         userLabels.put("key1", "value1");
         userLabels.put("key2", "value2");
@@ -214,8 +218,30 @@ public class LabelsTest {
         Map<String, String> expectedLabels = new HashMap<String, String>(2);
         expectedLabels.put("key1", "value1");
         expectedLabels.put("key2", "value2");
+        expectedLabels.put(Labels.KUBERNETES_PART_OF_LABEL, "strimzi-my-cluster");
 
         Labels l = Labels.fromResource(kafka);
+        assertThat(l.toMap(), is(expectedLabels));
+    }
+
+    @Test
+    public void testWithKubernetesLabelsCorrect() {
+        String instance = "my-cluster";
+        String operatorName  = "my-operator";
+        String appName = "strimzi";
+
+        Map<String, String> expectedLabels = new HashMap<>();
+        expectedLabels.put(Labels.KUBERNETES_NAME_LABEL, appName);
+        expectedLabels.put(Labels.KUBERNETES_INSTANCE_LABEL, instance);
+        expectedLabels.put(Labels.KUBERNETES_MANAGED_BY_LABEL, operatorName);
+        expectedLabels.put(Labels.KUBERNETES_PART_OF_LABEL, Labels.KUBERNETES_NAME + "-" + instance);
+
+        Labels l = Labels.EMPTY
+                .withKubernetesName()
+                .withKubernetesInstance(instance)
+                .withKubernetesManagedBy(operatorName)
+                .withKubernetesPartOf(instance);
+
         assertThat(l.toMap(), is(expectedLabels));
     }
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -79,6 +79,7 @@ public class KafkaUserModel {
         this.name = name;
         this.labels = labels.withKubernetesName()
             .withKubernetesInstance(name)
+            .withKubernetesPartOf(name)
             .withKubernetesManagedBy(KAFKA_USER_OPERATOR_NAME);
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
@@ -150,6 +150,7 @@ public class ResourceUtils {
                     .withLabels(Labels.userLabels(LABELS)
                         .withKubernetesName()
                         .withKubernetesInstance(NAME)
+                        .withKubernetesPartOf(NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .withKind(KafkaUser.RESOURCE_KIND)
                         .toMap())

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -53,6 +53,7 @@ public class KafkaUserModelTest {
                         .withKind(KafkaUser.RESOURCE_KIND)
                         .withKubernetesName()
                         .withKubernetesInstance(ResourceUtils.NAME)
+                        .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)));
         assertThat(model.authentication.getType(), is(KafkaUserTlsClientAuthentication.TYPE_TLS));
 
@@ -70,6 +71,7 @@ public class KafkaUserModelTest {
                         .withKind(KafkaUser.RESOURCE_KIND)
                         .withKubernetesName()
                         .withKubernetesInstance(ResourceUtils.NAME)
+                        .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)));
         KafkaUserQuotas quotas = quotasUser.getSpec().getQuotas();
         assertThat(model.getQuotas().getConsumerByteRate(), is(quotas.getConsumerByteRate()));
@@ -88,6 +90,7 @@ public class KafkaUserModelTest {
                 .withKind(KafkaUser.RESOURCE_KIND)
                 .withKubernetesName()
                 .withKubernetesInstance(ResourceUtils.NAME)
+                .withKubernetesPartOf(ResourceUtils.NAME)
                 .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)));
         KafkaUserQuotas quotas = quotasUserWithNulls.getSpec().getQuotas();
         assertThat(model.getQuotas().getConsumerByteRate(), is(quotas.getConsumerByteRate()));
@@ -109,6 +112,7 @@ public class KafkaUserModelTest {
                         .withKind(KafkaUser.RESOURCE_KIND)
                         .withKubernetesName()
                         .withKubernetesInstance(ResourceUtils.NAME)
+                        .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
         // Check owner reference
@@ -218,6 +222,7 @@ public class KafkaUserModelTest {
                         .withKind(KafkaUser.RESOURCE_KIND)
                         .withKubernetesName()
                         .withKubernetesInstance(ResourceUtils.NAME)
+                        .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
 
@@ -241,6 +246,7 @@ public class KafkaUserModelTest {
                 is(Labels.userLabels(ResourceUtils.LABELS)
                         .withKubernetesName()
                         .withKubernetesInstance(ResourceUtils.NAME)
+                        .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .withKind(KafkaUser.RESOURCE_KIND)
                         .toMap()));
@@ -264,6 +270,7 @@ public class KafkaUserModelTest {
                         .withKind(KafkaUser.RESOURCE_KIND)
                         .withKubernetesName()
                         .withKubernetesInstance(ResourceUtils.NAME)
+                        .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
@@ -116,6 +116,7 @@ public class KafkaUserOperatorTest {
                             .withKind(KafkaUser.RESOURCE_KIND)
                             .withKubernetesName()
                             .withKubernetesInstance(ResourceUtils.NAME)
+                            .withKubernetesPartOf(ResourceUtils.NAME)
                             .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                             .toMap())));
             context.verify(() -> assertThat(new String(Base64.getDecoder().decode(captured.getData().get("ca.crt"))), is("clients-ca-crt")));
@@ -453,6 +454,7 @@ public class KafkaUserOperatorTest {
                             .withKind(KafkaUser.RESOURCE_KIND)
                             .withKubernetesName()
                             .withKubernetesInstance(ResourceUtils.NAME)
+                            .withKubernetesPartOf(ResourceUtils.NAME)
                             .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                             .toMap())));
             context.verify(() -> assertThat(new String(Base64.getDecoder().decode(captured.getData().get("ca.crt"))), is("clients-ca-crt")));
@@ -535,6 +537,7 @@ public class KafkaUserOperatorTest {
                     is(Labels.userLabels(user.getMetadata().getLabels())
                             .withKubernetesName()
                             .withKubernetesInstance(ResourceUtils.NAME)
+                            .withKubernetesPartOf(ResourceUtils.NAME)
                             .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                             .withKind(KafkaUser.RESOURCE_KIND)
                             .toMap())));
@@ -741,6 +744,7 @@ public class KafkaUserOperatorTest {
                     is(Labels.userLabels(user.getMetadata().getLabels())
                             .withKubernetesName()
                             .withKubernetesInstance(ResourceUtils.NAME)
+                            .withKubernetesPartOf(ResourceUtils.NAME)
                             .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                             .withKind(KafkaUser.RESOURCE_KIND)
                             .toMap())));
@@ -824,6 +828,7 @@ public class KafkaUserOperatorTest {
                     is(Labels.userLabels(user.getMetadata().getLabels())
                             .withKubernetesName()
                             .withKubernetesInstance(ResourceUtils.NAME)
+                            .withKubernetesPartOf(ResourceUtils.NAME)
                             .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                             .withKind(KafkaUser.RESOURCE_KIND)
                             .toMap())));


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Enhancement / new feature

### Description

This PR adds the Kubertenetes related `part-of` label and its propagation to the resources from a user defined template.
It brings part of the #2730 on the 0.17.x release branch.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

