### PR TITLE
ST: Remove 'kafka' string from methods which are not connected to kafka directly

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/ConfigMapUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/ConfigMapUtils.java
@@ -51,7 +51,7 @@ public class ConfigMapUtils {
         }
     }
 
-    public static void waitForKafkaConfigMapLabelsDeletion(String configMapName, String... labelKeys) {
+    public static void waitForConfigMapLabelsDeletion(String configMapName, String... labelKeys) {
         for (final String labelKey : labelKeys) {
             LOGGER.info("Waiting for Kafka ConfigMap label {} change to {}", labelKey, null);
             TestUtils.waitFor("Kafka configMap label" + labelKey + " change to " + null, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/ConfigMapUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/ConfigMapUtils.java
@@ -36,14 +36,14 @@ public class ConfigMapUtils {
         LOGGER.info("Config map {} was recovered", name);
     }
 
-    public static void waitForKafkaConfigMapLabelsChange(String configMapName, Map<String, String> labels) {
+    public static void waitForConfigMapLabelsChange(String configMapName, Map<String, String> labels) {
         for (Map.Entry<String, String> entry : labels.entrySet()) {
             boolean isK8sTag = entry.getKey().equals("controller-revision-hash") || entry.getKey().equals("statefulset.kubernetes.io/pod-name");
             boolean isStrimziTag = entry.getKey().startsWith(Labels.STRIMZI_DOMAIN);
             // ignoring strimzi.io and k8s labels
             if (!(isStrimziTag || isK8sTag)) {
-                LOGGER.info("Waiting for Kafka ConfigMap label change {} -> {}", entry.getKey(), entry.getValue());
-                TestUtils.waitFor("Kafka ConfigMap label change " + entry.getKey() + " -> " + entry.getValue(), Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,
+                LOGGER.info("Waiting for ConfigMap {} label change {} -> {}", configMapName, entry.getKey(), entry.getValue());
+                TestUtils.waitFor("ConfigMap label change " + entry.getKey() + " -> " + entry.getValue(), Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,
                     Constants.TIMEOUT_FOR_RESOURCE_READINESS, () ->
                         kubeClient().getConfigMap(configMapName).getMetadata().getLabels().get(entry.getKey()).equals(entry.getValue())
                 );
@@ -53,12 +53,12 @@ public class ConfigMapUtils {
 
     public static void waitForConfigMapLabelsDeletion(String configMapName, String... labelKeys) {
         for (final String labelKey : labelKeys) {
-            LOGGER.info("Waiting for Kafka ConfigMap label {} change to {}", labelKey, null);
+            LOGGER.info("Waiting for ConfigMap {} label {} change to {}", configMapName, labelKey, null);
             TestUtils.waitFor("Kafka configMap label" + labelKey + " change to " + null, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,
                 Constants.TIMEOUT_FOR_RESOURCE_READINESS, () ->
                     kubeClient().getConfigMap(configMapName).getMetadata().getLabels().get(labelKey) == null
             );
-            LOGGER.info("Kafka ConfigMap label {} change to {}", labelKey, null);
+            LOGGER.info("ConfigMap {} label {} change to {}", configMapName, labelKey, null);
         }
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
@@ -115,7 +115,7 @@ public class DeploymentUtils {
 
     /**
      * Method to wait when DeploymentConfig will be recreated after rolling update
-     * @param clusterName Kafka Connect S2I cluster name
+     * @param clusterName DeploymentConfig name
      * @param snapshot Snapshot of pods for DeploymentConfig before the rolling update
      * @return The snapshot of the DeploymentConfig after rolling update with Uid for every pod
      */

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/ReplicaSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/ReplicaSetUtils.java
@@ -24,7 +24,7 @@ public class ReplicaSetUtils {
      */
     public static void waitForReplicaSetDeletion(String name) {
         LOGGER.debug("Waiting for ReplicaSet of Deployment {} deletion", name);
-        TestUtils.waitFor("StatefulSet " + name + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.TIMEOUT_FOR_RESOURCE_DELETION,
+        TestUtils.waitFor("ReplicaSet " + name + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.TIMEOUT_FOR_RESOURCE_DELETION,
             () -> {
                 if (!kubeClient().replicaSetExists(name)) {
                     return true;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
@@ -135,7 +135,7 @@ public class StatefulSetUtils {
         String resourceName = statefulSetName.contains("-kafka") ? statefulSetName.replace("-kafka", "") : statefulSetName.replace("-zookeeper", "");
 
         LOGGER.info("Waiting for StatefulSet {} to be ready", statefulSetName);
-        TestUtils.waitFor("statefulset " + statefulSetName + " to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+        TestUtils.waitFor("StatefulSet " + statefulSetName + " to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
             () -> kubeClient().getStatefulSetStatus(statefulSetName),
             () -> StUtils.logCurrentStatus(KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get()));
 
@@ -182,7 +182,7 @@ public class StatefulSetUtils {
             // ignoring strimzi.io and k8s labels
             if (!(isStrimziTag || isK8sTag)) {
                 LOGGER.info("Waiting for Stateful set label change {} -> {}", entry.getKey(), entry.getValue());
-                TestUtils.waitFor("Waits for Kafka stateful set label change " + entry.getKey() + " -> " + entry.getValue(), Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,
+                TestUtils.waitFor("Waits for StatefulSet label change " + entry.getKey() + " -> " + entry.getValue(), Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,
                     Constants.TIMEOUT_FOR_RESOURCE_READINESS, () ->
                         kubeClient().getStatefulSet(statefulSetName).getMetadata().getLabels().get(entry.getKey()).equals(entry.getValue())
                 );
@@ -190,12 +190,12 @@ public class StatefulSetUtils {
         }
     }
 
-    public static void waitForStatefulSetLabelsDeletion(String statefulSet, String... labelKeys) {
+    public static void waitForStatefulSetLabelsDeletion(String statefulSetName, String... labelKeys) {
         for (final String labelKey : labelKeys) {
             LOGGER.info("Waiting for StatefulSet label {} change to {}", labelKey, null);
-            TestUtils.waitFor("Waiting for Kafka statefulSet label" + labelKey + " change to " + null, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,
+            TestUtils.waitFor("Waiting for StatefulSet label" + labelKey + " change to " + null, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,
                 Constants.TIMEOUT_FOR_RESOURCE_READINESS, () ->
-                    kubeClient().getStatefulSet(statefulSet).getMetadata().getLabels().get(labelKey) == null
+                    kubeClient().getStatefulSet(statefulSetName).getMetadata().getLabels().get(labelKey) == null
             );
             LOGGER.info("StatefulSet label {} change to {}", labelKey, null);
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
@@ -175,7 +175,7 @@ public class StatefulSetUtils {
         LOGGER.info("StatefulSet {} was recovered", name);
     }
 
-    public static void waitForKafkaStatefulSetLabelsChange(String statefulSetName, Map<String, String> labels) {
+    public static void waitForStatefulSetLabelsChange(String statefulSetName, Map<String, String> labels) {
         for (Map.Entry<String, String> entry : labels.entrySet()) {
             boolean isK8sTag = entry.getKey().equals("controller-revision-hash") || entry.getKey().equals("statefulset.kubernetes.io/pod-name");
             boolean isStrimziTag = entry.getKey().startsWith(Labels.STRIMZI_DOMAIN);
@@ -190,7 +190,7 @@ public class StatefulSetUtils {
         }
     }
 
-    public static void waitForKafkaStatefulSetLabelsDeletion(String statefulSet, String... labelKeys) {
+    public static void waitForStatefulSetLabelsDeletion(String statefulSet, String... labelKeys) {
         for (final String labelKey : labelKeys) {
             LOGGER.info("Waiting for StatefulSet label {} change to {}", labelKey, null);
             TestUtils.waitFor("Waiting for Kafka statefulSet label" + labelKey + " change to " + null, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -105,11 +105,11 @@ public class PodUtils {
     }
 
     /**
-     * The method to wait when all pods for Kafka cluster will be deleted.
+     * The method to wait when all pods of specific prefix will be deleted
      * To wait for the cluster to be updated, the following methods must be used: {@link StatefulSetUtils#ssHasRolled(String, Map)}, {@link StatefulSetUtils#waitTillSsHasRolled(String, int, Map)} )}
      * @param clusterName Cluster name where pods should be deleted
      */
-    public static void waitForKafkaClusterPodsDeletion(String clusterName) {
+    public static void waitForPodsWithPrefixDeletion(String clusterName) {
         LOGGER.info("Waiting when all Pods in Kafka cluster {} will be deleted", clusterName);
         kubeClient().listPods().stream()
             .filter(p -> p.getMetadata().getName().startsWith(clusterName))

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -107,12 +107,12 @@ public class PodUtils {
     /**
      * The method to wait when all pods of specific prefix will be deleted
      * To wait for the cluster to be updated, the following methods must be used: {@link StatefulSetUtils#ssHasRolled(String, Map)}, {@link StatefulSetUtils#waitTillSsHasRolled(String, int, Map)} )}
-     * @param clusterName Cluster name where pods should be deleted
+     * @param podsNamePrefix Cluster name where pods should be deleted
      */
-    public static void waitForPodsWithPrefixDeletion(String clusterName) {
-        LOGGER.info("Waiting when all Pods in Kafka cluster {} will be deleted", clusterName);
+    public static void waitForPodsWithPrefixDeletion(String podsNamePrefix) {
+        LOGGER.info("Waiting when all Pods with prefix {} will be deleted", podsNamePrefix);
         kubeClient().listPods().stream()
-            .filter(p -> p.getMetadata().getName().startsWith(clusterName))
+            .filter(p -> p.getMetadata().getName().startsWith(podsNamePrefix))
             .forEach(p -> waitForPodDeletion(p.getMetadata().getName()));
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -36,11 +36,11 @@ public class SecretUtils {
     }
 
     public static void waitForSecretReady(String secretName, Runnable onTimeout) {
-        LOGGER.info("Waiting for KafkaUser secret {}", secretName);
+        LOGGER.info("Waiting for Secret {}", secretName);
         TestUtils.waitFor("Expected secret " + secretName + " exists", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_SECRET_CREATION,
             () -> kubeClient().getSecret(secretName) != null,
             onTimeout);
-        LOGGER.info("KafkaUser secret {} created", secretName);
+        LOGGER.info("Secret {} created", secretName);
     }
 
     public static void createSecret(String secretName, String dataKey, String dataValue) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/ServiceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/ServiceUtils.java
@@ -22,7 +22,7 @@ public class ServiceUtils {
 
     private ServiceUtils() { }
 
-    public static void waitForKafkaServiceLabelsChange(String serviceName, Map<String, String> labels) {
+    public static void waitForServiceLabelsChange(String serviceName, Map<String, String> labels) {
         for (Map.Entry<String, String> entry : labels.entrySet()) {
             boolean isK8sTag = entry.getKey().equals("controller-revision-hash") || entry.getKey().equals("statefulset.kubernetes.io/pod-name");
             boolean isStrimziTag = entry.getKey().startsWith(Labels.STRIMZI_DOMAIN);
@@ -37,7 +37,7 @@ public class ServiceUtils {
         }
     }
 
-    public static void waitForKafkaServiceLabelsDeletion(String serviceName, String... labelKeys) {
+    public static void waitForServiceLabelsDeletion(String serviceName, String... labelKeys) {
         for (final String labelKey : labelKeys) {
             LOGGER.info("Service label {} change to {}", labelKey, null);
             TestUtils.waitFor("Service label" + labelKey + " change to " + null, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -1624,7 +1624,7 @@ class KafkaST extends BaseST {
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaStatefulSetName(CLUSTER_NAME));
 
         LOGGER.info("Waiting for kafka stateful set labels changed {}", labels);
-        StatefulSetUtils.waitForKafkaStatefulSetLabelsChange(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), labels);
+        StatefulSetUtils.waitForStatefulSetLabelsChange(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), labels);
 
         LOGGER.info("Getting labels from stateful set resource");
         StatefulSet statefulSet = kubeClient().getStatefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
@@ -1654,7 +1654,7 @@ class KafkaST extends BaseST {
         labels.put(labelKeys[2], labelValues[2]);
 
         LOGGER.info("Waiting for kafka service labels changed {}", labels);
-        ServiceUtils.waitForKafkaServiceLabelsChange(brokerServiceName, labels);
+        ServiceUtils.waitForServiceLabelsChange(brokerServiceName, labels);
 
         LOGGER.info("Verifying kafka labels via services");
         Service service = kubeClient().getService(brokerServiceName);
@@ -1670,7 +1670,7 @@ class KafkaST extends BaseST {
         verifyPresentLabels(labels, configMap);
 
         LOGGER.info("Waiting for kafka stateful set labels changed {}", labels);
-        StatefulSetUtils.waitForKafkaStatefulSetLabelsChange(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), labels);
+        StatefulSetUtils.waitForStatefulSetLabelsChange(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), labels);
 
         LOGGER.info("Verifying kafka labels via stateful set");
         statefulSet = kubeClient().getStatefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
@@ -1699,7 +1699,7 @@ class KafkaST extends BaseST {
         labels.remove(labelKeys[2]);
 
         LOGGER.info("Waiting for kafka service labels deletion {}", labels.toString());
-        ServiceUtils.waitForKafkaServiceLabelsDeletion(brokerServiceName, labelKeys[0], labelKeys[1], labelKeys[2]);
+        ServiceUtils.waitForServiceLabelsDeletion(brokerServiceName, labelKeys[0], labelKeys[1], labelKeys[2]);
 
         LOGGER.info("Verifying kafka labels via services");
         service = kubeClient().getService(brokerServiceName);
@@ -1707,7 +1707,7 @@ class KafkaST extends BaseST {
         verifyNullLabels(labelKeys, service);
 
         LOGGER.info("Verifying kafka labels via config maps");
-        ConfigMapUtils.waitForKafkaConfigMapLabelsDeletion(configMapName, labelKeys[0], labelKeys[1], labelKeys[2]);
+        ConfigMapUtils.waitForConfigMapLabelsDeletion(configMapName, labelKeys[0], labelKeys[1], labelKeys[2]);
 
         configMap = kubeClient().getConfigMap(configMapName);
 
@@ -1715,7 +1715,7 @@ class KafkaST extends BaseST {
 
         LOGGER.info("Waiting for kafka stateful set labels changed {}", labels);
         String statefulSetName = kubeClient().getStatefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).getMetadata().getName();
-        StatefulSetUtils.waitForKafkaStatefulSetLabelsDeletion(statefulSetName, labelKeys[0], labelKeys[1], labelKeys[2]);
+        StatefulSetUtils.waitForStatefulSetLabelsDeletion(statefulSetName, labelKeys[0], labelKeys[1], labelKeys[2]);
 
         statefulSet = kubeClient().getStatefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -1662,7 +1662,7 @@ class KafkaST extends BaseST {
         verifyPresentLabels(labels, service);
 
         LOGGER.info("Waiting for kafka config map labels changed {}", labels);
-        ConfigMapUtils.waitForKafkaConfigMapLabelsChange(configMapName, labels);
+        ConfigMapUtils.waitForConfigMapLabelsChange(configMapName, labels);
 
         LOGGER.info("Verifying kafka labels via config maps");
         ConfigMap configMap = kubeClient().getConfigMap(configMapName);


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Refactoring


### Description

In some utils method, we had `Kafka` in method name even if the method was general for service usage. This PR removes this string from method names. I also remove it from few log calls.


