### PR TITLE
[systemtest] Repair failing MM2 test and add logging

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MirrorMaker2ST.java
@@ -108,15 +108,21 @@ class MirrorMaker2ST extends BaseST {
             .build();
 
         // Check brokers availability
+        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
+            availabilityTopicSourceName, kafkaClusterSourceName, MESSAGE_COUNT);
         internalKafkaClient.checkProducedAndConsumedMessages(
             internalKafkaClient.sendMessagesPlain(),
             internalKafkaClient.receiveMessagesPlain()
         );
 
+        LOGGER.info("Setting topic to {}, cluster to {} and changing consumer group",
+            availabilityTopicTargetName, kafkaClusterTargetName);
         internalKafkaClient.setTopicName(availabilityTopicTargetName);
         internalKafkaClient.setClusterName(kafkaClusterTargetName);
         internalKafkaClient.setConsumerGroup(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
 
+        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
+            availabilityTopicTargetName, kafkaClusterTargetName, MESSAGE_COUNT);
         internalKafkaClient.checkProducedAndConsumedMessages(
             internalKafkaClient.sendMessagesPlain(),
             internalKafkaClient.receiveMessagesPlain()
@@ -139,34 +145,44 @@ class MirrorMaker2ST extends BaseST {
         verifyLabelsForConfigMaps(kafkaClusterSourceName, null, kafkaClusterTargetName);
         verifyLabelsForServiceAccounts(kafkaClusterSourceName, null);
 
+        LOGGER.info("Setting topic to {}, cluster to {} and changing consumer group",
+            topicSourceName, kafkaClusterSourceName);
         internalKafkaClient.setTopicName(topicSourceName);
         internalKafkaClient.setClusterName(kafkaClusterSourceName);
         internalKafkaClient.setConsumerGroup(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
 
+        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
+            topicSourceName, kafkaClusterSourceName, MESSAGE_COUNT);
         int sent = internalKafkaClient.sendMessagesPlain();
 
+        LOGGER.info("Consumer in source cluster and topic should receive {} messages", MESSAGE_COUNT);
         internalKafkaClient.checkProducedAndConsumedMessages(
             sent,
             internalKafkaClient.receiveMessagesPlain()
         );
 
+        LOGGER.info("Now setting topic to {} and cluster to {} - the messages should be mirrored",
+            topicTargetName, kafkaClusterTargetName);
         internalKafkaClient.setTopicName(topicTargetName);
         internalKafkaClient.setClusterName(kafkaClusterTargetName);
         internalKafkaClient.setConsumerGroup(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
 
+        LOGGER.info("Consumer in target cluster and topic should receive {} messages", MESSAGE_COUNT);
         internalKafkaClient.checkProducedAndConsumedMessages(
             sent,
             internalKafkaClient.receiveMessagesPlain()
         );
 
+        LOGGER.info("Changing topic to {}", topicSourceNameMirrored);
         internalKafkaClient.setTopicName(topicSourceNameMirrored);
         internalKafkaClient.setConsumerGroup(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
 
-        // Check that mm2 mirror automatically created topic
+        LOGGER.info("Check if mm2 mirror automatically created topic");
         internalKafkaClient.checkProducedAndConsumedMessages(
             sent,
             internalKafkaClient.receiveMessagesPlain()
         );
+        LOGGER.info("Mirrored successful");
 
         KafkaTopic mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(topicTargetName).get();
         assertThat(mirroredTopic.getSpec().getPartitions(), is(3));
@@ -242,16 +258,22 @@ class MirrorMaker2ST extends BaseST {
             .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
             .build();
 
+        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
+            "my-topic-test-1", kafkaClusterSourceName, messagesCount);
         // Check brokers availability
         internalKafkaClient.checkProducedAndConsumedMessages(
             internalKafkaClient.sendMessagesTls(),
             internalKafkaClient.receiveMessagesTls()
         );
 
+        LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
+            "my-topic-test-2", kafkaClusterTargetName, userTarget.getMetadata().getName());
         internalKafkaClient.setTopicName("my-topic-test-2");
         internalKafkaClient.setClusterName(kafkaClusterTargetName);
         internalKafkaClient.setKafkaUsername(userTarget.getMetadata().getName());
 
+        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
+            "my-topic-test-2", kafkaClusterTargetName, messagesCount);
         internalKafkaClient.checkProducedAndConsumedMessages(
             internalKafkaClient.sendMessagesTls(),
             internalKafkaClient.receiveMessagesTls()
@@ -310,25 +332,35 @@ class MirrorMaker2ST extends BaseST {
             .endSpec()
             .done();
 
+        LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
+            topicSourceName, kafkaClusterSourceName, userSource.getMetadata().getName());
         internalKafkaClient.setTopicName(topicSourceName);
         internalKafkaClient.setClusterName(kafkaClusterSourceName);
         internalKafkaClient.setKafkaUsername(userSource.getMetadata().getName());
 
+        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
+            topicSourceName, kafkaClusterSourceName, messagesCount);
         int sent = internalKafkaClient.sendMessagesTls();
 
+        LOGGER.info("Receiving messages from - topic {}, cluster {} and message count of {}",
+            topicSourceName, kafkaClusterSourceName, messagesCount);
         internalKafkaClient.checkProducedAndConsumedMessages(
             sent,
             internalKafkaClient.receiveMessagesTls()
         );
 
+        LOGGER.info("Now setting topic to {}, cluster to {} and user to {} - the messages should be mirrored",
+            topicTargetName, kafkaClusterTargetName, userTarget.getMetadata().getName());
         internalKafkaClient.setTopicName(topicTargetName);
         internalKafkaClient.setClusterName(kafkaClusterTargetName);
         internalKafkaClient.setKafkaUsername(userTarget.getMetadata().getName());
 
+        LOGGER.info("Consumer in target cluster and topic should receive {} messages", messagesCount);
         internalKafkaClient.checkProducedAndConsumedMessages(
             sent,
             internalKafkaClient.receiveMessagesTls()
         );
+        LOGGER.info("Messages successfully mirrored");
 
         KafkaTopic mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(topicTargetName).get();
         assertThat(mirroredTopic.getSpec().getPartitions(), is(3));
@@ -418,22 +450,23 @@ class MirrorMaker2ST extends BaseST {
             .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
             .build();
 
-        LOGGER.info("Sending {} messages to cluster {} and topic {} and should receive {}",
-            messagesCount, kafkaClusterSourceName, availabilityTopicSourceName, messagesCount);
+        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
+            availabilityTopicSourceName, kafkaClusterSourceName, messagesCount);
         // Check brokers availability
         internalKafkaClient.checkProducedAndConsumedMessages(
             internalKafkaClient.sendMessagesTls(),
             internalKafkaClient.receiveMessagesTls()
         );
 
-        LOGGER.info("Changing to target - topic {}, cluster {}, user {} and consumer group",
+        LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
             availabilityTopicTargetName, kafkaClusterTargetName, userTarget.getMetadata().getName());
         internalKafkaClient.setTopicName(availabilityTopicTargetName);
         internalKafkaClient.setClusterName(kafkaClusterTargetName);
         internalKafkaClient.setKafkaUsername(userTarget.getMetadata().getName());
         internalKafkaClient.setConsumerGroup(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
 
-        LOGGER.info("Sending messages, should receive {} messages", messagesCount);
+        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
+            availabilityTopicTargetName, kafkaClusterTargetName, messagesCount);
         internalKafkaClient.checkProducedAndConsumedMessages(
             internalKafkaClient.sendMessagesTls(),
             internalKafkaClient.receiveMessagesTls()
@@ -475,39 +508,33 @@ class MirrorMaker2ST extends BaseST {
                 .endMirror()
             .endSpec().done();
 
-        // Deploy topic
-        KafkaTopicResource.topic(kafkaClusterSourceName, topicSourceName, 3).done();
-
-        LOGGER.info("Changing to source - topic {}, cluster {}, user {} and consumer group",
+        LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
             topicSourceName, kafkaClusterSourceName, userSource.getMetadata().getName());
         internalKafkaClient.setTopicName(topicSourceName);
         internalKafkaClient.setClusterName(kafkaClusterSourceName);
         internalKafkaClient.setKafkaUsername(userSource.getMetadata().getName());
         internalKafkaClient.setConsumerGroup(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
 
-        LOGGER.info("Sending messages to source cluster and source topic, should receive {}", messagesCount);
+        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
+            topicSourceName, kafkaClusterSourceName, messagesCount);
+        int sent = internalKafkaClient.sendMessagesTls();
+
         internalKafkaClient.checkProducedAndConsumedMessages(
-            internalKafkaClient.sendMessagesTls(),
+            sent,
             internalKafkaClient.receiveMessagesTls()
         );
-
-        LOGGER.info("Sending messages again to source cluster and source topic, should receive {}", messagesCount * 2);
-        internalKafkaClient.sendMessagesTls();
-        internalKafkaClient.setConsumerGroup(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
-        int received = internalKafkaClient.receiveMessagesTls();
 
         LOGGER.info("Changing to target - topic {}, cluster {}, user {}", topicTargetName, kafkaClusterTargetName, userTarget.getMetadata().getName());
         internalKafkaClient.setTopicName(topicTargetName);
         internalKafkaClient.setClusterName(kafkaClusterTargetName);
         internalKafkaClient.setKafkaUsername(userTarget.getMetadata().getName());
+        internalKafkaClient.setConsumerGroup(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
 
         LOGGER.info("Now messages should be mirrored to target topic and cluster");
-        TestUtils.waitFor("Waiting for Mirror Maker 2 will copy messages from " + kafkaClusterSourceName + " to " + kafkaClusterTargetName,
-            Constants.POLL_INTERVAL_FOR_RESOURCE_CREATION, Constants.TIMEOUT_FOR_MIRROR_MAKER_COPY_MESSAGES_BETWEEN_BROKERS,
-            () -> {
-                internalKafkaClient.setConsumerGroup(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
-                return received == internalKafkaClient.receiveMessagesTls();
-            });
+        internalKafkaClient.checkProducedAndConsumedMessages(
+            sent,
+            internalKafkaClient.receiveMessagesTls()
+        );
         LOGGER.info("Messages successfully mirrored");
 
         KafkaTopic mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(topicTargetName).get();


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lkral@redhat.com>

### Type of change

- Bugfix
- Enhancement

### Description

This PR gonna add logging for MM2 tests - for sending messages, changing topics, users, clusters and etc.

Also is fixing `testMirrorMaker2TlsAndScramSha512Auth` -> the problem here was bad message count in waitFor. After further investigation I found out that it can be done better way - no need for waitFor, the messages should be mirrored to 2 mins, that's basic timeout for `receiveMessages()` method.

I fixed this test sooner -> the problem was in topic creation and mirroring the topic -> if we create topic before mm2, the topic is successfully mirrored before sending messages and mirroring messages takes less time.

Also removing redundant topic creation, which is created sooner in test.

### Checklist

- [X] Add logging to tests
- [X] Remove redundant methods
- [ ] Make sure all tests pass

