### PR TITLE
Make log message in Utisl.waitFor configurable

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -2667,7 +2667,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         // We have to wait for the pod to be actually deleted
                         log.debug("{}: Checking if Pod {} has been deleted", reconciliation, podName);
 
-                        Future<Void> waitForDeletion = podOperations.waitFor(namespace, podName, pollingIntervalMs, timeoutMs, (ignore1, ignore2) -> {
+                        Future<Void> waitForDeletion = podOperations.waitFor(namespace, podName, "deleted", pollingIntervalMs, timeoutMs, (ignore1, ignore2) -> {
                             Pod deletion = podOperations.get(namespace, podName);
                             log.trace("Checking if Pod {} in namespace {} has been deleted or recreated", podName, namespace);
                             return deletion == null;
@@ -2686,7 +2686,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
                             log.debug("{}: Checking if PVC {} for Pod {} has been deleted", reconciliation, pvcName, podName);
 
-                            Future<Void> waitForDeletion = pvcOperations.waitFor(namespace, pvcName, pollingIntervalMs, timeoutMs, (ignore1, ignore2) -> {
+                            Future<Void> waitForDeletion = pvcOperations.waitFor(namespace, pvcName, "deleted", pollingIntervalMs, timeoutMs, (ignore1, ignore2) -> {
                                 PersistentVolumeClaim deletion = pvcOperations.get(namespace, pvcName);
                                 log.trace("Checking if {} {} in namespace {} has been deleted", pvc.getKind(), pvcName, namespace);
                                 return deletion == null || (deletion.getMetadata() != null && !uid.equals(deletion.getMetadata().getUid()));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -325,7 +325,7 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
 
             operation().inNamespace(namespace).withName(name).cascading(cascading).withGracePeriod(-1L).delete();
 
-            Future<Void> deletedFut = waitFor(namespace, name, pollingIntervalMs, timeoutMs, (ignore1, ignore2) -> {
+            Future<Void> deletedFut = waitFor(namespace, name, "deleted", pollingIntervalMs, timeoutMs, (ignore1, ignore2) -> {
                 StatefulSet sts = get(namespace, name);
                 log.trace("Checking if {} {} in namespace {} has been deleted", resourceKind, name, namespace);
                 return sts == null;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
@@ -141,6 +141,7 @@ public class ZookeeperScaler implements AutoCloseable {
 
             Util.waitFor(vertx,
                 String.format("ZooKeeperAdmin connection to %s", zookeeperConnectionString),
+                "connected",
                 1_000,
                 operationTimeoutMs,
                 () -> zkAdmin.getState().isAlive() && zkAdmin.getState().isConnected())

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -419,7 +419,7 @@ public class StatefulSetOperatorTest
             }
 
             @Override
-            public Future<Void> waitFor(String namespace, String name, long pollIntervalMs, final long timeoutMs, BiPredicate<String, String> predicate) {
+            public Future<Void> waitFor(String namespace, String name, String logState, long pollIntervalMs, final long timeoutMs, BiPredicate<String, String> predicate) {
                 return Future.succeededFuture();
             }
         };

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -55,10 +55,10 @@ public class Util {
      * @param logState The state we are waiting for use in log messages
      * @param pollIntervalMs The poll interval in milliseconds.
      * @param timeoutMs The timeout, in milliseconds.
-     * @param ready Determines when the wait is complete by returning true.
-     * @return A future that completes when the given {@code ready} indicates readiness.
+     * @param completed Determines when the wait is complete by returning true.
+     * @return A future that completes when the given {@code completed} indicates readiness.
      */
-    public static Future<Void> waitFor(Vertx vertx, String logContext, String logState, long pollIntervalMs, long timeoutMs, BooleanSupplier ready) {
+    public static Future<Void> waitFor(Vertx vertx, String logContext, String logState, long pollIntervalMs, long timeoutMs, BooleanSupplier completed) {
         Promise<Void> promise = Promise.promise();
         LOGGER.debug("Waiting for {} to get {}", logContext, logState);
         long deadline = System.currentTimeMillis() + timeoutMs;
@@ -68,7 +68,7 @@ public class Util {
                 vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
                     future -> {
                         try {
-                            if (ready.getAsBoolean())   {
+                            if (completed.getAsBoolean())   {
                                 future.complete();
                             } else {
                                 LOGGER.trace("{} is not {}", logContext, logState);

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -52,14 +52,15 @@ public class Util {
     /**
      * @param vertx The vertx instance.
      * @param logContext A string used for context in logging.
+     * @param logState The state we are waiting for use in log messages
      * @param pollIntervalMs The poll interval in milliseconds.
      * @param timeoutMs The timeout, in milliseconds.
      * @param ready Determines when the wait is complete by returning true.
      * @return A future that completes when the given {@code ready} indicates readiness.
      */
-    public static Future<Void> waitFor(Vertx vertx, String logContext, long pollIntervalMs, long timeoutMs, BooleanSupplier ready) {
+    public static Future<Void> waitFor(Vertx vertx, String logContext, String logState, long pollIntervalMs, long timeoutMs, BooleanSupplier ready) {
         Promise<Void> promise = Promise.promise();
-        LOGGER.debug("Waiting for {} to get ready", logContext);
+        LOGGER.debug("Waiting for {} to get {}", logContext, logState);
         long deadline = System.currentTimeMillis() + timeoutMs;
         Handler<Long> handler = new Handler<Long>() {
             @Override
@@ -70,11 +71,11 @@ public class Util {
                             if (ready.getAsBoolean())   {
                                 future.complete();
                             } else {
-                                LOGGER.trace("{} is not ready", logContext);
-                                future.fail("Not ready yet");
+                                LOGGER.trace("{} is not {}", logContext, logState);
+                                future.fail("Not " + logState + " yet");
                             }
                         } catch (Throwable e) {
-                            LOGGER.warn("Caught exception while waiting for {} to get ready", logContext, e);
+                            LOGGER.warn("Caught exception while waiting for {} to get {}", logContext, logState, e);
                             future.fail(e);
                         }
                     },
@@ -86,7 +87,7 @@ public class Util {
                         } else {
                             long timeLeft = deadline - System.currentTimeMillis();
                             if (timeLeft <= 0) {
-                                String exceptionMessage = String.format("Exceeded timeout of %dms while waiting for %s to be ready", timeoutMs, logContext);
+                                String exceptionMessage = String.format("Exceeded timeout of %dms while waiting for %s to be %s", timeoutMs, logContext, logState);
                                 LOGGER.error(exceptionMessage);
                                 promise.fail(new TimeoutException(exceptionMessage));
                             } else {

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -82,7 +82,7 @@ public class Util {
                     true,
                     res -> {
                         if (res.succeeded()) {
-                            LOGGER.debug("{} is ready", logContext);
+                            LOGGER.debug("{} is {}", logContext, logState);
                             promise.complete();
                         } else {
                             long timeLeft = deadline - System.currentTimeMillis();

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
@@ -281,14 +281,16 @@ public abstract class AbstractNonNamespacedResourceOperator<C extends Kubernetes
      * is ready.
      *
      * @param name The resource name.
+     * @param logState The state we are waiting for use in log messages
      * @param pollIntervalMs The poll interval in milliseconds.
      * @param timeoutMs The timeout, in milliseconds.
      * @param predicate The predicate.
      * @return a future that completes when the resource identified by the given {@code name} is ready.
      */
-    public Future<Void> waitFor(String name, long pollIntervalMs, final long timeoutMs, Predicate<String> predicate) {
+    public Future<Void> waitFor(String name, String logState, long pollIntervalMs, final long timeoutMs, Predicate<String> predicate) {
         return Util.waitFor(vertx,
             String.format("%s resource %s", resourceKind, name),
+            logState,
             pollIntervalMs,
             timeoutMs,
             () -> predicate.test(name));

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -335,6 +335,29 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
     public Future<Void> waitFor(String namespace, String name, long pollIntervalMs, final long timeoutMs, BiPredicate<String, String> predicate) {
         return Util.waitFor(vertx,
             String.format("%s resource %s in namespace %s", resourceKind, name, namespace),
+            "ready",
+            pollIntervalMs,
+            timeoutMs,
+            () -> predicate.test(namespace, name));
+    }
+
+    /**
+     * Returns a future that completes when the resource identified by the given {@code namespace} and {@code name}
+     * is ready.
+     *
+     * @param namespace The namespace.
+     * @param name The resource name.
+     * @param logState The state we are waiting for use in log messages
+     * @param pollIntervalMs The poll interval in milliseconds.
+     * @param timeoutMs The timeout, in milliseconds.
+     * @param predicate The predicate.
+     * @return A future that completes when the resource identified by the given {@code namespace} and {@code name}
+     * is ready.
+     */
+    public Future<Void> waitFor(String namespace, String name, String logState, long pollIntervalMs, final long timeoutMs, BiPredicate<String, String> predicate) {
+        return Util.waitFor(vertx,
+            String.format("%s resource %s in namespace %s", resourceKind, name, namespace),
+            logState,
             pollIntervalMs,
             timeoutMs,
             () -> predicate.test(namespace, name));

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -333,12 +333,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
      * is ready.
      */
     public Future<Void> waitFor(String namespace, String name, long pollIntervalMs, final long timeoutMs, BiPredicate<String, String> predicate) {
-        return Util.waitFor(vertx,
-            String.format("%s resource %s in namespace %s", resourceKind, name, namespace),
-            "ready",
-            pollIntervalMs,
-            timeoutMs,
-            () -> predicate.test(namespace, name));
+        return waitFor(namespace, name, "ready", pollIntervalMs, timeoutMs, predicate);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperator.java
@@ -59,7 +59,7 @@ public class DeploymentConfigOperator extends AbstractScalableResourceOperator<O
      * generation sequence number of the desired state.
      */
     public Future<Void> waitForObserved(String namespace, String name, long pollIntervalMs, long timeoutMs) {
-        return waitFor(namespace, name, pollIntervalMs, timeoutMs, this::isObserved);
+        return waitFor(namespace, name, "observed", pollIntervalMs, timeoutMs, this::isObserved);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
@@ -97,7 +97,7 @@ public class DeploymentOperator extends AbstractScalableResourceOperator<Kuberne
      * generation sequence number of the desired state.
      */
     public Future<Void> waitForObserved(String namespace, String name, long pollIntervalMs, long timeoutMs) {
-        return waitFor(namespace, name, pollIntervalMs, timeoutMs, this::isObserved);
+        return waitFor(namespace, name, "observed", pollIntervalMs, timeoutMs, this::isObserved);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodOperator.java
@@ -71,7 +71,7 @@ public class PodOperator extends AbstractReadyResourceOperator<KubernetesClient,
         log.debug("{}}: Waiting for pod {} to be deleted", logContext, podName);
         Future<Void> podReconcileFuture =
                 reconcile(namespace, podName, null).compose(ignore -> {
-                    Future<Void> del = waitFor(namespace, podName, pollingIntervalMs, timeoutMs, (ignore1, ignore2) -> {
+                    Future<Void> del = waitFor(namespace, podName, "deleted", pollingIntervalMs, timeoutMs, (ignore1, ignore2) -> {
                         // predicate - changed generation means pod has been updated
                         String newUid = getPodUid(get(namespace, podName));
                         boolean done = !deleted.equals(newUid);

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RouteOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RouteOperator.java
@@ -41,7 +41,7 @@ public class RouteOperator extends AbstractResourceOperator<OpenShiftClient, Rou
      * @return A future that succeeds when the Route has an assigned address.
      */
     public Future<Void> hasAddress(String namespace, String name, long pollIntervalMs, long timeoutMs) {
-        return waitFor(namespace, name, pollIntervalMs, timeoutMs, this::isAddressReady);
+        return waitFor(namespace, name, "addressable", pollIntervalMs, timeoutMs, this::isAddressReady);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
@@ -116,7 +116,7 @@ public class ServiceOperator extends AbstractResourceOperator<KubernetesClient, 
      * @return A future that succeeds when the Service has an assigned address.
      */
     public Future<Void> hasIngressAddress(String namespace, String name, long pollIntervalMs, long timeoutMs) {
-        return waitFor(namespace, name, pollIntervalMs, timeoutMs, this::isIngressAddressReady);
+        return waitFor(namespace, name, "addressable", pollIntervalMs, timeoutMs, this::isIngressAddressReady);
     }
 
     /**

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
@@ -94,7 +94,7 @@ public class K8sImpl implements K8s {
                     LOGGER.warn("KafkaTopic {} could not be deleted, since it doesn't seem to exist", resourceName.toString());
                     future.complete();
                 } else {
-                    Util.waitFor(vertx, "sync resource deletion " + resourceName, 1000, Long.MAX_VALUE, () -> {
+                    Util.waitFor(vertx, "sync resource deletion " + resourceName, "deleted", 1000, Long.MAX_VALUE, () -> {
                         KafkaTopic kafkaTopic = operation().inNamespace(namespace).withName(resourceName.toString()).get();
                         boolean notExists = kafkaTopic == null;
                         LOGGER.debug("KafkaTopic {} deleted {}", resourceName.toString(), notExists);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaImpl.java
@@ -225,7 +225,7 @@ public class KafkaImpl implements Kafka {
                 Collections.singleton(topicName.toString())).values().get(topicName.toString());
         queueWork(new UniWork<>("deleteTopic", future, handler));
         return handler.future().compose(ig ->
-                Util.waitFor(vertx, "deleted sync " + topicName, 1000, 120_000, () -> {
+                Util.waitFor(vertx, "deleted sync " + topicName, "deleted", 1000, 120_000, () -> {
                     try {
                         return adminClient.describeTopics(Collections.singleton(topicName.toString())).all().get().get(topicName.toString()) == null;
                     } catch (ExecutionException e) {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The `waitFor` method in `Utils` class is used on many different purposes - deletions, comparing generations, connecting to Zookeeper etc. But it is logging only the original purpose - waiting for readiness. When this method is used in several places right after each other, this is very confusing because you do not know which of them really failed.

This PR changes this method and its callers to make the log messages clear about what we are waiting for by making the log state configurable.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally