### PR TITLE
Fix mm2 status ordering

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -372,7 +373,9 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
         return securityProtocol;
     }
 
-    class ConnectorsComparator implements Comparator<Map<String, Object>> {
+    static class ConnectorsComparator implements Comparator<Map<String, Object>>, Serializable {
+        private static final long serialVersionUID = 1L;
+
         @Override
         public int compare(Map<String, Object> m1, Map<String, Object> m2) {
             String name1 = m1.get("name") == null ? "" : m1.get("name").toString();

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/StatusDiff.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/StatusDiff.java
@@ -26,7 +26,7 @@ public class StatusDiff extends AbstractResourceDiff {
 
     public StatusDiff(Status current, Status desired) {
         JsonNode source = patchMapper().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true).valueToTree(current == null ? "{}" : current);
-        JsonNode target = patchMapper().valueToTree(desired == null ? "{}" : desired);
+        JsonNode target = patchMapper().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true).valueToTree(desired == null ? "{}" : desired);
         JsonNode diff = JsonDiff.asJson(source, target);
 
         int num = 0;
@@ -54,7 +54,7 @@ public class StatusDiff extends AbstractResourceDiff {
     /**
      * Returns whether the Diff is empty or not
      *
-     * @return true when the statuses are the same
+     * @return true when the diffed statuses match
      */
     @Override
     public boolean isEmpty() {

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/StatusDiff.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/StatusDiff.java
@@ -25,6 +25,7 @@ public class StatusDiff extends AbstractResourceDiff {
     private final boolean isEmpty;
 
     public StatusDiff(Status current, Status desired) {
+        // use SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS just for better human readability in the logs
         JsonNode source = patchMapper().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true).valueToTree(current == null ? "{}" : current);
         JsonNode target = patchMapper().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true).valueToTree(desired == null ? "{}" : desired);
         JsonNode diff = JsonDiff.asJson(source, target);

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/StatusDiff.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/StatusDiff.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.cluster.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import io.fabric8.zjsonpatch.JsonDiff;
 import io.strimzi.api.kafka.model.status.Status;
 import io.strimzi.operator.common.operator.resource.AbstractResourceDiff;
@@ -24,7 +25,7 @@ public class StatusDiff extends AbstractResourceDiff {
     private final boolean isEmpty;
 
     public StatusDiff(Status current, Status desired) {
-        JsonNode source = patchMapper().valueToTree(current == null ? "{}" : current);
+        JsonNode source = patchMapper().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true).valueToTree(current == null ? "{}" : current);
         JsonNode target = patchMapper().valueToTree(desired == null ? "{}" : desired);
         JsonNode diff = JsonDiff.asJson(source, target);
 
@@ -53,7 +54,7 @@ public class StatusDiff extends AbstractResourceDiff {
     /**
      * Returns whether the Diff is empty or not
      *
-     * @return true when the storage configurations are the same
+     * @return true when the statuses are the same
      */
     @Override
     public boolean isEmpty() {


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
Contacting REST API to get connectors does not guarantee the same order. We should patch it.

### Checklist

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

