### PR TITLE
Fix waitForObserved for DeploymentConfigs to make the operator wait for roll outs

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperator.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.common.operator.resource;
 
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.fabric8.openshift.api.model.DeploymentCondition;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.DeploymentConfigList;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperator.java
@@ -76,15 +76,15 @@ public class DeploymentConfigOperator extends AbstractScalableResourceOperator<O
             // Get the roll out status
             //     => Sometimes it takes OCP some time before the generations are updated.
             //        So we need to check the conditions in addition to detect such situation.
-            boolean rollOutNotStartedYet = false;
+            boolean rollOutNotStarting = true;
             DeploymentCondition progressing = getProgressingCondition(dep);
 
             if (progressing != null)    {
-                rollOutNotStartedYet = progressing.getReason() == null && "Unknown".equals(progressing.getStatus());
+                rollOutNotStarting = progressing.getReason() != null && !"Unknown".equals(progressing.getStatus());
             }
 
             return dep.getMetadata().getGeneration().equals(dep.getStatus().getObservedGeneration())
-                    && !rollOutNotStartedYet;
+                    && rollOutNotStarting;
         } else {
             return false;
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The operator should always wait until the deployment or a new update is finished. With DeploymentConfigs on OCP, this currently does not seem to work. The `waitForObserved` which waits for the roll out of the new version to be started doesn't seem to catch the roll out properly. It is currently based on the current generation from metadata and the observed generation from status. But with DeploymentConfig, the generation seems to take more time to change and this test is passing with the old generation.

This PR adds additional condition to detect whether the generation change is still in progress and waits for the generation to update.

This needs ot be covered by system tests, since we need to make sure it works and doesn't cause any problems on real OCP deployments, to be covered to catch all the different behaviours whcih might occur. Writting a system test for single variant would not help much.

Tested on OCP 3.11 and 4.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally