### PR TITLE
[systemtest] Fix javadoc in PodUtils

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -245,7 +245,7 @@ public class PodUtils {
     }
 
     /**
-     * * Waits until all matching pods are {@linkplain #verifyThatPodsAreStable(Supplier, int[])} stable} in the "Running" phase.
+     * * Waits until all matching pods are {@linkplain #verifyThatPodsAreStable(Supplier)} stable} in the "Running" phase.
      * @param pods all pods that will be verified
      */
     public static void waitUntilPodsStability(List<Pod> pods) {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lkral@redhat.com>

### Type of change

- Bugfix

### Description

Fix of wrong javadoc in `PodUtils` -> this caused that project can't be build just by `mvn clean install -DskipTests`

### Checklist

- [x] Make sure all tests pass


