### PR TITLE
Added cruise control metrics reporter dependency to Kafka 2.5.0

### DIFF
--- a/docker-images/kafka/kafka-thirdparty-libs/2.4.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.4.x/pom.xml
@@ -146,11 +146,6 @@
             <groupId>com.linkedin.cruisecontrol</groupId>
             <artifactId>cruise-control-metrics-reporter</artifactId>
             <version>${cruise-control.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.linkedin.cruisecontrol</groupId>
-            <artifactId>cruise-control-metrics-reporter</artifactId>
-            <version>${cruise-control.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
@@ -20,6 +20,13 @@
         <cruise-control.version>2.0.100</cruise-control.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>jcenter</id>
+            <url>https://jcenter.bintray.com/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- https://mvnrepository.com/artifact/io.prometheus.jmx/jmx_prometheus_javaagent -->
         <dependency>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.4.0</strimzi-oauth.version>
+        <cruise-control.version>2.0.100</cruise-control.version>
     </properties>
 
     <dependencies>
@@ -131,6 +132,33 @@
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.linkedin.cruisecontrol</groupId>
+            <artifactId>cruise-control-metrics-reporter</artifactId>
+            <version>${cruise-control.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka_2.11</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka-clients</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-math3</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/examples/kafka/kafka-cruise-control.yaml
+++ b/examples/kafka/kafka-cruise-control.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 2.4.1
+    version: 2.5.0
     replicas: 3
     listeners:
       plain: {}


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Bugfix

### Description

This PR adds the cruise control metrics reporter dependency to Kafka 2.5.0 pom file for third party libs. It also removes doubled dep in Kafka 2.4.0 pom file and fixes the Kafka with cruise control example.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

