### PR TITLE
Roll Cruise Control deployment for new CA keys

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -733,6 +733,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         .compose(i -> rollDeploymentIfExists(io.strimzi.operator.cluster.model.TopicOperator.topicOperatorName(name), reasons))
                         .compose(i -> rollDeploymentIfExists(EntityOperator.entityOperatorName(name), reasons))
                         .compose(i -> rollDeploymentIfExists(KafkaExporter.kafkaExporterName(name), reasons))
+                        .compose(i -> rollDeploymentIfExists(CruiseControl.cruiseControlName(name), reasons))
                         .map(i -> this);
             } else {
                 return Future.succeededFuture(this);


### PR DESCRIPTION
Signed-off-by: Kyle Liberti <kliberti@redhat.com>

### Type of change

- Bugfix

### Description

Make sure the Cruise Control deployment is rolled to pick up new CA keys

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

