### PR TITLE
feat: Enable structural schemas in Strimzi CRDs

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractConnectorSpec.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -47,6 +48,7 @@ public abstract class AbstractConnectorSpec implements Serializable, UnknownProp
         this.tasksMax = tasksMax;
     }
 
+    @PreserveUnknownFields(true)
     @Description("The Kafka Connector configuration. The following properties cannot be set: " + FORBIDDEN_PARAMETERS)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, Object> getConfig() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.template.KafkaConnectTemplate;
 import io.strimzi.api.kafka.model.tracing.Tracing;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
@@ -136,6 +137,7 @@ public abstract class AbstractKafkaConnectSpec implements Serializable, UnknownP
         this.jvmOptions = jvmOptions;
     }
 
+    @PreserveUnknownFields(true)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Description("The Prometheus JMX Exporter configuration. " +
             "See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/InlineLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/InlineLogging.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 
 import java.util.HashMap;
@@ -35,6 +36,7 @@ public class InlineLogging extends Logging {
         return TYPE_INLINE;
     }
 
+    @PreserveUnknownFields(true)
     @Description("A Map from logger name to logger level.")
     public Map<String, String> getLoggers() {
         return loggers;

--- a/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Pattern;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -87,6 +88,7 @@ public class JvmOptions implements UnknownPropertyPreserving, Serializable {
         this.javaSystemProperties = javaSystemProperties;
     }
 
+    @PreserveUnknownFields(true)
     @JsonProperty("-XX")
     @Description("A map of -XX options to the JVM")
     public Map<String, String> getXx() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeClientSpec.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -28,6 +29,7 @@ public abstract class KafkaBridgeClientSpec implements UnknownPropertyPreserving
 
     private Map<String, Object> additionalProperties;
 
+    @PreserveUnknownFields(true)
     public Map<String, Object> getConfig() {
         return config;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeConsumerSpec.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -24,6 +25,7 @@ public class KafkaBridgeConsumerSpec extends KafkaBridgeClientSpec {
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 
     @Override
+    @PreserveUnknownFields(true)
     @Description("The Kafka consumer configuration used for consumer instances created by the bridge. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
         return config;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeProducerSpec.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -24,6 +25,7 @@ public class KafkaBridgeProducerSpec extends KafkaBridgeClientSpec {
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 
     @Override
+    @PreserveUnknownFields(true)
     @Description("The Kafka producer configuration used for producer instances created by the bridge. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
         return config;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.template.KafkaBridgeTemplate;
 import io.strimzi.api.kafka.model.tracing.Tracing;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
@@ -65,6 +66,7 @@ public class KafkaBridgeSpec implements UnknownPropertyPreserving, Serializable 
         this.replicas = replicas;
     }
 
+    @PreserveUnknownFields(true)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Description("**Currently not supported** The Prometheus JMX Exporter configuration. " +
             "See {JMXExporter} for details of the structure of this configuration.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
@@ -17,6 +17,7 @@ import io.strimzi.api.kafka.model.template.KafkaClusterTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.Minimum;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -89,6 +90,7 @@ public class KafkaClusterSpec implements UnknownPropertyPreserving, Serializable
         this.version = version;
     }
 
+    @PreserveUnknownFields(true)
     @Description("The kafka broker config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, Object> getConfig() {
@@ -222,6 +224,7 @@ public class KafkaClusterSpec implements UnknownPropertyPreserving, Serializable
         this.jmxOptions = jmxOptions;
     }
 
+    @PreserveUnknownFields(true)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("The Prometheus JMX Exporter configuration. " +
             "See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthentication;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -39,6 +40,7 @@ public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
     private KafkaConnectTls tls;
     private KafkaClientAuthentication authentication;
 
+    @PreserveUnknownFields(true)
     @Description("The Kafka Connect configuration. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
         return config;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ClusterSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthentication;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Pattern;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -62,7 +63,7 @@ public class KafkaMirrorMaker2ClusterSpec implements UnknownPropertyPreserving, 
         this.authentication = authentication;
     }
 
-
+    @PreserveUnknownFields(true)
     @Description("The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
         return config;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerClientSpec.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthentication;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -43,6 +44,7 @@ public class KafkaMirrorMakerClientSpec implements UnknownPropertyPreserving, Se
         this.authentication = authentication;
     }
 
+    @PreserveUnknownFields(true)
     public Map<String, Object> getConfig() {
         return config;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerConsumerSpec.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -35,6 +36,7 @@ public class KafkaMirrorMakerConsumerSpec extends KafkaMirrorMakerClientSpec {
     private Integer offsetCommitInterval;
 
     @Override
+    @PreserveUnknownFields(true)
     @Description("The MirrorMaker consumer config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
         return config;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerProducerSpec.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -38,6 +39,7 @@ public class KafkaMirrorMakerProducerSpec extends KafkaMirrorMakerClientSpec {
     }
 
     @Override
+    @PreserveUnknownFields(true)
     @Description("The MirrorMaker producer config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
         return config;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.tracing.Tracing;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.Minimum;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -120,6 +121,7 @@ public class KafkaMirrorMakerSpec implements UnknownPropertyPreserving, Serializ
         this.producer = producer;
     }
 
+    @PreserveUnknownFields(true)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Description("The Prometheus JMX Exporter configuration. " +
             "See {JMXExporter} for details of the structure of this configuration.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopicSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopicSpec.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Maximum;
 import io.strimzi.crdgenerator.annotations.Minimum;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -79,6 +80,7 @@ public class KafkaTopicSpec implements UnknownPropertyPreserving, Serializable {
         this.replicas = replicas;
     }
 
+    @PreserveUnknownFields(true)
     @Description("The topic configuration.")
     public Map<String, Object> getConfig() {
         return config;

--- a/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.template.ZookeeperClusterTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.Minimum;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -66,6 +67,7 @@ public class ZookeeperClusterSpec implements UnknownPropertyPreserving, Serializ
     private ZookeeperClusterTemplate template;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
+    @PreserveUnknownFields(true)
     @Description("The ZooKeeper broker config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, Object> getConfig() {
@@ -167,6 +169,7 @@ public class ZookeeperClusterSpec implements UnknownPropertyPreserving, Serializ
         this.jvmOptions = jvmOptions;
     }
 
+    @PreserveUnknownFields(true)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("The Prometheus JMX Exporter configuration. " +
             "See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBootstrapConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBootstrapConfiguration.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -40,6 +41,7 @@ public class IngressListenerBootstrapConfiguration extends ExternalListenerBoots
         this.host = host;
     }
 
+    @PreserveUnknownFields(true)
     @Description("Annotations that will be added to the `Ingress` resource. " +
             "You can use this field to configure DNS providers such as External DNS.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBrokerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBrokerConfiguration.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -42,6 +43,7 @@ public class IngressListenerBrokerConfiguration extends ExternalListenerBrokerOv
         this.host = host;
     }
 
+    @PreserveUnknownFields(true)
     @Description("Annotations that will be added to the `Ingress` resources for individual brokers. " +
             "You can use this field to configure DNS providers such as External DNS.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBootstrapOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBootstrapOverride.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model.listener;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -28,6 +29,7 @@ public class LoadBalancerListenerBootstrapOverride extends ExternalListenerBoots
     private Map<String, String> dnsAnnotations = new HashMap<>(0);
     private String loadBalancerIP;
 
+    @PreserveUnknownFields(true)
     @Description("Annotations that will be added to the `Service` resource. " +
             "You can use this field to configure DNS providers such as External DNS.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBrokerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBrokerOverride.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -30,6 +31,7 @@ public class LoadBalancerListenerBrokerOverride extends ExternalListenerBrokerOv
     private Map<String, String> dnsAnnotations = new HashMap<>(0);
     private String loadBalancerIP;
 
+    @PreserveUnknownFields(true)
     @Description("Annotations that will be added to the `Service` resources for individual brokers. " +
             "You can use this field to configure DNS providers such as External DNS.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBootstrapOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBootstrapOverride.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model.listener;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -42,6 +43,7 @@ public class NodePortListenerBootstrapOverride extends ExternalListenerBootstrap
         this.nodePort = nodePort;
     }
 
+    @PreserveUnknownFields(true)
     @Description("Annotations that will be added to the `Service` resource. " +
             "You can use this field to configure DNS providers such as External DNS.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBrokerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBrokerOverride.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -40,6 +41,7 @@ public class NodePortListenerBrokerOverride extends ExternalListenerBrokerOverri
         this.nodePort = nodePort;
     }
 
+    @PreserveUnknownFields(true)
     @Description("Annotations that will be added to the `Service` resources for individual brokers. " +
             "You can use this field to configure DNS providers such as External DNS.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectorStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectorStatus.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -30,6 +31,7 @@ public class KafkaConnectorStatus extends Status {
 
     private Map<String, Object> connectorStatus;
 
+    @PreserveUnknownFields(true)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Description("The connector status, as reported by the Kafka Connect REST API.")
     public Map<String, Object> getConnectorStatus() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaMirrorMaker2Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaMirrorMaker2Status.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -33,6 +34,7 @@ public class KafkaMirrorMaker2Status extends KafkaConnectStatus {
 
     private List<Map<String, Object>> connectors = new ArrayList<>();
 
+    @PreserveUnknownFields(true)
     @Description("List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<Map<String, Object>> getConnectors() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/storage/PersistentClaimStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/storage/PersistentClaimStorage.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -77,6 +78,7 @@ public class PersistentClaimStorage extends SingleVolumeStorage {
         this.storageClass = storageClass;
     }
 
+    @PreserveUnknownFields(true)
     @Description("Specifies a specific persistent volume to use. " +
             "It contains key:value pairs representing labels for selecting such a volume.")
     public Map<String, String> getSelector() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/MetadataTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/MetadataTemplate.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -34,6 +35,7 @@ public class MetadataTemplate implements Serializable, UnknownPropertyPreserving
     private Map<String, String> annotations = new HashMap<>(0);
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
+    @PreserveUnknownFields(true)
     @Description("Labels which should be added to the resource template. " +
             "Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -45,6 +47,7 @@ public class MetadataTemplate implements Serializable, UnknownPropertyPreserving
         this.labels = labels;
     }
 
+    @PreserveUnknownFields(true)
     @Description("Annotations which should be added to the resource template. " +
             "Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -24,6 +24,7 @@ import io.strimzi.crdgenerator.annotations.Maximum;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.OneOf;
 import io.strimzi.crdgenerator.annotations.Pattern;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.strimzi.crdgenerator.annotations.Type;
 
 import java.io.File;
@@ -260,6 +261,7 @@ public class CrdGenerator {
             }
             result.set("subresources", statusNode);
         }
+        result.put("preserveUnknownFields", false);
         result.set("validation", buildValidation(crdClass));
         return result;
     }
@@ -475,6 +477,7 @@ public class CrdGenerator {
             schema = buildObjectSchema(property, returnType);
         }
         addDescription(schema, property);
+        addPreserveUnknownFields(schema, property);
         return schema;
     }
 
@@ -522,6 +525,13 @@ public class CrdGenerator {
         if (element.isAnnotationPresent(Description.class)) {
             Description description = element.getAnnotation(Description.class);
             result.put("description", DocGenerator.getDescription(description));
+        }
+    }
+
+    private void addPreserveUnknownFields(ObjectNode result, AnnotatedElement element) {
+        if (element.isAnnotationPresent(PreserveUnknownFields.class)) {
+            PreserveUnknownFields preserve = element.getAnnotation(PreserveUnknownFields.class);
+            result.put("x-kubernetes-preserve-unknown-fields", preserve.value());
         }
     }
 

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/PreserveUnknownFields.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/PreserveUnknownFields.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.crdgenerator.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface PreserveUnknownFields {
+    boolean value();
+}

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -25,6 +25,7 @@ spec:
     description: "The foo"
     JSONPath: "..."
     type: "integer"
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       properties:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -31,6 +31,7 @@ spec:
     description: "The foo"
     JSONPath: "..."
     type: "integer"
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       properties:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -36,6 +36,7 @@ spec:
     type: integer
   subresources:
     status: {}
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       properties:
@@ -88,6 +89,7 @@ spec:
                       description: Specifies a specific persistent volume to use.
                         It contains key:value pairs representing labels for selecting
                         such a volume.
+                      x-kubernetes-preserve-unknown-fields: true
                     size:
                       type: string
                       description: When type=persistent-claim, defines the size of
@@ -145,6 +147,7 @@ spec:
                             description: Specifies a specific persistent volume to
                               use. It contains key:value pairs representing labels
                               for selecting such a volume.
+                            x-kubernetes-preserve-unknown-fields: true
                           size:
                             type: string
                             description: When type=persistent-claim, defines the size
@@ -674,6 +677,7 @@ spec:
                                   description: Annotations that will be added to the
                                     `Ingress` resource. You can use this field to
                                     configure DNS providers such as External DNS.
+                                  x-kubernetes-preserve-unknown-fields: true
                                 host:
                                   type: string
                                   description: Host for the bootstrap route. This
@@ -707,6 +711,7 @@ spec:
                                       the `Ingress` resources for individual brokers.
                                       You can use this field to configure DNS providers
                                       such as External DNS.
+                                    x-kubernetes-preserve-unknown-fields: true
                                 required:
                                 - host
                               description: External broker ingress configuration.
@@ -806,6 +811,7 @@ spec:
                                   description: Annotations that will be added to the
                                     `Service` resource. You can use this field to
                                     configure DNS providers such as External DNS.
+                                  x-kubernetes-preserve-unknown-fields: true
                                 nodePort:
                                   type: integer
                                   description: Node port for the bootstrap service.
@@ -835,6 +841,7 @@ spec:
                                       the `Service` resources for individual brokers.
                                       You can use this field to configure DNS providers
                                       such as External DNS.
+                                    x-kubernetes-preserve-unknown-fields: true
                               description: External broker services configuration.
                           description: Overrides for external bootstrap and broker
                             services and externally advertised addresses.
@@ -921,6 +928,7 @@ spec:
                     zookeeper.set.acl, authorizer., super.user (with the exception
                     of: zookeeper.connection.timeout.ms, ssl.cipher.suites, ssl.protocol,
                     ssl.enabled.protocols).'
+                  x-kubernetes-preserve-unknown-fields: true
                 rack:
                   type: object
                   properties:
@@ -1222,6 +1230,7 @@ spec:
                     "-XX":
                       type: object
                       description: A map of -XX options to the JVM.
+                      x-kubernetes-preserve-unknown-fields: true
                     "-Xms":
                       type: string
                       pattern: '[0-9]+[mMgG]?'
@@ -1278,12 +1287,14 @@ spec:
                   type: object
                   description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
                     for details of the structure of this configuration.
+                  x-kubernetes-preserve-unknown-fields: true
                 logging:
                   type: object
                   properties:
                     loggers:
                       type: object
                       description: A Map from logger name to logger level.
+                      x-kubernetes-preserve-unknown-fields: true
                     name:
                       type: string
                       description: The name of the `ConfigMap` from which to get the
@@ -1393,12 +1404,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                         podManagementPolicy:
                           type: string
@@ -1420,12 +1433,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -1736,12 +1751,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka bootstrap `Service`.
                     brokersService:
@@ -1755,12 +1772,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka broker `Service`.
                     externalBootstrapService:
@@ -1774,12 +1793,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                         externalTrafficPolicy:
                           type: string
@@ -1817,12 +1838,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                         externalTrafficPolicy:
                           type: string
@@ -1861,12 +1884,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka external bootstrap `Route`.
                     perPodRoute:
@@ -1880,12 +1905,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka per-pod `Routes` used for access
                         from outside of OpenShift.
@@ -1900,12 +1927,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka external bootstrap `Ingress`.
                     perPodIngress:
@@ -1919,12 +1948,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka per-pod `Ingress` used for access
                         from outside of Kubernetes.
@@ -1939,12 +1970,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                       description: Template for all Kafka `PersistentVolumeClaims`.
                     podDisruptionBudget:
@@ -1958,12 +1991,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata to apply to the `PodDistruptionBugetTemplate`
                             resource.
                         maxUnavailable:
@@ -2226,6 +2261,7 @@ spec:
                       description: Specifies a specific persistent volume to use.
                         It contains key:value pairs representing labels for selecting
                         such a volume.
+                      x-kubernetes-preserve-unknown-fields: true
                     size:
                       type: string
                       description: When type=persistent-claim, defines the size of
@@ -2250,6 +2286,7 @@ spec:
                   description: 'The ZooKeeper broker config. Properties with the following
                     prefixes cannot be set: server., dataDir, dataLogDir, clientPort,
                     authProvider, quorum.auth, requireClientAuthScheme.'
+                  x-kubernetes-preserve-unknown-fields: true
                 affinity:
                   type: object
                   properties:
@@ -2535,6 +2572,7 @@ spec:
                     "-XX":
                       type: object
                       description: A map of -XX options to the JVM.
+                      x-kubernetes-preserve-unknown-fields: true
                     "-Xms":
                       type: string
                       pattern: '[0-9]+[mMgG]?'
@@ -2573,12 +2611,14 @@ spec:
                   type: object
                   description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
                     for details of the structure of this configuration.
+                  x-kubernetes-preserve-unknown-fields: true
                 logging:
                   type: object
                   properties:
                     loggers:
                       type: object
                       description: A Map from logger name to logger level.
+                      x-kubernetes-preserve-unknown-fields: true
                     name:
                       type: string
                       description: The name of the `ConfigMap` from which to get the
@@ -2688,12 +2728,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                         podManagementPolicy:
                           type: string
@@ -2715,12 +2757,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -3031,12 +3075,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                       description: Template for ZooKeeper client `Service`.
                     nodesService:
@@ -3050,12 +3096,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                       description: Template for ZooKeeper nodes `Service`.
                     persistentVolumeClaim:
@@ -3069,12 +3117,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                       description: Template for all ZooKeeper `PersistentVolumeClaims`.
                     podDisruptionBudget:
@@ -3088,12 +3138,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata to apply to the `PodDistruptionBugetTemplate`
                             resource.
                         maxUnavailable:
@@ -3567,6 +3619,7 @@ spec:
                     loggers:
                       type: object
                       description: A Map from logger name to logger level.
+                      x-kubernetes-preserve-unknown-fields: true
                     name:
                       type: string
                       description: The name of the `ConfigMap` from which to get the
@@ -3586,6 +3639,7 @@ spec:
                     "-XX":
                       type: object
                       description: A map of -XX options to the JVM.
+                      x-kubernetes-preserve-unknown-fields: true
                     "-Xms":
                       type: string
                       pattern: '[0-9]+[mMgG]?'
@@ -3759,6 +3813,7 @@ spec:
                         loggers:
                           type: object
                           description: A Map from logger name to logger level.
+                          x-kubernetes-preserve-unknown-fields: true
                         name:
                           type: string
                           description: The name of the `ConfigMap` from which to get
@@ -3778,6 +3833,7 @@ spec:
                         "-XX":
                           type: object
                           description: A map of -XX options to the JVM.
+                          x-kubernetes-preserve-unknown-fields: true
                         "-Xms":
                           type: string
                           pattern: '[0-9]+[mMgG]?'
@@ -3890,6 +3946,7 @@ spec:
                         loggers:
                           type: object
                           description: A Map from logger name to logger level.
+                          x-kubernetes-preserve-unknown-fields: true
                         name:
                           type: string
                           description: The name of the `ConfigMap` from which to get
@@ -3909,6 +3966,7 @@ spec:
                         "-XX":
                           type: object
                           description: A map of -XX options to the JVM.
+                          x-kubernetes-preserve-unknown-fields: true
                         "-Xms":
                           type: string
                           pattern: '[0-9]+[mMgG]?'
@@ -4257,12 +4315,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                       description: Template for Entity Operator `Deployment`.
                     pod:
@@ -4276,12 +4336,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -4945,12 +5007,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                       description: Template for JmxTrans `Deployment`.
                     pod:
@@ -4964,12 +5028,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -5386,12 +5452,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka Exporter `Deployment`.
                     pod:
@@ -5405,12 +5473,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -5721,12 +5791,14 @@ spec:
                               description: Labels which should be added to the resource
                                 template. Can be applied to different resources such
                                 as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                             annotations:
                               type: object
                               description: Annotations which should be added to the
                                 resource template. Can be applied to different resources
                                 such as `StatefulSets`, `Deployments`, `Pods`, and
                                 `Services`.
+                              x-kubernetes-preserve-unknown-fields: true
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka Exporter `Service`.
                     container:

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -32,6 +32,7 @@ spec:
     type: integer
   subresources:
     status: {}
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       properties:
@@ -220,6 +221,7 @@ spec:
                 rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes
                 (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites,
                 ssl.protocol, ssl.enabled.protocols).'
+              x-kubernetes-preserve-unknown-fields: true
             resources:
               type: object
               properties:
@@ -289,6 +291,7 @@ spec:
                 "-XX":
                   type: object
                   description: A map of -XX options to the JVM.
+                  x-kubernetes-preserve-unknown-fields: true
                 "-Xms":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
@@ -546,6 +549,7 @@ spec:
                 loggers:
                   type: object
                   description: A Map from logger name to logger level.
+                  x-kubernetes-preserve-unknown-fields: true
                 name:
                   type: string
                   description: The name of the `ConfigMap` from which to get the logging
@@ -563,6 +567,7 @@ spec:
               type: object
               description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
                 for details of the structure of this configuration.
+              x-kubernetes-preserve-unknown-fields: true
             tracing:
               type: object
               properties:
@@ -589,11 +594,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
@@ -607,11 +614,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
@@ -921,11 +930,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect API `Service`.
                 connectContainer:
@@ -1003,11 +1014,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata to apply to the `PodDistruptionBugetTemplate`
                         resource.
                     maxUnavailable:

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -32,6 +32,7 @@ spec:
     type: integer
   subresources:
     status: {}
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       properties:
@@ -112,6 +113,7 @@ spec:
                 "-XX":
                   type: object
                   description: A map of -XX options to the JVM.
+                  x-kubernetes-preserve-unknown-fields: true
                 "-Xms":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
@@ -353,6 +355,7 @@ spec:
                 loggers:
                   type: object
                   description: A Map from logger name to logger level.
+                  x-kubernetes-preserve-unknown-fields: true
                 name:
                   type: string
                   description: The name of the `ConfigMap` from which to get the logging
@@ -370,6 +373,7 @@ spec:
               type: object
               description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
                 for details of the structure of this configuration.
+              x-kubernetes-preserve-unknown-fields: true
             template:
               type: object
               properties:
@@ -384,11 +388,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
@@ -402,11 +408,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
@@ -716,11 +724,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect API `Service`.
                 connectContainer:
@@ -798,11 +808,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata to apply to the `PodDistruptionBugetTemplate`
                         resource.
                     maxUnavailable:
@@ -969,6 +981,7 @@ spec:
                 rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes
                 (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites,
                 ssl.protocol, ssl.enabled.protocols).'
+              x-kubernetes-preserve-unknown-fields: true
             externalConfiguration:
               type: object
               properties:

--- a/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -36,6 +36,7 @@ spec:
     type: integer
   subresources:
     status: {}
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       properties:
@@ -57,6 +58,7 @@ spec:
             config:
               type: object
               description: The topic configuration.
+              x-kubernetes-preserve-unknown-fields: true
             topicName:
               type: string
               description: The name of the topic. When absent this will default to

--- a/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -36,6 +36,7 @@ spec:
     type: string
   subresources:
     status: {}
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       properties:

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -42,6 +42,7 @@ spec:
     priority: 1
   subresources:
     status: {}
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       properties:
@@ -233,6 +234,7 @@ spec:
                     sasl., security., interceptor.classes (with the exception of:
                     ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol,
                     ssl.enabled.protocols).'
+                  x-kubernetes-preserve-unknown-fields: true
                 tls:
                   type: object
                   properties:
@@ -417,6 +419,7 @@ spec:
                     following prefixes cannot be set: ssl., bootstrap.servers, sasl.,
                     security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm,
                     ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
+                  x-kubernetes-preserve-unknown-fields: true
                 tls:
                   type: object
                   properties:
@@ -679,6 +682,7 @@ spec:
                 "-XX":
                   type: object
                   description: A map of -XX options to the JVM.
+                  x-kubernetes-preserve-unknown-fields: true
                 "-Xms":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
@@ -711,6 +715,7 @@ spec:
                 loggers:
                   type: object
                   description: A Map from logger name to logger level.
+                  x-kubernetes-preserve-unknown-fields: true
                 name:
                   type: string
                   description: The name of the `ConfigMap` from which to get the logging
@@ -728,6 +733,7 @@ spec:
               type: object
               description: The Prometheus JMX Exporter configuration. See {JMXExporter}
                 for details of the structure of this configuration.
+              x-kubernetes-preserve-unknown-fields: true
             tracing:
               type: object
               properties:
@@ -754,11 +760,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka MirrorMaker `Deployment`.
                 pod:
@@ -772,11 +780,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
@@ -1150,11 +1160,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata to apply to the `PodDistruptionBugetTemplate`
                         resource.
                     maxUnavailable:

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -34,6 +34,7 @@ spec:
     priority: 1
   subresources:
     status: {}
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       properties:
@@ -229,6 +230,7 @@ spec:
                     prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl.,
                     security. (with the exception of: ssl.endpoint.identification.algorithm,
                     ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
+                  x-kubernetes-preserve-unknown-fields: true
               description: Kafka consumer related configuration.
             producer:
               type: object
@@ -240,6 +242,7 @@ spec:
                     prefixes cannot be set: ssl., bootstrap.servers, sasl., security.
                     (with the exception of: ssl.endpoint.identification.algorithm,
                     ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
+                  x-kubernetes-preserve-unknown-fields: true
               description: Kafka producer related configuration.
             resources:
               type: object
@@ -255,6 +258,7 @@ spec:
                 "-XX":
                   type: object
                   description: A map of -XX options to the JVM.
+                  x-kubernetes-preserve-unknown-fields: true
                 "-Xms":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
@@ -287,6 +291,7 @@ spec:
                 loggers:
                   type: object
                   description: A Map from logger name to logger level.
+                  x-kubernetes-preserve-unknown-fields: true
                 name:
                   type: string
                   description: The name of the `ConfigMap` from which to get the logging
@@ -305,6 +310,7 @@ spec:
               description: '**Currently not supported** The Prometheus JMX Exporter
                 configuration. See {JMXExporter} for details of the structure of this
                 configuration.'
+              x-kubernetes-preserve-unknown-fields: true
             livenessProbe:
               type: object
               properties:
@@ -373,11 +379,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Bridge `Deployment`.
                 pod:
@@ -391,11 +399,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
@@ -705,11 +715,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Bridge API `Service`.
                 bridgeContainer:
@@ -787,11 +799,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata to apply to the `PodDistruptionBugetTemplate`
                         resource.
                     maxUnavailable:

--- a/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -24,6 +24,7 @@ spec:
     - strimzi
   subresources:
     status: {}
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       properties:
@@ -41,6 +42,7 @@ spec:
               type: object
               description: 'The Kafka Connector configuration. The following properties
                 cannot be set: connector.class, tasks.max.'
+              x-kubernetes-preserve-unknown-fields: true
             pause:
               type: boolean
               description: Whether the connector should be paused. Defaults to false.
@@ -83,4 +85,5 @@ spec:
               type: object
               description: The connector status, as reported by the Kafka Connect
                 REST API.
+              x-kubernetes-preserve-unknown-fields: true
           description: The status of the Kafka Connector.

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -29,6 +29,7 @@ spec:
     type: integer
   subresources:
     status: {}
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       properties:
@@ -70,6 +71,7 @@ spec:
                       listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes,
                       producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm,
                       ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
+                    x-kubernetes-preserve-unknown-fields: true
                   tls:
                     type: object
                     properties:
@@ -265,6 +267,7 @@ spec:
                         type: object
                         description: 'The Kafka Connector configuration. The following
                           properties cannot be set: connector.class, tasks.max.'
+                        x-kubernetes-preserve-unknown-fields: true
                       pause:
                         type: boolean
                         description: Whether the connector should be paused. Defaults
@@ -282,6 +285,7 @@ spec:
                         type: object
                         description: 'The Kafka Connector configuration. The following
                           properties cannot be set: connector.class, tasks.max.'
+                        x-kubernetes-preserve-unknown-fields: true
                       pause:
                         type: boolean
                         description: Whether the connector should be paused. Defaults
@@ -299,6 +303,7 @@ spec:
                         type: object
                         description: 'The Kafka Connector configuration. The following
                           properties cannot be set: connector.class, tasks.max.'
+                        x-kubernetes-preserve-unknown-fields: true
                       pause:
                         type: boolean
                         description: Whether the connector should be paused. Defaults
@@ -395,6 +400,7 @@ spec:
                 "-XX":
                   type: object
                   description: A map of -XX options to the JVM.
+                  x-kubernetes-preserve-unknown-fields: true
                 "-Xms":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
@@ -652,6 +658,7 @@ spec:
                 loggers:
                   type: object
                   description: A Map from logger name to logger level.
+                  x-kubernetes-preserve-unknown-fields: true
                 name:
                   type: string
                   description: The name of the `ConfigMap` from which to get the logging
@@ -669,6 +676,7 @@ spec:
               type: object
               description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
                 for details of the structure of this configuration.
+              x-kubernetes-preserve-unknown-fields: true
             tracing:
               type: object
               properties:
@@ -695,11 +703,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
@@ -713,11 +723,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
@@ -1027,11 +1039,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect API `Service`.
                 connectContainer:
@@ -1109,11 +1123,13 @@ spec:
                           description: Labels which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           type: object
                           description: Annotations which should be added to the resource
                             template. Can be applied to different resources such as
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          x-kubernetes-preserve-unknown-fields: true
                       description: Metadata to apply to the `PodDistruptionBugetTemplate`
                         resource.
                     maxUnavailable:
@@ -1296,4 +1312,5 @@ spec:
                 type: object
               description: List of MirrorMaker 2.0 connector statuses, as reported
                 by the Kafka Connect REST API.
+              x-kubernetes-preserve-unknown-fields: true
           description: The status of the Kafka MirrorMaker 2.0 cluster.


### PR DESCRIPTION
Strimzi relies on being able to store some fields not explicitly
defined in the CRD (such as in metrics or config objects).

The default behaviour for this is changing in Kubernetes, so ahead of
this change, this commit makes it explicit exactly where storing
unknown fields is required (rather than depending on it across the
entire CRD).

This commit updates CrdGenerator to set preserveUnknownFields to false
for the CRD as a whole, and uses x-kubernetes-preserve-unknown-fields
to override this for objects where pruning would cause a problem.

The initial motivation for investigating this was because the OpenShift
Console (in versions of OpenShift after 4.2) is unable to validate the
Strimzi CRDs.

![image](https://user-images.githubusercontent.com/1444788/80157619-803d4180-85be-11ea-905c-d7d087dc6e25.png)

This can be seen in the OpenShift UI as invalid validation errors in
the YAML editor, broken auto-complete and hover help, failure to 
display schema documentation in the sidebar, etc.

Support engineers for the OpenShift Console recommended making the CRDs
pruning requirements explicit would allow them to be correctly parsed
and validated.  

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>