### PR TITLE
Fix doc standalone UO not connected to ZK via TLS

### DIFF
--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -22,7 +22,7 @@ a standalone deployment is more flexible as the User Operator can operate with _
 The `Secret` must contain the public key of the Certificate Authority under the key `ca.crt`.
 .. `STRIMZI_CA_KEY_NAME` to point to a Kubernetes `Secret` that contains the private key of the Certificate Authority for signing new user certificates for TLS client authentication.
 The `Secret` must contain the private key of the Certificate Authority under the key `ca.key`.
-.. `STRIMZI_ZOOKEEPER_CONNECT` to list the ZooKeeper nodes, given as a comma-separated list of `_hostname_:‍_port_` pairs. This must be the same ZooKeeper cluster that your Kafka cluster is using.
+.. `STRIMZI_ZOOKEEPER_CONNECT` to list the ZooKeeper nodes, given as a comma-separated list of `_hostname_:‍_port_` pairs. This must be the same ZooKeeper cluster that your Kafka cluster is using. Connecting to ZooKeeper nodes with TLS encryption is not supported. 
 .. `STRIMZI_NAMESPACE` to the Kubernetes namespace in which you want the operator to watch for `KafkaUser` resources.
 .. `STRIMZI_JAVA_OPTS` to the Java options used for the JVM running User Operator. An example is `-Xmx=512M -Xms=256M`.
 .. `STRIMZI_JAVA_SYSTEM_PROPERTIES` to list the `-D` options which are set to the User Operator. An example is `-Djavax.net.debug=verbose -DpropertyName=value`.


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Documentation

### Description

When deploying the UO as standalone, it's not clear from the doc that it doesn't support (out-of-box) connecting to ZooKeeper nodes which are TLS protected.
(The CO deployment is leveraging the TLS sidecar with UO for allowing it).
This PR comes after a discussion with @Frawless which was trying to deploy UO as standalone and connect to a ZooKeeper "protected" via TLS (because deployed via CO).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

