### PR TITLE
Make sure KafkaConnect and KafkaConnectS2I can be scaled to zero

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -206,6 +206,10 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
             <classifier>linux-x86_64</classifier>
         </dependency>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -223,7 +223,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                                                     log.info("{}: {} {} in namespace {} was {}", reconciliation, connectorKind, connectorName, connectorNamespace, action);
 
                                                     return connectOperator.withLock(reconciliation, LOCK_TIMEOUT_MS,
-                                                            () -> connectOperator.reconcileConnectorAndHandleResult(reconciliation,
+                                                        () -> connectOperator.reconcileConnectorAndHandleResult(reconciliation,
                                                                     KafkaConnectResources.qualifiedServiceName(connectName, connectNamespace), apiClient,
                                                                     isUseResources(connect),
                                                                     kafkaConnector.getMetadata().getName(), action == Action.DELETED ? null : kafkaConnector)
@@ -246,7 +246,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                                                     log.info("{}: {} {} in namespace {} was {}", reconciliation, connectorKind, connectorName, connectorNamespace, action);
 
                                                     return connectS2IOperator.withLock(reconciliation, LOCK_TIMEOUT_MS,
-                                                            () -> connectS2IOperator.reconcileConnectorAndHandleResult(reconciliation,
+                                                        () -> connectS2IOperator.reconcileConnectorAndHandleResult(reconciliation,
                                                                     KafkaConnectResources.qualifiedServiceName(connectName, connectNamespace), apiClient,
                                                                     isUseResources(connectS2i),
                                                                     kafkaConnector.getMetadata().getName(), action == Action.DELETED ? null : kafkaConnector)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -210,7 +210,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                                                 updateStatus(noConnectCluster(connectNamespace, connectName), kafkaConnector, connectOperator.connectorOperator);
                                                 return Future.succeededFuture();
                                             } else if ((connect != null && connect.getSpec() != null && connect.getSpec().getReplicas() == 0)
-                                                    || (connect != null && connect.getSpec() != null && connect.getSpec().getReplicas() == 0))    {
+                                                    || (connectS2i != null && connectS2i.getSpec() != null && connectS2i.getSpec().getReplicas() == 0))    {
                                                 log.info("{} {} in namespace {} was {}, but Connect cluster {} has 0 replicas", connectorKind, connectorName, connectorNamespace, action, connectName);
                                                 updateStatus(zeroReplicas(connectNamespace, connectName), kafkaConnector, connectOperator.connectorOperator);
                                                 return Future.succeededFuture();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -292,13 +292,6 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                 "KafkaConnect resource '" + connectName + "' identified by label '" + Labels.STRIMZI_CLUSTER_LABEL + "' does not exist in namespace " + connectNamespace + ".");
     }
 
-    private Throwable zeroReplicasError(T connect) {
-        return new Throwable(
-                "KafkaConnect cluster '" + connect.getMetadata().getName() + "' in namespace "
-                        + connect.getMetadata().getNamespace() + " has zero replicas."
-        );
-    }
-
     /**
      * Reconcile all the connectors selected by the given connect instance, updated each connectors status with the result.
      * @param reconciliation The reconciliation

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -299,7 +299,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
 
     private static RuntimeException zeroReplicas(String connectNamespace, String connectName) {
         return new RuntimeException(
-                "KafkaConnect resource '" + connectName + "' identified by label '" + Labels.STRIMZI_CLUSTER_LABEL + "' in namespace " + connectNamespace + " has 0 replicas.");
+                "Kafka Connect cluster '" + connectName + "' in namespace " + connectNamespace + " has 0 replicas.");
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -155,7 +155,10 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                         }))
                 .setHandler(reconciliationResult -> {
                     StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnect, kafkaConnectStatus, reconciliationResult);
-                    kafkaConnectStatus.setUrl(KafkaConnectResources.url(connect.getCluster(), namespace, KafkaConnectCluster.REST_API_PORT));
+
+                    if (connect.getReplicas() > 0) {
+                        kafkaConnectStatus.setUrl(KafkaConnectResources.url(connect.getCluster(), namespace, KafkaConnectCluster.REST_API_PORT));
+                    }
 
                     this.maybeUpdateStatusCommon(resourceOperator, kafkaConnect, reconciliation, kafkaConnectStatus,
                         (connect1, status) -> new KafkaConnectBuilder(connect1).withStatus(status).build()).setHandler(statusResult -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.netty.channel.ConnectTimeoutException;
 import io.strimzi.api.kafka.KafkaConnectList;
 import io.strimzi.api.kafka.KafkaConnectS2IList;
 import io.strimzi.api.kafka.model.DoneableKafkaConnect;
@@ -154,14 +153,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<Ope
                 .compose(i -> deploymentConfigOperations.scaleUp(namespace, connect.getName(), connect.getReplicas()))
                 .compose(i -> deploymentConfigOperations.waitForObserved(namespace, connect.getName(), 1_000, operationTimeoutMs))
                 .compose(i -> connect.getReplicas() > 0 ? deploymentConfigOperations.readiness(namespace, connect.getName(), 1_000, operationTimeoutMs) : Future.succeededFuture())
-                .compose(i -> reconcileConnectors(reconciliation, kafkaConnectS2I, kafkaConnectS2Istatus)
-                        .recover(error -> {
-                            if (error instanceof ConnectTimeoutException && connect.getReplicas() == 0)   {
-                                return Future.succeededFuture();
-                            } else {
-                                return Future.failedFuture(error);
-                            }
-                        }))
+                .compose(i -> reconcileConnectors(reconciliation, kafkaConnectS2I, kafkaConnectS2Istatus, connect.getReplicas() == 0))
                 .setHandler(reconciliationResult -> {
                     StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnectS2I, kafkaConnectS2Istatus, reconciliationResult);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -164,8 +164,11 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<Ope
                         }))
                 .setHandler(reconciliationResult -> {
                     StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnectS2I, kafkaConnectS2Istatus, reconciliationResult);
-                    kafkaConnectS2Istatus.setUrl(KafkaConnectS2IResources.url(connect.getCluster(), namespace, KafkaConnectS2ICluster.REST_API_PORT));
-                    kafkaConnectS2Istatus.setBuildConfigName(KafkaConnectS2IResources.buildConfigName(connect.getCluster()));
+
+                    if (connect.getReplicas() > 0) {
+                        kafkaConnectS2Istatus.setUrl(KafkaConnectS2IResources.url(connect.getCluster(), namespace, KafkaConnectS2ICluster.REST_API_PORT));
+                        kafkaConnectS2Istatus.setBuildConfigName(KafkaConnectS2IResources.buildConfigName(connect.getCluster()));
+                    }
 
                     updateStatus(kafkaConnectS2I, reconciliation, kafkaConnectS2Istatus).setHandler(statusResult -> {
                         // If both features succeeded, createOrUpdate succeeded as well

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -432,6 +432,7 @@ public class ConnectorMockTest {
                     .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
                 .endMetadata()
                 .withNewSpec()
+                    .withReplicas(1)
                 .endSpec()
                 .done();
         waitForConnectReady(connectName);
@@ -458,6 +459,7 @@ public class ConnectorMockTest {
                     //.addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
                 .endMetadata()
                 .withNewSpec()
+                    .withReplicas(1)
                 .endSpec()
                 .done();
         waitForConnectReady(connectName);
@@ -487,6 +489,7 @@ public class ConnectorMockTest {
                     .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
                 .endMetadata()
                 .withNewSpec()
+                    .withReplicas(1)
                 .endSpec()
             .done();
         waitForConnectReady(connectName);
@@ -567,6 +570,7 @@ public class ConnectorMockTest {
                     .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
                 .endMetadata()
                 .withNewSpec()
+                    .withReplicas(1)
                 .endSpec()
                 .done();
         waitForConnectReady(connectName);
@@ -605,6 +609,7 @@ public class ConnectorMockTest {
                     .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
                 .endMetadata()
                 .withNewSpec()
+                    .withReplicas(1)
                 .endSpec()
                 .done();
         waitForConnectReady(connectName);
@@ -686,6 +691,7 @@ public class ConnectorMockTest {
                     .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
                 .endMetadata()
                 .withNewSpec()
+                    .withReplicas(1)
                 .endSpec()
                 .done();
         waitForConnectReady(connectName);
@@ -730,6 +736,7 @@ public class ConnectorMockTest {
                     .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
                 .endMetadata()
                 .withNewSpec()
+                    .withReplicas(1)
                 .endSpec()
                 .done();
         waitForConnectReady(oldConnectClusterName);
@@ -741,6 +748,7 @@ public class ConnectorMockTest {
                     .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
                 .endMetadata()
                 .withNewSpec()
+                    .withReplicas(1)
                 .endSpec()
                 .done();
         waitForConnectReady(newConnectClusterName);
@@ -822,6 +830,7 @@ public class ConnectorMockTest {
                     .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
                 .endMetadata()
                 .withNewSpec()
+                    .withReplicas(1)
                 .endSpec()
                 .done();
         waitForConnectReady(connectName);
@@ -863,11 +872,12 @@ public class ConnectorMockTest {
         // Create KafkaConnect cluster and wait till it's ready
         Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
                 .withNewMetadata()
-                .withNamespace(NAMESPACE)
-                .withName(connectName)
-                .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+                    .withNamespace(NAMESPACE)
+                    .withName(connectName)
+                    .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
                 .endMetadata()
                 .withNewSpec()
+                    .withReplicas(1)
                 .endSpec()
                 .done();
         waitForConnectReady(connectName);
@@ -948,9 +958,9 @@ public class ConnectorMockTest {
         // Create KafkaConnect cluster and wait till it's ready
         Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
                 .withNewMetadata()
-                .withNamespace(NAMESPACE)
-                .withName(connectName)
-                .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+                    .withNamespace(NAMESPACE)
+                    .withName(connectName)
+                    .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
                 .endMetadata()
                 .withNewSpec()
                     .withReplicas(1)
@@ -969,13 +979,13 @@ public class ConnectorMockTest {
         // Create KafkaConnector and wait till it's ready
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
                 .withNewMetadata()
-                .withName(connectorName)
-                .withNamespace(NAMESPACE)
-                .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                    .withName(connectorName)
+                    .withNamespace(NAMESPACE)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
                 .endMetadata()
                 .withNewSpec()
-                .withTasksMax(1)
-                .withClassName("Dummy")
+                    .withTasksMax(1)
+                    .withClassName("Dummy")
                 .endSpec()
                 .done();
         waitForConnectorReady(connectorName);
@@ -1000,7 +1010,7 @@ public class ConnectorMockTest {
                 .done();
 
         waitForConnectReady(connectName);
-        waitForConnectorNotReady(connectorName, "ConnectTimeoutException", "connection timed out");
+        waitForConnectorNotReady(connectorName, "RuntimeException", "Kafka Connect cluster 'cluster' in namespace ns has 0 replicas.");
     }
 
     /** Create connect, create connector, break the REST API */
@@ -1012,12 +1022,12 @@ public class ConnectorMockTest {
         // Create KafkaConnect cluster and wait till it's ready
         Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
                 .withNewMetadata()
-                .withNamespace(NAMESPACE)
-                .withName(connectName)
-                .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+                    .withNamespace(NAMESPACE)
+                    .withName(connectName)
+                    .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
                 .endMetadata()
                 .withNewSpec()
-                .withReplicas(1)
+                    .withReplicas(1)
                 .endSpec()
                 .done();
         waitForConnectReady(connectName);
@@ -1033,13 +1043,13 @@ public class ConnectorMockTest {
         // Create KafkaConnector and wait till it's ready
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
                 .withNewMetadata()
-                .withName(connectorName)
-                .withNamespace(NAMESPACE)
-                .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                    .withName(connectorName)
+                    .withNamespace(NAMESPACE)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
                 .endMetadata()
                 .withNewSpec()
-                .withTasksMax(1)
-                .withClassName("Dummy")
+                    .withTasksMax(1)
+                    .withClassName("Dummy")
                 .endSpec()
                 .done();
         waitForConnectorReady(connectorName);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -939,7 +939,7 @@ public class ConnectorMockTest {
                 eq(connectorName));
     }
 
-    /** Create connect, create connector, delete connector, delete connect */
+    /** Create connect, create connector, Scale to 0 */
     @Test
     public void testConnectScaleToZero() {
         String connectName = "cluster";
@@ -1001,6 +1001,71 @@ public class ConnectorMockTest {
 
         waitForConnectReady(connectName);
         waitForConnectorNotReady(connectorName, "ConnectTimeoutException", "connection timed out");
+    }
 
+    /** Create connect, create connector, break the REST API */
+    @Test
+    public void testConnectRestAPIIssues() {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                .withNamespace(NAMESPACE)
+                .withName(connectName)
+                .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+                .endMetadata()
+                .withNewSpec()
+                .withReplicas(1)
+                .endSpec()
+                .done();
+        waitForConnectReady(connectName);
+
+        // triggered twice (creation followed by status update)
+        verify(api, times(2)).list(
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
+
+        verify(api, never()).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+
+        // Create KafkaConnector and wait till it's ready
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                .withName(connectorName)
+                .withNamespace(NAMESPACE)
+                .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                .endMetadata()
+                .withNewSpec()
+                .withTasksMax(1)
+                .withClassName("Dummy")
+                .endSpec()
+                .done();
+        waitForConnectorReady(connectorName);
+
+        verify(api, times(2)).list(
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, times(2)).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+        assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+
+        when(api.list(any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
+        when(api.listConnectorPlugins(any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
+        when(api.createOrUpdatePutRequest(any(), anyInt(), anyString(), any())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
+        when(api.getConnectorConfig(any(), any(), anyInt(), any())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
+        when(api.getConnector(any(), anyInt(), any())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
+
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).withName(connectName).edit()
+                .editSpec()
+                    .withNewTemplate()
+                    .endTemplate()
+                .endSpec()
+                .done();
+
+        // Wait for Status change due to the broker REST API
+        waitForConnectNotReady(connectName, "ConnectTimeoutException", "connection timed out");
+        waitForConnectorNotReady(connectorName, "ConnectTimeoutException", "connection timed out");
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.netty.channel.ConnectTimeoutException;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaConnectList;
 import io.strimzi.api.kafka.KafkaConnectS2IList;
@@ -938,4 +939,68 @@ public class ConnectorMockTest {
                 eq(connectorName));
     }
 
+    /** Create connect, create connector, delete connector, delete connect */
+    @Test
+    public void testConnectScaleToZero() {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                .withNamespace(NAMESPACE)
+                .withName(connectName)
+                .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(1)
+                .endSpec()
+                .done();
+        waitForConnectReady(connectName);
+
+        // triggered twice (creation followed by status update)
+        verify(api, times(2)).list(
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
+
+        verify(api, never()).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+
+        // Create KafkaConnector and wait till it's ready
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                .withName(connectorName)
+                .withNamespace(NAMESPACE)
+                .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                .endMetadata()
+                .withNewSpec()
+                .withTasksMax(1)
+                .withClassName("Dummy")
+                .endSpec()
+                .done();
+        waitForConnectorReady(connectorName);
+
+        verify(api, times(2)).list(
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, times(2)).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+        assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+
+        when(api.list(any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
+        when(api.listConnectorPlugins(any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
+        when(api.createOrUpdatePutRequest(any(), anyInt(), anyString(), any())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
+        when(api.getConnectorConfig(any(), any(), anyInt(), any())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
+        when(api.getConnector(any(), anyInt(), any())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
+
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).withName(connectName).edit()
+                .editSpec()
+                    .withReplicas(0)
+                .endSpec()
+                .done();
+
+        waitForConnectReady(connectName);
+        waitForConnectorNotReady(connectorName, "ConnectTimeoutException", "connection timed out");
+
+    }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When KafkaConnect or KafkaConnectS2I are sclaed to 0 (`replicas=0`), they currently start failing. This PR updates the behaviour to:
* Make sure the Connect reocnciliations are passing in such situation
* Make sure Connector statuses are updated with an error in such situation

This PR additionally improves the behaviour when the connector reocnciliation failes for not being able to connect to the REST API also for other reasons and sets the appropriatte status in the connectors in that case as well.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally