### PR TITLE
Allow Role strimzi-user-operator to modify kafkausers/status. Closes …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * New Grafana dashboard for Operator monitoring 
 * Allow `ssl.cipher.suites`, `ssl.protocol` and `ssl.enabled.protocols` to be configurable for Kafka and the different components supported by Strimzi
 * Add support for user configurable SecurityContext for each Strimzi container
+* Allow standalone User Operator to modify status on KafkaUser
 
 ## 0.17.0
 

--- a/install/user-operator/02-Role-strimzi-user-operator.yaml
+++ b/install/user-operator/02-Role-strimzi-user-operator.yaml
@@ -9,6 +9,7 @@ rules:
   - "kafka.strimzi.io"
   resources:
   - kafkausers
+  - kafkausers/status
   verbs:
   - get
   - list


### PR DESCRIPTION
Closes #2858

### Type of change
Bugfix

### Description
Added `kafkausers/status` to resources in `strimzi-user-operator` Role

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

