### PR TITLE
Make it possible to configure different TLS options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Update build system to use `yq` version 3 (https://github.com/mikefarah/yq)
 * Add more metrics to Cluster and User Operators
 * New Grafana dashboard for Operator monitoring 
-* Allow ssl.cipher.suites to be configured for Kafka
+* Allow `ssl.cipher.suites`, `ssl.protocol` and `ssl.enabled.protocols` to be configurable for Kafka and the different components supported by Strimzi
 
 ## 0.17.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeConsumerSpec.java
@@ -21,9 +21,10 @@ public class KafkaBridgeConsumerSpec extends KafkaBridgeClientSpec {
     private static final long serialVersionUID = 1L;
 
     public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, group.id, sasl., security.";
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 
     @Override
-    @Description("The Kafka consumer configuration used for consumer instances created by the bridge. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES)
+    @Description("The Kafka consumer configuration used for consumer instances created by the bridge. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
         return config;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeProducerSpec.java
@@ -21,9 +21,10 @@ public class KafkaBridgeProducerSpec extends KafkaBridgeClientSpec {
     private static final long serialVersionUID = 1L;
 
     public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, sasl., security.";
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 
     @Override
-    @Description("The Kafka producer configuration used for producer instances created by the bridge. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES)
+    @Description("The Kafka producer configuration used for producer instances created by the bridge. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
         return config;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
@@ -49,7 +49,7 @@ public class KafkaClusterSpec implements UnknownPropertyPreserving, Serializable
     public static final String FORBIDDEN_PREFIXES = "listeners, advertised., broker., listener., host.name, port, "
             + "inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, "
             + "zookeeper.connect, zookeeper.set.acl, authorizer., super.user";
-    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "zookeeper.connection.timeout.ms, ssl.cipher.suites";
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "zookeeper.connection.timeout.ms, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 
     protected Storage storage;
 
@@ -89,7 +89,7 @@ public class KafkaClusterSpec implements UnknownPropertyPreserving, Serializable
         this.version = version;
     }
 
-    @Description("The kafka broker config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES)
+    @Description("The kafka broker config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, Object> getConfig() {
         return config;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
@@ -31,7 +31,7 @@ public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
     private static final long serialVersionUID = 1L;
 
     public static final String FORBIDDEN_PREFIXES = "ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes";
-    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm";
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 
     private Map<String, Object> config = new HashMap<>(0);
 
@@ -39,7 +39,7 @@ public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
     private KafkaConnectTls tls;
     private KafkaClientAuthentication authentication;
 
-    @Description("The Kafka Connect configuration. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES)
+    @Description("The Kafka Connect configuration. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
         return config;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ClusterSpec.java
@@ -30,7 +30,7 @@ import static java.util.Collections.emptyMap;
 public class KafkaMirrorMaker2ClusterSpec implements UnknownPropertyPreserving, Serializable {
 
     public static final String FORBIDDEN_PREFIXES = "ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes";
-    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm";
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerConsumerSpec.java
@@ -26,7 +26,7 @@ public class KafkaMirrorMakerConsumerSpec extends KafkaMirrorMakerClientSpec {
     private static final long serialVersionUID = 1L;
 
     public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes";
-    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm";
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 
     private Integer numStreams;
 
@@ -35,7 +35,7 @@ public class KafkaMirrorMakerConsumerSpec extends KafkaMirrorMakerClientSpec {
     private Integer offsetCommitInterval;
 
     @Override
-    @Description("The MirrorMaker consumer config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES)
+    @Description("The MirrorMaker consumer config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
         return config;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerProducerSpec.java
@@ -25,7 +25,7 @@ public class KafkaMirrorMakerProducerSpec extends KafkaMirrorMakerClientSpec {
     private Boolean abortOnSendFailure;
 
     public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, sasl., security., interceptor.classes";
-    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm";
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 
     @Description("Flag to set the MirrorMaker to exit on a failed send. Default value is `true`.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -38,7 +38,7 @@ public class KafkaMirrorMakerProducerSpec extends KafkaMirrorMakerClientSpec {
     }
 
     @Override
-    @Description("The MirrorMaker producer config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES)
+    @Description("The MirrorMaker producer config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
         return config;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConsumerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConsumerConfiguration.java
@@ -6,6 +6,7 @@
 package io.strimzi.operator.cluster.model;
 
 import io.strimzi.api.kafka.model.KafkaBridgeConsumerSpec;
+import io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec;
 
 import java.util.HashMap;
 import java.util.List;
@@ -19,12 +20,12 @@ import static java.util.Arrays.asList;
 public class KafkaBridgeConsumerConfiguration extends AbstractConfiguration {
 
     private static final List<String> FORBIDDEN_OPTIONS;
-
+    private static final List<String> EXCEPTIONS;
     private static final Map<String, String> DEFAULTS;
 
     static {
         FORBIDDEN_OPTIONS = asList(KafkaBridgeConsumerSpec.FORBIDDEN_PREFIXES.split(", "));
-
+        EXCEPTIONS = asList(KafkaMirrorMakerConsumerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
         DEFAULTS = new HashMap<>();
     }
 
@@ -35,6 +36,6 @@ public class KafkaBridgeConsumerConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaBridgeConsumerConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS, DEFAULTS);
+        super(jsonOptions, FORBIDDEN_OPTIONS, EXCEPTIONS, DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConsumerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConsumerConfiguration.java
@@ -6,7 +6,6 @@
 package io.strimzi.operator.cluster.model;
 
 import io.strimzi.api.kafka.model.KafkaBridgeConsumerSpec;
-import io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec;
 
 import java.util.HashMap;
 import java.util.List;
@@ -25,7 +24,7 @@ public class KafkaBridgeConsumerConfiguration extends AbstractConfiguration {
 
     static {
         FORBIDDEN_OPTIONS = asList(KafkaBridgeConsumerSpec.FORBIDDEN_PREFIXES.split(", "));
-        EXCEPTIONS = asList(KafkaMirrorMakerConsumerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
+        EXCEPTIONS = asList(KafkaBridgeConsumerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
         DEFAULTS = new HashMap<>();
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeProducerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeProducerConfiguration.java
@@ -19,12 +19,12 @@ import static java.util.Arrays.asList;
 public class KafkaBridgeProducerConfiguration extends AbstractConfiguration {
 
     private static final List<String> FORBIDDEN_OPTIONS;
-
+    private static final List<String> EXCEPTIONS;
     private static final Map<String, String> DEFAULTS;
 
     static {
         FORBIDDEN_OPTIONS = asList(KafkaBridgeProducerSpec.FORBIDDEN_PREFIXES.split(", "));
-
+        EXCEPTIONS = asList(KafkaBridgeProducerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
         DEFAULTS = new HashMap<>();
     }
 
@@ -35,6 +35,6 @@ public class KafkaBridgeProducerConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaBridgeProducerConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS, DEFAULTS);
+        super(jsonOptions, FORBIDDEN_OPTIONS, EXCEPTIONS, DEFAULTS);
     }
 }

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -62,7 +62,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |xref:type-KafkaListeners-{context}[`KafkaListeners`]
 |authorization        1.2+<.<|Authorization configuration for Kafka brokers. The type depends on the value of the `authorization.type` property within the given object, which must be one of [simple, keycloak].
 |xref:type-KafkaAuthorizationSimple-{context}[`KafkaAuthorizationSimple`], xref:type-KafkaAuthorizationKeycloak-{context}[`KafkaAuthorizationKeycloak`]
-|config               1.2+<.<|The kafka broker config. Properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, authorizer., super.user.
+|config               1.2+<.<|The kafka broker config. Properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, authorizer., super.user (with the exception of: zookeeper.connection.timeout.ms, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
 |rack                 1.2+<.<|Configuration of the `broker.rack` broker config.
 |xref:type-Rack-{context}[`Rack`]
@@ -1548,7 +1548,7 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |xref:type-KafkaConnectTls-{context}[`KafkaConnectTls`]
 |authentication         1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
-|config                 1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.
+|config                 1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
 |resources              1.2+<.<|The maximum limits for CPU and memory resources and the requested initial resources.
 |xref:type-ResourceRequirements-{context}[`ResourceRequirements`]
@@ -1888,7 +1888,7 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
 |bootstrapServers          1.2+<.<|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
 |string
-|config                    1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.
+|config                    1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
 |externalConfiguration     1.2+<.<|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
@@ -2260,7 +2260,7 @@ Used in: xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
 |string
 |authentication        1.2+<.<|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
-|config                1.2+<.<|The MirrorMaker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes.
+|config                1.2+<.<|The MirrorMaker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
 |tls                   1.2+<.<|TLS configuration for connecting MirrorMaker to the cluster.
 |xref:type-KafkaMirrorMakerTls-{context}[`KafkaMirrorMakerTls`]
@@ -2295,7 +2295,7 @@ Used in: xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
 |boolean
 |authentication      1.2+<.<|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
-|config              1.2+<.<|The MirrorMaker producer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security., interceptor.classes.
+|config              1.2+<.<|The MirrorMaker producer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
 |tls                 1.2+<.<|TLS configuration for connecting MirrorMaker to the cluster.
 |xref:type-KafkaMirrorMakerTls-{context}[`KafkaMirrorMakerTls`]
@@ -2426,7 +2426,7 @@ Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`]
 [options="header"]
 |====
 |Property       |Description
-|config  1.2+<.<|The Kafka consumer configuration used for consumer instances created by the bridge. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security.
+|config  1.2+<.<|The Kafka consumer configuration used for consumer instances created by the bridge. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
 |====
 
@@ -2439,7 +2439,7 @@ Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`]
 [options="header"]
 |====
 |Property       |Description
-|config  1.2+<.<|The Kafka producer configuration used for producer instances created by the bridge. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security.
+|config  1.2+<.<|The Kafka producer configuration used for producer instances created by the bridge. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
 |====
 
@@ -2605,7 +2605,7 @@ Used in: xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`]
 |string
 |bootstrapServers  1.2+<.<|A comma-separated list of `host:port` pairs for establishing the connection to the Kafka cluster.
 |string
-|config            1.2+<.<|The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm).
+|config            1.2+<.<|The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
 |tls               1.2+<.<|TLS configuration for connecting MirrorMaker 2.0 connectors to a cluster.
 |xref:type-KafkaMirrorMaker2Tls-{context}[`KafkaMirrorMaker2Tls`]

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -923,7 +923,9 @@ spec:
                     prefixes cannot be set: listeners, advertised., broker., listener.,
                     host.name, port, inter.broker.listener.name, sasl., ssl., security.,
                     password., principal.builder.class, log.dir, zookeeper.connect,
-                    zookeeper.set.acl, authorizer., super.user.'
+                    zookeeper.set.acl, authorizer., super.user (with the exception
+                    of: zookeeper.connection.timeout.ms, ssl.cipher.suites, ssl.protocol,
+                    ssl.enabled.protocols).'
                 rack:
                   type: object
                   properties:

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -222,7 +222,9 @@ spec:
               type: object
               description: 'The Kafka Connect configuration. Properties with the following
                 prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
-                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.'
+                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes
+                (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites,
+                ssl.protocol, ssl.enabled.protocols).'
             resources:
               type: object
               properties:

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -924,7 +924,9 @@ spec:
               type: object
               description: 'The Kafka Connect configuration. Properties with the following
                 prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
-                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.'
+                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes
+                (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites,
+                ssl.protocol, ssl.enabled.protocols).'
             externalConfiguration:
               type: object
               properties:

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -235,7 +235,9 @@ spec:
                   type: object
                   description: 'The MirrorMaker consumer config. Properties with the
                     following prefixes cannot be set: ssl., bootstrap.servers, group.id,
-                    sasl., security., interceptor.classes.'
+                    sasl., security., interceptor.classes (with the exception of:
+                    ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol,
+                    ssl.enabled.protocols).'
                 tls:
                   type: object
                   properties:
@@ -418,7 +420,8 @@ spec:
                   type: object
                   description: 'The MirrorMaker producer config. Properties with the
                     following prefixes cannot be set: ssl., bootstrap.servers, sasl.,
-                    security., interceptor.classes.'
+                    security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm,
+                    ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
                 tls:
                   type: object
                   properties:

--- a/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -232,7 +232,8 @@ spec:
                   description: 'The Kafka consumer configuration used for consumer
                     instances created by the bridge. Properties with the following
                     prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl.,
-                    security.'
+                    security. (with the exception of: ssl.endpoint.identification.algorithm,
+                    ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
               description: Kafka consumer related configuration.
             producer:
               type: object
@@ -241,7 +242,9 @@ spec:
                   type: object
                   description: 'The Kafka producer configuration used for producer
                     instances created by the bridge. Properties with the following
-                    prefixes cannot be set: ssl., bootstrap.servers, sasl., security.'
+                    prefixes cannot be set: ssl., bootstrap.servers, sasl., security.
+                    (with the exception of: ssl.endpoint.identification.algorithm,
+                    ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
               description: Kafka producer related configuration.
             resources:
               type: object

--- a/helm-charts/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -73,7 +73,8 @@ spec:
                     description: 'The MirrorMaker 2.0 cluster config. Properties with
                       the following prefixes cannot be set: ssl., sasl., security.,
                       listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes,
-                      producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm).'
+                      producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm,
+                      ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
                   tls:
                     type: object
                     properties:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -918,7 +918,9 @@ spec:
                     prefixes cannot be set: listeners, advertised., broker., listener.,
                     host.name, port, inter.broker.listener.name, sasl., ssl., security.,
                     password., principal.builder.class, log.dir, zookeeper.connect,
-                    zookeeper.set.acl, authorizer., super.user.'
+                    zookeeper.set.acl, authorizer., super.user (with the exception
+                    of: zookeeper.connection.timeout.ms, ssl.cipher.suites, ssl.protocol,
+                    ssl.enabled.protocols).'
                 rack:
                   type: object
                   properties:

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -217,7 +217,9 @@ spec:
               type: object
               description: 'The Kafka Connect configuration. Properties with the following
                 prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
-                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.'
+                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes
+                (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites,
+                ssl.protocol, ssl.enabled.protocols).'
             resources:
               type: object
               properties:

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -919,7 +919,9 @@ spec:
               type: object
               description: 'The Kafka Connect configuration. Properties with the following
                 prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
-                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.'
+                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes
+                (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites,
+                ssl.protocol, ssl.enabled.protocols).'
             externalConfiguration:
               type: object
               properties:

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -230,7 +230,9 @@ spec:
                   type: object
                   description: 'The MirrorMaker consumer config. Properties with the
                     following prefixes cannot be set: ssl., bootstrap.servers, group.id,
-                    sasl., security., interceptor.classes.'
+                    sasl., security., interceptor.classes (with the exception of:
+                    ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol,
+                    ssl.enabled.protocols).'
                 tls:
                   type: object
                   properties:
@@ -413,7 +415,8 @@ spec:
                   type: object
                   description: 'The MirrorMaker producer config. Properties with the
                     following prefixes cannot be set: ssl., bootstrap.servers, sasl.,
-                    security., interceptor.classes.'
+                    security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm,
+                    ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
                 tls:
                   type: object
                   properties:

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -227,7 +227,8 @@ spec:
                   description: 'The Kafka consumer configuration used for consumer
                     instances created by the bridge. Properties with the following
                     prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl.,
-                    security.'
+                    security. (with the exception of: ssl.endpoint.identification.algorithm,
+                    ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
               description: Kafka consumer related configuration.
             producer:
               type: object
@@ -236,7 +237,9 @@ spec:
                   type: object
                   description: 'The Kafka producer configuration used for producer
                     instances created by the bridge. Properties with the following
-                    prefixes cannot be set: ssl., bootstrap.servers, sasl., security.'
+                    prefixes cannot be set: ssl., bootstrap.servers, sasl., security.
+                    (with the exception of: ssl.endpoint.identification.algorithm,
+                    ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
               description: Kafka producer related configuration.
             resources:
               type: object

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -68,7 +68,8 @@ spec:
                     description: 'The MirrorMaker 2.0 cluster config. Properties with
                       the following prefixes cannot be set: ssl., sasl., security.,
                       listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes,
-                      producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm).'
+                      producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm,
+                      ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
                   tls:
                     type: object
                     properties:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR enhances the TLS configuration possibilities for users.
* It makes `ssl.cipher.suites` configurable in all our compoenents and not just in Kafka
* It makes `ssl.protocol` and `ssl.enabled.protocols` configurable in all our compoenents
* In HTTP Bridge it also makes it possible to configure `ssl.endpoint.identification.algorithm` which was not possible until now

This should let users to allow only selected cipher suites or only some TLS versions (e.g. TLSv1.2). This is using the existing concept of of forbidden confgiuration and its exceptions which is already covered by configuration tests.

This should close the issues #2772  #2774 #2406 

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

