### PR TITLE
Clean up some log messages in the MirrorMaker2 operator

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -121,7 +121,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
         KafkaMirrorMaker2Status kafkaMirrorMaker2Status = new KafkaMirrorMaker2Status();
         try {
             if (kafkaMirrorMaker2.getSpec() == null) {
-                log.error("{}: Resource lacks spec property", reconciliation, kafkaMirrorMaker2.getMetadata().getName());
+                log.error("{}: Resource lacks spec property", reconciliation);
                 throw new InvalidResourceException("spec property is required");
             }
             mirrorMaker2Cluster = KafkaMirrorMaker2Cluster.fromCrd(kafkaMirrorMaker2, versions);
@@ -203,7 +203,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                         .map(mirror -> mirror.getSourceCluster() + "->" + mirror.getTargetCluster() + connectorEntry.getKey())
                         .collect(Collectors.toSet()));
             }
-            log.debug("{}: {}} cluster: delete MirrorMaker 2.0 connectors: {}", reconciliation, kind(), deleteMirrorMaker2ConnectorNames);
+            log.debug("{}: delete MirrorMaker 2.0 connectors: {}", reconciliation, deleteMirrorMaker2ConnectorNames);
             Stream<Future<Void>> deletionFutures = deleteMirrorMaker2ConnectorNames.stream()
                     .map(connectorName -> apiClient.delete(host, KafkaConnectCluster.REST_API_PORT, connectorName));
             Stream<Future<Void>> createUpdateFutures = mirrors.stream()
@@ -250,7 +250,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                                 .build();                      
 
                         prepareMirrorMaker2ConnectorConfig(mirror, clusterMap.get(sourceClusterAlias), clusterMap.get(targetClusterAlias), connectorSpec, mirrorMaker2Cluster);
-                        log.debug("{}: {}} cluster: creating/updating connector {} config: {}", reconciliation, kind(), connectorName, asJson(connectorSpec).toString());
+                        log.debug("{}: creating/updating connector {} config: {}", reconciliation, connectorName, asJson(connectorSpec).toString());
                         return reconcileMirrorMaker2Connector(reconciliation, mirrorMaker2, apiClient, host, connectorName, connectorSpec, mirrorMaker2Status);
                     })                            
                     .collect(Collectors.toList()))

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodOperator.java
@@ -68,7 +68,7 @@ public class PodOperator extends AbstractReadyResourceOperator<KubernetesClient,
         String deleted = getPodUid(pod);
 
         // Delete the pod
-        log.debug("{}}: Waiting for pod {} to be deleted", logContext, podName);
+        log.debug("{}: Waiting for pod {} to be deleted", logContext, podName);
         Future<Void> podReconcileFuture =
                 reconcile(namespace, podName, null).compose(ignore -> {
                     Future<Void> del = waitFor(namespace, podName, pollingIntervalMs, timeoutMs, (ignore1, ignore2) -> {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Mirror Maker 2 operator seems to contain some log messages with duplicate information. For example:

```
2020-04-16 10:21:11 DEBUG KafkaMirrorMaker2AssemblyOperator:253 - Reconciliation #135(watch) KafkaMirrorMaker2(metrics-cluster-test/mm2-cluster): KafkaMirrorMaker2} cluster: creating/updating connector second-kafka-cluster->my-cluster.MirrorHeartbeatConnector config: {"heartbeats.topic.replication.factor":1,"target.cluster.alias":"my-cluster","target.cluster.bootstrap.servers":"my-cluster-kafka-bootstrap:9092","target.cluster.status.storage.replication.factor":1,"target.cluster.offset.storage.replication.factor":1,"target.cluster.config.storage.replication.factor":1,"source.cluster.alias":"second-kafka-cluster","source.cluster.bootstrap.servers":"second-kafka-cluster-kafka-bootstrap:9092","topics":".*","groups":".*","connector.class":"org.apache.kafka.connect.mirror.MirrorHeartbeatConnector"}
```

The reconcilaition marker already contains the information abotu the kind and name of the cluster, so it does not have to be in the log twice. Also the one `}` seems to be a typo which I found in other classes as well. In other log message, this PR deletes a variable which is not used in the actual log message.