### PR TITLE
ST: Fix message count and remove old upgrade test

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/VerifiableClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/VerifiableClient.java
@@ -168,10 +168,8 @@ public class VerifiableClient {
         arguments.clear();
         String argument;
         for (ClientArgument arg : args.getArguments()) {
-            LOGGER.info(arg);
             if (validateArgument(arg)) {
                 for (String value : args.getValues(arg)) {
-                    LOGGER.info(value);
                     if (arg.equals(ClientArgument.USER)) {
                         argument = String.format("%s=%s", arg.command(), value);
                         arguments.add(argument);

--- a/systemtest/src/main/resources/StrimziUpgradeST.json
+++ b/systemtest/src/main/resources/StrimziUpgradeST.json
@@ -1,42 +1,5 @@
 [
   {
-    "fromVersion":"0.8.2",
-    "toVersion":"0.11.4",
-    "fromExamples":"strimzi-0.8.2",
-    "toExamples":"strimzi-0.11.4",
-    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.8.2/strimzi-0.8.2.zip",
-    "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.11.4/strimzi-0.11.4.zip",
-    "imagesBeforeKafkaUpdate": {
-      "zookeeper": "strimzi/zookeeper:0.11.4-kafka-2.0.0",
-      "kafka": "strimzi/kafka:0.11.4-kafka-2.0.0",
-      "topicOperator": "strimzi/topic-operator:0.11.4",
-      "userOperator": "strimzi/user-operator:0.11.4"
-    },
-    "imagesAfterKafkaUpdate": {
-      "zookeeper": "strimzi/zookeeper:0.11.4-kafka-2.0.0",
-      "kafka": "strimzi/kafka:0.11.4-kafka-2.1.0",
-      "topicOperator": "strimzi/topic-operator:0.11.4",
-      "userOperator": "strimzi/user-operator:0.11.4"
-    },
-    "proceduresBefore": {
-      "kafkaVersion": "2.0.0",
-      "logMessageVersion": "2.0"
-    },
-    "proceduresAfter": {
-      "kafkaVersion": "2.1.0",
-      "logMessageVersion": "2.1"
-    },
-    "client": {
-      "beforeKafkaUpdate": "strimzi/test-client:0.12.1-kafka-2.1.0",
-      "afterKafkaUpdate": "strimzi/test-client:0.12.1-kafka-2.1.0",
-      "reason": "0.8.2 and 0.11.4 test clients images are not compatible with current client execution mechanism in system tests"
-    },
-    "supportedK8sVersion": {
-      "version": "1.11",
-      "reason" : "Currently 0.8.2 CO cannot be deployed on newer versions of Kubernetes than 1.11.x. This test will be skipped until better understanding of the issue."
-    }
-  },
-  {
     "fromVersion":"0.11.4",
     "toVersion":"0.12.1",
     "fromExamples":"strimzi-0.11.4",

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -271,14 +271,14 @@ public class StrimziUpgradeST extends BaseST {
             .withNamespaceName(NAMESPACE)
             .withClusterName(kafkaClusterName)
             .withKafkaUsername(userName)
-            .withMessageCount(MESSAGE_COUNT)
+            .withMessageCount(produceMessagesCount)
             .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
             .build();
 
         int sent = internalKafkaClient.sendMessagesTls();
         assertThat(sent, is(produceMessagesCount));
 
-        internalKafkaClient.setMessageCount(produceMessagesCount);
+        internalKafkaClient.setMessageCount(consumeMessagesCount);
 
         int received = internalKafkaClient.receiveMessagesTls();
         assertThat(received, is(consumeMessagesCount));

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -89,7 +89,7 @@ public class StrimziUpgradeST extends BaseST {
         assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(parameters.getJsonObject("supportedK8sVersion").getString("version")));
 
         try {
-            performUpgrade(parameters, 50, 50);
+            performUpgrade(parameters, MESSAGE_COUNT, MESSAGE_COUNT);
             // Tidy up
         } catch (KubeClusterException e) {
             e.printStackTrace();
@@ -131,14 +131,13 @@ public class StrimziUpgradeST extends BaseST {
         JsonReader jsonReader = Json.createReader(inputStream);
         JsonArray parameters = jsonReader.readArray();
 
-        int produceMessagesCount = 50;
-        int consumedMessagesCount = 50;
+        int consumedMessagesCount = MESSAGE_COUNT;
 
         try {
             for (JsonValue testParameters : parameters) {
                 if (StUtils.isAllowedOnCurrentK8sVersion(testParameters.asJsonObject().getJsonObject("supportedK8sVersion").getString("version"))) {
-                    performUpgrade(testParameters.asJsonObject(), produceMessagesCount, consumedMessagesCount);
-                    consumedMessagesCount = consumedMessagesCount + produceMessagesCount;
+                    performUpgrade(testParameters.asJsonObject(), MESSAGE_COUNT, consumedMessagesCount);
+                    consumedMessagesCount = consumedMessagesCount + MESSAGE_COUNT;
                 } else {
                     LOGGER.info("Upgrade of Cluster Operator from version {} to version {} is not allowed on this K8S version!", testParameters.asJsonObject().getString("fromVersion"), testParameters.asJsonObject().getString("toVersion"));
                 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes several issues in upgrade tests:

- message count was wrong, it causes fail for each test
- `group-instnace-id` wasn't set properly for old clients, which caused the failure of old upgrade tests

I also removed upgrade from 0.8.2 to 0.11.4, because it looks that currently used fabric8 version doesn't work with old CRDs properly.

### Checklist

- [ ] Make sure all tests pass

