### PR TITLE
Add some example git hooks to prevent common PR format/signoff errors

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -247,6 +247,16 @@ The project requires that all commits are signed-off, indicating that _you_ cert
 This can be done using `git commit -s` for each commit in your pull request. 
 Alternatively, to signoff a bunch of commits you can use `git rebase --signoff _your-branch_`.
 
+## Checkstyle pre-commit hook
+
+The Checkstyle plugin in run on all pull requests to the Strimzi repository. If you haven't compiled the code via maven, before you submit the PR, then formatting bugs can slip through and this can lead to annoying extra pushes to fix things. In the first instance you should see if your IDE has a Checkstyle plugin that can highlight errors in-line, such as [this one](https://plugins.jetbrains.com/plugin/1065-checkstyle-idea) for IntelliJ. 
+
+You can also run the Checkstyle plugin for every commit you make by adding a pre-commit hook to your local Strimzi git repository. To do this, add the following line to your `.git/hooks/pre-commit` script, to execute the checks and fail the commit if errors are detected:
+
+```
+./tools/git-hooks/checkstyle-pre-commit
+```
+
 ## IDE build problems
 
 The build also uses a Java annotation processor. Some IDEs (such as IntelliJ) don't, by default, run the annotation processor in their build process. You can run `mvn clean install -DskipTests -DskipITs` to run the annotation processor as part of the `maven` build and the IDE should then be able to use the generated classes. It is also possible to configure the IDE to run the annotation processor directly.

--- a/HACKING.md
+++ b/HACKING.md
@@ -247,6 +247,12 @@ The project requires that all commits are signed-off, indicating that _you_ cert
 This can be done using `git commit -s` for each commit in your pull request. 
 Alternatively, to signoff a bunch of commits you can use `git rebase --signoff _your-branch_`.
 
+You can add a commit-msg hook to warn you if the commit you just made locally has not been signed off. Add the following line to you `.git/hooks/commit-msg` script to print the warning:
+
+```
+./tools/git-hooks/signoff-warning-commit-msg $1
+```
+
 ## Checkstyle pre-commit hook
 
 The Checkstyle plugin in run on all pull requests to the Strimzi repository. If you haven't compiled the code via maven, before you submit the PR, then formatting bugs can slip through and this can lead to annoying extra pushes to fix things. In the first instance you should see if your IDE has a Checkstyle plugin that can highlight errors in-line, such as [this one](https://plugins.jetbrains.com/plugin/1065-checkstyle-idea) for IntelliJ. 

--- a/tools/git-hooks/checkstyle-pre-commit
+++ b/tools/git-hooks/checkstyle-pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+mvn checkstyle:checkstyle@validate
+STATUS=$?
+if [ $STATUS -eq 0 ]; then
+    exit 0
+else
+    printf >&2 "\nERROR: Checkstyle issues found! Check the log output above for ERROR lines.\n\n"
+    exit 1
+fi

--- a/tools/git-hooks/signoff-warning-commit-msg
+++ b/tools/git-hooks/signoff-warning-commit-msg
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [ "1" != "$(grep -c '^Signed-off-by: ' "$1")" ]; then
+    printf >&2 "\nERROR: Missing Signed-off-by line. Run 'git commit --amend --signoff' to fix.\n\n"
+    # Uncomment the below to cause the commit to be cancelled if there is no signoff.
+    # Be aware that this will erase the commit message
+    # exit 1
+fi


### PR DESCRIPTION
### Type of change

Enhancement

### Description

Add some example git hooks to run the Checkstyle plugin on each commit and print a warning if you forget to sign off a commit.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
