### PR TITLE
[systemtest] Make wait for CR status methods more generic way

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -7,6 +7,8 @@ package io.strimzi.systemtest.resources;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodCondition;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -20,12 +22,15 @@ import io.strimzi.api.kafka.model.KafkaBridgeResources;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
+import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaExporterResources;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.status.HasStatus;
 import io.strimzi.systemtest.Constants;
@@ -367,18 +372,36 @@ public class ResourceManager {
      * Log actual status of custom resource with pods.
      * @param customResource - Kafka, KafkaConnect etc. - every resource that HasMetadata and HasStatus (Strimzi status)
      */
-    public static <T extends HasMetadata & HasStatus> void logCurrentStatus(T customResource) {
+    public static <T extends HasMetadata & HasStatus> void logCurrentResourceStatus(T customResource) {
+        List<String> printWholeCr = new ArrayList<>(asList(KafkaConnector.RESOURCE_KIND, KafkaTopic.RESOURCE_KIND, KafkaUser.RESOURCE_KIND));
+
         String kind = customResource.getKind();
         String name = customResource.getMetadata().getName();
 
-        List<String> log = new ArrayList<>(asList("\n", kind, " status:\n", "\nConditions:\n"));
+        if (printWholeCr.contains(kind)) {
+            LOGGER.info(customResource);
+        } else {
+            List<String> log = new ArrayList<>(asList("\n", kind, " status:\n", "\nConditions:\n"));
 
-        for (Condition condition : customResource.getStatus().getConditions()) {
-            log.add("\tType: " + condition.getType() + "\n");
-            log.add("\tMessage: " + condition.getMessage() + "\n");
+            for (Condition condition : customResource.getStatus().getConditions()) {
+                log.add("\tType: " + condition.getType() + "\n");
+                log.add("\tMessage: " + condition.getMessage() + "\n");
+            }
+
+            log.add("\nPods with conditions and messages:\n\n");
+
+            for (Pod pod : kubeClient().listPodsByPrefixInName(name)) {
+                log.add(pod.getMetadata().getName() + ":");
+                for (PodCondition podCondition : pod.getStatus().getConditions()) {
+                    if (podCondition.getMessage() != null) {
+                        log.add("\n\tType: " + podCondition.getType() + "\n");
+                        log.add("\tMessage: " + podCondition.getMessage() + "\n");
+                    }
+                }
+                log.add("\n\n");
+            }
+            LOGGER.info("{}", String.join("", log));
         }
-
-        PodUtils.logCurrentPodStatus(name, log);
     }
 
     /**
@@ -388,21 +411,15 @@ public class ResourceManager {
      * @param status - desired status
      * @return returns CR
      */
-    public static <T extends HasMetadata & HasStatus> T waitForStatus(MixedOperation<T, ?, ?, ?> operation, T resource, String status) {
-        List<String> printWholeCr = new ArrayList<>(asList("KafkaConnector", "KafkaTopic", "KafkaUser"));
+    public static <T extends HasMetadata & HasStatus> T waitForResourceStatus(MixedOperation<T, ?, ?, ?> operation, T resource, String status) {
+        LOGGER.info("Wait for {}: {} will have desired state: {}", resource.getKind(), resource.getMetadata().getName(), status);
 
-        TestUtils.waitFor("Wait for {}" + resource.getKind() + ":{} " + resource.getMetadata().getName() + "will have desired state {}" + status,
+        TestUtils.waitFor(String.format("Wait for %s: %s will have desired state: %s", resource.getKind(), resource.getMetadata().getName(), status),
             Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
             () -> operation.inNamespace(resource.getMetadata().getNamespace())
             .withName(resource.getMetadata().getName())
             .get().getStatus().getConditions().stream().anyMatch(condition -> condition.getType().equals(status)),
-            () -> {
-                if (printWholeCr.contains(resource.getKind())) {
-                    LOGGER.info(operation.inNamespace(kubeClient().getNamespace()).withName(resource.getMetadata().getName()).get());
-                } else {
-                    logCurrentStatus(resource);
-                }
-            });
+            () -> logCurrentResourceStatus(resource));
 
         LOGGER.info("{}:{} is in desired state: {}", resource.getKind(), resource.getMetadata().getName(), status);
         return resource;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -49,6 +49,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Stack;
@@ -373,12 +374,12 @@ public class ResourceManager {
      * @param customResource - Kafka, KafkaConnect etc. - every resource that HasMetadata and HasStatus (Strimzi status)
      */
     public static <T extends HasMetadata & HasStatus> void logCurrentResourceStatus(T customResource) {
-        List<String> printWholeCr = new ArrayList<>(asList(KafkaConnector.RESOURCE_KIND, KafkaTopic.RESOURCE_KIND, KafkaUser.RESOURCE_KIND));
+        List<String> printWholeCR = Arrays.asList(KafkaConnector.RESOURCE_KIND, KafkaTopic.RESOURCE_KIND, KafkaUser.RESOURCE_KIND);
 
         String kind = customResource.getKind();
         String name = customResource.getMetadata().getName();
 
-        if (printWholeCr.contains(kind)) {
+        if (printWholeCR.contains(kind)) {
             LOGGER.info(customResource);
         } else {
             List<String> log = new ArrayList<>(asList("\n", kind, " status:\n", "\nConditions:\n"));

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
@@ -13,16 +13,12 @@ import io.strimzi.api.kafka.model.DoneableKafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridgeBuilder;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaBridgeUtils;
 import io.strimzi.test.TestUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import io.strimzi.systemtest.resources.ResourceManager;
 
 import java.util.function.Consumer;
 
 public class KafkaBridgeResource {
-    private static final Logger LOGGER = LogManager.getLogger(KafkaBridgeResource.class);
 
     public static final String PATH_TO_KAFKA_BRIDGE_CONFIG = "../examples/kafka-bridge/kafka-bridge.yaml";
 
@@ -89,13 +85,7 @@ public class KafkaBridgeResource {
     }
 
     private static KafkaBridge waitFor(KafkaBridge kafkaBridge) {
-        String kafkaBridgeCrName = kafkaBridge.getMetadata().getName();
-
-        LOGGER.info("Waiting for KafkaBridge {}", kafkaBridgeCrName);
-        KafkaBridgeUtils.waitForKafkaBridgeReady(kafkaBridgeCrName);
-        LOGGER.info("KafkaBridge {} is ready", kafkaBridgeCrName);
-
-        return kafkaBridge;
+        return ResourceManager.waitForStatus(kafkaBridgeClient(), kafkaBridge, "Ready");
     }
 
     private static KafkaBridge deleteLater(KafkaBridge kafkaBridge) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
@@ -85,7 +85,7 @@ public class KafkaBridgeResource {
     }
 
     private static KafkaBridge waitFor(KafkaBridge kafkaBridge) {
-        return ResourceManager.waitForStatus(kafkaBridgeClient(), kafkaBridge, "Ready");
+        return ResourceManager.waitForResourceStatus(kafkaBridgeClient(), kafkaBridge, "Ready");
     }
 
     private static KafkaBridge deleteLater(KafkaBridge kafkaBridge) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -116,7 +116,7 @@ public class KafkaConnectResource {
     }
 
     private static KafkaConnect waitFor(KafkaConnect kafkaConnect) {
-        return ResourceManager.waitForStatus(kafkaConnectClient(), kafkaConnect, "Ready");
+        return ResourceManager.waitForResourceStatus(kafkaConnectClient(), kafkaConnect, "Ready");
     }
 
     private static KafkaConnect deleteLater(KafkaConnect kafkaConnect) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -18,17 +18,12 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.KubernetesResource;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.test.TestUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import io.strimzi.systemtest.resources.ResourceManager;
 
 import java.util.function.Consumer;
 
 public class KafkaConnectResource {
-    private static final Logger LOGGER = LogManager.getLogger(KafkaConnectResource.class);
-
     public static final String PATH_TO_KAFKA_CONNECT_CONFIG = "../examples/kafka-connect/kafka-connect.yaml";
     public static final String PATH_TO_KAFKA_CONNECT_METRICS_CONFIG = "../examples/metrics/kafka-connect-metrics.yaml";
 
@@ -121,13 +116,7 @@ public class KafkaConnectResource {
     }
 
     private static KafkaConnect waitFor(KafkaConnect kafkaConnect) {
-        String kafkaConnectCrName = kafkaConnect.getMetadata().getName();
-
-        LOGGER.info("Waiting for KafkaConnect {}", kafkaConnectCrName);
-        KafkaConnectUtils.waitForConnectReady(kafkaConnectCrName);
-        LOGGER.info("KafkaConnect {} is ready", kafkaConnectCrName);
-
-        return kafkaConnect;
+        return ResourceManager.waitForStatus(kafkaConnectClient(), kafkaConnect, "Ready");
     }
 
     private static KafkaConnect deleteLater(KafkaConnect kafkaConnect) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
@@ -100,7 +100,7 @@ public class KafkaConnectS2IResource {
     }
 
     private static KafkaConnectS2I waitFor(KafkaConnectS2I kafkaConnectS2I) {
-        return ResourceManager.waitForStatus(kafkaConnectS2IClient(), kafkaConnectS2I, "Ready");
+        return ResourceManager.waitForResourceStatus(kafkaConnectS2IClient(), kafkaConnectS2I, "Ready");
     }
 
     private static KafkaConnectS2I deleteLater(KafkaConnectS2I kafkaConnectS2I) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
@@ -18,17 +18,12 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.KubernetesResource;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectS2IUtils;
 import io.strimzi.test.TestUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import io.strimzi.systemtest.resources.ResourceManager;
 
 import java.util.function.Consumer;
 
 public class KafkaConnectS2IResource {
-    private static final Logger LOGGER = LogManager.getLogger(KafkaConnectS2IResource.class);
-
     public static final String PATH_TO_KAFKA_CONNECT_S2I_CONFIG = "../examples/kafka-connect/kafka-connect-s2i.yaml";
 
     public static MixedOperation<KafkaConnectS2I, KafkaConnectS2IList, DoneableKafkaConnectS2I, Resource<KafkaConnectS2I, DoneableKafkaConnectS2I>> kafkaConnectS2IClient() {
@@ -105,13 +100,7 @@ public class KafkaConnectS2IResource {
     }
 
     private static KafkaConnectS2I waitFor(KafkaConnectS2I kafkaConnectS2I) {
-        String kafkaConnectS2ICrName = kafkaConnectS2I.getMetadata().getName();
-
-        LOGGER.info("Waiting for KafkaConnectS2I {}", kafkaConnectS2ICrName);
-        KafkaConnectS2IUtils.waitForConnectS2IReady(kafkaConnectS2ICrName);
-        LOGGER.info("KafkaConnectS2I {} is ready", kafkaConnectS2ICrName);
-
-        return kafkaConnectS2I;
+        return ResourceManager.waitForStatus(kafkaConnectS2IClient(), kafkaConnectS2I, "Ready");
     }
 
     private static KafkaConnectS2I deleteLater(KafkaConnectS2I kafkaConnectS2I) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
@@ -87,7 +87,7 @@ public class KafkaConnectorResource {
     }
 
     private static KafkaConnector waitFor(KafkaConnector kafkaConnector) {
-        return ResourceManager.waitForStatus(kafkaConnectorClient(), kafkaConnector, "Ready");
+        return ResourceManager.waitForResourceStatus(kafkaConnectorClient(), kafkaConnector, "Ready");
     }
 
     private static KafkaConnector deleteLater(KafkaConnector kafkaConnector) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
@@ -14,17 +14,12 @@ import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
 import io.strimzi.test.TestUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import io.strimzi.systemtest.resources.ResourceManager;
 
 import java.util.function.Consumer;
 
 public class KafkaConnectorResource {
-    private static final Logger LOGGER = LogManager.getLogger(KafkaConnectorResource.class);
-
     public static final String PATH_TO_KAFKA_CONNECTOR_CONFIG = "../examples/connector/source-connector.yaml";
 
     public static MixedOperation<KafkaConnector, KafkaConnectorList, DoneableKafkaConnector, Resource<KafkaConnector, DoneableKafkaConnector>> kafkaConnectorClient() {
@@ -92,13 +87,7 @@ public class KafkaConnectorResource {
     }
 
     private static KafkaConnector waitFor(KafkaConnector kafkaConnector) {
-        String kafkaConnectorCrName = kafkaConnector.getMetadata().getName();
-
-        LOGGER.info("Waiting for KafkaConnector {}", kafkaConnectorCrName);
-        KafkaConnectorUtils.waitForConnectorReady(kafkaConnectorCrName);
-        LOGGER.info("KafkaConnector {} is ready", kafkaConnectorCrName);
-
-        return kafkaConnector;
+        return ResourceManager.waitForStatus(kafkaConnectorClient(), kafkaConnector, "Ready");
     }
 
     private static KafkaConnector deleteLater(KafkaConnector kafkaConnector) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
@@ -132,7 +132,7 @@ public class KafkaMirrorMaker2Resource {
     }
 
     private static KafkaMirrorMaker2 waitFor(KafkaMirrorMaker2 kafkaMirrorMaker2) {
-        return ResourceManager.waitForStatus(kafkaMirrorMaker2Client(), kafkaMirrorMaker2, "Ready");
+        return ResourceManager.waitForResourceStatus(kafkaMirrorMaker2Client(), kafkaMirrorMaker2, "Ready");
     }
 
     private static KafkaMirrorMaker2 deleteLater(KafkaMirrorMaker2 kafkaMirrorMaker2) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
@@ -15,7 +15,6 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Builder;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpecBuilder;
-import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
@@ -15,20 +15,16 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Builder;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpecBuilder;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaMirrorMaker2Utils;
 import io.strimzi.test.TestUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import io.strimzi.systemtest.resources.ResourceManager;
 
 import java.util.function.Consumer;
 
 public class KafkaMirrorMaker2Resource {
-    private static final Logger LOGGER = LogManager.getLogger(KafkaMirrorMaker2Resource.class);
-
     public static final String PATH_TO_KAFKA_MIRROR_MAKER_2_CONFIG = "../examples/kafka-mirror-maker-2/kafka-mirror-maker-2.yaml";
     public static final String PATH_TO_KAFKA_MIRROR_MAKER_2_METRICS_CONFIG = "../examples/metrics/kafka-mirror-maker-2-metrics.yaml";
 
@@ -137,13 +133,7 @@ public class KafkaMirrorMaker2Resource {
     }
 
     private static KafkaMirrorMaker2 waitFor(KafkaMirrorMaker2 kafkaMirrorMaker2) {
-        String kafkaMirrorMaker2CrName = kafkaMirrorMaker2.getMetadata().getName();
-
-        LOGGER.info("Waiting for KafkaMirrorMaker2 {}", kafkaMirrorMaker2CrName);
-        KafkaMirrorMaker2Utils.waitForKafkaMirrorMaker2Ready(kafkaMirrorMaker2CrName);
-        LOGGER.info("KafkaMirrorMaker2 {} is ready", kafkaMirrorMaker2CrName);
-
-        return kafkaMirrorMaker2;
+        return ResourceManager.waitForStatus(kafkaMirrorMaker2Client(), kafkaMirrorMaker2, "Ready");
     }
 
     private static KafkaMirrorMaker2 deleteLater(KafkaMirrorMaker2 kafkaMirrorMaker2) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
@@ -109,7 +109,7 @@ public class KafkaMirrorMakerResource {
     }
 
     private static KafkaMirrorMaker waitFor(KafkaMirrorMaker kafkaMirrorMaker) {
-        return ResourceManager.waitForStatus(kafkaMirrorMakerClient(), kafkaMirrorMaker, "Ready");
+        return ResourceManager.waitForResourceStatus(kafkaMirrorMakerClient(), kafkaMirrorMaker, "Ready");
     }
 
     private static KafkaMirrorMaker deleteLater(KafkaMirrorMaker kafkaMirrorMaker) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
@@ -15,19 +15,14 @@ import io.strimzi.api.kafka.model.KafkaMirrorMakerBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaMirrorMakerUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import io.strimzi.systemtest.resources.ResourceManager;
 
 import java.util.function.Consumer;
 
 public class KafkaMirrorMakerResource {
-    private static final Logger LOGGER = LogManager.getLogger(KafkaMirrorMakerResource.class);
-
     public static final String PATH_TO_KAFKA_MIRROR_MAKER_CONFIG = "../examples/kafka-mirror-maker/kafka-mirror-maker.yaml";
 
     public static MixedOperation<KafkaMirrorMaker, KafkaMirrorMakerList, DoneableKafkaMirrorMaker, Resource<KafkaMirrorMaker, DoneableKafkaMirrorMaker>> kafkaMirrorMakerClient() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
@@ -114,13 +114,7 @@ public class KafkaMirrorMakerResource {
     }
 
     private static KafkaMirrorMaker waitFor(KafkaMirrorMaker kafkaMirrorMaker) {
-        String kafkaMirrorMakerCrName = kafkaMirrorMaker.getMetadata().getName();
-
-        LOGGER.info("Waiting for KafkaMirrorMaker {}", kafkaMirrorMakerCrName);
-        KafkaMirrorMakerUtils.waitForKafkaMirrorMakerReady(kafkaMirrorMakerCrName);
-        LOGGER.info("KafkaMirrorMaker {} is ready", kafkaMirrorMakerCrName);
-
-        return kafkaMirrorMaker;
+        return ResourceManager.waitForStatus(kafkaMirrorMakerClient(), kafkaMirrorMaker, "Ready");
     }
 
     private static KafkaMirrorMaker deleteLater(KafkaMirrorMaker kafkaMirrorMaker) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
@@ -12,7 +12,6 @@ import io.strimzi.api.kafka.model.DoneableKafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -64,7 +63,7 @@ public class KafkaTopicResource {
         return new DoneableKafkaTopic(topic, kt -> {
             kafkaTopicClient().inNamespace(topic.getMetadata().getNamespace()).createOrReplace(kt);
             LOGGER.info("Created KafkaTopic {}", kt.getMetadata().getName());
-            return waitFor(deleteLater(kt));
+            return waitForStatus(deleteLater(kt));
         });
     }
 
@@ -77,14 +76,8 @@ public class KafkaTopicResource {
         return TestUtils.configFromYaml(yamlPath, KafkaTopic.class);
     }
 
-    private static KafkaTopic waitFor(KafkaTopic kafkaTopic) {
-        String kafkaTopicCrName = kafkaTopic.getMetadata().getName();
-
-        LOGGER.info("Waiting for KafkaTopic {}", kafkaTopicCrName);
-        KafkaTopicUtils.waitForKafkaTopicCreation(kafkaTopicCrName);
-        LOGGER.info("KafkaTopic {} is ready", kafkaTopicCrName);
-
-        return kafkaTopic;
+    private static KafkaTopic waitForStatus(KafkaTopic kafkaTopic) {
+        return ResourceManager.waitForStatus(kafkaTopicClient(), kafkaTopic, "Ready");
     }
 
     private static KafkaTopic deleteLater(KafkaTopic kafkaTopic) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
@@ -63,7 +63,7 @@ public class KafkaTopicResource {
         return new DoneableKafkaTopic(topic, kt -> {
             kafkaTopicClient().inNamespace(topic.getMetadata().getNamespace()).createOrReplace(kt);
             LOGGER.info("Created KafkaTopic {}", kt.getMetadata().getName());
-            return waitForStatus(deleteLater(kt));
+            return waitFor(deleteLater(kt));
         });
     }
 
@@ -76,8 +76,8 @@ public class KafkaTopicResource {
         return TestUtils.configFromYaml(yamlPath, KafkaTopic.class);
     }
 
-    private static KafkaTopic waitForStatus(KafkaTopic kafkaTopic) {
-        return ResourceManager.waitForStatus(kafkaTopicClient(), kafkaTopic, "Ready");
+    private static KafkaTopic waitFor(KafkaTopic kafkaTopic) {
+        return ResourceManager.waitForResourceStatus(kafkaTopicClient(), kafkaTopic, "Ready");
     }
 
     private static KafkaTopic deleteLater(KafkaTopic kafkaTopic) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
@@ -12,7 +12,6 @@ import io.strimzi.api.kafka.model.DoneableKafkaUser;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserBuilder;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -72,7 +71,7 @@ public class KafkaUserResource {
 
     private static KafkaUser waitFor(KafkaUser kafkaUser) {
         SecretUtils.waitForSecretReady(kafkaUser.getMetadata().getName(),
-            () -> LOGGER.info(KafkaUserResource.kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(kafkaUser.getMetadata().getName()).get())
+            () -> LOGGER.info(kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(kafkaUser.getMetadata().getName()).get())
         );
         return ResourceManager.waitForStatus(kafkaUserClient(), kafkaUser, "Ready");
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
@@ -12,14 +12,11 @@ import io.strimzi.api.kafka.model.DoneableKafkaUser;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserBuilder;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import io.strimzi.systemtest.resources.ResourceManager;
 
 import java.util.function.Consumer;
-
-import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class KafkaUserResource {
     private static final Logger LOGGER = LogManager.getLogger(KafkaUserResource.class);
@@ -70,10 +67,7 @@ public class KafkaUserResource {
     }
 
     private static KafkaUser waitFor(KafkaUser kafkaUser) {
-        SecretUtils.waitForSecretReady(kafkaUser.getMetadata().getName(),
-            () -> LOGGER.info(kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(kafkaUser.getMetadata().getName()).get())
-        );
-        return ResourceManager.waitForStatus(kafkaUserClient(), kafkaUser, "Ready");
+        return ResourceManager.waitForResourceStatus(kafkaUserClient(), kafkaUser, "Ready");
     }
 
     private static KafkaUser deleteLater(KafkaUser kafkaUser) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -6,13 +6,9 @@ package io.strimzi.systemtest.utils;
 
 import com.jayway.jsonpath.JsonPath;
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.client.CustomResource;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.ContainerEnvVarBuilder;
-import io.strimzi.api.kafka.model.status.Condition;
-import io.strimzi.api.kafka.model.status.HasStatus;
 import io.strimzi.systemtest.Environment;
-import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
@@ -29,7 +25,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
-import static java.util.Arrays.asList;
 
 public class StUtils {
 
@@ -219,24 +214,5 @@ public class StUtils {
             }
         }
         return isJSON;
-    }
-    /**
-     * Log actual status of custom resource with pods.
-     * @param customResource - Kafka, KafkaConnect etc. - every resource that HasMetadata and HasStatus (Strimzi status)
-     */
-    public static <T extends CustomResource & HasStatus> void logCurrentStatus(T customResource) {
-        String kind = customResource.getKind();
-        String name = customResource.getMetadata().getName();
-
-        List<String> log = new ArrayList<>(asList("\n", kind, " status:\n", "\nConditions:\n"));
-
-        for (Condition condition : customResource.getStatus().getConditions()) {
-            log.add("\tType: " + condition.getType() + "\n");
-            log.add("\tMessage: " + condition.getMessage() + "\n");
-        }
-
-        PodUtils.logCurrentPodStatus(kind, name, log);
-
-        LOGGER.info("{}", String.join("", log));
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaBridgeUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaBridgeUtils.java
@@ -5,10 +5,9 @@
 package io.strimzi.systemtest.utils.kafkaUtils;
 
 import io.fabric8.kubernetes.api.model.Service;
+import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.resources.crd.KafkaBridgeResource;
-import io.strimzi.systemtest.utils.StUtils;
-import io.strimzi.test.TestUtils;
+import io.strimzi.systemtest.resources.ResourceManager;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.strimzi.operator.common.model.Labels;
@@ -19,6 +18,7 @@ import io.strimzi.systemtest.resources.KubernetesResource;
 import java.util.HashMap;
 import java.util.Map;
 
+import static io.strimzi.systemtest.resources.crd.KafkaBridgeResource.kafkaBridgeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -70,13 +70,9 @@ public class KafkaBridgeUtils {
      * @param clusterName name of KafkaBridge cluster
      * @param state desired state
      */
-    public static void waitForKafkaBridgeStatus(String clusterName, String state) {
-        LOGGER.info("Wait until KafkaBridge {} will be in state: {}", clusterName, state);
-        TestUtils.waitFor("Waiting for Kafka resource status is: " + state, Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> KafkaBridgeResource.kafkaBridgeClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get().getStatus().getConditions().get(0).getType().equals(state),
-            () -> StUtils.logCurrentStatus(KafkaBridgeResource.kafkaBridgeClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get())
-        );
-        LOGGER.info("KafkaBridge {}} is in state: {}", clusterName, state);
+    public static void waitUntilKafkaBridgeStatus(String clusterName, String state) {
+        KafkaBridge kafkaBridge = kafkaBridgeClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
+        ResourceManager.waitForStatus(kafkaBridgeClient(), kafkaBridge, state);
     }
 
     public static void waitForKafkaBridgeReady(String clusterName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaBridgeUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaBridgeUtils.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaBridgeResource;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.strimzi.operator.common.model.Labels;
@@ -18,7 +19,6 @@ import io.strimzi.systemtest.resources.KubernetesResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import static io.strimzi.systemtest.resources.crd.KafkaBridgeResource.kafkaBridgeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -71,8 +71,8 @@ public class KafkaBridgeUtils {
      * @param state desired state
      */
     public static void waitUntilKafkaBridgeStatus(String clusterName, String state) {
-        KafkaBridge kafkaBridge = kafkaBridgeClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
-        ResourceManager.waitForStatus(kafkaBridgeClient(), kafkaBridge, state);
+        KafkaBridge kafkaBridge = KafkaBridgeResource.kafkaBridgeClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
+        ResourceManager.waitForResourceStatus(KafkaBridgeResource.kafkaBridgeClient(), kafkaBridge, state);
     }
 
     public static void waitForKafkaBridgeReady(String clusterName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaBridgeUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaBridgeUtils.java
@@ -70,7 +70,7 @@ public class KafkaBridgeUtils {
      * @param clusterName name of KafkaBridge cluster
      * @param state desired state
      */
-    public static void waitUntilKafkaBridgeStatus(String clusterName, String state) {
+    public static void waitForKafkaBridgeStatus(String clusterName, String state) {
         KafkaBridge kafkaBridge = KafkaBridgeResource.kafkaBridgeClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
         ResourceManager.waitForResourceStatus(KafkaBridgeResource.kafkaBridgeClient(), kafkaBridge, state);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
@@ -4,13 +4,17 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
+import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaConnectS2IResource;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import static io.strimzi.systemtest.resources.ResourceManager.logCurrentStatus;
+import static io.strimzi.systemtest.resources.crd.KafkaConnectS2IResource.kafkaConnectS2IClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class KafkaConnectS2IUtils {
@@ -24,13 +28,9 @@ public class KafkaConnectS2IUtils {
      * @param clusterName The name of the Kafka ConnectS2I cluster.
      * @param status desired status value
      */
-    public static void waitForConnectS2IStatus(String clusterName, String status) {
-        LOGGER.info("Wait until KafkaConnectS2I {} will be in state: {}", clusterName, status);
-        TestUtils.waitFor("KafkaConnectS2I " + clusterName + " state: " + status, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> KafkaConnectS2IResource.kafkaConnectS2IClient().inNamespace(kubeClient().getNamespace())
-                    .withName(clusterName).get().getStatus().getConditions().get(0).getType().equals(status),
-            () -> StUtils.logCurrentStatus(KafkaConnectS2IResource.kafkaConnectS2IClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get()));
-        LOGGER.info("KafkaConnectS2I {} is in desired state: {}", clusterName, status);
+    public static void waitForConnectS2IStatus(String name, String status) {
+        KafkaConnectS2I kafkaConnectS2I = kafkaConnectS2IClient().inNamespace(kubeClient().getNamespace()).withName(name).get();
+        ResourceManager.waitForStatus(kafkaConnectS2IClient(), kafkaConnectS2I, status);
     }
 
     public static void waitForConnectS2IReady(String clusterName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
@@ -7,13 +7,10 @@ package io.strimzi.systemtest.utils.kafkaUtils;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
-import io.strimzi.systemtest.resources.crd.KafkaConnectS2IResource;
-import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import static io.strimzi.systemtest.resources.ResourceManager.logCurrentStatus;
 import static io.strimzi.systemtest.resources.crd.KafkaConnectS2IResource.kafkaConnectS2IClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
@@ -5,18 +5,12 @@
 package io.strimzi.systemtest.utils.kafkaUtils;
 
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
-import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaConnectS2IResource;
-import io.strimzi.test.TestUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class KafkaConnectS2IUtils {
-
-    private static final Logger LOGGER = LogManager.getLogger(KafkaConnectS2IUtils.class);
 
     private KafkaConnectS2IUtils() {}
 
@@ -25,8 +19,8 @@ public class KafkaConnectS2IUtils {
      * @param clusterName The name of the Kafka ConnectS2I cluster.
      * @param status desired status value
      */
-    public static void waitForConnectS2IStatus(String name, String status) {
-        KafkaConnectS2I kafkaConnectS2I = KafkaConnectS2IResource.kafkaConnectS2IClient().inNamespace(kubeClient().getNamespace()).withName(name).get();
+    public static void waitForConnectS2IStatus(String clusterName, String status) {
+        KafkaConnectS2I kafkaConnectS2I = KafkaConnectS2IResource.kafkaConnectS2IClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
         ResourceManager.waitForResourceStatus(KafkaConnectS2IResource.kafkaConnectS2IClient(), kafkaConnectS2I, status);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
@@ -7,11 +7,11 @@ package io.strimzi.systemtest.utils.kafkaUtils;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaConnectS2IResource;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import static io.strimzi.systemtest.resources.crd.KafkaConnectS2IResource.kafkaConnectS2IClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class KafkaConnectS2IUtils {
@@ -26,8 +26,8 @@ public class KafkaConnectS2IUtils {
      * @param status desired status value
      */
     public static void waitForConnectS2IStatus(String name, String status) {
-        KafkaConnectS2I kafkaConnectS2I = kafkaConnectS2IClient().inNamespace(kubeClient().getNamespace()).withName(name).get();
-        ResourceManager.waitForStatus(kafkaConnectS2IClient(), kafkaConnectS2I, status);
+        KafkaConnectS2I kafkaConnectS2I = KafkaConnectS2IResource.kafkaConnectS2IClient().inNamespace(kubeClient().getNamespace()).withName(name).get();
+        ResourceManager.waitForResourceStatus(KafkaConnectS2IResource.kafkaConnectS2IClient(), kafkaConnectS2I, status);
     }
 
     public static void waitForConnectS2IReady(String clusterName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
@@ -26,8 +26,8 @@ public class KafkaConnectUtils {
      * @param clusterName name of KafkaConnect cluster
      * @param status desired state
      */
-    public static void waitForConnectStatus(String name, String status) {
-        KafkaConnect kafkaConnect = KafkaConnectResource.kafkaConnectClient().inNamespace(kubeClient().getNamespace()).withName(name).get();
+    public static void waitForConnectStatus(String clusterName, String status) {
+        KafkaConnect kafkaConnect = KafkaConnectResource.kafkaConnectClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
         ResourceManager.waitForResourceStatus(KafkaConnectResource.kafkaConnectClient(), kafkaConnect, status);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
@@ -4,13 +4,15 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
+import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
+import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import static io.strimzi.systemtest.resources.crd.KafkaConnectResource.kafkaConnectClient;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
@@ -25,12 +27,9 @@ public class KafkaConnectUtils {
      * @param clusterName name of KafkaConnect cluster
      * @param status desired state
      */
-    public static void waitForConnectStatus(String clusterName, String status) {
-        LOGGER.info("Waiting for Kafka Connect {} state: {}", clusterName, status);
-        TestUtils.waitFor("Kafka Connect " + clusterName + " state: " + status, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> KafkaConnectResource.kafkaConnectClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get().getStatus().getConditions().get(0).getType().equals(status),
-            () -> StUtils.logCurrentStatus(KafkaConnectResource.kafkaConnectClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get()));
-        LOGGER.info("Kafka Connect {} is in desired state: {}", clusterName, status);
+    public static void waitForConnectStatus(String name, String status) {
+        KafkaConnect kafkaConnect = kafkaConnectClient().inNamespace(kubeClient().getNamespace()).withName(name).get();
+        ResourceManager.waitForStatus(kafkaConnectClient(), kafkaConnect, status);
     }
 
     public static void waitForConnectReady(String clusterName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
@@ -7,12 +7,11 @@ package io.strimzi.systemtest.utils.kafkaUtils;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
-import io.strimzi.systemtest.utils.StUtils;
+import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import static io.strimzi.systemtest.resources.crd.KafkaConnectResource.kafkaConnectClient;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
@@ -28,8 +27,8 @@ public class KafkaConnectUtils {
      * @param status desired state
      */
     public static void waitForConnectStatus(String name, String status) {
-        KafkaConnect kafkaConnect = kafkaConnectClient().inNamespace(kubeClient().getNamespace()).withName(name).get();
-        ResourceManager.waitForStatus(kafkaConnectClient(), kafkaConnect, status);
+        KafkaConnect kafkaConnect = KafkaConnectResource.kafkaConnectClient().inNamespace(kubeClient().getNamespace()).withName(name).get();
+        ResourceManager.waitForResourceStatus(KafkaConnectResource.kafkaConnectClient(), kafkaConnect, status);
     }
 
     public static void waitForConnectReady(String clusterName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectorUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectorUtils.java
@@ -50,8 +50,8 @@ public class KafkaConnectorUtils {
      * @param connectorName name of KafkaConnector
      * @param state desired state
      */
-    public static void waitForConnectorStatus(String name, String state) {
-        KafkaConnector kafkaConnector = KafkaConnectorResource.kafkaConnectorClient().inNamespace(kubeClient().getNamespace()).withName(name).get();
+    public static void waitForConnectorStatus(String connectorName, String state) {
+        KafkaConnector kafkaConnector = KafkaConnectorResource.kafkaConnectorClient().inNamespace(kubeClient().getNamespace()).withName(connectorName).get();
         ResourceManager.waitForResourceStatus(KafkaConnectorResource.kafkaConnectorClient(), kafkaConnector, state);
     }
 
@@ -74,5 +74,14 @@ public class KafkaConnectorUtils {
             String availableConnectors = getCreatedConnectors(connectS2IPodName);
             return availableConnectors.contains(connectorName);
         }, () -> ResourceManager.logCurrentResourceStatus(KafkaConnectorResource.kafkaConnectorClient().inNamespace(kubeClient().getNamespace()).withName(connectorName).get()));
+    }
+
+    public static void createFileSinkConnector(String podName, String topicName, String sinkFileName, String apiUrl) {
+        cmdKubeClient().execInPod(podName, "/bin/bash", "-c",
+            "curl -X POST -H \"Content-Type: application/json\" " + "--data '{ \"name\": \"sink-test\", " +
+                "\"config\": " + "{ \"connector.class\": \"FileStreamSink\", " +
+                "\"tasks.max\": \"1\", \"topics\": \"" + topicName + "\"," + " \"file\": \"" + sinkFileName + "\" } }' " +
+                apiUrl + "/connectors"
+        );
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectorUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectorUtils.java
@@ -7,12 +7,11 @@ package io.strimzi.systemtest.utils.kafkaUtils;
 import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaConnectorResource;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import static io.strimzi.systemtest.resources.ResourceManager.logCurrentStatus;
-import static io.strimzi.systemtest.resources.crd.KafkaConnectorResource.kafkaConnectorClient;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
@@ -42,7 +41,7 @@ public class KafkaConnectorUtils {
                 } else {
                     throw new RuntimeException("Connector" + connectorName + " is not stable!");
                 }
-            }, () -> logCurrentStatus(kafkaConnectorClient().inNamespace(kubeClient().getNamespace()).withName(connectorName).get())
+            }, () -> ResourceManager.logCurrentResourceStatus(KafkaConnectorResource.kafkaConnectorClient().inNamespace(kubeClient().getNamespace()).withName(connectorName).get())
         );
     }
 
@@ -52,8 +51,8 @@ public class KafkaConnectorUtils {
      * @param state desired state
      */
     public static void waitForConnectorStatus(String name, String state) {
-        KafkaConnector kafkaConnector = kafkaConnectorClient().inNamespace(kubeClient().getNamespace()).withName(name).get();
-        ResourceManager.waitForStatus(kafkaConnectorClient(), kafkaConnector, state);
+        KafkaConnector kafkaConnector = KafkaConnectorResource.kafkaConnectorClient().inNamespace(kubeClient().getNamespace()).withName(name).get();
+        ResourceManager.waitForResourceStatus(KafkaConnectorResource.kafkaConnectorClient(), kafkaConnector, state);
     }
 
     public static void waitForConnectorReady(String connectorName) {
@@ -74,6 +73,6 @@ public class KafkaConnectorUtils {
         TestUtils.waitFor(connectorName + " connector creation", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
             String availableConnectors = getCreatedConnectors(connectS2IPodName);
             return availableConnectors.contains(connectorName);
-        }, () -> logCurrentStatus(kafkaConnectorClient().inNamespace(kubeClient().getNamespace()).withName(connectorName).get()));
+        }, () -> ResourceManager.logCurrentResourceStatus(KafkaConnectorResource.kafkaConnectorClient().inNamespace(kubeClient().getNamespace()).withName(connectorName).get()));
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaMirrorMaker2Utils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaMirrorMaker2Utils.java
@@ -4,18 +4,13 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
-import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.resources.crd.KafkaMirrorMaker2Resource;
-import io.strimzi.systemtest.utils.StUtils;
-import io.strimzi.test.TestUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
+import io.strimzi.systemtest.resources.ResourceManager;
 
+import static io.strimzi.systemtest.resources.crd.KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class KafkaMirrorMaker2Utils {
-
-    private static final Logger LOGGER = LogManager.getLogger(KafkaMirrorMaker2Utils.class);
 
     private KafkaMirrorMaker2Utils() {}
 
@@ -24,12 +19,9 @@ public class KafkaMirrorMaker2Utils {
      * @param clusterName name of KafkaMirrorMaker2 cluster
      * @param state desired state
      */
-    public static void waitForKafkaMirrorMaker2Status(String clusterName, String state) {
-        LOGGER.info("Wait until KafkaMirrorMaker2 will be in state: {}", state);
-        TestUtils.waitFor("KafkaMirrorMaker2 resource status is: " + state, Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(kubeClient().getNamespace()).withName(clusterName).get().getStatus().getConditions().get(0).getType().equals(state),
-            () -> StUtils.logCurrentStatus(KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(kubeClient().getNamespace()).withName(clusterName).get()));
-        LOGGER.info("KafkaMirrorMaker2 is in state: {}", state);
+    public static void waitUntilKafkaMirrorMaker2Status(String clusterName, String state) {
+        KafkaMirrorMaker2 kafkaMirrorMaker2 = kafkaMirrorMaker2Client().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
+        ResourceManager.waitForStatus(kafkaMirrorMaker2Client(), kafkaMirrorMaker2, state);
     }
 
     public static void waitForKafkaMirrorMaker2Ready(String clusterName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaMirrorMaker2Utils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaMirrorMaker2Utils.java
@@ -6,8 +6,8 @@ package io.strimzi.systemtest.utils.kafkaUtils;
 
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaMirrorMaker2Resource;
 
-import static io.strimzi.systemtest.resources.crd.KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class KafkaMirrorMaker2Utils {
@@ -20,8 +20,8 @@ public class KafkaMirrorMaker2Utils {
      * @param state desired state
      */
     public static void waitUntilKafkaMirrorMaker2Status(String clusterName, String state) {
-        KafkaMirrorMaker2 kafkaMirrorMaker2 = kafkaMirrorMaker2Client().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
-        ResourceManager.waitForStatus(kafkaMirrorMaker2Client(), kafkaMirrorMaker2, state);
+        KafkaMirrorMaker2 kafkaMirrorMaker2 = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
+        ResourceManager.waitForResourceStatus(KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client(), kafkaMirrorMaker2, state);
     }
 
     public static void waitForKafkaMirrorMaker2Ready(String clusterName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaMirrorMaker2Utils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaMirrorMaker2Utils.java
@@ -19,7 +19,7 @@ public class KafkaMirrorMaker2Utils {
      * @param clusterName name of KafkaMirrorMaker2 cluster
      * @param state desired state
      */
-    public static void waitUntilKafkaMirrorMaker2Status(String clusterName, String state) {
+    public static void waitForKafkaMirrorMaker2Status(String clusterName, String state) {
         KafkaMirrorMaker2 kafkaMirrorMaker2 = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
         ResourceManager.waitForResourceStatus(KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client(), kafkaMirrorMaker2, state);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaMirrorMakerUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaMirrorMakerUtils.java
@@ -4,18 +4,13 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
-import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.resources.crd.KafkaMirrorMakerResource;
-import io.strimzi.systemtest.utils.StUtils;
-import io.strimzi.test.TestUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker;
+import io.strimzi.systemtest.resources.ResourceManager;
 
+import static io.strimzi.systemtest.resources.crd.KafkaMirrorMakerResource.kafkaMirrorMakerClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class KafkaMirrorMakerUtils {
-
-    private static final Logger LOGGER = LogManager.getLogger(KafkaMirrorMakerUtils.class);
 
     private KafkaMirrorMakerUtils() {}
 
@@ -24,12 +19,9 @@ public class KafkaMirrorMakerUtils {
      * @param clusterName name of KafkaMirrorMaker cluster
      * @param state desired state - like Ready
      */
-    public static void waitForKafkaMirrorMakerStatus(String clusterName, String state) {
-        LOGGER.info("Wait until KafkaMirrorMaker CR will be in state: {}", state);
-        TestUtils.waitFor("Waiting for Kafka resource status is: " + state, Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get().getStatus().getConditions().get(0).getType().equals(state),
-            () -> StUtils.logCurrentStatus(KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get()));
-        LOGGER.info("KafkaMirrorMaker CR is in state: {}", state);
+    public static void waitUntilKafkaMirrorMakerStatus(String clusterName, String state) {
+        KafkaMirrorMaker kafkaMirrorMaker = kafkaMirrorMakerClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
+        ResourceManager.waitForStatus(kafkaMirrorMakerClient(), kafkaMirrorMaker, state);
     }
 
     public static void waitForKafkaMirrorMakerReady(String clusterName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaMirrorMakerUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaMirrorMakerUtils.java
@@ -19,7 +19,7 @@ public class KafkaMirrorMakerUtils {
      * @param clusterName name of KafkaMirrorMaker cluster
      * @param state desired state - like Ready
      */
-    public static void waitUntilKafkaMirrorMakerStatus(String clusterName, String state) {
+    public static void waitForKafkaMirrorMakerStatus(String clusterName, String state) {
         KafkaMirrorMaker kafkaMirrorMaker = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
         ResourceManager.waitForResourceStatus(KafkaMirrorMakerResource.kafkaMirrorMakerClient(), kafkaMirrorMaker, state);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaMirrorMakerUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaMirrorMakerUtils.java
@@ -6,8 +6,8 @@ package io.strimzi.systemtest.utils.kafkaUtils;
 
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaMirrorMakerResource;
 
-import static io.strimzi.systemtest.resources.crd.KafkaMirrorMakerResource.kafkaMirrorMakerClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class KafkaMirrorMakerUtils {
@@ -20,8 +20,8 @@ public class KafkaMirrorMakerUtils {
      * @param state desired state - like Ready
      */
     public static void waitUntilKafkaMirrorMakerStatus(String clusterName, String state) {
-        KafkaMirrorMaker kafkaMirrorMaker = kafkaMirrorMakerClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
-        ResourceManager.waitForStatus(kafkaMirrorMakerClient(), kafkaMirrorMaker, state);
+        KafkaMirrorMaker kafkaMirrorMaker = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
+        ResourceManager.waitForResourceStatus(KafkaMirrorMakerResource.kafkaMirrorMakerClient(), kafkaMirrorMaker, state);
     }
 
     public static void waitForKafkaMirrorMakerReady(String clusterName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -9,11 +9,11 @@ import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import static io.strimzi.systemtest.resources.crd.KafkaTopicResource.kafkaTopicClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class KafkaTopicUtils {
@@ -83,8 +83,8 @@ public class KafkaTopicUtils {
      * @param state desired state
      */
     public static void waitForKafkaTopicStatus(String topicName, String status) {
-        KafkaTopic kafkaTopic = kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(topicName).get();
-        ResourceManager.waitForStatus(kafkaTopicClient(), kafkaTopic, status);
+        KafkaTopic kafkaTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(topicName).get();
+        ResourceManager.waitForResourceStatus(KafkaTopicResource.kafkaTopicClient(), kafkaTopic, status);
     }
 
     public static void waitForKafkaTopicReady(String topicName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
@@ -82,9 +81,9 @@ public class KafkaTopicUtils {
      * @param topicName name of KafkaTopic
      * @param state desired state
      */
-    public static void waitForKafkaTopicStatus(String topicName, String status) {
+    public static void waitForKafkaTopicStatus(String topicName, String state) {
         KafkaTopic kafkaTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(topicName).get();
-        ResourceManager.waitForResourceStatus(KafkaTopicResource.kafkaTopicClient(), kafkaTopic, status);
+        ResourceManager.waitForResourceStatus(KafkaTopicResource.kafkaTopicClient(), kafkaTopic, state);
     }
 
     public static void waitForKafkaTopicReady(String topicName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -4,13 +4,19 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
+import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.test.TestUtils;
+import jdk.internal.loader.Resource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import static io.strimzi.systemtest.resources.crd.KafkaTopicResource.kafkaTopicClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class KafkaTopicUtils {
@@ -79,14 +85,9 @@ public class KafkaTopicUtils {
      * @param topicName name of KafkaTopic
      * @param state desired state
      */
-    public static void waitForKafkaTopicStatus(String topicName, String state) {
-        LOGGER.info("Wait until KafkaTopic {} is in desired state: {}", topicName, state);
-        TestUtils.waitFor("KafkaTopic " + topicName + " status is not in desired state: " + state, Constants.GLOBAL_POLL_INTERVAL, Constants.CONNECT_STATUS_TIMEOUT,
-            () -> KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace())
-                    .withName(topicName).get().getStatus().getConditions().get(0).getType().equals(state),
-            () -> LOGGER.info(KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(topicName).get())
-        );
-        LOGGER.info("Kafka Topic {} is in desired state: {}", topicName, state);
+    public static void waitForKafkaTopicStatus(String topicName, String status) {
+        KafkaTopic kafkaTopic = kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(topicName).get();
+        ResourceManager.waitForStatus(kafkaTopicClient(), kafkaTopic, status);
     }
 
     public static void waitForKafkaTopicReady(String topicName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -6,13 +6,10 @@ package io.strimzi.systemtest.utils.kafkaUtils;
 
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaTopic;
-import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.resources.ResourceManager;
-import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.test.TestUtils;
-import jdk.internal.loader.Resource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
@@ -8,7 +8,6 @@ import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
-import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
@@ -8,12 +8,12 @@ import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import static io.strimzi.systemtest.resources.crd.KafkaUserResource.kafkaUserClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class KafkaUserUtils {
@@ -23,12 +23,12 @@ public class KafkaUserUtils {
     private KafkaUserUtils() {}
 
     public static void waitForKafkaUserCreation(String userName) {
-        KafkaUser kafkaUser = kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName).get();
+        KafkaUser kafkaUser = KafkaUserResource.kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName).get();
 
         SecretUtils.waitForSecretReady(userName,
-            () -> LOGGER.info(kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName).get()));
+            () -> LOGGER.info(KafkaUserResource.kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName).get()));
 
-        ResourceManager.waitForStatus(kafkaUserClient(), kafkaUser, "Ready");
+        ResourceManager.waitForResourceStatus(KafkaUserResource.kafkaUserClient(), kafkaUser, "Ready");
     }
 
     public static void waitForKafkaUserDeletion(String userName) {
@@ -62,8 +62,8 @@ public class KafkaUserUtils {
      * @param state desired state
      */
     public static void waitForKafkaUserStatus(String userName, String state) {
-        KafkaUser kafkaUser = kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName).get();
-        ResourceManager.waitForStatus(kafkaUserClient(), kafkaUser, state);
+        KafkaUser kafkaUser = KafkaUserResource.kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName).get();
+        ResourceManager.waitForResourceStatus(KafkaUserResource.kafkaUserClient(), kafkaUser, state);
     }
 
     public static void waitForKafkaUserReady(String userName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.status.ListenerStatus;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.test.TestUtils;
@@ -25,7 +26,6 @@ import java.util.regex.Pattern;
 
 import static io.strimzi.api.kafka.model.KafkaResources.kafkaStatefulSetName;
 import static io.strimzi.api.kafka.model.KafkaResources.zookeeperStatefulSetName;
-import static io.strimzi.systemtest.resources.crd.KafkaResource.kafkaClient;
 import static io.strimzi.test.TestUtils.indent;
 import static io.strimzi.test.TestUtils.waitFor;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -46,8 +46,8 @@ public class KafkaUtils {
     }
 
     public static void waitUntilKafkaStatus(String clusterName, String state) {
-        Kafka kafka = kafkaClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
-        ResourceManager.waitForStatus(kafkaClient(), kafka, state);
+        Kafka kafka = KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
+        ResourceManager.waitForResourceStatus(KafkaResource.kafkaClient(), kafka, state);
     }
 
     public static void waitUntilKafkaStatusConditionContainsMessage(String clusterName, String namespace, String message) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -4,11 +4,12 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
+import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.status.ListenerStatus;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.test.TestUtils;
@@ -21,10 +22,10 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static io.strimzi.api.kafka.model.KafkaResources.kafkaStatefulSetName;
 import static io.strimzi.api.kafka.model.KafkaResources.zookeeperStatefulSetName;
+import static io.strimzi.systemtest.resources.crd.KafkaResource.kafkaClient;
 import static io.strimzi.test.TestUtils.indent;
 import static io.strimzi.test.TestUtils.waitFor;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -45,21 +46,8 @@ public class KafkaUtils {
     }
 
     public static void waitUntilKafkaStatus(String clusterName, String state) {
-        LOGGER.info("Wait until Kafka CR will be in state: {}", state);
-        TestUtils.waitFor("Waiting for Kafka resource status is: " + state, Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT, () -> {
-            List<Condition> conditions =
-                   KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(clusterName)
-                            .get().getStatus().getConditions().stream().filter(condition -> !condition.getType().equals("Warning"))
-                            .collect(Collectors.toList());
-
-            for (Condition condition : conditions) {
-                if (!condition.getType().matches(state))
-                    return false;
-            }
-
-            return true;
-        });
-        LOGGER.info("Kafka CR is in state: {}", state);
+        Kafka kafka = kafkaClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
+        ResourceManager.waitForStatus(kafkaClient(), kafka, state);
     }
 
     public static void waitUntilKafkaStatusConditionContainsMessage(String clusterName, String namespace, String message) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
@@ -262,7 +262,9 @@ public class DeploymentUtils {
             log.add("\tMessage: " + deploymentCondition.getMessage() + "\n");
         }
 
-        PodUtils.logCurrentPodStatus(kind, name, log);
+        if(kubeClient().listPodsByPrefixInName(name).size() != 0) {
+            PodUtils.logCurrentPodStatus(name, log);
+        }
 
         LOGGER.info("{}", String.join("", log));
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
@@ -6,6 +6,8 @@ package io.strimzi.systemtest.utils.kubeUtils.controllers;
 
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodCondition;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentCondition;
 import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
@@ -263,7 +265,19 @@ public class DeploymentUtils {
         }
 
         if (kubeClient().listPodsByPrefixInName(name).size() != 0) {
-            PodUtils.logCurrentPodStatus(name, log);
+            log.add("\nPods with conditions and messages:\n\n");
+
+            for (Pod pod : kubeClient().listPodsByPrefixInName(name)) {
+                log.add(pod.getMetadata().getName() + ":");
+                for (PodCondition podCondition : pod.getStatus().getConditions()) {
+                    if (podCondition.getMessage() != null) {
+                        log.add("\n\tType: " + podCondition.getType() + "\n");
+                        log.add("\tMessage: " + podCondition.getMessage() + "\n");
+                    }
+                }
+                log.add("\n\n");
+            }
+            LOGGER.info("{}", String.join("", log));
         }
 
         LOGGER.info("{}", String.join("", log));

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
@@ -262,7 +262,7 @@ public class DeploymentUtils {
             log.add("\tMessage: " + deploymentCondition.getMessage() + "\n");
         }
 
-        if(kubeClient().listPodsByPrefixInName(name).size() != 0) {
+        if (kubeClient().listPodsByPrefixInName(name).size() != 0) {
             PodUtils.logCurrentPodStatus(name, log);
         }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
-import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -18,6 +17,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.Map;
 import java.util.TreeMap;
 
+import static io.strimzi.systemtest.resources.ResourceManager.logCurrentStatus;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
@@ -137,11 +137,11 @@ public class StatefulSetUtils {
         LOGGER.info("Waiting for StatefulSet {} to be ready", statefulSetName);
         TestUtils.waitFor("statefulset " + statefulSetName + " to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
             () -> kubeClient().getStatefulSetStatus(statefulSetName),
-            () -> StUtils.logCurrentStatus(KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get()));
+            () -> logCurrentStatus(KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get()));
 
         LOGGER.info("Waiting for {} Pod(s) of StatefulSet {} to be ready", expectPods, statefulSetName);
         PodUtils.waitForPodsReady(kubeClient().getStatefulSetSelectors(statefulSetName), expectPods, true,
-            () -> StUtils.logCurrentStatus(KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get()));
+            () -> logCurrentStatus(KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get()));
         LOGGER.info("StatefulSet {} is ready", statefulSetName);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
@@ -17,7 +18,6 @@ import org.apache.logging.log4j.Logger;
 import java.util.Map;
 import java.util.TreeMap;
 
-import static io.strimzi.systemtest.resources.ResourceManager.logCurrentStatus;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
@@ -137,11 +137,11 @@ public class StatefulSetUtils {
         LOGGER.info("Waiting for StatefulSet {} to be ready", statefulSetName);
         TestUtils.waitFor("statefulset " + statefulSetName + " to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
             () -> kubeClient().getStatefulSetStatus(statefulSetName),
-            () -> logCurrentStatus(KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get()));
+            () -> ResourceManager.logCurrentResourceStatus(KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get()));
 
         LOGGER.info("Waiting for {} Pod(s) of StatefulSet {} to be ready", expectPods, statefulSetName);
         PodUtils.waitForPodsReady(kubeClient().getStatefulSetSelectors(statefulSetName), expectPods, true,
-            () -> logCurrentStatus(KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get()));
+            () -> ResourceManager.logCurrentResourceStatus(KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get()));
         LOGGER.info("StatefulSet {} is ready", statefulSetName);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -7,7 +7,6 @@ package io.strimzi.systemtest.utils.kubeUtils.objects;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodCondition;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
@@ -264,24 +263,5 @@ public class PodUtils {
                 }
                 return false;
             });
-    }
-
-    /**
-     * Log actual pod statuses list by prefix name
-     * @param name - custom resource / deployment name - used for prefix
-     * @param log - ArrayList - add statuses, pods and conditions for future display
-     */
-    public static void logCurrentPodStatus(String name, List<String> log) {
-        log.add("\nPods with conditions and messages:\n\n");
-        for (Pod pod : kubeClient().listPodsByPrefixInName(name)) {
-            log.add(pod.getMetadata().getName() + ":");
-            for (PodCondition podCondition : pod.getStatus().getConditions()) {
-                if (podCondition.getMessage() != null) {
-                    log.add("\n\tType: " + podCondition.getType() + "\n");
-                    log.add("\tMessage: " + podCondition.getMessage() + "\n");
-                }
-            }
-            log.add("\n\n");
-        }
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -268,7 +268,6 @@ public class PodUtils {
 
     /**
      * Log actual pod statuses list by prefix name
-     * @param kind - custom resource / deployment kind - Kafka, KafkaBridge etc.
      * @param name - custom resource / deployment name - used for prefix
      * @param log - ArrayList - add statuses, pods and conditions for future display
      */

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -272,19 +272,17 @@ public class PodUtils {
      * @param name - custom resource / deployment name - used for prefix
      * @param log - ArrayList - add statuses, pods and conditions for future display
      */
-    public static void logCurrentPodStatus(String kind, String name, List<String> log) {
-        if (!(kind.equals("KafkaConnector"))) {
-            log.add("\nPods with conditions and messages:\n\n");
-            for (Pod pod : kubeClient().listPodsByPrefixInName(name)) {
-                log.add(pod.getMetadata().getName() + ":");
-                for (PodCondition podCondition : pod.getStatus().getConditions()) {
-                    if (podCondition.getMessage() != null) {
-                        log.add("\n\tType: " + podCondition.getType() + "\n");
-                        log.add("\tMessage: " + podCondition.getMessage() + "\n");
-                    }
+    public static void logCurrentPodStatus(String name, List<String> log) {
+        log.add("\nPods with conditions and messages:\n\n");
+        for (Pod pod : kubeClient().listPodsByPrefixInName(name)) {
+            log.add(pod.getMetadata().getName() + ":");
+            for (PodCondition podCondition : pod.getStatus().getConditions()) {
+                if (podCondition.getMessage() != null) {
+                    log.add("\n\tType: " + podCondition.getType() + "\n");
+                    log.add("\tMessage: " + podCondition.getMessage() + "\n");
                 }
-                log.add("\n\n");
             }
+            log.add("\n\n");
         }
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR gonna add generic method `waitForStatus` to `ResourceManager` and also move there `logCurrentStatus` method from `StUtils`. By this we will make code cleaner and more readable.

Also editing all methods `waitFor*Status` in `utils` to use this generic method.

### Checklist

- [ ] Make sure all tests pass
