### PR TITLE
Update package list before install java

### DIFF
--- a/.azure/templates/setup_java.yaml
+++ b/.azure/templates/setup_java.yaml
@@ -8,14 +8,16 @@ parameters:
 steps:
 
 - bash: |
+    sudo apt-get update
+  displayName: 'Update package list'
+
+- bash: |
     sudo apt-get install openjdk-8-jdk
-    ls /usr/lib/jvm/
   displayName: 'Install openjdk8'
   condition: eq(variables['JDK_VERSION'], '1.8')
 
 - bash: |
     sudo apt-get install openjdk-11-jdk
-    ls /usr/lib/jvm/
   displayName: 'Install openjdk11'
   condition: eq(variables['JDK_VERSION'], '11')
 


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

We probably need to update the package list before install java8 on azure, because after some internal updates, the installation of Java 8 is failing. This PR adds this step.

### Checklist

- [x] Make sure all tests pass

