### PR TITLE
[systemtest] Add process method and update OpenShift template tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
@@ -514,7 +514,7 @@ public abstract class BaseST implements TestSeparator {
         kubeClient().listCustomResourceDefinition().stream()
             .filter(crd -> crd.getMetadata().getName().startsWith("kafka"))
             .forEach(crd -> {
-                LOGGER.info("Verifying labels for custom resource {]", crd.getMetadata().getName());
+                LOGGER.info("Verifying labels for custom resource {}", crd.getMetadata().getName());
                 assertThat(crd.getMetadata().getLabels().get("app"), is("strimzi"));
             });
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -61,7 +61,6 @@ import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.ServiceUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.executor.ExecResult;
-import io.strimzi.test.k8s.cmdClient.Oc;
 import io.strimzi.test.timemeasuring.Operation;
 import io.vertx.core.json.JsonArray;
 import org.apache.kafka.common.security.auth.SecurityProtocol;

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -125,9 +125,8 @@ class KafkaST extends BaseST {
     void testDeployKafkaClusterViaTemplate() {
         cluster.createCustomResources("../examples/templates/cluster-operator");
         String templateName = "strimzi-ephemeral";
-        Oc oc = (Oc) cmdKubeClient();
         String clusterName = "openshift-my-cluster";
-        oc.createResourceAndApply(templateName, map("CLUSTER_NAME", clusterName));
+        cmdKubeClient().createResourceAndApply(templateName, map("CLUSTER_NAME", clusterName));
 
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(clusterName), 3);
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(clusterName), 3);
@@ -140,10 +139,10 @@ class KafkaST extends BaseST {
         verifyLabelsForKafkaCluster(clusterName, templateName);
 
         LOGGER.info("Deleting Kafka cluster {} after test", clusterName);
-        oc.deleteByName("Kafka", clusterName);
+        cmdKubeClient().deleteByName("Kafka", clusterName);
 
         //Wait for kafka deletion
-        oc.waitForResourceDeletion("Kafka", clusterName);
+        cmdKubeClient().waitForResourceDeletion("Kafka", clusterName);
         kubeClient().listPods().stream()
             .filter(p -> p.getMetadata().getName().startsWith(clusterName))
             .forEach(p -> PodUtils.waitForPodDeletion(p.getMetadata().getName()));

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -124,10 +124,11 @@ class KafkaST extends BaseST {
     @OpenShiftOnly
     void testDeployKafkaClusterViaTemplate() {
         cluster.createCustomResources("../examples/templates/cluster-operator");
-        String appName = "strimzi-ephemeral";
+        String templateName = "strimzi-ephemeral";
         Oc oc = (Oc) cmdKubeClient();
         String clusterName = "openshift-my-cluster";
-        oc.newApp(appName, map("CLUSTER_NAME", clusterName));
+        oc.createResourceAndApply(templateName, map("CLUSTER_NAME", clusterName));
+
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(clusterName), 3);
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(clusterName), 3);
         DeploymentUtils.waitForDeploymentReady(KafkaResources.entityOperatorDeploymentName(clusterName), 1);
@@ -136,7 +137,7 @@ class KafkaST extends BaseST {
         testDockerImagesForKafkaCluster(clusterName, NAMESPACE, 3, 3, false);
 
         //Testing labels
-        verifyLabelsForKafkaCluster(clusterName, appName);
+        verifyLabelsForKafkaCluster(clusterName, templateName);
 
         LOGGER.info("Deleting Kafka cluster {} after test", clusterName);
         oc.deleteByName("Kafka", clusterName);

--- a/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesST.java
@@ -70,7 +70,7 @@ public class OpenShiftTemplatesST extends BaseST {
     @Test
     void testStrimziEphemeral() {
         String clusterName = "foo";
-        oc.newApp("strimzi-ephemeral", map("CLUSTER_NAME", clusterName,
+        oc.createResourceAndApply("strimzi-ephemeral", map("CLUSTER_NAME", clusterName,
                 "ZOOKEEPER_NODE_COUNT", "1",
                 "KAFKA_NODE_COUNT", "1"));
 
@@ -86,7 +86,7 @@ public class OpenShiftTemplatesST extends BaseST {
     @Test
     void testStrimziPersistent() {
         String clusterName = "bar";
-        oc.newApp("strimzi-persistent", map("CLUSTER_NAME", clusterName,
+        oc.createResourceAndApply("strimzi-persistent", map("CLUSTER_NAME", clusterName,
                 "ZOOKEEPER_NODE_COUNT", "1",
                 "KAFKA_NODE_COUNT", "1"));
 
@@ -101,7 +101,7 @@ public class OpenShiftTemplatesST extends BaseST {
     @Test
     void testStrimziEphemeralWithCustomParameters() {
         String clusterName = "test-ephemeral-with-custom-parameters";
-        oc.newApp("strimzi-ephemeral", map("CLUSTER_NAME", clusterName,
+        oc.createResourceAndApply("strimzi-ephemeral", map("CLUSTER_NAME", clusterName,
                 "ZOOKEEPER_HEALTHCHECK_DELAY", "30",
                 "ZOOKEEPER_HEALTHCHECK_TIMEOUT", "10",
                 "KAFKA_HEALTHCHECK_DELAY", "30",
@@ -130,7 +130,7 @@ public class OpenShiftTemplatesST extends BaseST {
     @Test
     void testStrimziPersistentWithCustomParameters() {
         String clusterName = "test-persistent-with-custom-parameters";
-        oc.newApp("strimzi-persistent", map("CLUSTER_NAME", clusterName,
+        oc.createResourceAndApply("strimzi-persistent", map("CLUSTER_NAME", clusterName,
                 "ZOOKEEPER_HEALTHCHECK_DELAY", "30",
                 "ZOOKEEPER_HEALTHCHECK_TIMEOUT", "10",
                 "KAFKA_HEALTHCHECK_DELAY", "30",
@@ -163,7 +163,7 @@ public class OpenShiftTemplatesST extends BaseST {
     @Test
     void testConnect() {
         String clusterName = "test-connect";
-        oc.newApp("strimzi-connect", map("CLUSTER_NAME", clusterName,
+        oc.createResourceAndApply("strimzi-connect", map("CLUSTER_NAME", clusterName,
                 "INSTANCES", "1"));
 
         KafkaConnect connect = getKafkaConnect(clusterName);
@@ -174,7 +174,7 @@ public class OpenShiftTemplatesST extends BaseST {
     @Test
     void testS2i() {
         String clusterName = "test-s2i";
-        oc.newApp("strimzi-connect-s2i", map("CLUSTER_NAME", clusterName,
+        oc.createResourceAndApply("strimzi-connect-s2i", map("CLUSTER_NAME", clusterName,
                 "INSTANCES", "1"));
 
         KafkaConnectS2I cm = getKafkaConnectS2I(clusterName);
@@ -185,7 +185,7 @@ public class OpenShiftTemplatesST extends BaseST {
     @Test
     void testTopicOperator() {
         String topicName = "test-topic-topic";
-        oc.newApp("strimzi-topic", map(
+        oc.createResourceAndApply("strimzi-topic", map(
                 "TOPIC_NAME", topicName,
                 "TOPIC_PARTITIONS", "10",
                 "TOPIC_REPLICAS", "2"));

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -188,15 +188,6 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
 
     @Override
     @SuppressWarnings("unchecked")
-    public K createContent(String yamlContent) {
-        try (Context context = defaultContext()) {
-            Exec.exec(yamlContent, namespacedCommand(CREATE, "-f", "-"));
-            return (K) this;
-        }
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
     public K deleteContent(String yamlContent) {
         try (Context context = defaultContext()) {
             Exec.exec(yamlContent, namespacedCommand(DELETE, "-f", "-"), 0, true, false);

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -360,7 +360,7 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
         }
 
         String yaml = Exec.exec(cmd).out();
-        createContent(yaml);
+        applyContent(yaml);
     }
 
     @Override

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
@@ -9,6 +9,7 @@ import io.strimzi.test.executor.ExecResult;
 import java.io.File;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
@@ -58,6 +59,8 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
     K clientWithAdmin();
 
     K applyContent(String yamlContent);
+
+    K createContent(String yamlContent);
 
     K deleteContent(String yamlContent);
 
@@ -126,6 +129,8 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
     List<String> list(String resourceType);
 
     String getResourceAsYaml(String resourceType, String resourceName);
+
+    void createResourceAndApply(String template, Map<String, String> params);
 
     String describe(String resourceType, String resourceName);
 

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
@@ -60,8 +60,6 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
 
     K applyContent(String yamlContent);
 
-    K createContent(String yamlContent);
-
     K deleteContent(String yamlContent);
 
     K createNamespace(String name);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In this PR I'm gonna introduce new method to `cmdKubeClient()` for `oc process ..` to get yaml of template and then apply it.
This way I fixed our failing test `testDeployKafkaClusterViaTemplate` in `KafkaST` and updated our tests in `OpenShiftTemplateST` to prevent future failures.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

