### PR TITLE
[systemtest] Fix of two failing tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -147,7 +147,7 @@ class ConnectST extends BaseST {
         KafkaConnectUtils.createFileSinkConnector(kafkaClientsPodName, CONNECT_TOPIC_NAME, Constants.DEFAULT_SINK_FILE_PATH, KafkaConnectResources.url(CLUSTER_NAME, NAMESPACE, 8083));
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(kafkaConnectPodName)
+            .withUsingPodName(kafkaClientsPodName)
             .withTopicName(CONNECT_TOPIC_NAME)
             .withNamespaceName(NAMESPACE)
             .withClusterName(CLUSTER_NAME)

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -867,6 +867,7 @@ class RollingUpdateST extends BaseST {
 
         // some kind of accident happened and the CA secret has been deleted
         kubeClient().deleteSecret(KafkaResources.clusterCaKeySecretName(CLUSTER_NAME));
+        StatefulSetUtils.waitTillSsHasRolled(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME), 3, zkPods);
         StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaPods);
 
         assertThat(kubeClient(NAMESPACE).getSecret(CLUSTER_NAME + "-zookeeper-nodes").getData().get(CLUSTER_NAME + "-zookeeper-0.crt"), is(not(zkCrtBeforeAccident)));


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lkral@redhat.com>

### Type of change

- Bugfix

### Description

This PR gonna fix two of our failing tests:

`testClusterCaRemovedTriggersRollingUpdate` - here was problem with rolling update - in original test there is only wait for **Kafka** rolling update, but **Zookeeper** is rolled before Kafka -> I added wait for Zookeeper rolling update and now should be problem fixed - the timeout here was too short.

`testKafkaConnectWithFileSinkPlugin` - here was problem sending messages - network policies block communication, so we are using KafkaClients pod with network policies set and option to send messages.


### Checklist

- [x] Make sure all tests pass


