### PR TITLE
[MO] - [refactor] -> topic suite

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.utils.kafkaUtils;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -74,12 +75,20 @@ public class KafkaTopicUtils {
         );
     }
 
-    public static void waitForKafkaTopicStatus(String status, String topicName) {
+    public static void waitForKafkaTopicStatus(String topicName, String status) {
         LOGGER.info("Wait until Kafka Topic {} is in desired state: {}", topicName, status);
-        TestUtils.waitFor("Kafka Topic " + topicName + " status is not in desired state: " + status, Constants.GLOBAL_POLL_INTERVAL, Constants.CONNECT_STATUS_TIMEOUT, () -> {
+        TestUtils.waitFor("Kafka Topic " + topicName + " status is not in desired state: " + status, Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT
+            , () -> {
             Condition kafkaCondition = KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(topicName).get().getStatus().getConditions().get(0);
             return kafkaCondition.getType().equals(status);
         });
-        LOGGER.info("Kafka Topic {} is in desired state: {}", topicName, status);
+    }
+
+    public static void waitForKafkaTopicsCount(int topicCount, String clusterName) {
+        LOGGER.info("Wait until we create {} Kafka Topics", topicCount);
+        TestUtils.waitFor("Wait until we create" + topicCount + " Kafka Topics",
+            Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> KafkaCmdClient.listTopicsUsingPodCli(clusterName, 0).size() == topicCount);
+        LOGGER.info("We created {} Kafka Topics", topicCount);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -77,8 +77,7 @@ public class KafkaTopicUtils {
 
     public static void waitForKafkaTopicStatus(String topicName, String status) {
         LOGGER.info("Wait until Kafka Topic {} is in desired state: {}", topicName, status);
-        TestUtils.waitFor("Kafka Topic " + topicName + " status is not in desired state: " + status, Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT
-            , () -> {
+        TestUtils.waitFor("Kafka Topic " + topicName + " status is not in desired state: " + status, Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT, () -> {
             Condition kafkaCondition = KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(topicName).get().getStatus().getConditions().get(0);
             return kafkaCondition.getType().equals(status);
         });

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -311,7 +311,7 @@ class CustomResourceStatusST extends BaseST {
 
     @Test
     void testKafkaTopicStatus() {
-        KafkaTopicUtils.waitForKafkaTopicStatus("Ready", TOPIC_NAME);
+        KafkaTopicUtils.waitForKafkaTopicStatus(TOPIC_NAME, "Ready");
         // The reason why we have there Observed Generation = 2 cause Kafka sync message.format.version when topic is created
         assertKafkaTopicStatus(2, TOPIC_NAME);
     }
@@ -320,7 +320,7 @@ class CustomResourceStatusST extends BaseST {
     void testKafkaTopicStatusNotReady() {
         String topicName = "my-topic";
         KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME, topicName, 1, 10, 10).build());
-        KafkaTopicUtils.waitForKafkaTopicStatus("NotReady", topicName);
+        KafkaTopicUtils.waitForKafkaTopicStatus(topicName, "NotReady");
         assertKafkaTopicStatus(1, topicName);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicST.java
@@ -2,10 +2,12 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.systemtest;
+package io.strimzi.systemtest.topic;
 
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.systemtest.BaseST;
+import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
 import io.strimzi.systemtest.resources.KubernetesResource;
@@ -29,7 +31,6 @@ import org.junit.jupiter.api.TestMethodOrder;
 import java.util.List;
 
 import static io.strimzi.systemtest.Constants.REGRESSION;
-import static io.strimzi.systemtest.Constants.SCALABILITY;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -45,7 +46,6 @@ public class TopicST extends BaseST {
 
     private static final Logger LOGGER = LogManager.getLogger(TopicST.class);
     private static final String NAMESPACE = "topic-cluster-test";
-    private static final int NUMBER_OF_TOPICS = 5000;
 
     @Test
     @Order(1)
@@ -88,28 +88,8 @@ public class TopicST extends BaseST {
         assertThat("Topic exists in Kafka CR (Kubernetes)", hasTopicInCRK8s(kafkaTopic, newTopicName));
     }
 
-    @Tag(SCALABILITY)
     @Test
     @Order(2)
-    void testBigAmountOfTopicsCreatingViaK8s() {
-        final String topicName = "topic-example";
-        String currentTopic;
-        int topicPartitions = 3;
-
-        LOGGER.info("Creating topics via Kubernetes");
-        for (int i = 0; i < NUMBER_OF_TOPICS; i++) {
-            currentTopic = topicName + i;
-            KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME,
-                currentTopic, topicPartitions, 1, 1).build());
-        }
-
-        LOGGER.info("Verifying that we created {} topics", NUMBER_OF_TOPICS);
-
-        assertThat(KafkaCmdClient.listTopicsUsingPodCli(CLUSTER_NAME, 0).size(), is(NUMBER_OF_TOPICS));
-    }
-
-    @Test
-    @Order(3)
     void testCreateTopicViaKafka() {
         int topicPartitions = 3;
 
@@ -132,7 +112,7 @@ public class TopicST extends BaseST {
     }
 
     @Test
-    @Order(4)
+    @Order(3)
     void testTopicModificationOfReplicationFactor() {
         String topicName = "topic-with-changed-replication";
 
@@ -163,7 +143,7 @@ public class TopicST extends BaseST {
     }
 
     @Test
-    @Order(5)
+    @Order(4)
     void testSendingMessagesToNonExistingTopic() {
         String topicName = TOPIC_NAME + "-" + rng.nextInt(Integer.MAX_VALUE);
 
@@ -201,7 +181,7 @@ public class TopicST extends BaseST {
     }
 
     @Test
-    @Order(6)
+    @Order(5)
     void testDeleteTopicEnableFalse() {
         String topicName = "my-deleted-topic";
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicScalabilityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicScalabilityST.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.topic;
+
+import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static io.strimzi.systemtest.Constants.SCALABILITY;
+
+@Tag(SCALABILITY)
+public class TopicScalabilityST extends TopicST {
+
+    private static final Logger LOGGER = LogManager.getLogger(TopicST.class);
+    private static final int NUMBER_OF_TOPICS = 2500;
+
+    @Test
+    void testBigAmountOfTopicsCreatingViaK8s() {
+        final String topicName = "topic-example";
+
+        LOGGER.info("Creating topics via Kubernetes");
+        for (int i = 0; i < NUMBER_OF_TOPICS; i++) {
+            String currentTopic = topicName + i;
+            LOGGER.debug("Creating {} topic", currentTopic);
+            KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME,
+                currentTopic, 3, 1, 1).build());
+        }
+
+        LOGGER.info("Verifying that we created {} topics", NUMBER_OF_TOPICS);
+
+        KafkaTopicUtils.waitForKafkaTopicsCount(NUMBER_OF_TOPICS, CLUSTER_NAME);
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicScalabilityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicScalabilityST.java
@@ -16,7 +16,7 @@ import static io.strimzi.systemtest.Constants.SCALABILITY;
 @Tag(SCALABILITY)
 public class TopicScalabilityST extends TopicST {
 
-    private static final Logger LOGGER = LogManager.getLogger(TopicST.class);
+    private static final Logger LOGGER = LogManager.getLogger(TopicScalabilityST.class);
     private static final int NUMBER_OF_TOPICS = 2500;
 
     @Test


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR adding a few changes to the TopicST. 

1. Removing scale test with the Kafka, where we delegate the task to the executor. Instead of using a scale, I have replaced it in just smoke test that creates & verify that topics were created.
2. Order of tests because of shared Kafka cluster, where I replaced it and with that reduce time cost.
3. Change the test when we creating topics with the Kubernetes client API and do not wait for ack and just simply verify the size of topics.
### Checklist

- [ ] Make sure all tests pass
