### PR TITLE
[DOC] Cluster Operator environment variable DNS domain

### DIFF
--- a/documentation/modules/ref-operators-cluster-operator-configuration.adoc
+++ b/documentation/modules/ref-operators-cluster-operator-configuration.adoc
@@ -114,7 +114,7 @@ Overrides the default Kubernetes DNS domain name suffix.
 +
 By default, services assigned in the Kubernetes cluster have a DNS domain name that uses the default suffix `cluster.local`.
 +
-For example, for broker _Kafka-0_:
+For example, for broker _kafka-0_:
 +
 [source,shell,subs="+quotes"]
 ----

--- a/documentation/modules/ref-operators-cluster-operator-configuration.adoc
+++ b/documentation/modules/ref-operators-cluster-operator-configuration.adoc
@@ -108,3 +108,19 @@ env:
            compiler=gc
            platform=linux/amd64
 ----
+
+`KUBERNETES_SERVICE_DNS_DOMAIN`:: Optional.
+Overrides the default Kubernetes DNS domain name suffix.
++
+By default, services assigned in the Kubernetes cluster have a DNS domain name that uses the default suffix `cluster.local`.
++
+For example, for broker _Kafka-0_:
++
+[source,shell,subs="+quotes"]
+----
+`_<cluster-name>_-kafka-0._<cluster-name>_-kafka-brokers._<namespace>_.svc._cluster.local_`
+----
++
+The DNS domain name is added to the Kafka broker certificates used for hostname verification.
++
+If you are using a different DNS domain name suffix in your cluster, change the `KUBERNETES_SERVICE_DNS_DOMAIN` environment variable from the default to the one you are using in order to establish a connection with the Kafka brokers.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Add a description of the DNS Domain environment variable to the section on _Cluster Operator Configuration_.

https://github.com/strimzi/strimzi-kafka-operator/issues/1486

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

