### PR TITLE
Added default Cruise Control image if the env var is missing

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -162,6 +162,7 @@ public class CruiseControl extends AbstractModel {
     public static CruiseControl fromCrd(Kafka kafkaAssembly, KafkaVersion.Lookup versions) {
         CruiseControl cruiseControl = null;
         CruiseControlSpec spec  = kafkaAssembly.getSpec().getCruiseControl();
+        KafkaClusterSpec kafkaClusterSpec = kafkaAssembly.getSpec().getKafka();
 
         if (spec != null) {
             cruiseControl = new CruiseControl(kafkaAssembly);
@@ -170,7 +171,7 @@ public class CruiseControl extends AbstractModel {
             cruiseControl.setReplicas(DEFAULT_REPLICAS);
             String image = spec.getImage();
             if (image == null) {
-                image = System.getenv().get(ClusterOperatorConfig.STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE);
+                image = System.getenv().getOrDefault(ClusterOperatorConfig.STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE, versions.kafkaImage(kafkaClusterSpec.getImage(), versions.defaultVersion().version()));
             }
             cruiseControl.setImage(image);
 
@@ -181,7 +182,6 @@ public class CruiseControl extends AbstractModel {
 
             String tlsSideCarImage = tlsSidecar.getImage();
             if (tlsSideCarImage == null) {
-                KafkaClusterSpec kafkaClusterSpec = kafkaAssembly.getSpec().getKafka();
                 tlsSideCarImage = System.getenv().getOrDefault(ClusterOperatorConfig.STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE, versions.kafkaImage(kafkaClusterSpec.getImage(), versions.defaultVersion().version()));
             }
 
@@ -191,7 +191,6 @@ public class CruiseControl extends AbstractModel {
 
             cruiseControl = updateConfiguration(spec, cruiseControl);
 
-            KafkaClusterSpec kafkaClusterSpec = kafkaAssembly.getSpec().getKafka();
             KafkaConfiguration configuration = new KafkaConfiguration(kafkaClusterSpec.getConfig().entrySet());
             if (configuration.getConfigOption(MIN_INSYNC_REPLICAS) != null) {
                 cruiseControl.minInsyncReplicas = configuration.getConfigOption(MIN_INSYNC_REPLICAS);


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Bugfix

### Description

This PR set the default Kafka image as default for Cruise Control is the corresponding `STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE` env var is somehow missing in the CO deployment file.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

