### PR TITLE
ST: Minor fixes for nightly builds

### DIFF
--- a/docker-images/test-client/scripts/consumer.sh
+++ b/docker-images/test-client/scripts/consumer.sh
@@ -4,7 +4,7 @@ set -x
 . ./set_kafka_gc_options.sh
 
 # Defaults
-CONFIG_REGEX="USER=([A-Za-z\_]*)"
+CONFIG_REGEX="USER=([A-Za-z0-9\_]*)"
 CONSUMER_CONFIGURATION_ENV="CONSUMER_CONFIGURATION"
 
 # Create options for consumer

--- a/docker-images/test-client/scripts/producer.sh
+++ b/docker-images/test-client/scripts/producer.sh
@@ -2,7 +2,7 @@
 set -x
 
 # Defaults
-CONFIG_REGEX="USER=([A-Za-z\_]*)"
+CONFIG_REGEX="USER=([A-Za-z0-9\_]*)"
 PRODUCER_CONFIGURATION_ENV="PRODUCER_CONFIGURATION"
 
 # Create options for consumer

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -72,7 +72,7 @@ public interface Constants {
     String KAFKA_CLIENTS = "kafka-clients";
     String STRIMZI_DEPLOYMENT_NAME = "strimzi-cluster-operator";
     String ALWAYS_IMAGE_PULL_POLICY = "Always";
-    String IF_NOT_PRESENT_IMAGE_PULL_POLICY = "Always";
+    String IF_NOT_PRESENT_IMAGE_PULL_POLICY = "IfNotPresent";
 
     /**
      * Constants for specific ports

--- a/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
@@ -170,6 +170,7 @@ class AllNamespaceST extends AbstractNamespaceST {
             .withNamespaceName(THIRD_NAMESPACE)
             .withClusterName(CLUSTER_NAME)
             .withMessageCount(MESSAGE_COUNT)
+            .withKafkaUsername(USER_NAME)
             .withConsumerGroupName(CONSUMER_GROUP_NAME)
             .build();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -231,8 +231,8 @@ class ConnectST extends BaseST {
             .build();
 
         internalKafkaClient.checkProducedAndConsumedMessages(
-                internalKafkaClient.sendMessagesTls(),
-                internalKafkaClient.receiveMessagesTls()
+                internalKafkaClient.sendMessagesPlain(),
+                internalKafkaClient.receiveMessagesPlain()
         );
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "99");


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

During ST failures investigation I found several problems:

- test client cannot handle numbers in user names which caused some failures
- testUserInDifferentNamespace does not use user name in the client so message exchange fails
- testKafkaConnectWithPlainAndScramShaAuthentication used tls listener instead plain
- constant `IF_NOT_PRESENT_IMAGE_PULL_POLICY` had wrong values as a leftover from one of my previous PR

All these issues are addressed in this PR.


### Checklist

- [x] Make sure all tests pass

