### PR TITLE
Fix timeout and NPE in Multiple and AllNamespace ST

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.systemtest;
 
-import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
+import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
@@ -67,7 +67,7 @@ public abstract class AbstractNamespaceST extends BaseST {
         KafkaMirrorMakerResource.kafkaMirrorMaker(CLUSTER_NAME, kafkaSourceName, kafkaTargetName, "my-group", 1, false).done();
 
         LOGGER.info("Waiting for creation {} in namespace {}", CLUSTER_NAME + "-mirror-maker", SECOND_NAMESPACE);
-        DeploymentUtils.waitForDeploymentAndPodsReady(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME), 1);
+        DeploymentUtils.waitForDeploymentAndPodsReady(KafkaMirrorMakerResources.deploymentName(CLUSTER_NAME), 1);
         cluster.setNamespace(previousNamespace);
     }
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This PR fix mirrormaker cluster name in  wait during `testDeployMirrorMakerAcrossMultipleNamespace` tests. We used there a name for mm2 instead of simple mm which caused timeout of wait and NPE.

### Checklist

- [x] Make sure all tests pass

