### PR TITLE
Allow changes to storage overrides before scale-up or after scale-down

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1278,13 +1278,13 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     .compose(sts -> {
                         Storage oldStorage = getOldStorage(sts);
 
-                        this.zkCluster = ZookeeperCluster.fromCrd(kafkaAssembly, versions, oldStorage);
-                        this.zkService = zkCluster.generateService();
-                        this.zkHeadlessService = zkCluster.generateHeadlessService();
-
                         if (sts != null && sts.getSpec() != null)   {
                             this.zkCurrentReplicas = sts.getSpec().getReplicas();
                         }
+
+                        this.zkCluster = ZookeeperCluster.fromCrd(kafkaAssembly, versions, oldStorage, zkCurrentReplicas != null ? zkCurrentReplicas : 0);
+                        this.zkService = zkCluster.generateService();
+                        this.zkHeadlessService = zkCluster.generateHeadlessService();
 
                         if (zkCluster.getLogging() instanceof  ExternalLogging) {
                             return configMapOperations.getAsync(kafkaAssembly.getMetadata().getNamespace(), ((ExternalLogging) zkCluster.getLogging()).getName());
@@ -1617,7 +1617,12 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     .compose(sts -> {
                         Storage oldStorage = getOldStorage(sts);
 
-                        this.kafkaCluster = KafkaCluster.fromCrd(kafkaAssembly, versions, oldStorage);
+                        int oldReplicas = 0;
+                        if (sts != null && sts.getSpec() != null)   {
+                            oldReplicas = sts.getSpec().getReplicas();
+                        }
+
+                        this.kafkaCluster = KafkaCluster.fromCrd(kafkaAssembly, versions, oldStorage, oldReplicas);
                         this.kafkaService = kafkaCluster.generateService();
                         this.kafkaHeadlessService = kafkaCluster.generateHeadlessService();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -2292,7 +2292,7 @@ public class KafkaClusterTest {
                     .endKafka()
                     .endSpec()
                     .build();
-            KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, oldStorage);
+            KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, oldStorage, replicas);
         });
     }
 
@@ -2339,7 +2339,7 @@ public class KafkaClusterTest {
                 .endKafka()
                 .endSpec()
                 .build();
-        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, ephemeral);
+        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, ephemeral, replicas);
         assertThat(kc.getStorage(), is(ephemeral));
 
         kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
@@ -2350,7 +2350,7 @@ public class KafkaClusterTest {
                 .endKafka()
                 .endSpec()
                 .build();
-        kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, persistent);
+        kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, persistent, replicas);
         assertThat(kc.getStorage(), is(persistent));
 
         kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
@@ -2361,7 +2361,7 @@ public class KafkaClusterTest {
                 .endKafka()
                 .endSpec()
                 .build();
-        kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, jbod);
+        kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, jbod, replicas);
         assertThat(kc.getStorage(), is(jbod));
 
         kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
@@ -2372,7 +2372,7 @@ public class KafkaClusterTest {
                 .endKafka()
                 .endSpec()
                 .build();
-        kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, jbod);
+        kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, jbod, replicas);
         assertThat(kc.getStorage(), is(jbod));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
@@ -27,12 +27,12 @@ public class StorageDiffTest {
                 new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(true).withId(1).withSize("1000Gi").build())
                 .build();
 
-        StorageDiff diff = new StorageDiff(jbod, jbod);
+        StorageDiff diff = new StorageDiff(jbod, jbod, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
 
-        diff = new StorageDiff(jbod, jbod2);
+        diff = new StorageDiff(jbod, jbod2, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(false));
         assertThat(diff.shrinkSize(), is(false));
@@ -43,13 +43,13 @@ public class StorageDiffTest {
         Storage persistent = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build();
         Storage persistent2 = new PersistentClaimStorageBuilder().withStorageClass("gp2-st1").withDeleteClaim(false).withId(0).withSize("1000Gi").build();
 
-        assertThat(new StorageDiff(persistent, persistent).changesType(), is(false));
-        assertThat(new StorageDiff(persistent, persistent).isEmpty(), is(true));
-        assertThat(new StorageDiff(persistent, persistent).shrinkSize(), is(false));
+        assertThat(new StorageDiff(persistent, persistent, 3, 3).changesType(), is(false));
+        assertThat(new StorageDiff(persistent, persistent, 3, 3).isEmpty(), is(true));
+        assertThat(new StorageDiff(persistent, persistent, 3, 3).shrinkSize(), is(false));
 
-        assertThat(new StorageDiff(persistent, persistent2).changesType(), is(false));
-        assertThat(new StorageDiff(persistent, persistent2).isEmpty(), is(false));
-        assertThat(new StorageDiff(persistent, persistent2).shrinkSize(), is(false));
+        assertThat(new StorageDiff(persistent, persistent2, 3, 3).changesType(), is(false));
+        assertThat(new StorageDiff(persistent, persistent2, 3, 3).isEmpty(), is(false));
+        assertThat(new StorageDiff(persistent, persistent2, 3, 3).shrinkSize(), is(false));
     }
 
     @Test
@@ -81,17 +81,17 @@ public class StorageDiffTest {
                         .build())
                 .build();
 
-        assertThat(new StorageDiff(persistent, persistent).changesType(), is(false));
-        assertThat(new StorageDiff(persistent, persistent).isEmpty(), is(true));
-        assertThat(new StorageDiff(persistent, persistent).shrinkSize(), is(false));
+        assertThat(new StorageDiff(persistent, persistent, 3, 3).changesType(), is(false));
+        assertThat(new StorageDiff(persistent, persistent, 3, 3).isEmpty(), is(true));
+        assertThat(new StorageDiff(persistent, persistent, 3, 3).shrinkSize(), is(false));
 
-        assertThat(new StorageDiff(persistent, persistent2).changesType(), is(false));
-        assertThat(new StorageDiff(persistent, persistent2).isEmpty(), is(false));
-        assertThat(new StorageDiff(persistent, persistent2).shrinkSize(), is(false));
+        assertThat(new StorageDiff(persistent, persistent2, 3, 3).changesType(), is(false));
+        assertThat(new StorageDiff(persistent, persistent2, 3, 3).isEmpty(), is(false));
+        assertThat(new StorageDiff(persistent, persistent2, 3, 3).shrinkSize(), is(false));
 
-        assertThat(new StorageDiff(persistent2, persistent3).changesType(), is(false));
-        assertThat(new StorageDiff(persistent2, persistent3).isEmpty(), is(false));
-        assertThat(new StorageDiff(persistent2, persistent3).shrinkSize(), is(false));
+        assertThat(new StorageDiff(persistent2, persistent3, 3, 3).changesType(), is(false));
+        assertThat(new StorageDiff(persistent2, persistent3, 3, 3).isEmpty(), is(false));
+        assertThat(new StorageDiff(persistent2, persistent3, 3, 3).shrinkSize(), is(false));
     }
 
     @Test
@@ -100,18 +100,18 @@ public class StorageDiffTest {
         Storage persistent2 = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("1000Gi").build();
         Storage persistent3 = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("10Gi").build();
 
-        assertThat(new StorageDiff(persistent, persistent).shrinkSize(), is(false));
-        assertThat(new StorageDiff(persistent, persistent2).shrinkSize(), is(false));
-        assertThat(new StorageDiff(persistent, persistent3).shrinkSize(), is(true));
+        assertThat(new StorageDiff(persistent, persistent, 3, 3).shrinkSize(), is(false));
+        assertThat(new StorageDiff(persistent, persistent2, 3, 3).shrinkSize(), is(false));
+        assertThat(new StorageDiff(persistent, persistent3, 3, 3).shrinkSize(), is(true));
     }
 
     @Test
     public void testEphemeralDiff()    {
         Storage ephemeral = new EphemeralStorageBuilder().build();
 
-        assertThat(new StorageDiff(ephemeral, ephemeral).changesType(), is(false));
-        assertThat(new StorageDiff(ephemeral, ephemeral).isEmpty(), is(true));
-        assertThat(new StorageDiff(ephemeral, ephemeral).shrinkSize(), is(false));
+        assertThat(new StorageDiff(ephemeral, ephemeral, 3, 3).changesType(), is(false));
+        assertThat(new StorageDiff(ephemeral, ephemeral, 3, 3).isEmpty(), is(true));
+        assertThat(new StorageDiff(ephemeral, ephemeral, 3, 3).shrinkSize(), is(false));
     }
 
     @Test
@@ -125,9 +125,9 @@ public class StorageDiffTest {
 
         Storage persistent = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build();
 
-        StorageDiff diffJbodEphemeral = new StorageDiff(jbod, ephemeral);
-        StorageDiff diffPersistentEphemeral = new StorageDiff(persistent, ephemeral);
-        StorageDiff fiddJbodPersistent = new StorageDiff(jbod, persistent);
+        StorageDiff diffJbodEphemeral = new StorageDiff(jbod, ephemeral, 3, 3);
+        StorageDiff diffPersistentEphemeral = new StorageDiff(persistent, ephemeral, 3, 3);
+        StorageDiff fiddJbodPersistent = new StorageDiff(jbod, persistent, 3, 3);
 
         assertThat(diffJbodEphemeral.changesType(), is(true));
         assertThat(diffPersistentEphemeral.changesType(), is(true));
@@ -168,49 +168,49 @@ public class StorageDiffTest {
                 .build();
 
         // Volume added
-        StorageDiff diff = new StorageDiff(jbod, jbod2);
+        StorageDiff diff = new StorageDiff(jbod, jbod2, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
 
         // Volume removed
-        diff = new StorageDiff(jbod2, jbod);
+        diff = new StorageDiff(jbod2, jbod, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
 
         // Volume added with changes
-        diff = new StorageDiff(jbod, jbod3);
+        diff = new StorageDiff(jbod, jbod3, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(false));
         assertThat(diff.shrinkSize(), is(true));
 
         // Volume removed from the beginning
-        diff = new StorageDiff(jbod3, jbod5);
+        diff = new StorageDiff(jbod3, jbod5, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
 
         // Volume added to the beginning
-        diff = new StorageDiff(jbod5, jbod3);
+        diff = new StorageDiff(jbod5, jbod3, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
 
         // Volume replaced with another ID and another volume which is kept changed
-        diff = new StorageDiff(jbod3, jbod6);
+        diff = new StorageDiff(jbod3, jbod6, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(false));
         assertThat(diff.shrinkSize(), is(false));
 
         // Volume replaced with another ID in single volume broker
-        diff = new StorageDiff(jbod, jbod4);
+        diff = new StorageDiff(jbod, jbod4, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
 
         // Volume replaced with another ID without chenging the volumes which are kept
-        diff = new StorageDiff(jbod2, jbod6);
+        diff = new StorageDiff(jbod2, jbod6, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
@@ -233,8 +233,214 @@ public class StorageDiffTest {
                 new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(true).withId(1).withSize("500Gi").build())
                 .build();
 
-        assertThat(new StorageDiff(jbod, jbod).shrinkSize(), is(false));
-        assertThat(new StorageDiff(jbod, jbod2).shrinkSize(), is(false));
-        assertThat(new StorageDiff(jbod, jbod3).shrinkSize(), is(true));
+        assertThat(new StorageDiff(jbod, jbod, 3, 3).shrinkSize(), is(false));
+        assertThat(new StorageDiff(jbod, jbod2, 3, 3).shrinkSize(), is(false));
+        assertThat(new StorageDiff(jbod, jbod3, 3, 3).shrinkSize(), is(true));
+    }
+
+    @Test
+    public void testPersistentDiffWithOverridesChangesToExistingOverrides()    {
+        Storage persistent = new PersistentClaimStorageBuilder()
+                .withStorageClass("gp2-ssd")
+                .withDeleteClaim(false)
+                .withId(0)
+                .withSize("100Gi")
+                .withOverrides(
+                        new PersistentClaimStorageOverrideBuilder()
+                                .withBroker(0)
+                                .withStorageClass("gp2-ssd-az1")
+                                .build(),
+                        new PersistentClaimStorageOverrideBuilder()
+                                .withBroker(1)
+                                .withStorageClass("gp2-ssd-az2")
+                                .build())
+                .build();
+
+        Storage persistent2 = new PersistentClaimStorageBuilder()
+                .withStorageClass("gp2-ssd")
+                .withDeleteClaim(false)
+                .withId(0)
+                .withSize("100Gi")
+                .withOverrides(
+                        new PersistentClaimStorageOverrideBuilder()
+                                .withBroker(0)
+                                .withStorageClass("gp2-ssd-az1")
+                                .build(),
+                        new PersistentClaimStorageOverrideBuilder()
+                                .withBroker(1)
+                                .withStorageClass("new-sc")
+                                .build())
+                .build();
+
+        // Test no changes when the diff is the same
+        assertThat(new StorageDiff(persistent, persistent, 2, 2).isEmpty(), is(true));
+        assertThat(new StorageDiff(persistent2, persistent2, 2, 2).isEmpty(), is(true));
+
+        // Override changed for node which does not exist => is allowed
+        assertThat(new StorageDiff(persistent, persistent2, 1, 1).isEmpty(), is(true));
+
+        // Override changed for node which is being scaled up => is allowed
+        assertThat(new StorageDiff(persistent, persistent2, 1, 2).isEmpty(), is(true));
+
+        // Override changed for existing node  => is not allowed
+        assertThat(new StorageDiff(persistent, persistent2, 2, 2).isEmpty(), is(false));
+
+        // Override changed for node being scaled down => is allowed
+        assertThat(new StorageDiff(persistent, persistent2, 2, 1).isEmpty(), is(true));
+    }
+
+    @Test
+    public void testPersistentDiffWithOverridesBeingAdded()    {
+        Storage persistent = new PersistentClaimStorageBuilder()
+                .withStorageClass("gp2-ssd")
+                .withDeleteClaim(false)
+                .withId(0)
+                .withSize("100Gi")
+                .build();
+
+        Storage persistent2 = new PersistentClaimStorageBuilder()
+                .withStorageClass("gp2-ssd")
+                .withDeleteClaim(false)
+                .withId(0)
+                .withSize("100Gi")
+                .withOverrides(
+                        new PersistentClaimStorageOverrideBuilder()
+                                .withBroker(0)
+                                .withStorageClass("gp2-ssd-az1")
+                                .build())
+                .build();
+
+        Storage persistent3 = new PersistentClaimStorageBuilder()
+                .withStorageClass("gp2-ssd")
+                .withDeleteClaim(false)
+                .withId(0)
+                .withSize("100Gi")
+                .withOverrides(
+                        new PersistentClaimStorageOverrideBuilder()
+                                .withBroker(0)
+                                .withStorageClass("gp2-ssd-az1")
+                                .build(),
+                        new PersistentClaimStorageOverrideBuilder()
+                                .withBroker(1)
+                                .withStorageClass("gp2-ssd-az2")
+                                .build())
+                .build();
+
+        // Test no changes
+        assertThat(new StorageDiff(persistent, persistent, 2, 2).isEmpty(), is(true));
+        assertThat(new StorageDiff(persistent2, persistent2, 2, 2).isEmpty(), is(true));
+        assertThat(new StorageDiff(persistent3, persistent3, 2, 2).isEmpty(), is(true));
+
+        // Overrides added for existing nodes => not allowed
+        assertThat(new StorageDiff(persistent, persistent2, 2, 2).isEmpty(), is(false));
+        assertThat(new StorageDiff(persistent, persistent3, 2, 2).isEmpty(), is(false));
+        assertThat(new StorageDiff(persistent2, persistent3, 2, 2).isEmpty(), is(false));
+
+        // Overrides added for new nodes => allowed
+        assertThat(new StorageDiff(persistent2, persistent3, 1, 2).isEmpty(), is(true));
+
+        // Overrides added for removed nodes => allowed
+        assertThat(new StorageDiff(persistent2, persistent3, 2, 1).isEmpty(), is(true));
+
+        // Overrides added for non-existing nodes => allowed
+        assertThat(new StorageDiff(persistent2, persistent3, 1, 1).isEmpty(), is(true));
+    }
+
+    @Test
+    public void testPersistentDiffWithOverridesBeingRemoved()    {
+        Storage persistent = new PersistentClaimStorageBuilder()
+                .withStorageClass("gp2-ssd")
+                .withDeleteClaim(false)
+                .withId(0)
+                .withSize("100Gi")
+                .build();
+
+        Storage persistent2 = new PersistentClaimStorageBuilder()
+                .withStorageClass("gp2-ssd")
+                .withDeleteClaim(false)
+                .withId(0)
+                .withSize("100Gi")
+                .withOverrides(
+                        new PersistentClaimStorageOverrideBuilder()
+                                .withBroker(0)
+                                .withStorageClass("gp2-ssd-az1")
+                                .build())
+                .build();
+
+        Storage persistent3 = new PersistentClaimStorageBuilder()
+                .withStorageClass("gp2-ssd")
+                .withDeleteClaim(false)
+                .withId(0)
+                .withSize("100Gi")
+                .withOverrides(
+                        new PersistentClaimStorageOverrideBuilder()
+                                .withBroker(0)
+                                .withStorageClass("gp2-ssd-az1")
+                                .build(),
+                        new PersistentClaimStorageOverrideBuilder()
+                                .withBroker(1)
+                                .withStorageClass("gp2-ssd-az2")
+                                .build())
+                .build();
+
+        // Test no changes
+        assertThat(new StorageDiff(persistent, persistent, 2, 2).isEmpty(), is(true));
+        assertThat(new StorageDiff(persistent2, persistent2, 2, 2).isEmpty(), is(true));
+        assertThat(new StorageDiff(persistent3, persistent3, 2, 2).isEmpty(), is(true));
+
+        // Overrides removed for existing nodes => not allowed
+        assertThat(new StorageDiff(persistent3, persistent, 2, 2).isEmpty(), is(false));
+        assertThat(new StorageDiff(persistent3, persistent2, 2, 2).isEmpty(), is(false));
+        assertThat(new StorageDiff(persistent2, persistent, 2, 2).isEmpty(), is(false));
+
+        // Overrides removed for new nodes => allowed
+        assertThat(new StorageDiff(persistent3, persistent2, 1, 2).isEmpty(), is(true));
+
+        // Overrides removed for removed nodes => allowed
+        assertThat(new StorageDiff(persistent3, persistent2, 2, 1).isEmpty(), is(true));
+
+        // Overrides removed for non-existing nodes => allowed
+        assertThat(new StorageDiff(persistent3, persistent2, 1, 1).isEmpty(), is(true));
+    }
+
+    @Test
+    public void testPersistentDiffWithOverridesBeingAddedAndRemoved()    {
+        Storage persistent = new PersistentClaimStorageBuilder()
+                .withStorageClass("gp2-ssd")
+                .withDeleteClaim(false)
+                .withId(0)
+                .withSize("100Gi")
+                .withOverrides(
+                        new PersistentClaimStorageOverrideBuilder()
+                                .withBroker(0)
+                                .withStorageClass("gp2-ssd-az1")
+                                .build())
+                .build();
+
+        Storage persistent2 = new PersistentClaimStorageBuilder()
+                .withStorageClass("gp2-ssd")
+                .withDeleteClaim(false)
+                .withId(0)
+                .withSize("100Gi")
+                .withOverrides(
+                        new PersistentClaimStorageOverrideBuilder()
+                                .withBroker(1)
+                                .withStorageClass("gp2-ssd-az2")
+                                .build())
+                .build();
+
+        // Test no changes
+        assertThat(new StorageDiff(persistent, persistent, 2, 2).isEmpty(), is(true));
+        assertThat(new StorageDiff(persistent2, persistent2, 2, 2).isEmpty(), is(true));
+
+        // Overrides added and removed for existing nodes => not allowed
+        assertThat(new StorageDiff(persistent2, persistent, 2, 2).isEmpty(), is(false));
+        assertThat(new StorageDiff(persistent, persistent2, 2, 2).isEmpty(), is(false));
+
+        // Overrides added for new nodes but removed for old => not allowed
+        assertThat(new StorageDiff(persistent, persistent2, 1, 2).isEmpty(), is(false));
+
+        // Overrides removed for new nodes but added for old => not allowed
+        assertThat(new StorageDiff(persistent2, persistent, 1, 2).isEmpty(), is(false));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -1042,7 +1042,7 @@ public class ZookeeperClusterTest {
                 .endZookeeper()
                 .endSpec()
                 .build();
-        ZookeeperCluster zc = ZookeeperCluster.fromCrd(ka, VERSIONS, persistent);
+        ZookeeperCluster zc = ZookeeperCluster.fromCrd(ka, VERSIONS, persistent, replicas);
         assertThat(zc.getStorage(), is(persistent));
 
         ka = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson))
@@ -1052,7 +1052,7 @@ public class ZookeeperClusterTest {
                 .endZookeeper()
                 .endSpec()
                 .build();
-        zc = ZookeeperCluster.fromCrd(ka, VERSIONS, ephemeral);
+        zc = ZookeeperCluster.fromCrd(ka, VERSIONS, ephemeral, replicas);
         assertThat(zc.getStorage(), is(ephemeral));
     }
 
@@ -1071,7 +1071,7 @@ public class ZookeeperClusterTest {
                         .endZookeeper()
                     .endSpec()
                     .build();
-            ZookeeperCluster.fromCrd(kafkaAssembly, VERSIONS, oldStorage);
+            ZookeeperCluster.fromCrd(kafkaAssembly, VERSIONS, oldStorage, replicas);
         });
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
@@ -102,7 +102,7 @@ public class KafkaAssemblyOperatorCustomCertTest {
     @BeforeEach
     public void setup() {
         kafka = createKafka();
-        kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS, null);
+        kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
 
         supplier = ResourceUtils.supplierWithMocks(false);
         operator = new MockKafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
@@ -329,7 +329,7 @@ public class KafkaAssemblyOperatorCustomCertTest {
                     .endKafka()
                 .endSpec()
                 .build();
-        kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS, null);
+        kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
 
         // Mock the SecretOperator
         SecretOperator mockSecretOps = supplier.secretOperations;


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Strimzi doesn't support changes to existing storage configuration because it cannot really change the storage class of existing disk for example. The only changes currently supported are:
* Increasing the storage size (when supported by the storage class)
* Adding/removing volumes to/from JBOD storage

One of the problems of this is that we support per-broker overrides which let the users to specify the storage class for each broker. But right now these could be set only when deploying new cluster. That is ok as long as you don't plan to scale the brokers (Zookeepers). When you want to scale the brokers and want to add new overrides for them, the mechanism which protects the storage changes will not allow them.

This PR makes is possible to change the overrides (add, remove, modify) for the brokers which:
* Do not exist yet (and will be added later - e.g. broker 4 and 5 with 3 node cluster)
* Brokers which are being scaled-up (i.e. you can add/modify the overrides for the new brokers just as you change the `replicas` field)
* Brokers which are being scaled-down (i.e. you can remove the overrides for the old brokers just as you change the `replicas` field)

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally