### PR TITLE
Mask passwords in while printing environment variables in our operators

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -19,6 +19,7 @@ import io.strimzi.operator.cluster.operator.assembly.KafkaMirrorMakerAssemblyOpe
 import io.strimzi.operator.cluster.operator.assembly.KafkaMirrorMaker2AssemblyOperator;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.PasswordGenerator;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.operator.resource.ClusterRoleOperator;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
@@ -94,7 +95,7 @@ public class Main {
     }
 
     static CompositeFuture run(Vertx vertx, KubernetesClient client, PlatformFeaturesAvailability pfa, ClusterOperatorConfig config) {
-        printEnvInfo();
+        Util.printEnvInfo();
 
         ResourceOperatorSupplier resourceOperatorSupplier = new ResourceOperatorSupplier(vertx, client, pfa, config.getOperationTimeoutMs());
 
@@ -199,14 +200,5 @@ public class Main {
         } else {
             return Future.succeededFuture();
         }
-    }
-
-    static void printEnvInfo() {
-        Map<String, String> m = new HashMap<>(System.getenv());
-        StringBuilder sb = new StringBuilder();
-        for (Map.Entry<String, String> entry: m.entrySet()) {
-            sb.append("\t").append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
-        }
-        log.info("Using config:\n" + sb.toString());
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -151,8 +151,8 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                 .compose(i -> deploymentOperations.reconcile(namespace, mirrorMaker2Cluster.getName(), mirrorMaker2Cluster.generateDeployment(annotations, pfa.isOpenshift(), imagePullPolicy, imagePullSecrets)))
                 .compose(i -> deploymentOperations.scaleUp(namespace, mirrorMaker2Cluster.getName(), mirrorMaker2Cluster.getReplicas()))
                 .compose(i -> deploymentOperations.waitForObserved(namespace, mirrorMaker2Cluster.getName(), 1_000, operationTimeoutMs))
-                .compose(i -> mirrorMaker2Cluster.getReplicas() > 0 ? deploymentOperations.readiness(namespace, mirrorMaker2Cluster.getName(), 1_000, operationTimeoutMs) : Future.succeededFuture())
-                .compose(i -> mirrorMaker2Cluster.getReplicas() > 0 ? reconcileConnectors(reconciliation, kafkaMirrorMaker2, mirrorMaker2Cluster, kafkaMirrorMaker2Status) : Future.succeededFuture())
+                .compose(i -> deploymentOperations.readiness(namespace, mirrorMaker2Cluster.getName(), 1_000, operationTimeoutMs))
+                .compose(i -> reconcileConnectors(reconciliation, kafkaMirrorMaker2, mirrorMaker2Cluster, kafkaMirrorMaker2Status))
                 .map((Void) null)
                 .setHandler(reconciliationResult -> {
                     StatusUtils.setStatusConditionAndObservedGeneration(kafkaMirrorMaker2, kafkaMirrorMaker2Status, reconciliationResult);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -151,8 +151,8 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                 .compose(i -> deploymentOperations.reconcile(namespace, mirrorMaker2Cluster.getName(), mirrorMaker2Cluster.generateDeployment(annotations, pfa.isOpenshift(), imagePullPolicy, imagePullSecrets)))
                 .compose(i -> deploymentOperations.scaleUp(namespace, mirrorMaker2Cluster.getName(), mirrorMaker2Cluster.getReplicas()))
                 .compose(i -> deploymentOperations.waitForObserved(namespace, mirrorMaker2Cluster.getName(), 1_000, operationTimeoutMs))
-                .compose(i -> deploymentOperations.readiness(namespace, mirrorMaker2Cluster.getName(), 1_000, operationTimeoutMs))
-                .compose(i -> reconcileConnectors(reconciliation, kafkaMirrorMaker2, mirrorMaker2Cluster, kafkaMirrorMaker2Status))
+                .compose(i -> mirrorMaker2Cluster.getReplicas() > 0 ? deploymentOperations.readiness(namespace, mirrorMaker2Cluster.getName(), 1_000, operationTimeoutMs) : Future.succeededFuture())
+                .compose(i -> mirrorMaker2Cluster.getReplicas() > 0 ? reconcileConnectors(reconciliation, kafkaMirrorMaker2, mirrorMaker2Cluster, kafkaMirrorMaker2Status) : Future.succeededFuture())
                 .map((Void) null)
                 .setHandler(reconciliationResult -> {
                     StatusUtils.setStatusConditionAndObservedGeneration(kafkaMirrorMaker2, kafkaMirrorMaker2Status, reconciliationResult);

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -32,7 +32,6 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
 public class Util {
-
     private static final Logger LOGGER = LogManager.getLogger(Util.class);
 
     public static <T> Future<T> async(Vertx vertx, Supplier<T> supplier) {
@@ -222,5 +221,36 @@ public class Util {
             }
             throw e;
         }
+    }
+
+    /**
+     * Logs environment variables into the regular log file.
+     */
+    public static void printEnvInfo() {
+        Map<String, String> env = new HashMap<>(System.getenv());
+        StringBuilder sb = new StringBuilder();
+
+        for (Map.Entry<String, String> entry: env.entrySet()) {
+            sb.append("\t").append(entry.getKey()).append(": ").append(maskPassword(entry.getKey(), entry.getValue())).append("\n");
+        }
+
+        LOGGER.info("Using config:\n" + sb.toString());
+    }
+
+    /**
+     * Gets environment variable, checks if it contains a password and in case it does it masks the output. It expects
+     * environment variables with passwords to contain `PASSWORD` in their name.
+     *
+     * @param key   Name of the environment variable
+     * @param value Value of the environment variable
+     * @return      Value of the environment variable or masked text in case of password
+     */
+    public static String maskPassword(String key, String value)  {
+        if (key.contains("PASSWORD"))  {
+            return "********";
+        } else {
+            return value;
+        }
+
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static io.strimzi.operator.common.Util.parseMap;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.hasEntry;
@@ -73,5 +74,16 @@ public class UtilTest {
         assertThat(m, aMapWithSize(2));
         assertThat(m, hasEntry("key1", "value1"));
         assertThat(m, hasEntry("key2", "value2=value3"));
+    }
+
+    @Test
+    public void testMaskedPasswords()   {
+        String noPassword = "SOME_VARIABLE";
+        String passwordAtTheEnd = "SOME_PASSWORD";
+        String passwordInTheMiddle = "SOME_PASSWORD_TO_THE_BIG_SECRET";
+
+        assertThat(Util.maskPassword(noPassword, "123456"), is("123456"));
+        assertThat(Util.maskPassword(passwordAtTheEnd, "123456"), is("********"));
+        assertThat(Util.maskPassword(passwordInTheMiddle, "123456"), is("********"));
     }
 }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.DoneableKafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.topic.zk.Zk;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
@@ -65,7 +66,7 @@ public class Session extends AbstractVerticle {
         this.config = config;
         StringBuilder sb = new StringBuilder(System.lineSeparator());
         for (Config.Value<?> v: Config.keys()) {
-            sb.append("\t").append(v.key).append(": ").append(config.get(v)).append(System.lineSeparator());
+            sb.append("\t").append(v.key).append(": ").append(Util.maskPassword(v.key, config.get(v).toString())).append(System.lineSeparator());
         }
         LOGGER.info("Using config:{}", sb.toString());
         setupMetrics();

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.DefaultAdminClientProvider;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.user.operator.KafkaUserOperator;
@@ -34,8 +35,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.security.Security;
-import java.util.HashMap;
-import java.util.Map;
 
 @SuppressFBWarnings("DM_EXIT")
 @SuppressWarnings("deprecation")
@@ -72,7 +71,7 @@ public class Main {
     }
 
     static Future<String> run(Vertx vertx, KubernetesClient client, AdminClientProvider adminClientProvider, UserOperatorConfig config) {
-        printEnvInfo();
+        Util.printEnvInfo();
         String dnsCacheTtl = System.getenv("STRIMZI_DNS_CACHE_TTL") == null ? "30" : System.getenv("STRIMZI_DNS_CACHE_TTL");
         Security.setProperty("networkaddress.cache.ttl", dnsCacheTtl);
 
@@ -138,14 +137,5 @@ public class Main {
                 });
 
         return promise.future();
-    }
-
-    static void printEnvInfo() {
-        Map<String, String> m = new HashMap<>(System.getenv());
-        StringBuilder sb = new StringBuilder();
-        for (Map.Entry<String, String> entry: m.entrySet()) {
-            sb.append("\t").append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
-        }
-        log.info("Using config:\n" + sb.toString());
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Our operators are at startup always printing the environment variables or other configurations. This is useful for analysing issues etc. But currently they are this way also printing variables with things such as passwords. This issue tires to detect them and mask them with `********`.

The new _masked_ output could look for example like this:

```
[2020-04-28 21:46:33,763] INFO  <Session     :71> [main        ] Using config:
        STRIMZI_TRUSTSTORE_LOCATION: /tmp/topic-operator/replication.truststore.p12
        STRIMZI_RESOURCE_LABELS: strimzi.io/cluster=my-cluster
        STRIMZI_KAFKA_BOOTSTRAP_SERVERS: my-cluster-kafka-bootstrap:9091
        STRIMZI_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: HTTPS
        STRIMZI_NAMESPACE: myproject
        STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS: 20000
        STRIMZI_TOPICS_PATH: /strimzi/topics
        STRIMZI_FULL_RECONCILIATION_INTERVAL_MS: 90000
        STRIMZI_ZOOKEEPER_CONNECT: localhost:2181
        STRIMZI_TLS_ENABLED: true
        STRIMZI_KEYSTORE_PASSWORD: ********
        STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS: 6
        STRIMZI_REASSIGN_VERIFY_INTERVAL_MS: 120000
        STRIMZI_KEYSTORE_LOCATION: /tmp/topic-operator/replication.keystore.p12
        TC_ZK_CONNECTION_TIMEOUT_MS: 20000
        STRIMZI_TRUSTSTORE_PASSWORD: ********
        STRIMZI_REASSIGN_THROTTLE: 9223372036854775807
```

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally