### PR TITLE
Bump Cruise Control to 2.0.101

### DIFF
--- a/docker-images/kafka/kafka-thirdparty-libs/2.3.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.3.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.4.0</strimzi-oauth.version>
-        <cruise-control.version>2.0.100</cruise-control.version>
+        <cruise-control.version>2.0.101</cruise-control.version>
     </properties>
 
     <repositories>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.3.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.3.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.4.0</strimzi-oauth.version>
-        <cruise-control.version>2.0.101</cruise-control.version>
+        <cruise-control.version>2.0.100</cruise-control.version>
     </properties>
 
     <repositories>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.4.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.4.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.4.0</strimzi-oauth.version>
-        <cruise-control.version>2.0.100</cruise-control.version>
+        <cruise-control.version>2.0.101</cruise-control.version>
     </properties>
 
     <repositories>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.4.0</strimzi-oauth.version>
-        <cruise-control.version>2.0.100</cruise-control.version>
+        <cruise-control.version>2.0.101</cruise-control.version>
     </properties>
 
     <repositories>

--- a/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.0.100</cruise-control.version>
+        <cruise-control.version>2.0.101</cruise-control.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Signed-off-by: Kyle Liberti <kliberti@redhat.com>

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Updates Cruise Control to v2.0.101 which includes Kafka dependency update to 2.4.1

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

