### PR TITLE
Get rid of the metadata.managedFields in the StatefulSetDiff

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
@@ -25,7 +25,8 @@ public class StatefulSetDiff extends AbstractResourceDiff {
     private static final String SHORTENED_STRIMZI_DOMAIN = Annotations.STRIMZI_DOMAIN.substring(0, Annotations.STRIMZI_DOMAIN.length() - 1);
 
     private static final Pattern IGNORABLE_PATHS = Pattern.compile(
-        "^(/spec/revisionHistoryLimit"
+        "^(/metadata/managedFields"
+        + "|/spec/revisionHistoryLimit"
         + "|/spec/template/metadata/annotations/" + SHORTENED_STRIMZI_DOMAIN + "~1generation"
         + "|/spec/template/spec/initContainers/[0-9]+/resources"
         + "|/spec/template/spec/initContainers/[0-9]+/terminationMessagePath"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Kubernetes 1.18 has a new field in the `metadata` section called `managedFields`:

_ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object._

We currently do not use this field. But is is showing in the `StatefulSetDiff` and since it is relative big it messes up the log. This PR adds it to the ignored fields to make the log a bit cleaner.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally