### PR TITLE
[DOC] Node port preferred host address

### DIFF
--- a/documentation/modules/con-kafka-broker-external-listeners-nodeports.adoc
+++ b/documentation/modules/con-kafka-broker-external-listeners-nodeports.adoc
@@ -9,16 +9,44 @@
 When exposing Kafka using `NodePort` type `Services`, Kafka clients connect directly to the nodes of Kubernetes.
 You must enable access to the ports on the Kubernetes nodes for each client (for example, in firewalls or security groups).
 Each Kafka broker pod is then accessible on a separate port.
-Additional `NodePort` type `Service` is created to serve as a Kafka bootstrap address.
+
+An additional `NodePort` type `Service` is created to serve as a Kafka bootstrap address.
 
 When configuring the advertised addresses for the Kafka broker pods, {ProductName} uses the address of the node on which the given pod is running.
-When selecting the node address, the different address types are used with the following priority:
+Nodes often have multiple addresses.
+The address type used is based on the first type found in the following order of priority:
 
 . ExternalDNS
 . ExternalIP
 . Hostname
 . InternalDNS
 . InternalIP
+
+You can use the `preferredAddressType` property in your listener configuration to specify the first address type checked as the node address.
+This property is useful, for example, if your deployment does not have DNS support, or you only want to expose a broker internally through an internal DNS or IP address.
+If an address of this type is found, it is used.
+If the preferred address type if not found, {ProductName} proceeds through the types in the standard order of priority.
+
+.Example of an external listener configured with a preferred address type
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+spec:
+  kafka:
+    # ...
+    listeners:
+      external:
+        type: nodeport
+        tls: true
+        authentication:
+          type: tls
+        configuration:
+          preferredAddressType: InternalDNS
+    # ...
+  zookeeper:
+    # ...
+----
 
 By default, TLS encryption is enabled.
 To disable it, set the `tls` field to `false`.

--- a/documentation/modules/con-kafka-broker-external-listeners-nodeports.adoc
+++ b/documentation/modules/con-kafka-broker-external-listeners-nodeports.adoc
@@ -10,7 +10,7 @@ When exposing Kafka using `NodePort` type `Services`, Kafka clients connect dire
 You must enable access to the ports on the Kubernetes nodes for each client (for example, in firewalls or security groups).
 Each Kafka broker pod is then accessible on a separate port.
 
-An additional `NodePort` type `Service` is created to serve as a Kafka bootstrap address.
+An additional `NodePort` type of service is created to serve as a Kafka bootstrap address.
 
 When configuring the advertised addresses for the Kafka broker pods, {ProductName} uses the address of the node on which the given pod is running.
 Nodes often have multiple addresses.
@@ -25,7 +25,7 @@ The address type used is based on the first type found in the following order of
 You can use the `preferredAddressType` property in your listener configuration to specify the first address type checked as the node address.
 This property is useful, for example, if your deployment does not have DNS support, or you only want to expose a broker internally through an internal DNS or IP address.
 If an address of this type is found, it is used.
-If the preferred address type if not found, {ProductName} proceeds through the types in the standard order of priority.
+If the preferred address type is not found, {ProductName} proceeds through the types in the standard order of priority.
 
 .Example of an external listener configured with a preferred address type
 [source,yaml,subs=attributes+]

--- a/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
@@ -5,6 +5,11 @@
 [id='proc-accessing-kafka-using-nodeports-{context}']
 = Accessing Kafka using node ports
 
+This procedure describes how to access a {ProductName} Kafka cluster from an external client using node ports.
+
+To connect to a broker, you need the hostname (advertised address) and port number for the Kafka _bootstrap_ address,
+as well as the certificate used for authentication.
+
 .Prerequisites
 
 * A Kubernetes cluster
@@ -12,9 +17,9 @@
 
 .Procedure
 
-. Deploy Kafka cluster with an external listener enabled and configured to the type `nodeport`.
+. Deploy the Kafka cluster with an external listener enabled and configured to the type `nodeport`.
 +
-An example configuration with an external listener configured to use node ports:
+For example:
 +
 [source,yaml,subs=attributes+]
 ----
@@ -27,45 +32,51 @@ spec:
       external:
         type: nodeport
         tls: true
-        # ...
+        authentication:
+          type: tls
+        configuration:
+          brokerCertChainAndKey: <1>
+            secretName: my-secret
+            certificate: my-certificate.crt
+            key: my-key.key
+          preferredAddressType: InternalDNS <2>
     # ...
   zookeeper:
     # ...
 ----
+<1> Optional configuration for a xref:kafka-listener-certificates-str[Kafka listener certificate] managed by an external Certificate Authority. The `brokerCertChainAndKey` property specifies a `Secret` that holds a server certificate and a private key. Kafka listener certificates can also be configured for TLS listeners.
+<2> Optional configuration to xref:con-kafka-broker-external-listeners-nodeports-{context}[specify a preference for the first address type used by {ProductName} as the node address].
 
 . Create or update the resource.
 +
-This can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
 kubectl apply -f _your-file_
 
 . Find the port number of the bootstrap service.
 +
-This can be done using `kubectl get`:
 [source,shell,subs=+quotes]
 kubectl get service _cluster-name_-kafka-external-bootstrap -o=jsonpath='{.spec.ports[0].nodePort}{"\n"}'
 +
-The port should be used in the Kafka _bootstrap_ address.
+The port is used in the Kafka _bootstrap_ address.
 
 . Find the address of the Kubernetes node.
 +
-This can be done using `kubectl get`:
 [source,shell,subs=+quotes]
 kubectl get node _node-name_ -o=jsonpath='{range .status.addresses[*]}{.type}{"\t"}{.address}{"\n"}'
 +
 If several different addresses are returned, select the address type you want based on the following order:
 +
-.. ExternalDNS
-.. ExternalIP
-.. Hostname
-.. InternalDNS
-.. InternalIP
+--
+. ExternalDNS
+. ExternalIP
+. Hostname
+. InternalDNS
+. InternalIP
+--
 +
 Use the address with the port found in the previous step in the Kafka _bootstrap_ address.
 
 . Unless TLS encryption was disabled, extract the public certificate of the broker certification authority.
-+
-This can be done using `kubectl get`:
 +
 [source,shell,subs=+quotes]
 kubectl get secret _cluster-name_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Update to the doc to described the _preferredAddressType_ property for node port listeners.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

