### PR TITLE
[systemtest] Fix of wait for pods stability

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -234,28 +234,37 @@ public class PodUtils {
     }
 
     /**
-     * Method waitUntilPodsByNameStability ensuring for every pod listed for kafka or zookeeper statefulSet will be controlling
-     * their status in Running phase. If the pod will be running for selected time #Constants.GLOBAL_RECONCILIATION_COUNT
-     * pod is considered as a stable. Otherwise this procedure will be repeat.
-     * @param podNamePrefix all pods that matched the prefix will be verified
+     * Ensures that at least one pod from listed (by prefix) is in {@code Pending} phase
+     * @param podPrefix - all pods that matched the prefix will be verified
      */
-    public static void waitUntilPodsByNameStability(String podNamePrefix) {
-        verifyThatPodsAreStable(() -> ResourceManager.kubeClient().listPodsByPrefixInName(podNamePrefix));
+    public static void waitForPendingPod(String podPrefix) {
+        LOGGER.info("Wait for at least one pod with prefix: {} will be in pending phase", podPrefix);
+        TestUtils.waitFor("One pod to be in PENDING state", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> {
+                List<Pod> actualPods = kubeClient().listPodsByPrefixInName(podPrefix);
+                return actualPods.stream().anyMatch(pod -> pod.getStatus().getPhase().equals("Pending"));
+            });
     }
 
     /**
-     * * Waits until all matching pods are {@linkplain #verifyThatPodsAreStable(Supplier)} stable} in the "Running" phase.
-     * @param pods all pods that will be verified
-     */
-    public static void waitUntilPodsStability(List<Pod> pods) {
-        verifyThatPodsAreStable(() -> pods);
+     * Ensures every pod in a StatefulSet is stable in the {@code Running} phase.
+     * A pod must be in the Running phase for {@link Constants#GLOBAL_RECONCILIATION_COUNT} seconds for
+     * it to be considered as stable. Otherwise this procedure will be repeat.
+     * @param podPrefix all pods that matched the prefix will be verified
+     * */
+    public static void verifyThatRunningPodsAreStable(String podPrefix) {
+        LOGGER.info("Verify that all pods with prefix: {} are stable", podPrefix);
+        verifyThatPodsAreStable(podPrefix);
     }
 
-    private static void verifyThatPodsAreStable(Supplier<List<Pod>> pods) {
+    private static void verifyThatPodsAreStable(String podPrefix) {
         int[] stabilityCounter = {0};
+        List<Pod> runningPods = kubeClient().listPodsByPrefixInName(podPrefix).stream()
+            .filter(pod -> pod.getStatus().getPhase().equals("Running")).collect(Collectors.toList());
+
         TestUtils.waitFor("Pods stability", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
             () -> {
-                List<Pod> actualPods = pods.get().stream().map(p -> kubeClient().getPod(p.getMetadata().getName())).collect(Collectors.toList());
+                List<Pod> actualPods = runningPods.stream().map(p -> kubeClient().getPod(p.getMetadata().getName())).collect(Collectors.toList());
 
                 for (Pod pod : actualPods) {
                     if (pod.getStatus().getPhase().equals("Running")) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -19,7 +18,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -124,8 +124,8 @@ class RollingUpdateST extends BaseST {
         ClientUtils.waitUntilClientReceivedMessagesTls(internalKafkaClient, MESSAGE_COUNT);
 
         LOGGER.info("Verifying stability of kafka pods except the one, which is in pending phase");
-        PodUtils.waitUntilPodsStability(kubeClient().listPodsByPrefixInName(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME)).stream().filter(
-            p -> p.getStatus().getPhase().equals("Running")).collect(Collectors.toList()));
+        PodUtils.waitForPendingPod(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME));
+        PodUtils.verifyThatRunningPodsAreStable(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME));
 
         TestUtils.waitFor("Waiting for some zookeeper pod to be in the pending phase because of selected high cpu resource",
             Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
@@ -137,7 +137,7 @@ class RollingUpdateST extends BaseST {
             }
         );
 
-        PodUtils.waitUntilPodsStability(kubeClient().listPodsByPrefixInName(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)));
+        PodUtils.verifyThatRunningPodsAreStable(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
 
         internalKafkaClient.setConsumerGroup(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
 
@@ -216,7 +216,7 @@ class RollingUpdateST extends BaseST {
 
         ClientUtils.waitUntilClientReceivedMessagesTls(internalKafkaClient, MESSAGE_COUNT);
 
-        PodUtils.waitUntilPodsStability(kubeClient().listPodsByPrefixInName(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME)));
+        PodUtils.verifyThatRunningPodsAreStable(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME));
 
         TestUtils.waitFor("Waiting for some kafka pod to be in the pending phase because of selected high cpu resource",
             Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
@@ -231,8 +231,8 @@ class RollingUpdateST extends BaseST {
         internalKafkaClient.setConsumerGroup(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
 
         LOGGER.info("Verifying stability of kafka pods except the one, which is in pending phase");
-        PodUtils.waitUntilPodsStability(kubeClient().listPodsByPrefixInName(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).stream().filter(
-            p -> p.getStatus().getPhase().equals("Running")).collect(Collectors.toList()));
+        PodUtils.waitForPendingPod(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
+        PodUtils.verifyThatRunningPodsAreStable(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
 
         ClientUtils.waitUntilClientReceivedMessagesTls(internalKafkaClient, MESSAGE_COUNT);
 
@@ -427,7 +427,7 @@ class RollingUpdateST extends BaseST {
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
             .endMetadata().done();
 
-        PodUtils.waitUntilPodsStability(kubeClient().listPodsByPrefixInName(CLUSTER_NAME));
+        PodUtils.verifyThatRunningPodsAreStable(CLUSTER_NAME);
 
         Map<String, String> kafkaPodsScaleDown = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
 
@@ -676,7 +676,7 @@ class RollingUpdateST extends BaseST {
         configMap.getData().put("new.kafka.config", "new.config.value");
         kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMap);
 
-        PodUtils.waitUntilPodsStability(kubeClient().listPodsByPrefixInName(CLUSTER_NAME));
+        PodUtils.verifyThatRunningPodsAreStable(CLUSTER_NAME);
 
         assertThat(StatefulSetUtils.ssSnapshot(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME)), is(zkPods));
         assertThat(StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)), is(kafkaPods));

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -659,7 +659,7 @@ class SecurityST extends BaseST {
             kubeClient().deleteSecret(s.getMetadata().getName());
         }
 
-        PodUtils.waitUntilPodsStability(kubeClient().listPodsByPrefixInName(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)));
+        PodUtils.verifyThatRunningPodsAreStable(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
         StatefulSetUtils.waitTillSsHasRolled(kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaPods);
 
         for (Secret s : secrets) {
@@ -1340,7 +1340,7 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Verifying that Kafka Connect is stable");
 
-        PodUtils.waitUntilPodsByNameStability(KafkaConnectResources.deploymentName(CLUSTER_NAME));
+        PodUtils.verifyThatRunningPodsAreStable(KafkaConnectResources.deploymentName(CLUSTER_NAME));
 
         LOGGER.info("Verifying that Kafka Connect status is Ready because of same TLS version");
 
@@ -1400,7 +1400,7 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Verifying that Kafka Connect is stable");
 
-        PodUtils.waitUntilPodsByNameStability(KafkaConnectResources.deploymentName(CLUSTER_NAME));
+        PodUtils.verifyThatRunningPodsAreStable(KafkaConnectResources.deploymentName(CLUSTER_NAME));
 
         LOGGER.info("Verifying that Kafka Connect status is Ready because of the same cipher suites complexity of algorithm");
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
@@ -149,7 +149,7 @@ public class ZookeeperUpgradeST extends BaseST {
 
         LOGGER.info("Deployment of Kafka (" + newVersion.version() + ") complete");
 
-        PodUtils.waitUntilPodsStability(kubeClient().listPodsByPrefixInName(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)));
+        PodUtils.verifyThatRunningPodsAreStable(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
 
         // Extract the zookeeper version number from the jars in the lib directory
         zkResult = cmdKubeClient().execInPodContainer(KafkaResources.zookeeperPodName(CLUSTER_NAME, 0),


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Problem that this PR's gonna fix was in waitUntilPodsStability method - when we listed all pods that is in Running phase, method start even if there were no pods with Pending phase. So the whole tests crashed, because in like 5s there was Pending pod and stability was over. I add method that will wait for at least one Pending pod and after that will continue with method that will wait for stability. This should remove race conditions we had in tests.

Fixes #2929 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass


