### PR TITLE
[DOC] Kafka connect user access rights

### DIFF
--- a/documentation/assemblies/assembly-deployment-configuration-kafka-connect-s2i.adoc
+++ b/documentation/assemblies/assembly-deployment-configuration-kafka-connect-s2i.adoc
@@ -29,6 +29,8 @@ include::assembly-kafka-connect-authentication.adoc[leveloffset=+1]
 
 include::assembly-kafka-connect-configuration.adoc[leveloffset=+1]
 
+include::assembly-kafka-connect-authorization.adoc[leveloffset=+1]
+
 include::assembly-resource-limits-and-requests.adoc[leveloffset=+1]
 
 include::../modules/con-kafka-connect-s2i-logging.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-deployment-configuration-kafka-connect.adoc
+++ b/documentation/assemblies/assembly-deployment-configuration-kafka-connect.adoc
@@ -29,6 +29,8 @@ include::assembly-kafka-connect-authentication.adoc[leveloffset=+1]
 
 include::assembly-kafka-connect-configuration.adoc[leveloffset=+1]
 
+include::assembly-kafka-connect-authorization.adoc[leveloffset=+1]
+
 include::assembly-resource-limits-and-requests.adoc[leveloffset=+1]
 
 include::../modules/con-kafka-connect-logging.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-kafka-connect-authorization.adoc
+++ b/documentation/assemblies/assembly-kafka-connect-authorization.adoc
@@ -1,0 +1,34 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-deployment-configuration-kafka-connect.adoc
+// assembly-deployment-configuration-kafka-connect-s2i.adoc
+
+[id='assembly-kafka-connect-authorization-{context}']
+
+= Kafka Connect user authorization
+
+If simple authorization is enabled for Kafka Connect, the `KafkaUser` resource for the Kafka Connect user must be configured to provide access rights to the consumer group and
+internal topics, which are automatically configured or specified as configuration parameters in the `spec` for the `KafkaConnect` or `KafkaConnectS2I` configuration.
+
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: KafkaConnect
+metadata:
+  name: my-connect
+spec:
+  # ...
+  config:
+    group.id: my-connect-cluster <1>
+    offset.storage.topic: my-connect-cluster-offsets <2>
+    config.storage.topic: my-connect-cluster-configs <3>
+    status.storage.topic: my-connect-cluster-status <4>
+    # ...
+  # ...
+----
+<1> Kafka Connect cluster group the instance belongs to.
+<2> Kafka topic that stores connector offsets.
+<3> Kafka topic that stores connector and task status configurations.
+<4> Kafka topic that stores connector and task status updates.
+
+include::../modules/proc-configuring-kafka-connect-user-authorization.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-kafka-connect-authorization.adoc
+++ b/documentation/assemblies/assembly-kafka-connect-authorization.adoc
@@ -7,8 +7,12 @@
 
 = Kafka Connect user authorization
 
-If authorization is enabled for Kafka Connect, the `KafkaUser` resource for the Kafka Connect user must be configured to provide read/write access rights to the consumer group and
-internal topics, which are automatically configured or specified as configuration parameters in the `spec` for the `KafkaConnect` or `KafkaConnectS2I` configuration.
+If authorization is enabled for Kafka Connect, the Kafka Connect user must be configured to provide read/write access rights to the Kafka Connect consumer group and
+internal topics.
+
+The properties for the consumer group and internal topics are automatically configured by {ProductName}, or they can be specified explicitly in the `spec` for the `KafkaConnect` or `KafkaConnectS2I` configuration.
+
+The following example shows the configuration of the properties in the `KafkaConnect` resource, which need to be represented in the Kafka Connect user configuration.
 
 [source,yaml,subs=attributes+]
 ----
@@ -26,7 +30,7 @@ spec:
     # ...
   # ...
 ----
-<1> Kafka Connect cluster group the instance belongs to.
+<1> Kafka Connect cluster group that the instance belongs to.
 <2> Kafka topic that stores connector offsets.
 <3> Kafka topic that stores connector and task status configurations.
 <4> Kafka topic that stores connector and task status updates.

--- a/documentation/assemblies/assembly-kafka-connect-authorization.adoc
+++ b/documentation/assemblies/assembly-kafka-connect-authorization.adoc
@@ -7,7 +7,7 @@
 
 = Kafka Connect user authorization
 
-If simple authorization is enabled for Kafka Connect, the `KafkaUser` resource for the Kafka Connect user must be configured to provide access rights to the consumer group and
+If authorization is enabled for Kafka Connect, the `KafkaUser` resource for the Kafka Connect user must be configured to provide read/write access rights to the consumer group and
 internal topics, which are automatically configured or specified as configuration parameters in the `spec` for the `KafkaConnect` or `KafkaConnectS2I` configuration.
 
 [source,yaml,subs=attributes+]

--- a/documentation/modules/con-kafka-connect-multiple-instances.adoc
+++ b/documentation/modules/con-kafka-connect-multiple-instances.adoc
@@ -5,7 +5,7 @@
 [id='con-kafka-connect-multiple-instances-{context}']
 = Kafka Connect configuration for multiple instances
 
-If you are running multiple instances of Kafka Connect, pay attention to the default configuration of the following `config` properties:
+If you are running multiple instances of Kafka Connect, you have to change the default configuration of the following `config` properties:
 
 [source,yaml,subs="attributes+"]
 ----

--- a/documentation/modules/con-kafka-connect-multiple-instances.adoc
+++ b/documentation/modules/con-kafka-connect-multiple-instances.adoc
@@ -23,7 +23,7 @@ spec:
     # ...
 # ...
 ----
-<1> Kafka Connect cluster group the instance belongs to.
+<1> Kafka Connect cluster group that the instance belongs to.
 <2> Kafka topic that stores connector offsets.
 <3> Kafka topic that stores connector and task status configurations.
 <4> Kafka topic that stores connector and task status updates.

--- a/documentation/modules/con-kafka-connect-multiple-instances.adoc
+++ b/documentation/modules/con-kafka-connect-multiple-instances.adoc
@@ -5,15 +5,22 @@
 [id='con-kafka-connect-multiple-instances-{context}']
 = Kafka Connect configuration for multiple instances
 
-If you are running multiple instances of Kafka Connect, pay attention to the default configuration of the following properties:
+If you are running multiple instances of Kafka Connect, pay attention to the default configuration of the following `config` properties:
 
 [source,yaml,subs="attributes+"]
 ----
-# ...
-  group.id: connect-cluster <1>
-  offset.storage.topic: connect-cluster-offsets <2>
-  config.storage.topic: connect-cluster-configs <3>
-  status.storage.topic: connect-cluster-status  <4>
+apiVersion: {KafkaApiVersion}
+kind: KafkaConnect
+metadata:
+  name: my-connect
+spec:
+  # ...
+  config:
+    group.id: connect-cluster <1>
+    offset.storage.topic: connect-cluster-offsets <2>
+    config.storage.topic: connect-cluster-configs <3>
+    status.storage.topic: connect-cluster-status  <4>
+    # ...
 # ...
 ----
 <1> Kafka Connect cluster group the instance belongs to.

--- a/documentation/modules/proc-configuring-kafka-connect-user-authorization.adoc
+++ b/documentation/modules/proc-configuring-kafka-connect-user-authorization.adoc
@@ -10,9 +10,9 @@ This procedure describes how to authorize user access to Kafka Connect.
 When any type of authorization is being used in Kafka, a Kafka Connect user requires access rights to the consumer group
 and the internal topics of Kafka Connect.
 
-In this procedure, we show how access is provided when `simple` authorization is being used.
+This procedure shows how access is provided when `simple` authorization is being used.
 
-Simple authorization uses ACL rules to provide the right level of access, which are handled by the Kafka `SimpleAclAuthorizer` plugin.
+Simple authorization uses ACL rules, handled by the Kafka `SimpleAclAuthorizer` plugin, to provide the right level of access.
 For more information on configuring a `KafkaUser` resource to use simple authorization, see xref:ref-kafka-user-using-uo[Kafka User resource].
 
 NOTE: The default values for the consumer group and topics will differ when xref:con-kafka-connect-multiple-instances-{context}[running multiple instances].
@@ -26,7 +26,7 @@ NOTE: The default values for the consumer group and topics will differ when xref
 
 . Edit the `authorization` property in the `KafkaUser` resource to provide access rights to the user.
 +
-For example, here we see access rights configured for the Kafka Connect topics and consumer group using the following `literal` name values:
+For example, here access rights are configured for the Kafka Connect topics and consumer group using the following `literal` name values:
 +
 [table,stripes=none]
 |===

--- a/documentation/modules/proc-configuring-kafka-connect-user-authorization.adoc
+++ b/documentation/modules/proc-configuring-kafka-connect-user-authorization.adoc
@@ -26,7 +26,7 @@ NOTE: The default values for the consumer group and topics will differ when xref
 
 . Edit the `authorization` property in the `KafkaUser` resource to provide access rights to the user.
 +
-For example, here access rights are configured for the Kafka Connect topics and consumer group using the following `literal` name values:
+In the following example, access rights are configured for the Kafka Connect topics and consumer group using `literal` name values:
 +
 [table,stripes=none]
 |===

--- a/documentation/modules/proc-configuring-kafka-connect-user-authorization.adoc
+++ b/documentation/modules/proc-configuring-kafka-connect-user-authorization.adoc
@@ -1,0 +1,147 @@
+// Module included in the following assemblies:
+//
+// assembly-kafka-connect-configuration.adoc
+
+[id='proc-configuring-kafka-connect-user-authorization-{context}']
+= Configuring Kafka Connect user authorization
+
+This procedure describes how to authorize user access to Kafka Connect.
+
+When simple authorization is being used to access Kafka connect, a Kafka Connect user requires access rights to the consumer group
+and the internal topics of Kafka Connect.
+
+Simple authorization uses ACL rules to provide the right level of access, which are handled by the Kafka `SimpleAclAuthorizer` plugin.
+For more information on configuring a `KafkaUser` resource to use simple authorization, see xref:ref-kafka-user-using-uo[Kafka User resource].
+
+NOTE: The default values for the consumer group and topics will differ when xref:con-kafka-connect-multiple-instances-{context}[running multiple instances].
+
+.Prerequisites
+
+* A Kubernetes cluster
+* A running Cluster Operator
+
+.Procedure
+
+. Edit the `authorization` property in the `KafkaUser` resource to provide access rights to the user.
++
+For example, here we see access rights configured for the Kafka Connect topics and consumer group using the following `literal` name values:
++
+[table,stripes=none]
+|===
+|Property |Name
+
+|`offset.storage.topic`
+|`connect-cluster-offsets`
+
+|`status.storage.topic`
+|`connect-cluster-status`
+
+|`config.storage.topic`
+|`connect-cluster-configs`
+
+|`group`
+|`connect-cluster`
+
+|===
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaUserApiVersion}
+kind: KafkaUser
+metadata:
+  name: my-user
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  # ...
+  authorization:
+    type: simple
+    acls:
+      # access to offset.storage.topic
+      - resource:
+          type: topic
+          name: connect-cluster-offsets
+          patternType: literal
+        operation: Write
+        host: "*"
+      - resource:
+          type: topic
+          name: connect-cluster-offsets
+          patternType: literal
+        operation: Create
+        host: "*"
+      - resource:
+          type: topic
+          name: connect-cluster-offsets
+          patternType: literal
+        operation: Describe
+        host: "*"
+      - resource:
+          type: topic
+          name: connect-cluster-offsets
+          patternType: literal
+        operation: Read
+        host: "*"
+      # access to status.storage.topic
+      - resource:
+          type: topic
+          name: connect-cluster-status
+          patternType: literal
+        operation: Write
+        host: "*"
+      - resource:
+          type: topic
+          name: connect-cluster-status
+          patternType: literal
+        operation: Create
+        host: "*"
+      - resource:
+          type: topic
+          name: connect-cluster-status
+          patternType: literal
+        operation: Describe
+        host: "*"
+      - resource:
+          type: topic
+          name: connect-cluster-status
+          patternType: literal
+        operation: Read
+        host: "*"
+      # access to config.storage.topic
+      - resource:
+          type: topic
+          name: connect-cluster-configs
+          patternType: literal
+        operation: Write
+        host: "*"
+      - resource:
+          type: topic
+          name: connect-cluster-configs
+          patternType: literal
+        operation: Create
+        host: "*"
+      - resource:
+          type: topic
+          name: connect-cluster-configs
+          patternType: literal
+        operation: Describe
+        host: "*"
+      - resource:
+          type: topic
+          name: connect-cluster-configs
+          patternType: literal
+        operation: Read
+        host: "*"
+      # consumer group
+      - resource:
+          type: group
+          name: connect-cluster
+          patternType: literal
+        operation: Read
+        host: "*"
+----
+
+. Create or update the resource.
++
+[source,shell,subs=+quotes]
+kubectl apply -f _your-file_

--- a/documentation/modules/proc-configuring-kafka-connect-user-authorization.adoc
+++ b/documentation/modules/proc-configuring-kafka-connect-user-authorization.adoc
@@ -7,8 +7,10 @@
 
 This procedure describes how to authorize user access to Kafka Connect.
 
-When simple authorization is being used to access Kafka connect, a Kafka Connect user requires access rights to the consumer group
+When any type of authorization is being used in Kafka, a Kafka Connect user requires access rights to the consumer group
 and the internal topics of Kafka Connect.
+
+In this procedure, we show how access is provided when `simple` authorization is being used.
 
 Simple authorization uses ACL rules to provide the right level of access, which are handled by the Kafka `SimpleAclAuthorizer` plugin.
 For more information on configuring a `KafkaUser` resource to use simple authorization, see xref:ref-kafka-user-using-uo[Kafka User resource].

--- a/documentation/modules/proc-configuring-kafka-connect.adoc
+++ b/documentation/modules/proc-configuring-kafka-connect.adoc
@@ -43,3 +43,5 @@ spec:
 This can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
 kubectl apply -f _your-file_
+
+. If simple authorization is enabled for Kafka Connect, xref:assembly-kafka-connect-authorization-{context}[configure the Kafka Connect user to enable access to the Kafka Connect consumer group and topics].

--- a/documentation/modules/proc-configuring-kafka-connect.adoc
+++ b/documentation/modules/proc-configuring-kafka-connect.adoc
@@ -44,4 +44,4 @@ This can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
 kubectl apply -f _your-file_
 
-. If simple authorization is enabled for Kafka Connect, xref:assembly-kafka-connect-authorization-{context}[configure the Kafka Connect user to enable access to the Kafka Connect consumer group and topics].
+. If authorization is enabled for Kafka Connect, xref:assembly-kafka-connect-authorization-{context}[configure the Kafka Connect user to enable access to the Kafka Connect consumer group and topics].


### PR DESCRIPTION
### Type of change

**Documentation**
New authorization section for Kafka Connect and Kafka Connect S2I configuration.
Describes how to configure access to Kafka Connect topics and consumer group.

_Configuring Kafka Connect_ procedure also updated with optional step that links to the new authorization section.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

