### PR TITLE
Setup docker in different way for Azure Pipelines

### DIFF
--- a/.azure/scripts/setup_docker.sh
+++ b/.azure/scripts/setup_docker.sh
@@ -1,9 +1,22 @@
 #!/usr/bin/env bash
 
+set -e
+
 # Remove moby-engine which use docker 3.0.8 on azure
 sudo apt-get remove --purge iotedge
 sudo apt-get remove --purge moby-cli
 sudo apt-get remove --purge moby-engine
 
-wget -O docker.deb https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce_18.03.1~ce~3-0~ubuntu_amd64.deb
-sudo dpkg -i ./docker.deb
+# Do update and install docker
+sudo apt update
+sudo apt install docker.io
+sudo systemctl unmask docker
+
+sudo mkdir /mnt/docker
+
+sudo sh -c "sed -i 's#ExecStart=/usr/bin/dockerd -H fd://#ExecStart=/usr/bin/dockerd -g /mnt/docker -H fd://#' /lib/systemd/system/docker.service"
+
+sudo systemctl daemon-reload
+sudo rsync -aqxP /var/lib/docker/ /mnt/docker
+
+sudo systemctl start docker

--- a/.azure/templates/default_variables.yaml
+++ b/.azure/templates/default_variables.yaml
@@ -19,6 +19,4 @@ variables:
   test_helm_version: v2.16.3
   test_minikube_version: v1.2.0
   strimzi_default_log_level: DEBUG
-  docker_build_args: "-q"
-  mvn_args: "-q"
   docker_registry: docker.io

--- a/.azure/templates/log_variables.yaml
+++ b/.azure/templates/log_variables.yaml
@@ -12,7 +12,6 @@ steps:
     echo "REPO_SLUG: $(REPO_SLUG)"
     echo "PATH: $(PATH)"
     echo "JAVA_HOME: $(JAVA_HOME)"
-    echo "JAVA_HOME__X64: $(JAVA_HOME__X64)"
     java -version
     which java
   displayName: 'Print environment variables'


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes the issues with docker image removal during build process for azure pipelines. The problem seems to be fixed when docker is installed via `apt` instead directly from deb package.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

