### PR TITLE
Use quotation marks in 050 installation file consitently

### DIFF
--- a/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
@@ -57,15 +57,15 @@ spec:
               value: {{ .Values.operationTimeoutMs | quote }}
             {{- template "strimzi.kafka.image.map" . }}
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
-              value: "{{ default .Values.topicOperator.image.repository .Values.imageRepositoryOverride }}/{{ .Values.topicOperator.image.name }}:{{ default .Values.topicOperator.image.tag .Values.imageTagOverride }}"
+              value: {{ default .Values.topicOperator.image.repository .Values.imageRepositoryOverride }}/{{ .Values.topicOperator.image.name }}:{{ default .Values.topicOperator.image.tag .Values.imageTagOverride }}
             - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
-              value: "{{ default .Values.userOperator.image.repository .Values.imageRepositoryOverride }}/{{ .Values.userOperator.image.name }}:{{ default .Values.userOperator.image.tag .Values.imageTagOverride }}"
+              value: {{ default .Values.userOperator.image.repository .Values.imageRepositoryOverride }}/{{ .Values.userOperator.image.name }}:{{ default .Values.userOperator.image.tag .Values.imageTagOverride }}
             - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
-              value: "{{ default .Values.kafkaInit.image.repository .Values.imageRepositoryOverride }}/{{ .Values.kafkaInit.image.name }}:{{ default .Values.kafkaInit.image.tag .Values.imageTagOverride }}"
+              value: {{ default .Values.kafkaInit.image.repository .Values.imageRepositoryOverride }}/{{ .Values.kafkaInit.image.name }}:{{ default .Values.kafkaInit.image.tag .Values.imageTagOverride }}
             - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
-              value: "{{ default .Values.kafkaBridge.image.repository .Values.imageRepositoryOverride }}/{{ .Values.kafkaBridge.image.name }}:{{ default .Values.kafkaBridge.image.tag .Values.imageTagOverride }}"
+              value: {{ default .Values.kafkaBridge.image.repository .Values.imageRepositoryOverride }}/{{ .Values.kafkaBridge.image.name }}:{{ default .Values.kafkaBridge.image.tag .Values.imageTagOverride }}
             - name: STRIMZI_DEFAULT_JMXTRANS_IMAGE
-              value: "{{ default .Values.jmxTrans.image.repository .Values.imageRepositoryOverride }}/{{ .Values.jmxTrans.image.name }}:{{ default .Values.jmxTrans.image.tag .Values.imageTagOverride }}"
+              value: {{ default .Values.jmxTrans.image.repository .Values.imageRepositoryOverride }}/{{ .Values.jmxTrans.image.name }}:{{ default .Values.jmxTrans.image.tag .Values.imageTagOverride }}
             - name: STRIMZI_LOG_LEVEL
               value: {{ .Values.logLevel | quote }}
             {{- if .Values.image.imagePullSecrets }}

--- a/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
@@ -72,15 +72,15 @@ spec:
             2.4.1=strimzi/kafka:latest-kafka-2.4.1
             2.5.0=strimzi/kafka:latest-kafka-2.5.0
         - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
-          value: "strimzi/operator:latest"
+          value: strimzi/operator:latest
         - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
-          value: "strimzi/operator:latest"
+          value: strimzi/operator:latest
         - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
-          value: "strimzi/operator:latest"
+          value: strimzi/operator:latest
         - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
-          value: "strimzi/kafka-bridge:0.15.2"
+          value: strimzi/kafka-bridge:0.15.2
         - name: STRIMZI_DEFAULT_JMXTRANS_IMAGE
-          value: "strimzi/jmxtrans:latest"
+          value: strimzi/jmxtrans:latest
         - name: STRIMZI_LOG_LEVEL
           value: "INFO"
         livenessProbe:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The installation files are currently using quotation marks a bit inconsistently. Half of the image configuration options uses them and other halp doesn't. That looks a bit weird but also makes it harder to forexample update the images in the files using `sed` etc. This PR should fix that.