### PR TITLE
ST: Remove wrongly used inheritance in systemtest.topic.* tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicScalabilityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicScalabilityST.java
@@ -4,21 +4,29 @@
  */
 package io.strimzi.systemtest.topic;
 
+import io.strimzi.systemtest.BaseST;
+import io.strimzi.systemtest.resources.KubernetesResource;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static io.strimzi.systemtest.Constants.SCALABILITY;
 
 @Tag(SCALABILITY)
-public class TopicScalabilityST extends TopicST {
+public class TopicScalabilityST extends BaseST {
 
     private static final Logger LOGGER = LogManager.getLogger(TopicScalabilityST.class);
     private static final int NUMBER_OF_TOPICS = 1000;
     private static final int SAMPLE_OFFSET = 50;
+    static final String NAMESPACE = "topic-scale-cluster-test";
 
     @Test
     void testBigAmountOfTopicsCreatingViaK8s() {
@@ -43,4 +51,29 @@ public class TopicScalabilityST extends TopicST {
 
         KafkaTopicUtils.waitForKafkaTopicsCount(NUMBER_OF_TOPICS, CLUSTER_NAME);
     }
+
+    void deployTestSpecificResources() {
+        LOGGER.info("Deploying shared kafka across all test cases in {} namespace", NAMESPACE);
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1).done();
+    }
+
+    @Override
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws InterruptedException {
+        super.recreateTestEnv(coNamespace, bindingsNamespaces);
+        deployTestSpecificResources();
+    }
+
+    @BeforeAll
+    void setup() {
+        ResourceManager.setClassResources();
+        prepareEnvForOperator(NAMESPACE);
+
+        applyRoleBindings(NAMESPACE);
+        // 050-Deployment
+        KubernetesResource.clusterOperator(NAMESPACE).done();
+
+        LOGGER.info("Deploying shared kafka across all test cases in {} namespace", NAMESPACE);
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1).done();
+    }
+
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes wrongly used inheritance in `TopicScalabilityST`. When test class inherits from another test class, all tests from inherited class are executed by maven, which is not desired.

I also fixed NPE in one `TopicST` test.

### Checklist

- [x] Make sure all tests pass


