### PR TITLE
To issues

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ConflictingChangesException.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ConflictingChangesException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.topic;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+/**
+ * Thrown when the operator detects that the {@code KafkaTopic}
+ * and the topic in Kafka had conflicting changes.
+ */
+public class ConflictingChangesException extends OperatorException {
+    public ConflictingChangesException(HasMetadata resource, String message) {
+        super(resource, message);
+    }
+}

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/InvalidTopicException.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/InvalidTopicException.java
@@ -6,6 +6,10 @@ package io.strimzi.operator.topic;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 
+/**
+ * Used when an invalid topic is detected
+ * (e.g. one with a negative number of partitions, etc.).
+ */
 public class InvalidTopicException extends OperatorException {
     public InvalidTopicException(HasMetadata involvedObject, String message) {
         super(involvedObject, message);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/InvalidTopicException.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/InvalidTopicException.java
@@ -7,7 +7,7 @@ package io.strimzi.operator.topic;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 
 /**
- * Used when an invalid topic is detected
+ * Thrown when an invalid topic is detected
  * (e.g. one with a negative number of partitions, etc.).
  */
 public class InvalidTopicException extends OperatorException {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/PartitionDecreaseException.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/PartitionDecreaseException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.topic;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+/**
+ * Thrown when the operator detects an attempt to decrease the number of
+ * partitions in a topic (something which Kafka does not support).
+ */
+public class PartitionDecreaseException extends OperatorException {
+    public PartitionDecreaseException(HasMetadata resource, String message) {
+        super(resource, message);
+    }
+}

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ReplicationFactorChangeException.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ReplicationFactorChangeException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.topic;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+/**
+ * Thrown when the operator detects an attempt to change the
+ * replication factor of a topic
+ * (something which the operator does not currently support because
+ * it requires replica placement decisions).
+ */
+public class ReplicationFactorChangeException extends OperatorException {
+    public ReplicationFactorChangeException(HasMetadata resource, String message) {
+        super(resource, message);
+    }
+}

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
@@ -224,7 +224,8 @@ class TopicSerialization {
                 .withNumReplicas((short) meta.getDescription().partitions().get(0).replicas().size())
                 .withMetadata(null);
         for (ConfigEntry entry: meta.getConfig().entries()) {
-            if (!entry.isDefault()) {
+            if (entry.source() != ConfigEntry.ConfigSource.DEFAULT_CONFIG
+                && entry.source() != ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG) {
                 builder.withConfigEntry(entry.name(), entry.value());
             }
         }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.DoneableKafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaTopicStatus;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.cluster.KubeCluster;
@@ -72,6 +73,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @SuppressWarnings("checkstyle:ClassFanOutComplexity")
@@ -320,9 +322,11 @@ public abstract class TopicOperatorBaseIT {
         waitFor(() -> {
             KafkaTopic kafkaTopic = operation().inNamespace(NAMESPACE).withName(topicName).get();
             if (kafkaTopic != null) {
-                if (kafkaTopic.getStatus() != null
-                        && kafkaTopic.getStatus().getConditions() != null) {
-                    List<Condition> conditions = kafkaTopic.getStatus().getConditions();
+                KafkaTopicStatus status = kafkaTopic.getStatus();
+                if (status != null
+                        && Objects.equals(status.getObservedGeneration(), kafkaTopic.getMetadata().getGeneration())
+                        && status.getConditions() != null) {
+                    List<Condition> conditions = status.getConditions();
                     assertThat(conditions.size() > 0, is(true));
                     if (conditions.stream().anyMatch(condition ->
                             "Ready".equals(condition.getType()) &&
@@ -340,18 +344,28 @@ public abstract class TopicOperatorBaseIT {
     }
 
     protected void assertStatusNotReady(String topicName, String message) throws InterruptedException, ExecutionException, TimeoutException {
+        assertStatusNotReady(topicName, null, message);
+    }
+
+    protected void assertStatusNotReady(String topicName, Class<? extends Exception> reason, String message) throws InterruptedException, ExecutionException, TimeoutException {
         waitFor(() -> {
             KafkaTopic kafkaTopic = operation().inNamespace(NAMESPACE).withName(topicName).get();
             if (kafkaTopic != null) {
-                if (kafkaTopic.getStatus() != null
-                        && kafkaTopic.getStatus().getConditions() != null) {
-                    List<Condition> conditions = kafkaTopic.getStatus().getConditions();
+                KafkaTopicStatus status = kafkaTopic.getStatus();
+                if (status != null
+                        && Objects.equals(status.getObservedGeneration(), kafkaTopic.getMetadata().getGeneration())
+                        && status.getConditions() != null) {
+                    List<Condition> conditions = status.getConditions();
                     assertThat(conditions.size() > 0, is(true));
                     Optional<Condition> unreadyCondition = conditions.stream().filter(condition ->
                             "NotReady".equals(condition.getType()) &&
-                            "True".equals(condition.getStatus())).findFirst();
+                                    "True".equals(condition.getStatus())).findFirst();
                     if (unreadyCondition.isPresent()) {
-                        assertThat(unreadyCondition.get().getMessage(), is(message));
+                        if (reason != null) {
+                            assertThat(unreadyCondition.get().getReason() + ": " + unreadyCondition.get().getMessage(), is(reason.getSimpleName() + ": " + message));
+                        } else {
+                            assertThat(unreadyCondition.get().getMessage(), is(message));
+                        }
                         return true;
                     } else {
                         LOGGER.info(conditions);
@@ -393,7 +407,7 @@ public abstract class TopicOperatorBaseIT {
         return createTopic(topicName, new NewTopic(topicName, singletonMap(0, replicaAssignments)));
     }
 
-    private String createTopic(String topicName, NewTopic o) throws InterruptedException, ExecutionException, TimeoutException {
+    protected String createTopic(String topicName, NewTopic o) throws InterruptedException, ExecutionException, TimeoutException {
         LOGGER.info("Creating topic {}", topicName);
         // Create a topic
         String resourceName = new TopicName(topicName).asKubeName().toString();
@@ -444,7 +458,11 @@ public abstract class TopicOperatorBaseIT {
 
         Map<String, ConfigEntry> m = new HashMap<>();
         for (ConfigEntry entry: config.entries()) {
-            m.put(entry.name(), entry);
+            if (entry.name().equals(key)
+                || entry.source() != ConfigEntry.ConfigSource.DEFAULT_CONFIG
+                    && entry.source() != ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG) {
+                m.put(entry.name(), entry);
+            }
         }
         final String changedValue = mutator.apply(m.get(key).value());
         m.put(key, new ConfigEntry(key, changedValue));

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -4,6 +4,27 @@
  */
 package io.strimzi.operator.topic;
 
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import io.debezium.kafka.KafkaCluster;
 import io.debezium.kafka.ZookeeperServer;
 import io.fabric8.kubernetes.api.model.Event;
@@ -45,27 +66,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.nio.file.Files;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.BooleanSupplier;
-import java.util.function.Function;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static java.util.Collections.emptyMap;
@@ -73,7 +73,6 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @SuppressWarnings("checkstyle:ClassFanOutComplexity")

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import kafka.server.KafkaConfig$;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
@@ -83,6 +84,54 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
     @Test
     public void testTopicNumPartitionsChanged() throws Exception {
         createAndAlterNumPartitions("test-topic-partitions-changed");
+    }
+
+    @Test
+    public void testTopicNumPartitionsDecreased() throws Exception {
+        String topicName = "topic-partitions-decreased-in-kube";
+        String resourceName = createTopic(topicName, new NewTopic(topicName, 2, (short) 1));
+        KafkaTopic changedTopic = new KafkaTopicBuilder(operation().inNamespace(NAMESPACE).withName(resourceName).get())
+                .editOrNewSpec().withPartitions(1).endSpec().build();
+        KafkaTopic replaced = operation().inNamespace(NAMESPACE).withName(resourceName).replace(changedTopic);
+        assertStatusNotReady(topicName, PartitionDecreaseException.class,
+                "Number of partitions cannot be decreased");
+        Long generation = operation().inNamespace(NAMESPACE).withName(resourceName).get().getMetadata().getGeneration();
+        // Now modify Kafka-side to cause another reconciliation: We want the same status.
+        //alterTopicConfigInKafkaAndAwaitReconciliation(topicName, resourceName);
+        String key = "compression.type";
+        final String changedValue = alterTopicConfigInKafka(topicName, key, value -> "snappy".equals(value) ? "lz4" : "snappy");
+        // Check we're seeing the the message from the Kafka-side change, and not the message from the original reconciliation
+//        waitFor(() -> {
+//            return !generation.equals(operation().inNamespace(NAMESPACE).withName(resourceName).get().getMetadata().getGeneration());
+//        }, "Change to be picked up");
+        Thread.sleep(30_000);
+        assertStatusNotReady(topicName, PartitionDecreaseException.class,
+                "Number of partitions cannot be decreased");
+    }
+
+    @Test
+    public void testInvalidConfig() throws Exception {
+        String topicName = "topic-invalid-config";
+        String expectedMessage = "Invalid config value for resource ConfigResource(type=TOPIC, name='" + topicName + "'): Invalid value x for configuration min.insync.replicas: Not a number of type INT";
+
+        String resourceName = createTopic(topicName, new NewTopic(topicName, 2, (short) 1));
+        KafkaTopic changedTopic = new KafkaTopicBuilder(operation().inNamespace(NAMESPACE).withName(resourceName).get())
+                .editOrNewSpec().addToConfig("min.insync.replicas", "x").endSpec().build();
+        KafkaTopic replaced = operation().inNamespace(NAMESPACE).withName(resourceName).replace(changedTopic);
+        assertStatusNotReady(topicName, InvalidRequestException.class,
+                expectedMessage);
+        Long generation = operation().inNamespace(NAMESPACE).withName(resourceName).get().getMetadata().getGeneration();
+        // Now modify Kafka-side to cause another reconciliation: We want the same status.
+        //alterTopicConfigInKafkaAndAwaitReconciliation(topicName, resourceName);
+        String key = "compression.type";
+        final String changedValue = alterTopicConfigInKafka(topicName, key, value -> "snappy".equals(value) ? "lz4" : "snappy");
+        // Check we're seeing the the message from the Kafka-side change, and not the message from the original reconciliation
+//        waitFor(() -> {
+//            return !generation.equals(operation().inNamespace(NAMESPACE).withName(resourceName).get().getMetadata().getGeneration());
+//        }, "Change to be picked up");
+        Thread.sleep(30_000);
+        assertStatusNotReady(topicName, InvalidRequestException.class,
+                expectedMessage);
     }
 
     @Test

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -97,13 +97,8 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
                 "Number of partitions cannot be decreased");
         Long generation = operation().inNamespace(NAMESPACE).withName(resourceName).get().getMetadata().getGeneration();
         // Now modify Kafka-side to cause another reconciliation: We want the same status.
-        //alterTopicConfigInKafkaAndAwaitReconciliation(topicName, resourceName);
-        String key = "compression.type";
-        final String changedValue = alterTopicConfigInKafka(topicName, key, value -> "snappy".equals(value) ? "lz4" : "snappy");
-        // Check we're seeing the the message from the Kafka-side change, and not the message from the original reconciliation
-//        waitFor(() -> {
-//            return !generation.equals(operation().inNamespace(NAMESPACE).withName(resourceName).get().getMetadata().getGeneration());
-//        }, "Change to be picked up");
+        alterTopicConfigInKafka(topicName, "compression.type", value -> "snappy".equals(value) ? "lz4" : "snappy");
+        // Wait for a periodic reconciliation
         Thread.sleep(30_000);
         assertStatusNotReady(topicName, PartitionDecreaseException.class,
                 "Number of partitions cannot be decreased");
@@ -120,15 +115,9 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
         KafkaTopic replaced = operation().inNamespace(NAMESPACE).withName(resourceName).replace(changedTopic);
         assertStatusNotReady(topicName, InvalidRequestException.class,
                 expectedMessage);
-        Long generation = operation().inNamespace(NAMESPACE).withName(resourceName).get().getMetadata().getGeneration();
         // Now modify Kafka-side to cause another reconciliation: We want the same status.
-        //alterTopicConfigInKafkaAndAwaitReconciliation(topicName, resourceName);
-        String key = "compression.type";
-        final String changedValue = alterTopicConfigInKafka(topicName, key, value -> "snappy".equals(value) ? "lz4" : "snappy");
-        // Check we're seeing the the message from the Kafka-side change, and not the message from the original reconciliation
-//        waitFor(() -> {
-//            return !generation.equals(operation().inNamespace(NAMESPACE).withName(resourceName).get().getMetadata().getGeneration());
-//        }, "Change to be picked up");
+        alterTopicConfigInKafka(topicName, "compression.type", value -> "snappy".equals(value) ? "lz4" : "snappy");
+        // Wait for a periodic reconciliation
         Thread.sleep(30_000);
         assertStatusNotReady(topicName, InvalidRequestException.class,
                 expectedMessage);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -1048,7 +1048,7 @@ public class TopicOperatorTest {
         Future<?> reconcileFuture = topicOperator.reconcileAllTopics("periodic");
 
         reconcileFuture.setHandler(context.failing(e -> {
-            context.verify(() -> assertThat(e.getMessage(), is("Error getting KafkaTopic my-topic during periodic reconciliation")));
+            context.verify(() -> assertThat(e.getMessage(), is("Error getting topic my-topic from topic store during periodic reconciliation")));
             context.verify(() -> assertThat(e.getCause(), is(error)));
             context.verify(() -> {
                 MeterRegistry registry = metrics.meterRegistry();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The PR fixes a couple of related issues with the TO:

1. In an existing `KafkaTopic` decreasing the `spec.partitions` initially resulted in a `status` with the correct error message about this not being supported, but the next periodic reconciliation would result in a `Ready` status
2. In an existing `KafkaTopic` changing the `spec.config` to have an invalid parameter (e.g. `min.in.sync.replicas: x`) would initially result in a `status` with the correct error message about this not being supported, but the next periodic reconciliation would result in a `Ready` status

In addition to fixing these errors we now have specific exceptions for these and related conditions, which will manifest in the `reason` of the `NotReady` condition in the `status`.

Note that the change in `TopicSerialization.java` means that certain configs won't now get propagated to the `KafkaTopic` which were before. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

