### PR TITLE
Fix typo in comment in the KafkaUser example

### DIFF
--- a/examples/user/kafka-user.yaml
+++ b/examples/user/kafka-user.yaml
@@ -10,7 +10,7 @@ spec:
   authorization:
     type: simple
     acls:
-      # Example consumer Acls for topic my-topic suing consumer group my-group
+      # Example consumer Acls for topic my-topic using consumer group my-group
       - resource:
           type: topic
           name: my-topic


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes simply typo in the comments in the authorization section of our KafkaUser example.