### PR TITLE
[DOC] Make Cluster Operator namespace clear

### DIFF
--- a/documentation/assemblies/deploying/assembly-deploy-cluster-operator.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-cluster-operator.adoc
@@ -11,7 +11,7 @@ The procedures in this section show:
 
 * How to deploy the Cluster Operator to _watch_:
 ** xref:deploying-cluster-operator-{context}[A single namespace]
-** xref:deploying-cluster-operator-to-watch-multiple-namespaces{context}[Multiple namespaces]
+** xref:deploying-cluster-operator-to-watch-multiple-namespaces-{context}[Multiple namespaces]
 ** xref:deploying-cluster-operator-to-watch-whole-cluster-{context}[All namespaces]
 * Alternative deployment options:
 ifdef::Helm[]

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-multiple-namespaces.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-multiple-namespaces.adoc
@@ -2,7 +2,7 @@
 //
 // deploying/assembly_deploy-cluster-operator.adoc
 
-[id='deploying-cluster-operator-to-watch-multiple-namespaces{context}']
+[id='deploying-cluster-operator-to-watch-multiple-namespaces-{context}']
 = Deploying the Cluster Operator to watch multiple namespaces
 
 This procedure shows how to deploy the Cluster Operator to watch {ProductName} resources across multiple namespaces in your Kubernetes cluster.
@@ -16,7 +16,7 @@ Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means t
 
 . Edit the {ProductName} installation files to use the namespace the Cluster Operator is going to be installed to.
 +
-For example, in this procedure the Cluster Operator is installed to the namespace `_my-namespace_`.
+For example, in this procedure the Cluster Operator is installed to the namespace `_my-cluster-operator-namespace_`.
 +
 include::snip-cluster-operator-namespace-sed.adoc[]
 
@@ -56,7 +56,7 @@ kubectl apply -f install/cluster-operator/032-RoleBinding-strimzi-cluster-operat
 . Deploy the Cluster Operator
 +
 [source,shell,subs="+quotes,attributes+"]
-kubectl apply -f install/cluster-operator -n _my-namespace_
+kubectl apply -f install/cluster-operator -n _my-cluster-operator-namespace_
 
 . Verify that the Cluster Operator was successfully deployed:
 +

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-namespace.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-namespace.adoc
@@ -16,14 +16,14 @@ Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means t
 
 . Edit the {ProductName} installation files to use the namespace the Cluster Operator is going to be installed to.
 +
-For example, in this procedure the Cluster Operator is installed to the namespace `_my-namespace_`.
+For example, in this procedure the Cluster Operator is installed to the namespace `_my-cluster-operator-namespace_`.
 +
 include::snip-cluster-operator-namespace-sed.adoc[]
 
 . Deploy the Cluster Operator:
 +
 [source,shell,subs="+quotes,attributes+"]
-kubectl apply -f install/cluster-operator -n _my-namespace_
+kubectl apply -f install/cluster-operator -n _my-cluster-operator-namespace_
 
 . Verify that the Cluster Operator was successfully deployed:
 +

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-whole-cluster.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-whole-cluster.adoc
@@ -41,16 +41,16 @@ spec:
 . Create `ClusterRoleBindings` that grant cluster-wide access for all namespaces to the Cluster Operator.
 +
 [source,shell,subs="+quotes,attributes+"]
-kubectl create clusterrolebinding strimzi-cluster-operator-namespaced --clusterrole=strimzi-cluster-operator-namespaced --serviceaccount _my-namespace_:strimzi-cluster-operator
-kubectl create clusterrolebinding strimzi-cluster-operator-entity-operator-delegation --clusterrole=strimzi-entity-operator --serviceaccount _my-namespace_:strimzi-cluster-operator
-kubectl create clusterrolebinding strimzi-cluster-operator-topic-operator-delegation --clusterrole=strimzi-topic-operator --serviceaccount _my-namespace_:strimzi-cluster-operator
+kubectl create clusterrolebinding strimzi-cluster-operator-namespaced --clusterrole=strimzi-cluster-operator-namespaced --serviceaccount _my-cluster-operator-namespace_:strimzi-cluster-operator
+kubectl create clusterrolebinding strimzi-cluster-operator-entity-operator-delegation --clusterrole=strimzi-entity-operator --serviceaccount _my-cluster-operator-namespace_:strimzi-cluster-operator
+kubectl create clusterrolebinding strimzi-cluster-operator-topic-operator-delegation --clusterrole=strimzi-topic-operator --serviceaccount _my-cluster-operator-namespace_:strimzi-cluster-operator
 +
-Replace `_my-namespace_` with the namespace you want to install the Cluster Operator to.
+Replace `_my-cluster-operator-namespace_` with the namespace you want to install the Cluster Operator to.
 
 . Deploy the Cluster Operator to your Kubernetes cluster.
 +
 [source,shell,subs="+quotes,attributes+"]
-kubectl apply -f install/cluster-operator -n _my-namespace_
+kubectl apply -f install/cluster-operator -n _my-cluster-operator-namespace_
 
 . Verify that the Cluster Operator was successfully deployed:
 +

--- a/documentation/shared/snip-cluster-operator-namespace-sed.adoc
+++ b/documentation/shared/snip-cluster-operator-namespace-sed.adoc
@@ -2,12 +2,12 @@ On Linux, use:
 +
 [source, subs="+quotes"]
 ----
-sed -i 's/namespace: .\*/namespace: _my-namespace_/' install/cluster-operator/*RoleBinding*.yaml
+sed -i 's/namespace: .\*/namespace: _my-cluster-operator-namespace_/' install/cluster-operator/*RoleBinding*.yaml
 ----
 +
 On MacOS, use:
 +
 [source, subs="+quotes"]
 ----
-sed -i '' 's/namespace: .\*/namespace: _my-namespace_/' install/cluster-operator/*RoleBinding*.yaml
+sed -i '' 's/namespace: .\*/namespace: _my-cluster-operator-namespace_/' install/cluster-operator/*RoleBinding*.yaml
 ----


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Updated the Cluster Operator deployment procedures to make the namespaces clearer.

- Deploying the Cluster Operator to watch a single namespace
- Deploying the Cluster Operator to watch multiple namespaces
- Deploying the Cluster Operator to watch all namespaces

I think _watched-namespace-1_, _watched-namespace-2_  etc is fine for the names of the namespaces we want to watch. But we could change those too.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

