### PR TITLE
[systemtest] Weird usernames tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -883,8 +883,7 @@ class ConnectST extends BaseST {
                 .withTopicName(topicName)
                 .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), CoreMatchers.is(MESSAGE_COUNT));
+        assertThat(basicExternalKafkaClient.sendMessagesTls(), CoreMatchers.is(MESSAGE_COUNT));
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(connectorPodName, Constants.DEFAULT_SINK_FILE_PATH);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -57,6 +57,7 @@ import static io.strimzi.systemtest.Constants.CONNECTOR_OPERATOR;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.Constants.TRAVIS;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -750,10 +751,11 @@ class ConnectST extends BaseST {
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(connectorPodName, Constants.DEFAULT_SINK_FILE_PATH, "99");
     }
 
+    @Tag(NODEPORT_SUPPORTED)
     @Tag(EXTERNAL_CLIENTS_USED)
     @Tag(CONNECTOR_OPERATOR)
     @Test
-    void testConnectTlsAuthWithWeirdUserName() throws Exception {
+    void testConnectTlsAuthWithWeirdUserName() {
         // Create weird named user with . and maximum of 64 chars -> TLS
         String weirdUserName = "jjglmahyijoambryleyxjjglmahy.ijoambryleyxjjglmahyijoambryleyxasd";
         String connectClusterName = "connect-cluster";
@@ -797,6 +799,7 @@ class ConnectST extends BaseST {
         testConnectAuthorizationWithWeirdUserName(weirdUserName, SecurityProtocol.SSL);
     }
 
+    @Tag(NODEPORT_SUPPORTED)
     @Tag(EXTERNAL_CLIENTS_USED)
     @Tag(CONNECTOR_OPERATOR)
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
@@ -196,7 +196,6 @@ class HttpBridgeScramShaST extends HttpBridgeBaseST {
                 .editKafka()
                     .withNewListeners()
                         .withNewKafkaListenerExternalNodePort()
-                            .withTls(true)
                             .withAuth(new KafkaListenerAuthenticationScramSha512())
                         .endKafkaListenerExternalNodePort()
                         .withNewTls().withAuth(new KafkaListenerAuthenticationScramSha512()).endTls()

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
@@ -170,8 +170,7 @@ class HttpBridgeScramShaST extends HttpBridgeBaseST {
                 .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
                 .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        assertThat(basicExternalKafkaClient.sendMessagesTls(), is(MESSAGE_COUNT));
         // Try to consume messages
         JsonArray bridgeResponse = HttpUtils.receiveMessagesHttpRequest(bridgeHost, bridgePort, groupId, weirdUserName, client);
         if (bridgeResponse.size() == 0) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
@@ -69,14 +69,14 @@ class HttpBridgeScramShaST extends HttpBridgeBaseST {
         KafkaBridgeUtils.checkSendResponse(response, messageCount);
 
         BasicExternalKafkaClient kafkaClient = new BasicExternalKafkaClient.Builder()
-                .withTopicName(topicName)
-                .withNamespaceName(NAMESPACE)
-                .withClusterName(CLUSTER_NAME)
-                .withKafkaUsername(userName)
-                .withMessageCount(messageCount)
-                .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
-                .withSecurityProtocol(SecurityProtocol.SASL_SSL)
-                .build();
+            .withTopicName(topicName)
+            .withNamespaceName(NAMESPACE)
+            .withClusterName(CLUSTER_NAME)
+            .withKafkaUsername(userName)
+            .withMessageCount(messageCount)
+            .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
+            .withSecurityProtocol(SecurityProtocol.SASL_SSL)
+            .build();
 
         assertThat(kafkaClient.receiveMessagesTls(), is(messageCount));
     }
@@ -88,14 +88,14 @@ class HttpBridgeScramShaST extends HttpBridgeBaseST {
         KafkaTopicResource.topic(CLUSTER_NAME, topicName).done();
 
         BasicExternalKafkaClient kafkaClient = new BasicExternalKafkaClient.Builder()
-                .withTopicName(topicName)
-                .withNamespaceName(NAMESPACE)
-                .withClusterName(CLUSTER_NAME)
-                .withKafkaUsername(userName)
-                .withMessageCount(MESSAGE_COUNT)
-                .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
-                .withSecurityProtocol(SecurityProtocol.SASL_SSL)
-                .build();
+            .withTopicName(topicName)
+            .withNamespaceName(NAMESPACE)
+            .withClusterName(CLUSTER_NAME)
+            .withKafkaUsername(userName)
+            .withMessageCount(MESSAGE_COUNT)
+            .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
+            .withSecurityProtocol(SecurityProtocol.SASL_SSL)
+            .build();
 
         // Send messages to Kafka
         assertThat(kafkaClient.sendMessagesTls(), is(MESSAGE_COUNT));
@@ -161,14 +161,14 @@ class HttpBridgeScramShaST extends HttpBridgeBaseST {
         assertThat(HttpUtils.subscribeHttpConsumer(topics, bridgeHost, bridgePort, groupId, weirdUserName, client), is(true));
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
-                .withTopicName(topicName)
-                .withNamespaceName(NAMESPACE)
-                .withClusterName(CLUSTER_NAME)
-                .withMessageCount(MESSAGE_COUNT)
-                .withSecurityProtocol(SecurityProtocol.SASL_SSL)
-                .withKafkaUsername(weirdUserName)
-                .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
-                .build();
+            .withTopicName(topicName)
+            .withNamespaceName(NAMESPACE)
+            .withClusterName(CLUSTER_NAME)
+            .withMessageCount(MESSAGE_COUNT)
+            .withSecurityProtocol(SecurityProtocol.SASL_SSL)
+            .withKafkaUsername(weirdUserName)
+            .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
+            .build();
 
         assertThat(basicExternalKafkaClient.sendMessagesTls(), is(MESSAGE_COUNT));
         // Try to consume messages

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
@@ -132,20 +132,23 @@ class HttpBridgeTlsST extends HttpBridgeBaseST {
 
         // Create weird named user with . and maximum of 64 chars -> TLS
         String weirdUserName = "jjglmahyijoambryleyxjjglmahy.ijoambryleyxjjglmahyijoambryleyxasd";
+        // Create user with normal name -> we don't need to set weird name for consumer
+        String aliceUser = "alice";
 
         // Create topic
         KafkaTopicResource.topic(CLUSTER_NAME, topicName).done();
         // Create user
         KafkaUserResource.tlsUser(CLUSTER_NAME, weirdUserName).done();
+        KafkaUserResource.tlsUser(CLUSTER_NAME, aliceUser).done();
 
         JsonObject config = new JsonObject();
-        config.put("name", weirdUserName);
+        config.put("name", aliceUser);
         config.put("format", "json");
         config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
         // Create consumer
         JsonObject response = createBridgeConsumer(config, bridgeHost, bridgePort, groupId);
-        assertThat("Consumer wasn't created correctly", response.getString("instance_id"), is(weirdUserName));
+        assertThat("Consumer wasn't created correctly", response.getString("instance_id"), is(aliceUser));
 
         // Create topics json
         JsonArray topic = new JsonArray();
@@ -154,7 +157,7 @@ class HttpBridgeTlsST extends HttpBridgeBaseST {
         topics.put("topics", topic);
 
         // Subscribe
-        assertThat(HttpUtils.subscribeHttpConsumer(topics, bridgeHost, bridgePort, groupId, weirdUserName, client), is(true));
+        assertThat(HttpUtils.subscribeHttpConsumer(topics, bridgeHost, bridgePort, groupId, aliceUser, client), is(true));
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(topicName)
@@ -168,14 +171,14 @@ class HttpBridgeTlsST extends HttpBridgeBaseST {
 
         assertThat(basicExternalKafkaClient.sendMessagesTls(), is(MESSAGE_COUNT));
         // Try to consume messages
-        JsonArray bridgeResponse = HttpUtils.receiveMessagesHttpRequest(bridgeHost, bridgePort, groupId, weirdUserName, client);
+        JsonArray bridgeResponse = HttpUtils.receiveMessagesHttpRequest(bridgeHost, bridgePort, groupId, aliceUser, client);
         if (bridgeResponse.size() == 0) {
             // Real consuming
-            bridgeResponse = HttpUtils.receiveMessagesHttpRequest(bridgeHost, bridgePort, groupId, weirdUserName, client);
+            bridgeResponse = HttpUtils.receiveMessagesHttpRequest(bridgeHost, bridgePort, groupId, aliceUser, client);
         }
         assertThat("Sent message count is not equal with received message count", bridgeResponse.size(), is(MESSAGE_COUNT));
         // Delete consumer
-        assertThat(deleteConsumer(bridgeHost, bridgePort, groupId, weirdUserName), is(true));
+        assertThat(deleteConsumer(bridgeHost, bridgePort, groupId, aliceUser), is(true));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
@@ -157,14 +157,14 @@ class HttpBridgeTlsST extends HttpBridgeBaseST {
         assertThat(HttpUtils.subscribeHttpConsumer(topics, bridgeHost, bridgePort, groupId, weirdUserName, client), is(true));
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
-                .withTopicName(topicName)
-                .withNamespaceName(NAMESPACE)
-                .withClusterName(CLUSTER_NAME)
-                .withMessageCount(MESSAGE_COUNT)
-                .withSecurityProtocol(SecurityProtocol.SSL)
-                .withKafkaUsername(weirdUserName)
-                .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
-                .build();
+            .withTopicName(topicName)
+            .withNamespaceName(NAMESPACE)
+            .withClusterName(CLUSTER_NAME)
+            .withMessageCount(MESSAGE_COUNT)
+            .withSecurityProtocol(SecurityProtocol.SSL)
+            .withKafkaUsername(weirdUserName)
+            .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
+            .build();
 
         assertThat(basicExternalKafkaClient.sendMessagesTls(), is(MESSAGE_COUNT));
         // Try to consume messages

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
@@ -165,8 +165,7 @@ class HttpBridgeTlsST extends HttpBridgeBaseST {
                 .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
                 .build();
 
-        Future<Integer> producer = basicExternalKafkaClient.sendMessagesTls();
-        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        assertThat(basicExternalKafkaClient.sendMessagesTls(), is(MESSAGE_COUNT));
         // Try to consume messages
         JsonArray bridgeResponse = HttpUtils.receiveMessagesHttpRequest(bridgeHost, bridgePort, groupId, weirdUserName, client);
         if (bridgeResponse.size() == 0) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.bridge;
 import io.fabric8.kubernetes.api.model.Service;
 import io.strimzi.api.kafka.model.CertSecretSource;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationTls;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaBridgeUtils;
@@ -187,9 +188,8 @@ class HttpBridgeTlsST extends HttpBridgeBaseST {
                 .editKafka()
                     .editListeners()
                         .withNewKafkaListenerExternalNodePort()
+                            .withAuth(new KafkaListenerAuthenticationTls())
                         .endKafkaListenerExternalNodePort()
-                        .withNewTls()
-                        .endTls()
                     .endListeners()
                 .endKafka()
             .endSpec().done();


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lkral@redhat.com>

### Type of change

- New Tests

### Description

In this PR I added tests for KafkaBridge and KafkaConnect -> sending messages with TLS and SCRAM-SHA auth with KafkaUser that have "weird" names.

For SCRAM-SHA:
- more than 64 chars
- with `.`

For TLS:
- maximum of 64 chars
- with `.`

### Checklist

- [x] Write tests
- [ ] Make sure all tests pass


