### PR TITLE
ST: Delete all CRDs before helm install

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -362,16 +362,4 @@ public class ResourceManager {
     private static Deployment getDeploymentFromYaml(String yamlPath) {
         return TestUtils.configFromYaml(yamlPath, Deployment.class);
     }
-
-    public static void deleteCRDs() {
-        cmdKubeClient().delete(TestUtils.CRD_KAFKA);
-        cmdKubeClient().delete(TestUtils.CRD_KAFKA_BRIDGE);
-        cmdKubeClient().delete(TestUtils.CRD_KAFKA_CONNECT);
-        cmdKubeClient().delete(TestUtils.CRD_KAFKA_CONNECT_S2I);
-        cmdKubeClient().delete(TestUtils.CRD_KAFKA_MIRROR_MAKER);
-        cmdKubeClient().delete(TestUtils.CRD_KAFKA_MIRROR_MAKER_2);
-        cmdKubeClient().delete(TestUtils.CRD_KAFKA_USER);
-        cmdKubeClient().delete(TestUtils.CRD_TOPIC);
-        cmdKubeClient().delete(TestUtils.CRD_KAFKA_CONNECTOR);
-    }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -362,4 +362,16 @@ public class ResourceManager {
     private static Deployment getDeploymentFromYaml(String yamlPath) {
         return TestUtils.configFromYaml(yamlPath, Deployment.class);
     }
+
+    public static void deleteCRDs() {
+        cmdKubeClient().delete(TestUtils.CRD_KAFKA);
+        cmdKubeClient().delete(TestUtils.CRD_KAFKA_BRIDGE);
+        cmdKubeClient().delete(TestUtils.CRD_KAFKA_CONNECT);
+        cmdKubeClient().delete(TestUtils.CRD_KAFKA_CONNECT_S2I);
+        cmdKubeClient().delete(TestUtils.CRD_KAFKA_MIRROR_MAKER);
+        cmdKubeClient().delete(TestUtils.CRD_KAFKA_MIRROR_MAKER_2);
+        cmdKubeClient().delete(TestUtils.CRD_KAFKA_USER);
+        cmdKubeClient().delete(TestUtils.CRD_TOPIC);
+        cmdKubeClient().delete(TestUtils.CRD_KAFKA_CONNECTOR);
+    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
@@ -348,7 +348,7 @@ public abstract class BaseST implements TestSeparator {
         LOGGER.info("Creating cluster operator with Helm Chart before test class {}", testClass);
         // We need to delete all CRDs before install Strimzi via helm, otherwise install fail when some CRD is already created
         cmdKubeClient().exec("get", "crds");
-        cmdKubeClient().exec("delete", "crds", "-l", "app=strimzi");
+        ResourceManager.deleteCRDs();
         cmdKubeClient().exec("get", "crds", "-o", "yaml");
         Path pathToChart = new File(HELM_CHART).toPath();
         String oldNamespace = cluster.setNamespace("kube-system");

--- a/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
@@ -349,11 +349,6 @@ public abstract class BaseST implements TestSeparator {
         // We need to delete all CRDs before install Strimzi via helm, otherwise install fail when some CRD is already created
         cmdKubeClient().exec("get", "crds");
         cmdKubeClient().delete(KubeClusterResource.CO_INSTALL_DIR);
-        try {
-            Thread.sleep(30_000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
         cmdKubeClient().exec("get", "crds", "-o", "yaml");
         Path pathToChart = new File(HELM_CHART).toPath();
         String oldNamespace = cluster.setNamespace("kube-system");

--- a/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
@@ -349,6 +349,11 @@ public abstract class BaseST implements TestSeparator {
         // We need to delete all CRDs before install Strimzi via helm, otherwise install fail when some CRD is already created
         cmdKubeClient().exec("get", "crds");
         cmdKubeClient().delete(KubeClusterResource.CO_INSTALL_DIR);
+        try {
+            Thread.sleep(30_000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         cmdKubeClient().exec("get", "crds", "-o", "yaml");
         Path pathToChart = new File(HELM_CHART).toPath();
         String oldNamespace = cluster.setNamespace("kube-system");

--- a/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
@@ -348,7 +348,7 @@ public abstract class BaseST implements TestSeparator {
         LOGGER.info("Creating cluster operator with Helm Chart before test class {}", testClass);
         // We need to delete all CRDs before install Strimzi via helm, otherwise install fail when some CRD is already created
         cmdKubeClient().exec("get", "crds");
-        ResourceManager.deleteCRDs();
+        cmdKubeClient().delete(KubeClusterResource.CO_INSTALL_DIR);
         cmdKubeClient().exec("get", "crds", "-o", "yaml");
         Path pathToChart = new File(HELM_CHART).toPath();
         String oldNamespace = cluster.setNamespace("kube-system");

--- a/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
@@ -331,11 +331,12 @@ public abstract class BaseST implements TestSeparator {
      * Deploy CO via helm chart. Using config file stored in test resources.
      */
     public void deployClusterOperatorViaHelmChart() {
+        String dockerReg = Environment.STRIMZI_REGISTRY;
         String dockerOrg = Environment.STRIMZI_ORG;
         String dockerTag = Environment.STRIMZI_TAG;
 
         Map<String, String> values = Collections.unmodifiableMap(Stream.of(
-            entry("imageRepositoryOverride", dockerOrg),
+            entry("imageRepositoryOverride", dockerReg + "/" + dockerOrg),
             entry("imageTagOverride", dockerTag),
             entry("image.pullPolicy", Environment.OPERATOR_IMAGE_PULL_POLICY),
             entry("resources.requests.memory", REQUESTS_MEMORY),
@@ -347,9 +348,7 @@ public abstract class BaseST implements TestSeparator {
 
         LOGGER.info("Creating cluster operator with Helm Chart before test class {}", testClass);
         // We need to delete all CRDs before install Strimzi via helm, otherwise install fail when some CRD is already created
-        cmdKubeClient().exec("get", "crds");
         cmdKubeClient().delete(KubeClusterResource.CO_INSTALL_DIR);
-        cmdKubeClient().exec("get", "crds", "-o", "yaml");
         Path pathToChart = new File(HELM_CHART).toPath();
         String oldNamespace = cluster.setNamespace("kube-system");
         InputStream helmAccountAsStream = getClass().getClassLoader().getResourceAsStream("helm/helm-service-account.yaml");

--- a/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
@@ -347,7 +347,9 @@ public abstract class BaseST implements TestSeparator {
 
         LOGGER.info("Creating cluster operator with Helm Chart before test class {}", testClass);
         // We need to delete all CRDs before install Strimzi via helm, otherwise install fail when some CRD is already created
+        cmdKubeClient().exec("get", "crds");
         cmdKubeClient().exec("delete", "crds", "-l", "app=strimzi");
+        cmdKubeClient().exec("get", "crds", "-o", "yaml");
         Path pathToChart = new File(HELM_CHART).toPath();
         String oldNamespace = cluster.setNamespace("kube-system");
         InputStream helmAccountAsStream = getClass().getClassLoader().getResourceAsStream("helm/helm-service-account.yaml");

--- a/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
@@ -346,6 +346,8 @@ public abstract class BaseST implements TestSeparator {
             .collect(TestUtils.entriesToMap()));
 
         LOGGER.info("Creating cluster operator with Helm Chart before test class {}", testClass);
+        // We need to delete all CRDs before install Strimzi via helm, otherwise install fail when some CRD is already created
+        cmdKubeClient().exec("delete", "crds", "-l", "app=strimzi");
         Path pathToChart = new File(HELM_CHART).toPath();
         String oldNamespace = cluster.setNamespace("kube-system");
         InputStream helmAccountAsStream = getClass().getClassLoader().getResourceAsStream("helm/helm-service-account.yaml");

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -79,6 +79,8 @@ public final class TestUtils {
 
     public static final String CRD_KAFKA_MIRROR_MAKER_2 = "../install/cluster-operator/048-Crd-kafkamirrormaker2.yaml";
 
+    public static final String CRD_KAFKA_CONNECTOR = "../install/cluster-operator/047-Crd-kafkaconnector.yaml";
+
     private TestUtils() {
         // All static methods
     }

--- a/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
@@ -22,7 +22,7 @@ public class HelmClient {
     private static final Logger LOGGER = LogManager.getLogger(HelmClient.class);
 
     private static final String HELM_CMD = "helm";
-    private static final String INSTALL_TIMEOUT_SECONDS = "60";
+    private static final String INSTALL_TIMEOUT_SECONDS = "90";
 
     private boolean initialized;
     private String namespace;

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -43,7 +43,7 @@ public class KubeClusterResource {
 
     private static final Logger LOGGER = LogManager.getLogger(KubeClusterResource.class);
 
-    private static final String CO_INSTALL_DIR = "../install/cluster-operator";
+    public static final String CO_INSTALL_DIR = "../install/cluster-operator";
 
     private KubeCluster kubeCluster;
     private KubeCmdClient cmdClient;


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

`HelmChartST` fails when CRDs are already applied from some previous tests. This change remove all CRDs before installing strimzi via helm.

### Checklist

- [x] Make sure all tests pass

