### PR TITLE
[MO] - [NPE] -> dependency using of kafka connect

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
@@ -332,6 +332,11 @@ public class KubernetesResource {
      */
     public static void allowNetworkPolicySettingsForResource(HasMetadata resource, String deploymentName, String clusterName) {
         String clientsDeploymentName = clusterName + "-" + Constants.KAFKA_CLIENTS;
+
+        if (kubeClient().getDeployment(clientsDeploymentName).getSpec().getSelector() == null) {
+            throw new RuntimeException("You did not create the Kafka Client instance(pod) before using the Kafka Connect");
+        }
+
         LabelSelector labelSelector = kubeClient().getDeployment(clientsDeploymentName).getSpec().getSelector();
 
         LOGGER.info("Apply NetworkPolicy access to {} from {}", deploymentName, clientsDeploymentName);


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix

### Description

This PR handling the situation where we use the Kafka Connect, but we always need to have the Kafka Client pod for the calling of the KC API. 

### Checklist

- [ ] Make sure all tests pass
