### PR TITLE
Add computed property bootstrap to Kafka CR status

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerAddress.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerAddress.java
@@ -37,7 +37,7 @@ public class ListenerAddress implements UnknownPropertyPreserving, Serializable 
     private Integer port;
     private Map<String, Object> additionalProperties;
 
-    @Description("The DNS name or IP address of Kafka bootstrap service")
+    @Description("The DNS name or IP address of the Kafka bootstrap service")
     public String getHost() {
         return host;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
@@ -28,14 +28,14 @@ import static java.util.Collections.emptyMap;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "type", "addresses", "bootstrap", "certificates" })
+@JsonPropertyOrder({ "type", "addresses", "bootstrapServers", "certificates" })
 @EqualsAndHashCode
 public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 
     private String type;
     private List<ListenerAddress> addresses;
-    private String bootstrap;
+    private String bootstrapServers;
     private List<String> certificates;
     private Map<String, Object> additionalProperties;
 
@@ -56,17 +56,17 @@ public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
 
     public void setAddresses(List<ListenerAddress> addresses) {
         this.addresses = addresses;
-        if ((addresses == null) || (addresses.isEmpty())) {
-            bootstrap = null;
+        if ((addresses == null) || addresses.isEmpty()) {
+            bootstrapServers = null;
         } else {
-            bootstrap = addresses.stream().map(a -> a.getHost() + ":" + a.getPort()).collect(Collectors.joining(","));
+            bootstrapServers = addresses.stream().map(a -> a.getHost() + ":" + a.getPort()).collect(Collectors.joining(","));
         }
     }
 
-    @Description("A comma-separated list of hostname:‍port pairs for this listener.")
+    @Description("A comma-separated list of `host:port` pairs for connecting to the Kafka cluster using this listener.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public String getBootstrap() {
-        return bootstrap;
+    public String getBootstrapServers() {
+        return bootstrapServers;
     }
 
     @Description("A list of TLS certificates which can be used to verify the identity of the server when connecting " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
@@ -16,6 +16,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 
@@ -27,13 +28,14 @@ import static java.util.Collections.emptyMap;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "type", "addresses", "certificates" })
+@JsonPropertyOrder({ "type", "addresses", "bootstrap", "certificates" })
 @EqualsAndHashCode
 public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 
     private String type;
     private List<ListenerAddress> addresses;
+    private String bootstrap;
     private List<String> certificates;
     private Map<String, Object> additionalProperties;
 
@@ -54,6 +56,17 @@ public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
 
     public void setAddresses(List<ListenerAddress> addresses) {
         this.addresses = addresses;
+        if ((addresses == null) || (addresses.isEmpty())) {
+            bootstrap = null;
+        } else {
+            bootstrap = addresses.stream().map(a -> a.getHost() + ":" + a.getPort()).collect(Collectors.joining(","));
+        }
+    }
+
+    @Description("A concatenated list of the bootstrap addresses for this listener.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String getBootstrap() {
+        return bootstrap;
     }
 
     @Description("A list of TLS certificates which can be used to verify the identity of the server when connecting " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
@@ -63,7 +63,7 @@ public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
         }
     }
 
-    @Description("A concatenated list of the bootstrap addresses for this listener.")
+    @Description("A comma-separated list of hostname:‍port pairs for this listener.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String getBootstrap() {
         return bootstrap;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1240,7 +1240,7 @@ public class KafkaCluster extends AbstractModel {
                 host = listener.getConfiguration().getBootstrap().getHost();
                 dnsAnnotations = listener.getConfiguration().getBootstrap().getDnsAnnotations();
             } else {
-                throw new InvalidResourceException("Boostrap hostname is required for exposing Kafka cluster using Ingress");
+                throw new InvalidResourceException("Bootstrap hostname is required for exposing Kafka cluster using Ingress");
             }
 
             HTTPIngressPath path = new HTTPIngressPathBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -150,9 +150,11 @@ public class KafkaStatusTest {
             assertThat(status.getListeners().get(0).getType(), is("plain"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getHost(), is("my-service.my-namespace.svc"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(new Integer(9092)));
+            assertThat(status.getListeners().get(0).getBootstrap(), is("my-service.my-namespace.svc:9092"));
             assertThat(status.getListeners().get(1).getType(), is("external"));
-            assertThat(status.getListeners().get(1).getAddresses().get(0).getHost(),  is("my-route-address.domain.tld"));
+            assertThat(status.getListeners().get(1).getAddresses().get(0).getHost(), is("my-route-address.domain.tld"));
             assertThat(status.getListeners().get(1).getAddresses().get(0).getPort(), is(new Integer(443)));
+            assertThat(status.getListeners().get(1).getBootstrap(), is("my-route-address.domain.tld:443"));
 
             assertThat(status.getConditions().size(), is(1));
             assertThat(status.getConditions().get(0).getType(), is("Ready"));
@@ -258,6 +260,7 @@ public class KafkaStatusTest {
             assertThat(status.getListeners().get(0).getType(), is("plain"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getHost(), is("my-service.my-namespace.svc"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(new Integer(9092)));
+            assertThat(status.getListeners().get(0).getBootstrap(), is("my-service.my-namespace.svc:9092"));
 
             assertThat(status.getConditions().size(), is(1));
             assertThat(status.getConditions().get(0).getType(), is("NotReady"));
@@ -327,6 +330,7 @@ public class KafkaStatusTest {
             assertThat(status.getListeners().get(0).getType(), is("plain"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getHost(), is("my-service.my-namespace.svc"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(new Integer(9092)));
+            assertThat(status.getListeners().get(0).getBootstrap(), is("my-service.my-namespace.svc:9092"));
 
             assertThat(status.getConditions().size(), is(1));
             assertThat(status.getConditions().get(0).getType(), is("NotReady"));
@@ -887,6 +891,7 @@ public class KafkaStatusTest {
             assertThat(status.getListeners().get(0).getType(), is("external"));
 
             assertThat(status.getListeners().get(0).getAddresses(), is(nullValue()));
+            assertThat(status.getListeners().get(0).getBootstrap(), is(nullValue()));
 
             async.flag();
         });

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -150,11 +150,11 @@ public class KafkaStatusTest {
             assertThat(status.getListeners().get(0).getType(), is("plain"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getHost(), is("my-service.my-namespace.svc"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(new Integer(9092)));
-            assertThat(status.getListeners().get(0).getBootstrap(), is("my-service.my-namespace.svc:9092"));
+            assertThat(status.getListeners().get(0).getBootstrapServers(), is("my-service.my-namespace.svc:9092"));
             assertThat(status.getListeners().get(1).getType(), is("external"));
             assertThat(status.getListeners().get(1).getAddresses().get(0).getHost(), is("my-route-address.domain.tld"));
             assertThat(status.getListeners().get(1).getAddresses().get(0).getPort(), is(new Integer(443)));
-            assertThat(status.getListeners().get(1).getBootstrap(), is("my-route-address.domain.tld:443"));
+            assertThat(status.getListeners().get(1).getBootstrapServers(), is("my-route-address.domain.tld:443"));
 
             assertThat(status.getConditions().size(), is(1));
             assertThat(status.getConditions().get(0).getType(), is("Ready"));
@@ -260,7 +260,7 @@ public class KafkaStatusTest {
             assertThat(status.getListeners().get(0).getType(), is("plain"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getHost(), is("my-service.my-namespace.svc"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(new Integer(9092)));
-            assertThat(status.getListeners().get(0).getBootstrap(), is("my-service.my-namespace.svc:9092"));
+            assertThat(status.getListeners().get(0).getBootstrapServers(), is("my-service.my-namespace.svc:9092"));
 
             assertThat(status.getConditions().size(), is(1));
             assertThat(status.getConditions().get(0).getType(), is("NotReady"));
@@ -330,7 +330,7 @@ public class KafkaStatusTest {
             assertThat(status.getListeners().get(0).getType(), is("plain"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getHost(), is("my-service.my-namespace.svc"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(new Integer(9092)));
-            assertThat(status.getListeners().get(0).getBootstrap(), is("my-service.my-namespace.svc:9092"));
+            assertThat(status.getListeners().get(0).getBootstrapServers(), is("my-service.my-namespace.svc:9092"));
 
             assertThat(status.getConditions().size(), is(1));
             assertThat(status.getConditions().get(0).getType(), is("NotReady"));
@@ -891,7 +891,7 @@ public class KafkaStatusTest {
             assertThat(status.getListeners().get(0).getType(), is("external"));
 
             assertThat(status.getListeners().get(0).getAddresses(), is(nullValue()));
-            assertThat(status.getListeners().get(0).getBootstrap(), is(nullValue()));
+            assertThat(status.getListeners().get(0).getBootstrapServers(), is(nullValue()));
 
             async.flag();
         });

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1593,6 +1593,8 @@ Used in: xref:type-KafkaStatus-{context}[`KafkaStatus`]
 |string
 |addresses     1.2+<.<|A list of the addresses for this listener.
 |xref:type-ListenerAddress-{context}[`ListenerAddress`] array
+|bootstrap     1.2+<.<|A concatenated list of the bootstrap addresses for this listener.
+|string
 |certificates  1.2+<.<|A list of TLS certificates which can be used to verify the identity of the server when connecting to the given listener. Set only for `tls` and `external` listeners.
 |string array
 |====

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1593,7 +1593,7 @@ Used in: xref:type-KafkaStatus-{context}[`KafkaStatus`]
 |string
 |addresses     1.2+<.<|A list of the addresses for this listener.
 |xref:type-ListenerAddress-{context}[`ListenerAddress`] array
-|bootstrap     1.2+<.<|A concatenated list of the bootstrap addresses for this listener.
+|bootstrap     1.2+<.<|A comma-separated list of hostname:‍port pairs for this listener.
 |string
 |certificates  1.2+<.<|A list of TLS certificates which can be used to verify the identity of the server when connecting to the given listener. Set only for `tls` and `external` listeners.
 |string array

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1588,14 +1588,14 @@ Used in: xref:type-KafkaStatus-{context}[`KafkaStatus`]
 
 [options="header"]
 |====
-|Property             |Description
-|type          1.2+<.<|The type of the listener. Can be one of the following three types: `plain`, `tls`, and `external`.
+|Property                 |Description
+|type              1.2+<.<|The type of the listener. Can be one of the following three types: `plain`, `tls`, and `external`.
 |string
-|addresses     1.2+<.<|A list of the addresses for this listener.
+|addresses         1.2+<.<|A list of the addresses for this listener.
 |xref:type-ListenerAddress-{context}[`ListenerAddress`] array
-|bootstrap     1.2+<.<|A comma-separated list of hostname:‍port pairs for this listener.
+|bootstrapServers  1.2+<.<|A comma-separated list of `host:port` pairs for connecting to the Kafka cluster using this listener.
 |string
-|certificates  1.2+<.<|A list of TLS certificates which can be used to verify the identity of the server when connecting to the given listener. Set only for `tls` and `external` listeners.
+|certificates      1.2+<.<|A list of TLS certificates which can be used to verify the identity of the server when connecting to the given listener. Set only for `tls` and `external` listeners.
 |string array
 |====
 
@@ -1608,7 +1608,7 @@ Used in: xref:type-ListenerStatus-{context}[`ListenerStatus`]
 [options="header"]
 |====
 |Property     |Description
-|host  1.2+<.<|The DNS name or IP address of Kafka bootstrap service.
+|host  1.2+<.<|The DNS name or IP address of the Kafka bootstrap service.
 |string
 |port  1.2+<.<|The port of the Kafka bootstrap service.
 |integer

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -6678,6 +6678,10 @@ spec:
                           type: integer
                           description: The port of the Kafka bootstrap service.
                     description: A list of the addresses for this listener.
+                  bootstrap:
+                    type: string
+                    description: A comma-separated list of hostname:‍port pairs for
+                      this listener.
                   certificates:
                     type: array
                     items:

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -6672,16 +6672,16 @@ spec:
                       properties:
                         host:
                           type: string
-                          description: The DNS name or IP address of Kafka bootstrap
+                          description: The DNS name or IP address of the Kafka bootstrap
                             service.
                         port:
                           type: integer
                           description: The port of the Kafka bootstrap service.
                     description: A list of the addresses for this listener.
-                  bootstrap:
+                  bootstrapServers:
                     type: string
-                    description: A comma-separated list of hostname:‍port pairs for
-                      this listener.
+                    description: A comma-separated list of `host:port` pairs for connecting
+                      to the Kafka cluster using this listener.
                   certificates:
                     type: array
                     items:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -6667,16 +6667,16 @@ spec:
                       properties:
                         host:
                           type: string
-                          description: The DNS name or IP address of Kafka bootstrap
+                          description: The DNS name or IP address of the Kafka bootstrap
                             service.
                         port:
                           type: integer
                           description: The port of the Kafka bootstrap service.
                     description: A list of the addresses for this listener.
-                  bootstrap:
+                  bootstrapServers:
                     type: string
-                    description: A comma-separated list of hostname:‍port pairs for
-                      this listener.
+                    description: A comma-separated list of `host:port` pairs for connecting
+                      to the Kafka cluster using this listener.
                   certificates:
                     type: array
                     items:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -6673,6 +6673,10 @@ spec:
                           type: integer
                           description: The port of the Kafka bootstrap service.
                     description: A list of the addresses for this listener.
+                  bootstrap:
+                    type: string
+                    description: A concatenated list of the bootstrap addresses for
+                      this listener.
                   certificates:
                     type: array
                     items:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -6675,7 +6675,7 @@ spec:
                     description: A list of the addresses for this listener.
                   bootstrap:
                     type: string
-                    description: A concatenated list of the bootstrap addresses for
+                    description: A comma-separated list of hostname:‍port pairs for
                       this listener.
                   certificates:
                     type: array


### PR DESCRIPTION
Kafka CR status.

Contributes to strimzi/strimzi-kafka-operator#2905

Signed-off-by: Andrew Schofield <andrew_schofield@uk.ibm.com>

### Type of change

- Enhancement

### Description

Compute the derived property `bootstrap` from the addresses for each listener.
Calculate the value whenever the addresses are changed to make sure the two
sources of information stay in sync.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [X] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

