### PR TITLE
Exclude loadbalancer from azure and fix NPE in acceptance

### DIFF
--- a/.azure/pull-request-pipeline.yaml
+++ b/.azure/pull-request-pipeline.yaml
@@ -60,7 +60,7 @@ jobs:
           publishJUnitResults: true
           testResultsFiles: '**/failsafe-reports/TEST-*.xml'
           goals: 'verify'
-          options: '-Dgroups=acceptance -DexcludedGroups=flaky -Dmaven.javadoc.skip=true -B -V'
+          options: '-Dgroups=acceptance -DexcludedGroups=flaky,loadbalancer -Dmaven.javadoc.skip=true -B -V'
         env:
           OPERATOR_IMAGE_PULL_POLICY: "IfNotPresent"
         displayName: 'Run systemtests'

--- a/.azure/templates/default_variables.yaml
+++ b/.azure/templates/default_variables.yaml
@@ -20,3 +20,5 @@ variables:
   test_minikube_version: v1.2.0
   strimzi_default_log_level: DEBUG
   docker_registry: docker.io
+  operator_image_pull_policy: IfNotPresent
+  components_image_pull_policy: IfNotPresent

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -53,7 +53,7 @@ public class Environment {
     /**
      * Image pull policy env var for Components images (Kafka, Bridge, ...)
      */
-    private static final String COMPONENTS_IMAGE_PULL_POLICY_ENV = "IMAGE_PULL_POLICY";
+    private static final String COMPONENTS_IMAGE_PULL_POLICY_ENV = "COMPONENTS_IMAGE_PULL_POLICY";
     /**
      * Image pull policy env var for Operator images
      */

--- a/systemtest/src/test/java/io/strimzi/systemtest/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MirrorMakerST.java
@@ -269,8 +269,6 @@ public class MirrorMakerST extends BaseST {
             .endSpec()
             .done();
 
-        timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
-
         internalKafkaClient.setTopicName(topicSourceName);
         internalKafkaClient.setClusterName(kafkaClusterSourceName);
         internalKafkaClient.setKafkaUsername(userSource.getMetadata().getName());


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes NPE in mm test `testMirrorMakerTlsAuthenticated` and exclude loadbalancer tests from azure pipelines, because loadbalancer is not cofigured here.

### Checklist

- [x] Make sure all tests pass

