### PR TITLE
Pass the storage warnings into the KafkaStatus conditions

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -50,6 +50,7 @@ import io.strimzi.api.kafka.model.JvmOptions;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.api.kafka.model.SystemProperty;
+import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.storage.JbodStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorageOverride;
@@ -64,6 +65,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -150,6 +152,7 @@ public abstract class AbstractModel {
     protected List<SystemProperty> javaSystemProperties = null;
 
     protected Labels labels;
+
     // Templates
     protected Map<String, String> templateStatefulSetLabels;
     protected Map<String, String> templateStatefulSetAnnotations;
@@ -180,6 +183,8 @@ public abstract class AbstractModel {
 
     protected io.strimzi.api.kafka.model.Probe readinessProbeOptions;
     protected io.strimzi.api.kafka.model.Probe livenessProbeOptions;
+
+    protected List<Condition> warningConditions = new ArrayList<>(0);
 
     /**
      * Constructor
@@ -1165,5 +1170,23 @@ public abstract class AbstractModel {
                 }
             }
         }
+    }
+
+    /**
+     * Adds warning condition to the list
+     *
+     * @param warning   Condition which will be added to the warning
+     */
+    public void addWarningCondition(Condition warning)  {
+        warningConditions.add(warning);
+    }
+
+    /**
+     * Returns a list of warning conditions set by the model. Returns empty list if no warning conditions were set.
+     *
+     * @return  List of warning conditions.
+     */
+    public List<Condition> getWarningConditions()   {
+        return warningConditions;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -85,6 +85,7 @@ import io.strimzi.api.kafka.model.listener.NodePortListenerBrokerOverride;
 import io.strimzi.api.kafka.model.listener.NodePortListenerOverride;
 import io.strimzi.api.kafka.model.listener.RouteListenerBrokerOverride;
 import io.strimzi.api.kafka.model.listener.RouteListenerOverride;
+import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.storage.JbodStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
@@ -96,6 +97,7 @@ import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.resource.StatusUtils;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -476,6 +478,13 @@ public class KafkaCluster extends AbstractModel {
                 log.warn("Your desired Kafka storage configuration contains changes which are not allowed. As a " +
                         "result, all storage changes will be ignored. Use DEBUG level logging for more information " +
                         "about the detected changes.");
+
+                Condition warning = StatusUtils.buildWarningCondition("KafkaStorage",
+                        "The desired Kafka storage configuration contains changes which are not allowed. As a " +
+                                "result, all storage changes will be ignored. Use DEBUG level logging for more information " +
+                                "about the detected changes.");
+                result.addWarningCondition(warning);
+
                 result.setStorage(oldStorage);
             } else {
                 result.setStorage(newStorage);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -39,6 +39,7 @@ import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.ZookeeperClusterSpec;
+import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.storage.EphemeralStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
@@ -46,6 +47,7 @@ import io.strimzi.api.kafka.model.template.ZookeeperClusterTemplate;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.resource.StatusUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -261,6 +263,13 @@ public class ZookeeperCluster extends AbstractModel {
                 log.warn("Your desired Zookeeper storage configuration contains changes which are not allowed. As " +
                         "a result, all storage changes will be ignored. Use DEBUG level logging for more information " +
                         "about the detected changes.");
+
+                Condition warning = StatusUtils.buildWarningCondition("ZooKeeperStorage",
+                        "The desired ZooKeeper storage configuration contains changes which are not allowed. As a " +
+                                "result, all storage changes will be ignored. Use DEBUG level logging for more information " +
+                                "about the detected changes.");
+                zk.addWarningCondition(warning);
+
                 zk.setStorage(oldStorage);
             } else {
                 zk.setStorage(newStorage);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -255,6 +255,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 // Roll everything if a new CA is added to the trust store.
                 .compose(state -> state.rollingUpdateForNewCaKey())
                 .compose(state -> state.getZookeeperDescription())
+                .compose(state -> state.zkModelWarnings())
                 .compose(state -> state.zkManualPodCleaning())
                 .compose(state -> state.zkNetPolicy())
                 .compose(state -> state.zkManualRollingUpdate())
@@ -278,7 +279,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(state -> state.zkPersistentClaimDeletion())
 
                 .compose(state -> state.getKafkaClusterDescription())
-                .compose(state -> state.checkKafkaSpec(this::dateSupplier))
+                .compose(state -> state.checkKafkaSpec())
+                .compose(state -> state.kafkaModelWarnings())
                 .compose(state -> state.kafkaManualPodCleaning())
                 .compose(state -> state.kafkaNetPolicy())
                 .compose(state -> state.kafkaManualRollingUpdate())
@@ -533,10 +535,26 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          * Checks the requested Kafka spec for potential issues, and adds warnings and advice for best
          * practice to the status.
          */
-        Future<ReconciliationState> checkKafkaSpec(Supplier<Date> dateSupplier) {
-            KafkaSpecChecker checker = new KafkaSpecChecker(dateSupplier, kafkaAssembly.getSpec(), kafkaCluster, zkCluster);
+        Future<ReconciliationState> checkKafkaSpec() {
+            KafkaSpecChecker checker = new KafkaSpecChecker(kafkaAssembly.getSpec(), kafkaCluster, zkCluster);
             List<Condition> warnings = checker.run();
             kafkaStatus.addConditions(warnings);
+            return Future.succeededFuture(this);
+        }
+
+        /**
+         * Takes the warning conditions from the Model and adds them in the KafkaStatus
+         */
+        Future<ReconciliationState> kafkaModelWarnings() {
+            kafkaStatus.addConditions(kafkaCluster.getWarningConditions());
+            return Future.succeededFuture(this);
+        }
+
+        /**
+         * Takes the warning conditions from the Model and adds them in the KafkaStatus
+         */
+        Future<ReconciliationState> zkModelWarnings() {
+            kafkaStatus.addConditions(zkCluster.getWarningConditions());
             return Future.succeededFuture(this);
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -2340,7 +2340,13 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, ephemeral, replicas);
+
+        // Storage is reverted
         assertThat(kc.getStorage(), is(ephemeral));
+
+        // Warning status condition is set
+        assertThat(kc.getWarningConditions().size(), is(1));
+        assertThat(kc.getWarningConditions().get(0).getReason(), is("KafkaStorage"));
 
         kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
@@ -2351,7 +2357,13 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, persistent, replicas);
+
+        // Storage is reverted
         assertThat(kc.getStorage(), is(persistent));
+
+        // Warning status condition is set
+        assertThat(kc.getWarningConditions().size(), is(1));
+        assertThat(kc.getWarningConditions().get(0).getReason(), is("KafkaStorage"));
 
         kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
@@ -2362,7 +2374,13 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, jbod, replicas);
+
+        // Storage is reverted
         assertThat(kc.getStorage(), is(jbod));
+
+        // Warning status condition is set
+        assertThat(kc.getWarningConditions().size(), is(1));
+        assertThat(kc.getWarningConditions().get(0).getReason(), is("KafkaStorage"));
 
         kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
@@ -2373,7 +2391,13 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, jbod, replicas);
+
+        // Storage is reverted
         assertThat(kc.getStorage(), is(jbod));
+
+        // Warning status condition is set
+        assertThat(kc.getWarningConditions().size(), is(1));
+        assertThat(kc.getWarningConditions().get(0).getReason(), is("KafkaStorage"));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -1053,7 +1053,13 @@ public class ZookeeperClusterTest {
                 .endSpec()
                 .build();
         zc = ZookeeperCluster.fromCrd(ka, VERSIONS, ephemeral, replicas);
+
+        // Storage is reverted
         assertThat(zc.getStorage(), is(ephemeral));
+
+        // Warning status condition is set
+        assertThat(zc.getWarningConditions().size(), is(1));
+        assertThat(zc.getWarningConditions().get(0).getReason(), is("ZooKeeperStorage"));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -988,46 +988,6 @@ public class KafkaStatusTest {
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.getAsync(eq(namespace), eq(clusterName))).thenReturn(Future.succeededFuture(kafkaCluster.generateMetricsAndLogConfigMap(null)));
 
-        // Mock Pods Operator
-        /*Pod pod0 = new PodBuilder()
-                .withNewMetadata()
-                .withNewName(clusterName + "-kafka-" + 0)
-                .endMetadata()
-                .withNewStatus()
-                .withNewHostIP("10.0.0.1")
-                .endStatus()
-                .build();
-
-        Pod pod1 = new PodBuilder()
-                .withNewMetadata()
-                .withNewName(clusterName + "-kafka-" + 1)
-                .endMetadata()
-                .withNewStatus()
-                .withNewHostIP("10.0.0.1")
-                .endStatus()
-                .build();
-
-        Pod pod2 = new PodBuilder()
-                .withNewMetadata()
-                .withNewName(clusterName + "-kafka-" + 2)
-                .endMetadata()
-                .withNewStatus()
-                .withNewHostIP("10.0.0.1")
-                .endStatus()
-                .build();
-
-        List<Pod> pods = new ArrayList<>();
-        pods.add(pod0);
-        pods.add(pod1);
-        pods.add(pod2);
-
-        PodOperator mockPodOps = supplier.podOperations;
-        when(mockPodOps.listAsync(eq(namespace), any(Labels.class))).thenReturn(Future.succeededFuture(pods));
-
-        // Mock Node operator
-        NodeOperator mockNodeOps = supplier.nodeOperator;
-        when(mockNodeOps.listAsync(any(Labels.class))).thenReturn(Future.succeededFuture(getClusterNodes()));*/
-
         MockModelWarningsStatusKafkaAssemblyOperator kao = new MockModelWarningsStatusKafkaAssemblyOperator(
                 vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
                 certManager,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -1036,20 +1036,19 @@ public class KafkaStatusTest {
                 config);
 
         Checkpoint async = context.checkpoint();
-        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
-            assertThat(res.succeeded(), is(true));
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka)
+                .setHandler(context.succeeding(v -> context.verify(() -> {
+                    assertThat(kafkaCaptor.getValue(), is(notNullValue()));
+                    assertThat(kafkaCaptor.getValue().getStatus(), is(notNullValue()));
+                    KafkaStatus status = kafkaCaptor.getValue().getStatus();
 
-            assertThat(kafkaCaptor.getValue(), is(notNullValue()));
-            assertThat(kafkaCaptor.getValue().getStatus(), is(notNullValue()));
-            KafkaStatus status = kafkaCaptor.getValue().getStatus();
-            System.out.println(status.getConditions().get(0));
-            assertThat(status.getConditions().size(), is(2));
-            assertThat(status.getConditions().get(0).getType(), is("Warning"));
-            assertThat(status.getConditions().get(0).getReason(), is("KafkaStorage"));
-            assertThat(status.getConditions().get(1).getType(), is("Ready"));
+                    assertThat(status.getConditions().size(), is(2));
+                    assertThat(status.getConditions().get(0).getType(), is("Warning"));
+                    assertThat(status.getConditions().get(0).getReason(), is("KafkaStorage"));
+                    assertThat(status.getConditions().get(1).getType(), is("Ready"));
 
-            async.flag();
-        });
+                    async.flag();
+                })));
     }
 
     // This allows to test the status handling when reconciliation succeeds

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecCheckerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecCheckerTest.java
@@ -15,7 +15,6 @@ import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaConfiguration;
 import io.strimzi.operator.cluster.model.KafkaVersion;
-import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import org.junit.jupiter.api.Test;
 
@@ -52,7 +51,7 @@ public class KafkaSpecCheckerTest {
                 emptyMap()) { };
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, versions);
         ZookeeperCluster zkCluster = ZookeeperCluster.fromCrd(kafka, versions);
-        return new KafkaSpecChecker(this::dateSupplier, kafka.getSpec(), kafkaCluster, zkCluster);
+        return new KafkaSpecChecker(kafka.getSpec(), kafkaCluster, zkCluster);
     }
 
     @Test
@@ -78,7 +77,6 @@ public class KafkaSpecCheckerTest {
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
         assertThat(warning.getReason(), is("KafkaStorage"));
-        assertThat(warning.getLastTransitionTime(), is(ModelUtils.formatTimestamp(dateSupplier())));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("A Kafka cluster with a single replica and ephemeral storage will lose topic messages after any restart or rolling update."));
     }
@@ -101,7 +99,6 @@ public class KafkaSpecCheckerTest {
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
         assertThat(warning.getReason(), is("KafkaStorage"));
-        assertThat(warning.getLastTransitionTime(), is(ModelUtils.formatTimestamp(dateSupplier())));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("A Kafka cluster with a single replica and ephemeral storage will lose topic messages after any restart or rolling update."));
     }
@@ -122,7 +119,6 @@ public class KafkaSpecCheckerTest {
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
         assertThat(warning.getReason(), is("ZooKeeperStorage"));
-        assertThat(warning.getLastTransitionTime(), is(ModelUtils.formatTimestamp(dateSupplier())));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("A ZooKeeper cluster with a single replica and ephemeral storage will be in a defective state after any restart or rolling update. It is recommended that a minimum of three replicas are used."));
     }
@@ -135,7 +131,6 @@ public class KafkaSpecCheckerTest {
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
         assertThat(warning.getReason(), is("ZooKeeperReplicas"));
-        assertThat(warning.getLastTransitionTime(), is(ModelUtils.formatTimestamp(dateSupplier())));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("Running ZooKeeper with two nodes is not advisable as both replicas will be needed to avoid downtime. It is recommended that a minimum of three replicas are used."));
     }
@@ -148,7 +143,6 @@ public class KafkaSpecCheckerTest {
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
         assertThat(warning.getReason(), is("ZooKeeperReplicas"));
-        assertThat(warning.getLastTransitionTime(), is(ModelUtils.formatTimestamp(dateSupplier())));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("Running ZooKeeper with an odd number of replicas is recommended."));
     }
@@ -171,7 +165,6 @@ public class KafkaSpecCheckerTest {
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
         assertThat(warning.getReason(), is("KafkaLogMessageFormatVersion"));
-        assertThat(warning.getLastTransitionTime(), is(ModelUtils.formatTimestamp(dateSupplier())));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("log.message.format.version does not match the Kafka cluster version, which suggests that an upgrade is incomplete."));
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -48,6 +48,16 @@ public class StatusUtils {
         return readyCondition;
     }
 
+    public static Condition buildWarningCondition(String reason, String message) {
+        return new ConditionBuilder()
+                .withLastTransitionTime(iso8601Now())
+                .withType("Warning")
+                .withStatus("True")
+                .withReason(reason)
+                .withMessage(message)
+                .build();
+    }
+
     public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, AsyncResult<Void> result) {
         setStatusConditionAndObservedGeneration(resource, status, result.cause());
     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When ilegal change is done to the storage configuration, we currently print only warnings to the logs. This PR passed the warnings also to the KafkaStatus as a warning conditions to amek them more visible to the users.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally