### PR TITLE
Added network policy on ZooKeeper for the Cruise Control access

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -456,12 +456,20 @@ public class ZookeeperCluster extends AbstractModel {
             clusterOperatorPeer.setPodSelector(labelSelector4);
             clusterOperatorPeer.setNamespaceSelector(new LabelSelector());
 
+            NetworkPolicyPeer cruiseControlPeer = new NetworkPolicyPeer();
+            LabelSelector labelSelector5 = new LabelSelector();
+            Map<String, String> expressions5 = new HashMap<>();
+            expressions5.put(Labels.STRIMZI_NAME_LABEL, CruiseControl.cruiseControlName(cluster));
+            labelSelector5.setMatchLabels(expressions5);
+            cruiseControlPeer.setPodSelector(labelSelector5);
+            
             // This is a hack because we have no guarantee that the CO namespace has some particular labels
             List<NetworkPolicyPeer> clientsPortPeers = new ArrayList<>(4);
             clientsPortPeers.add(kafkaClusterPeer);
             clientsPortPeers.add(zookeeperClusterPeer);
             clientsPortPeers.add(entityOperatorPeer);
             clientsPortPeers.add(clusterOperatorPeer);
+            clientsPortPeers.add(cruiseControlPeer);
 
             clientsIngressRule.setFrom(clientsPortPeers);
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -813,7 +813,7 @@ public class ZookeeperClusterTest {
         assertThat(clientsRule.getPorts().size(), is(1));
         assertThat(clientsRule.getPorts().get(0).getPort(), is(new IntOrString(2181)));
 
-        assertThat(clientsRule.getFrom().size(), is(4));
+        assertThat(clientsRule.getFrom().size(), is(5));
 
         podSelector = new LabelSelector();
         podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(zc.getCluster())));
@@ -830,6 +830,10 @@ public class ZookeeperClusterTest {
         podSelector = new LabelSelector();
         podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator"));
         assertThat(clientsRule.getFrom().get(3), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).withNamespaceSelector(new LabelSelector()).build()));
+
+        podSelector = new LabelSelector();
+        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, CruiseControl.cruiseControlName(zc.getCluster())));
+        assertThat(clientsRule.getFrom().get(4), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build()));
 
         // Port 9404
         NetworkPolicyIngressRule metricsRule = rules.get(2);


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

_Select the type of your PR_

- Bugfix

### Description

On a Kubernetes/OpenShift installation where the network policies are enforced, the cruise control pod is not able to connect to ZooKeeper on the client port (2181) due to a missing network policy for that. This PR fixes this issue.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

