### PR TITLE
ST: Check CO logs not from begining but only for test execution time

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
@@ -5,6 +5,8 @@
 package io.strimzi.systemtest.logs;
 
 import io.strimzi.systemtest.Environment;
+import io.strimzi.test.timemeasuring.Operation;
+import io.strimzi.test.timemeasuring.TimeMeasuringSystem;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -52,6 +54,8 @@ public class TestExecutionWatcher implements TestExecutionExceptionHandler, Life
     }
 
     void collectLogs(String testClass, String testMethod) {
+        // Stop test execution time counter
+        TimeMeasuringSystem.getInstance().stopOperation(Operation.TEST_EXECUTION);
         // Get current date to create a unique folder
         final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss");
         simpleDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
@@ -54,7 +54,7 @@ public class TestExecutionWatcher implements TestExecutionExceptionHandler, Life
     }
 
     void collectLogs(String testClass, String testMethod) {
-        // Stop test execution time counter
+        // Stop test execution time counter in case of failures
         TimeMeasuringSystem.getInstance().stopOperation(Operation.TEST_EXECUTION);
         // Get current date to create a unique folder
         final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss");

--- a/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
@@ -738,9 +738,10 @@ public abstract class BaseST implements TestSeparator {
 
     @AfterEach
     void teardownEnvironmentMethod(ExtensionContext context) throws Exception {
+        TimeMeasuringSystem.getInstance().stopOperation(Operation.TEST_EXECUTION);
         AssertionError assertionError = null;
         try {
-            long testDuration = timeMeasuringSystem.getDuration(context.getTestClass().get().getName(), context.getTestMethod().get().getName(), Operation.TEST_EXECUTION.name());
+            long testDuration = timeMeasuringSystem.getDurationInSeconds(context.getTestClass().get().getName(), context.getTestMethod().get().getName(), Operation.TEST_EXECUTION.name());
             assertNoCoErrorsLogged(testDuration);
         } catch (AssertionError e) {
             LOGGER.error("Cluster Operator contains unexpected errors!");

--- a/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
@@ -24,6 +24,7 @@ import io.strimzi.test.k8s.HelmClient;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.cluster.Minishift;
 import io.strimzi.test.k8s.cluster.OpenShift;
+import io.strimzi.test.timemeasuring.Operation;
 import io.strimzi.test.timemeasuring.TimeMeasuringSystem;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -739,7 +740,8 @@ public abstract class BaseST implements TestSeparator {
     void teardownEnvironmentMethod(ExtensionContext context) throws Exception {
         AssertionError assertionError = null;
         try {
-            assertNoCoErrorsLogged(0);
+            long testDuration = timeMeasuringSystem.getDuration(context.getTestClass().get().getName(), context.getTestMethod().get().getName(), Operation.TEST_EXECUTION.name());
+            assertNoCoErrorsLogged(testDuration);
         } catch (AssertionError e) {
             LOGGER.error("Cluster Operator contains unexpected errors!");
             assertionError = new AssertionError(e);

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -983,7 +983,7 @@ class KafkaST extends BaseST {
         });
 
         timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
-        assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSecconds(testClass, testName, timeMeasuringSystem.getOperationID()));
+        assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSeconds(testClass, testName, timeMeasuringSystem.getOperationID()));
     }
 
     @Test
@@ -1026,7 +1026,7 @@ class KafkaST extends BaseST {
         });
 
         timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
-        assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSecconds(testClass, testName, timeMeasuringSystem.getOperationID()));
+        assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSeconds(testClass, testName, timeMeasuringSystem.getOperationID()));
     }
 
     @Test
@@ -1043,7 +1043,7 @@ class KafkaST extends BaseST {
             .done();
 
         timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
-        assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSecconds(testClass, testName, timeMeasuringSystem.getOperationID()));
+        assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSeconds(testClass, testName, timeMeasuringSystem.getOperationID()));
 
         //Checking that TO was not deployed
         kubeClient().listPodsByPrefixInName(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME)).forEach(pod -> {
@@ -1067,7 +1067,7 @@ class KafkaST extends BaseST {
             .done();
 
         timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
-        assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSecconds(testClass, testName, timeMeasuringSystem.getOperationID()));
+        assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSeconds(testClass, testName, timeMeasuringSystem.getOperationID()));
 
         //Checking that UO was not deployed
         kubeClient().listPodsByPrefixInName(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME)).forEach(pod -> {
@@ -1089,7 +1089,7 @@ class KafkaST extends BaseST {
             .done();
 
         timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
-        assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSecconds(testClass, testName, timeMeasuringSystem.getOperationID()));
+        assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSeconds(testClass, testName, timeMeasuringSystem.getOperationID()));
 
         //Checking that EO was not deployed
         assertThat("EO should not be deployed", kubeClient().listPodsByPrefixInName(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME)).size(), is(0));

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
@@ -247,9 +247,4 @@ class RecoveryST extends BaseST {
         super.recreateTestEnv(coNamespace, bindingsNamespaces);
         deployTestSpecificResources();
     }
-
-    @Override
-    protected void assertNoCoErrorsLogged(long sinceSeconds) {
-        LOGGER.info("No search in strimzi-cluster-operator log for errors");
-    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -412,7 +412,7 @@ class RollingUpdateST extends BaseST {
 
         //Test that CO doesn't have any exceptions in log
         timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
-        assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSecconds(testClass, testName, timeMeasuringSystem.getOperationID()));
+        assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSeconds(testClass, testName, timeMeasuringSystem.getOperationID()));
 
         // scale down
         int scaledDownReplicas = 3;

--- a/test/src/main/java/io/strimzi/test/timemeasuring/TimeMeasuringSystem.java
+++ b/test/src/main/java/io/strimzi/test/timemeasuring/TimeMeasuringSystem.java
@@ -208,7 +208,7 @@ public class TimeMeasuringSystem {
         instance.saveResults(instance.getSumDuration(), "duration_sum_report", path);
     }
 
-    public int getDurationInSecconds(String testClass, String testName, String operationID) {
+    public int getDurationInSeconds(String testClass, String testName, String operationID) {
         return (int) (instance.getTestDuration(testClass, testName, operationID) / 1000);
     }
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This PR changes the way how we check CO logs in tests. This new approach will check CO log only for recent X seconds, where X is equal to test duration. With this change, we should avoid test failures connected to race conditions during resource deletion, which cause expected errors in CO log, but our check will catch is as a problem.

### Checklist

- [ ] Make sure all tests pass

