### PR TITLE
Fixed wrong status when decreasing the number of partitions

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -1234,17 +1234,20 @@ class TopicOperator {
                                 return Future.succeededFuture();
                             } else {
                                 LOGGER.debug("{}: Have private topic for topic {} in Kafka", logContext, topicName);
-                                Future<Void> map = reconcileWithPrivateTopic(logContext, topicName, topic, this)
+                                Promise<Void> map = Promise.promise();
+                                        reconcileWithPrivateTopic(logContext, topicName, topic, this)
                                         .<Void>map(ignored -> {
                                             LOGGER.debug("{} reconcile success -> succeeded", topicName);
                                             succeeded.add(topicName);
+                                            map.complete();
                                             return null;
                                         }).otherwise(error -> {
                                             LOGGER.debug("{} reconcile error -> failed", topicName);
                                             failed.put(topicName, error);
+                                            map.fail(error.getCause());
                                             return null;
                                         });
-                                return map;
+                                return map.future();
                             }
                         });
 


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Bugfix

### Description

When we decrease partitions of a topic, the CR status is set to the "NotReady" state and shows the exception "java.lang.Exception: Number of partitions cannot be decreased" but on the next reconcile it's set back to "Ready" with no exception (while it's printed in the log).
This PR tries to fix it.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

