### PR TITLE
Add Sam Hawker as a maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,4 @@
 Jakub Scholz, Red Hat <github@scholzj.com> (@scholzj)
 Paolo Patierno, Red Hat <ppatierno@live.com> (@ppatierno)
 Tom Bentley, Red Hat <tbentley@redhat.com> (@tombentley)
+Sam Hawker, IBM <sam.b.hawker@gmail.com> (@samuel-hawker)


### PR DESCRIPTION
Add Sam Hawker as a Strimzi maintainer.

Signed-off-by: Tom Bentley <tbentley@redhat.com>
