### PR TITLE
Deflakiness of TO IT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <jsonpath.version>2.4.0</jsonpath.version>
         <slf4j.version>1.7.25</slf4j.version>
         <quartz.version>2.2.1</quartz.version>
-        <debezium.version>1.0.0.Final</debezium.version>
+        <debezium.version>1.1.0.Final</debezium.version>
         <jaeger.version>1.0.0</jaeger.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.4</opentracing-kafka.version>

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -137,7 +137,7 @@ public class TopicOperatorMockTest {
 
     @AfterEach
     public void tearDown(VertxTestContext context) {
-        Checkpoint checkpoint = context.checkpoint(1);
+        Checkpoint checkpoint = context.checkpoint();
         if (vertx != null && deploymentId != null) {
             vertx.undeploy(deploymentId, undeployResult -> {
                 if (adminClient != null) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -83,7 +83,6 @@ public class TopicOperatorMockTest {
 
     @BeforeEach
     public void createMockKube(VertxTestContext context) throws Exception {
-        assumeTrue(System.getenv("TRAVIS") == null, "This test is flaky on Travis, for unknown reasons");
         MockKube mockKube = new MockKube();
         mockKube.withCustomResourceDefinition(Crds.kafkaTopic(),
                         KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -48,7 +48,6 @@ import static io.strimzi.test.TestUtils.waitFor;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @ExtendWith(VertxExtension.class)
 public class TopicOperatorMockTest {
@@ -137,7 +136,8 @@ public class TopicOperatorMockTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown(VertxTestContext context) {
+        Checkpoint checkpoint = context.checkpoint(1);
         if (vertx != null && deploymentId != null) {
             vertx.undeploy(deploymentId, undeployResult -> {
                 if (adminClient != null) {
@@ -146,6 +146,7 @@ public class TopicOperatorMockTest {
                 if (kafkaCluster != null) {
                     kafkaCluster.shutdown();
                 }
+                checkpoint.flag();
             });
         }
     }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -28,9 +28,7 @@ import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -67,22 +65,14 @@ public class TopicOperatorMockTest {
 
     // TODO this is all in common with TOIT, so factor out a common base class
 
-    @BeforeAll
-    public static void before() {
+    @BeforeEach
+    public void createMockKube(VertxTestContext context) throws Exception {
         VertxOptions options = new VertxOptions().setMetricsOptions(
                 new MicrometerMetricsOptions()
                         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
                         .setEnabled(true));
         vertx = Vertx.vertx(options);
-    }
 
-    @AfterAll
-    public static void after() {
-        vertx.close();
-    }
-
-    @BeforeEach
-    public void createMockKube(VertxTestContext context) throws Exception {
         assumeTrue(System.getenv("TRAVIS") == null, "This test is flaky on Travis, for unknown reasons");
         MockKube mockKube = new MockKube();
         mockKube.withCustomResourceDefinition(Crds.kafkaTopic(),
@@ -148,6 +138,7 @@ public class TopicOperatorMockTest {
         if (kafkaCluster != null) {
             kafkaCluster.shutdown();
         }
+        vertx.close();
     }
 
     private static int zkPort(KafkaCluster cluster) {


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
Affected TO was flaky... The Kafka cluster was not closed sometimes because of NPE when unmapping files (https://issues.apache.org/jira/browse/KAFKA-8398). The Adminclient was sending request to wrong instance and thus the test was timeouting. 
Using vertex instance for each test helps.

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

