### PR TITLE
Skip unit and IT tests for system tests build in azure

### DIFF
--- a/.azure/pull-request-pipeline.yaml
+++ b/.azure/pull-request-pipeline.yaml
@@ -49,7 +49,7 @@ jobs:
           make docker_build
           make docker_tag
         env:
-          mvn_args: '-DskipTests'
+          MVN_ARGS: '-DskipTests'
         displayName: "Build Strimzi images locally"
 
       - task: Maven@3

--- a/.azure/pull-request-pipeline.yaml
+++ b/.azure/pull-request-pipeline.yaml
@@ -48,6 +48,8 @@ jobs:
       - bash: |
           make docker_build
           make docker_tag
+        env:
+          mvn_args: '-DskipTests'
         displayName: "Build Strimzi images locally"
 
       - task: Maven@3


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This PR skip unit and integration tests for azure builds which runs system tests. Unit and Integration tests are running in the build pipeline, which should be enough. This will reduce execution time for the system test pipeline.

### Checklist

- [x] Make sure all tests pass

