### PR TITLE
[jenkins] Add image pull policy for components and operator

### DIFF
--- a/Jenkinsfile-pr
+++ b/Jenkinsfile-pr
@@ -24,6 +24,8 @@ pipeline {
         string(name: 'TEST_CASE', defaultValue: '*ST', description: 'maven parameter for executing specific tests')
         string(name: 'TEST_PROFILE', defaultValue: 'acceptance', description: 'maven parameter for executing specific test profile')
         string(name: 'EXCLUDE', defaultValue: 'networkpolicies', description: 'maven parameter for exclude specific test tag')
+        string(name: 'OPERATOR_IMAGE_PULL_POLICY', defaultValue: 'IfNotPresent', description: 'parameter for pulling operator images')
+        string(name: 'COMPONENTS_IMAGE_PULL_POLICY', defaultValue: 'IfNotPresent', description: 'parameter for pulling component images')
     }
     options {
         timeout(time: 22, unit: 'HOURS')
@@ -35,6 +37,8 @@ pipeline {
         ORIGIN_BASE_DIR = "${env.WORKSPACE}/origin/"
         KUBE_CONFIG_PATH = "${env.WORKSPACE}/origin/kube-apiserver/admin.kubeconfig"
         TEST_CLUSTER_ADMIN = "admin"
+        OPERATOR_IMAGE_PULL_POLICY = "IfNotPresent"
+        COMPONENTS_IMAGE_PULL_POLICY = "IfNotPresent"
     }
     stages {
         stage('Clean WS') {

--- a/Jenkinsfile-pr
+++ b/Jenkinsfile-pr
@@ -24,8 +24,6 @@ pipeline {
         string(name: 'TEST_CASE', defaultValue: '*ST', description: 'maven parameter for executing specific tests')
         string(name: 'TEST_PROFILE', defaultValue: 'acceptance', description: 'maven parameter for executing specific test profile')
         string(name: 'EXCLUDE', defaultValue: 'networkpolicies', description: 'maven parameter for exclude specific test tag')
-        string(name: 'OPERATOR_IMAGE_PULL_POLICY', defaultValue: 'IfNotPresent', description: 'parameter for pulling operator images')
-        string(name: 'COMPONENTS_IMAGE_PULL_POLICY', defaultValue: 'IfNotPresent', description: 'parameter for pulling component images')
     }
     options {
         timeout(time: 22, unit: 'HOURS')


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lkral@redhat.com>

### Type of change

- Enhancement / new feature

### Description

This PR gonna add `COMPONENTS_IMAGE_PULL_POLICY`and `OPERATOR_IMAGE_PULL_POLICY` to `Jenkinsfile-pr` for PR jobs. It will help us determine if we want to pull images for operator or components, as we have this option in our STs.

### Checklist
- [ ] Make sure all tests pass
