### PR TITLE
Fixed network policy naming

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -2038,7 +2038,7 @@ public class KafkaCluster extends AbstractModel {
                     .build();
 
             NetworkPolicyPeer kafkaExporterPeer = new NetworkPolicyPeerBuilder()
-                    .withNewPodSelector() // cluster operator
+                    .withNewPodSelector() // kafka exporter
                         .addToMatchLabels(Labels.STRIMZI_NAME_LABEL, KafkaExporter.kafkaExporterName(cluster))
                     .endPodSelector()
                     .build();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -599,7 +599,7 @@ public class KafkaConnectCluster extends AbstractModel {
             List<NetworkPolicyIngressRule> rules = new ArrayList<>(2);
 
             // Give CO access to the REST API
-            NetworkPolicyIngressRule replicationRule = new NetworkPolicyIngressRuleBuilder()
+            NetworkPolicyIngressRule restApiRule = new NetworkPolicyIngressRuleBuilder()
                     .addNewPort()
                     .withNewPort(REST_API_PORT)
                     .endPort()
@@ -630,10 +630,10 @@ public class KafkaConnectCluster extends AbstractModel {
                         .build();
                 peers.add(clusterOperatorPeer);
 
-                replicationRule.setFrom(peers);
+                restApiRule.setFrom(peers);
             }
 
-            rules.add(replicationRule);
+            rules.add(restApiRule);
 
             // If metrics are enabled, we have to open them as well. Otherwise they will be blocked.
             if (isMetricsEnabled) {


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Refactoring

### Description

Trivial PR for fixing a couple of wrong network policy related naming.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

