### PR TITLE
[DOC] Service discovery

### DIFF
--- a/documentation/assemblies/managing/assembly-management-tasks.adoc
+++ b/documentation/assemblies/managing/assembly-management-tasks.adoc
@@ -7,6 +7,9 @@
 
 This chapter covers tasks to maintain a deployment of {ProductName}.
 
+//Discover internal bootstrap service and HTTP Bridge
+include::modules/con-service-discovery.adoc[leveloffset=+1]
+
 //Check the status of a resource
 include::assembly-resource-status-access.adoc[leveloffset=+1]
 

--- a/documentation/modules/managing/con-service-discovery.adoc
+++ b/documentation/modules/managing/con-service-discovery.adoc
@@ -1,0 +1,83 @@
+// Module included in the following assemblies:
+//
+// managing/assembly-management-tasks.adoc
+
+[id='proc-add-service-discovery-{context}']
+= Discovering services using labels and annotations
+
+Service discovery makes it easier for client applications running in the same cluster as {ProductName} to interact with a Kafka cluster.
+
+A _service discovery_ label and annotation is generated for services used to access the Kafka cluster:
+
+* Internal Kafka bootstrap service
+* HTTP Bridge service
+
+The label helps find the service, and the annotation provides connection details that a client application can use to make the connection.
+
+The service discovery label, `strimzi.io/discovery`, is set as `true` for the `Service` resources.
+The service discovery annotation has the same key, providing connection details in JSON format for each service.
+
+[discrete]
+== Example internal Kafka bootstrap service
+
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    strimzi.io/discovery: |-
+      [ {
+        "port" : 9092,
+        "tls" : false,
+        "protocol" : "kafka",
+        "auth" : "scram-sha-512"
+      }, {
+        "port" : 9093,
+        "tls" : true,
+        "protocol" : "kafka",
+        "auth" : "tls"
+      } ]
+  labels:
+    strimzi.io/cluster: my-cluster
+    strimzi.io/discovery: "true"
+    strimzi.io/kind: Kafka
+    strimzi.io/name: my-cluster-kafka-bootstrap
+  name: my-cluster-kafka-bootstrap
+spec:
+  #...
+----
+
+[discrete]
+== Example HTTP Bridge service
+
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    strimzi.io/discovery: |-
+      [ {
+        "port" : 8080,
+        "tls" : false,
+        "auth" : "none",
+        "protocol" : "http"
+      } ]
+  labels:
+    strimzi.io/cluster: my-bridge
+    strimzi.io/discovery: "true"
+    strimzi.io/kind: KafkaBridge
+    strimzi.io/name: my-bridge-bridge-service
+----
+
+== Returning connection details on services
+
+You can find the services by specifying the discovery label when fetching services from the command line or a corresponding API call.
+
+[source,yaml]
+----
+kubectl get service -l strimzi.io/discovery=true
+----
+
+The connection details are returned when retrieving the service label.

--- a/documentation/modules/managing/con-service-discovery.adoc
+++ b/documentation/modules/managing/con-service-discovery.adoc
@@ -5,14 +5,14 @@
 [id='proc-add-service-discovery-{context}']
 = Discovering services using labels and annotations
 
-Service discovery makes it easier for client applications running in the same cluster as {ProductName} to interact with a Kafka cluster.
+Service discovery makes it easier for client applications running in the same Kubernetes cluster as {ProductName} to interact with a Kafka cluster.
 
 A _service discovery_ label and annotation is generated for services used to access the Kafka cluster:
 
 * Internal Kafka bootstrap service
 * HTTP Bridge service
 
-The label helps find the service, and the annotation provides connection details that a client application can use to make the connection.
+The label helps to make the service discoverable, and the annotation provides connection details that a client application can use to make the connection.
 
 The service discovery label, `strimzi.io/discovery`, is set as `true` for the `Service` resources.
 The service discovery annotation has the same key, providing connection details in JSON format for each service.

--- a/documentation/modules/managing/con-service-discovery.adoc
+++ b/documentation/modules/managing/con-service-discovery.adoc
@@ -80,4 +80,4 @@ You can find the services by specifying the discovery label when fetching servic
 kubectl get service -l strimzi.io/discovery=true
 ----
 
-The connection details are returned when retrieving the service label.
+The connection details are returned when retrieving the service discovery label.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

Documentation

New section to describe service discovery for:

* Internal Kafka bootstrap service
* HTTP Bridge service

May need more detail.
May not need both examples

I've added it to the _Managing Strimzi_ section, to sit with _Checking the status of a custom resource_
We can move if there's a better spot.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

