### PR TITLE
ST: invoke clients with plain bootstrap properly

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/InternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/InternalKafkaClient.java
@@ -8,7 +8,6 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.AbstractKafkaClient;
 import io.strimzi.systemtest.kafkaclients.KafkaClientOperations;
-import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -79,11 +78,8 @@ public class InternalKafkaClient extends AbstractKafkaClient implements KafkaCli
         LOGGER.info("Starting verifiableClient plain producer with the following configuration: {}", producer.toString());
         LOGGER.info("Producing {} messages to {}:{} from pod {}", messageCount, producer.getBootstrapServer(), topicName, podName);
 
-        TestUtils.waitFor("produce messages", Constants.PRODUCER_POLL_INTERVAL, Constants.GLOBAL_CLIENTS_TIMEOUT, () -> {
-            producer.run(Constants.PRODUCER_TIMEOUT);
-            int sent = getSentMessagesCount(producer.getMessages().toString(), messageCount);
-            return sent == messageCount;
-        });
+        boolean hasPassed = producer.run(Constants.PRODUCER_TIMEOUT);
+        LOGGER.info("Producer finished correctly: {}", hasPassed);
 
         int sent = getSentMessagesCount(producer.getMessages().toString(), messageCount);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicST.java
@@ -138,6 +138,7 @@ public class TopicST extends BaseST {
 
     @Test
     void testSendingMessagesToNonExistingTopic() {
+        int sent = 0;
         String topicName = TOPIC_NAME + "-" + rng.nextInt(Integer.MAX_VALUE);
 
         KafkaClientsResource.deployKafkaClients(false, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).done();
@@ -160,8 +161,16 @@ public class TopicST extends BaseST {
         LOGGER.info("Topic with name {} is not created yet", topicName);
 
         LOGGER.info("Trying to send messages to non-existing topic {}", topicName);
+        // Try produce multiple times in case first try will fail because topic is not exists yet
+        for (int retry = 0; retry < 3; retry++) {
+            sent = internalKafkaClient.sendMessagesPlain();
+            if (MESSAGE_COUNT == sent) {
+                break;
+            }
+        }
+
         internalKafkaClient.assertSentAndReceivedMessages(
-                internalKafkaClient.sendMessagesPlain(),
+                sent,
                 internalKafkaClient.receiveMessagesPlain()
         );
 


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes`testNetworkPoliciesWithTlsListener`. We expected exception, but assertaitonError happened, cause clients wasn't invoked as expected. This change will ensure, that clients are used properly. I had to change `testSendingMessagesToNonExistingTopic` as well because it was impacted by the previous change. Now it tries to send messages and in case the client fail, the test will try it again.

### Checklist

- [x] Make sure all tests pass

