### PR TITLE
Make determineImagePullPolicy work with the images with latest-kafka-x.x.x

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1061,7 +1061,7 @@ public abstract class AbstractModel {
             return requestedImagePullPolicy.toString();
         }
 
-        if (image.toLowerCase(Locale.ENGLISH).endsWith(":latest"))  {
+        if (image.toLowerCase(Locale.ENGLISH).contains(":latest"))  {
             return ImagePullPolicy.ALWAYS.toString();
         } else {
             return ImagePullPolicy.IFNOTPRESENT.toString();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1050,7 +1050,9 @@ public abstract class AbstractModel {
      * When ImagePullPolicy is not specified by the user, Kubernetes will automatically set it based on the image
      *    :latest results in Always
      *    anything else results in IfNotPresent
-     * This causes issues in diffing. So we emulate here the Kubernetes defaults and set the policy accoridngly already on our side.
+     * This causes issues in diffing. So we emulate here the Kubernetes defaults and set the policy accordingly
+     * already on our side. This is applied also to our Kafka images which use the tag :latest-kafka-x.y.z but have
+     * the same function as if they were :latest and should behave the same.
      *
      * @param requestedImagePullPolicy  The imagePullPolicy requested by the user (is always preferred when set, ignored when null)
      * @param image The image used for the container. From its tag we determine the default policy

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -230,8 +230,11 @@ public class AbstractModelTest {
 
         assertThat(am.determineImagePullPolicy(ImagePullPolicy.ALWAYS, "docker.io/repo/image:tag"), is(ImagePullPolicy.ALWAYS.toString()));
         assertThat(am.determineImagePullPolicy(ImagePullPolicy.IFNOTPRESENT, "docker.io/repo/image:tag"), is(ImagePullPolicy.IFNOTPRESENT.toString()));
+        assertThat(am.determineImagePullPolicy(ImagePullPolicy.IFNOTPRESENT, "docker.io/repo/image:latest"), is(ImagePullPolicy.IFNOTPRESENT.toString()));
         assertThat(am.determineImagePullPolicy(ImagePullPolicy.NEVER, "docker.io/repo/image:tag"), is(ImagePullPolicy.NEVER.toString()));
+        assertThat(am.determineImagePullPolicy(ImagePullPolicy.NEVER, "docker.io/repo/image:latest-kafka-2.5.0"), is(ImagePullPolicy.NEVER.toString()));
         assertThat(am.determineImagePullPolicy(null, "docker.io/repo/image:latest"), is(ImagePullPolicy.ALWAYS.toString()));
         assertThat(am.determineImagePullPolicy(null, "docker.io/repo/image:not-so-latest"), is(ImagePullPolicy.IFNOTPRESENT.toString()));
+        assertThat(am.determineImagePullPolicy(null, "docker.io/repo/image:latest-kafka-2.5.0"), is(ImagePullPolicy.ALWAYS.toString()));
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

The method `determineImagePullPolicy` is used to replicate the Kubernetes default ImagePullPolicy -> use `always` when the mage with tag `latest` is used and use `IfNotPresent` for any other image. However, this method currently covers only the operator image which is using the `latest` tag. 

The Kafka images using the `latest-kafka-x.y.z` are not covered by this although these images are _as latest as the operator images_.

This PR updates the method to applied it not only on the images with the `latest`tag as well as with `latest-kafka-x.y.z`. This does not affect the images for releases or when the user configures some specific image pull policy. This should help anyone using master and latest images to have the fresher container image.