### PR TITLE
Chores: bump up f8 dep

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,7 +23,19 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model</artifactId>
+            <artifactId>kubernetes-model-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-rbac</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-networking</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apiextensions</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -107,7 +119,7 @@
                         <goals>
                             <goal>compile</goal>
                         </goals>
-                        <configuration combine.self="override">>
+                        <configuration combine.self="override">
                             <compilerArgs>
                                 <arg>-Xlint:unchecked,deprecation</arg>
                             </compilerArgs>

--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -14,6 +14,7 @@ import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.internal.KubernetesDeserializer;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.DoneableKafka;
@@ -261,11 +262,11 @@ public class Crds {
     }
 
     public static MixedOperation<Kafka, KafkaList, DoneableKafka, Resource<Kafka, DoneableKafka>> kafkaOperation(KubernetesClient client) {
-        return client.customResources(kafka(), Kafka.class, KafkaList.class, DoneableKafka.class);
+        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafka()), Kafka.class, KafkaList.class, DoneableKafka.class);
     }
 
     public static MixedOperation<Kafka, KafkaList, DoneableKafka, Resource<Kafka, DoneableKafka>> kafkaV1Alpha1Operation(KubernetesClient client) {
-        return client.customResources(crd(Kafka.class, Constants.V1ALPHA1), Kafka.class, KafkaList.class, DoneableKafka.class);
+        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd(Kafka.class, Constants.V1ALPHA1)), Kafka.class, KafkaList.class, DoneableKafka.class);
     }
 
     public static CustomResourceDefinition kafkaConnect() {
@@ -273,7 +274,7 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaConnect, KafkaConnectList, DoneableKafkaConnect, Resource<KafkaConnect, DoneableKafkaConnect>> kafkaConnectOperation(KubernetesClient client) {
-        return client.customResources(kafkaConnect(), KafkaConnect.class, KafkaConnectList.class, DoneableKafkaConnect.class);
+        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaConnect()), KafkaConnect.class, KafkaConnectList.class, DoneableKafkaConnect.class);
     }
 
     public static CustomResourceDefinition kafkaConnector() {
@@ -281,7 +282,7 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaConnector, KafkaConnectorList, DoneableKafkaConnector, Resource<KafkaConnector, DoneableKafkaConnector>> kafkaConnectorOperation(KubernetesClient client) {
-        return client.customResources(kafkaConnector(), KafkaConnector.class, KafkaConnectorList.class, DoneableKafkaConnector.class);
+        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaConnector()), KafkaConnector.class, KafkaConnectorList.class, DoneableKafkaConnector.class);
     }
 
     public static CustomResourceDefinition kafkaConnectS2I() {
@@ -289,7 +290,7 @@ public class Crds {
     }
 
     public static <D extends CustomResourceDoneable<T>, T extends CustomResource> MixedOperation<KafkaConnectS2I, KafkaConnectS2IList, DoneableKafkaConnectS2I, Resource<KafkaConnectS2I, DoneableKafkaConnectS2I>> kafkaConnectS2iOperation(KubernetesClient client) {
-        return client.customResources(Crds.kafkaConnectS2I(), KafkaConnectS2I.class, KafkaConnectS2IList.class, DoneableKafkaConnectS2I.class);
+        return client.customResources(CustomResourceDefinitionContext.fromCrd(Crds.kafkaConnectS2I()), KafkaConnectS2I.class, KafkaConnectS2IList.class, DoneableKafkaConnectS2I.class);
     }
 
     public static CustomResourceDefinition kafkaTopic() {
@@ -297,7 +298,7 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaTopic, KafkaTopicList, DoneableKafkaTopic, Resource<KafkaTopic, DoneableKafkaTopic>> topicOperation(KubernetesClient client) {
-        return client.customResources(kafkaTopic(), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
+        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaTopic()), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
     }
 
     public static CustomResourceDefinition kafkaUser() {
@@ -305,7 +306,7 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaUser, KafkaUserList, DoneableKafkaUser, Resource<KafkaUser, DoneableKafkaUser>> kafkaUserOperation(KubernetesClient client) {
-        return client.customResources(kafkaUser(), KafkaUser.class, KafkaUserList.class, DoneableKafkaUser.class);
+        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaUser()), KafkaUser.class, KafkaUserList.class, DoneableKafkaUser.class);
     }
 
     public static CustomResourceDefinition kafkaMirrorMaker() {
@@ -313,7 +314,7 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaMirrorMaker, KafkaMirrorMakerList, DoneableKafkaMirrorMaker, Resource<KafkaMirrorMaker, DoneableKafkaMirrorMaker>> mirrorMakerOperation(KubernetesClient client) {
-        return client.customResources(kafkaMirrorMaker(), KafkaMirrorMaker.class, KafkaMirrorMakerList.class, DoneableKafkaMirrorMaker.class);
+        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaMirrorMaker()), KafkaMirrorMaker.class, KafkaMirrorMakerList.class, DoneableKafkaMirrorMaker.class);
     }
 
     public static CustomResourceDefinition kafkaBridge() {
@@ -321,7 +322,7 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaBridge, KafkaBridgeList, DoneableKafkaBridge, Resource<KafkaBridge, DoneableKafkaBridge>> kafkaBridgeOperation(KubernetesClient client) {
-        return client.customResources(kafkaBridge(), KafkaBridge.class, KafkaBridgeList.class, DoneableKafkaBridge.class);
+        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaBridge()), KafkaBridge.class, KafkaBridgeList.class, DoneableKafkaBridge.class);
     }
 
     public static CustomResourceDefinition kafkaMirrorMaker2() {
@@ -329,7 +330,7 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaMirrorMaker2, KafkaMirrorMaker2List, DoneableKafkaMirrorMaker2, Resource<KafkaMirrorMaker2, DoneableKafkaMirrorMaker2>> kafkaMirrorMaker2Operation(KubernetesClient client) {
-        return client.customResources(kafkaMirrorMaker2(), KafkaMirrorMaker2.class, KafkaMirrorMaker2List.class, DoneableKafkaMirrorMaker2.class);
+        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaMirrorMaker2()), KafkaMirrorMaker2.class, KafkaMirrorMaker2List.class, DoneableKafkaMirrorMaker2.class);
     }
 
     public static CustomResourceDefinition kafkaRebalance() {
@@ -337,7 +338,7 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaRebalance, KafkaRebalanceList, DoneableKafkaRebalance, Resource<KafkaRebalance, DoneableKafkaRebalance>> kafkaRebalanceOperation(KubernetesClient client) {
-        return client.customResources(kafkaRebalance(), KafkaRebalance.class, KafkaRebalanceList.class, DoneableKafkaRebalance.class);
+        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaRebalance()), KafkaRebalance.class, KafkaRebalanceList.class, DoneableKafkaRebalance.class);
     }
 
     public static <T extends CustomResource, L extends CustomResourceList<T>, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>>
@@ -345,7 +346,7 @@ public class Crds {
                       Class<T> cls,
                       Class<L> listCls,
                       Class<D> doneableCls) {
-        return client.customResources(crd(cls), cls, listCls, doneableCls);
+        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd(cls)), cls, listCls, doneableCls);
     }
 
     public static <T extends CustomResource> String kind(Class<T> cls) {

--- a/certificate-manager/pom.xml
+++ b/certificate-manager/pom.xml
@@ -20,7 +20,7 @@
   <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-model</artifactId>
+      <artifactId>kubernetes-model-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -43,7 +43,39 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model</artifactId>
+            <artifactId>kubernetes-model-extensions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apiextensions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-policy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-rbac</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apps</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-storageclass</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-networking</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-model</artifactId>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -70,12 +70,6 @@ public class Main {
                         .setJvmMetricsEnabled(true)
                         .setEnabled(true));
         Vertx vertx = Vertx.vertx(options);
-
-        // Workaround for https://github.com/fabric8io/kubernetes-client/issues/2212
-        // Can be removed after upgrade to Fabric8 4.10.2 or higher or to Java 11
-        if (Util.shouldDisableHttp2()) {
-            System.setProperty("http2.disable", "true");
-        }
         
         KubernetesClient client = new DefaultKubernetesClient();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.operator.resource;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -333,7 +334,7 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
             long pollingIntervalMs = 1_000;
             long timeoutMs = operationTimeoutMs;
 
-            operation().inNamespace(namespace).withName(name).cascading(cascading).withGracePeriod(-1L).delete();
+            operation().inNamespace(namespace).withName(name).withPropagationPolicy(cascading ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN).withGracePeriod(-1L).delete();
 
             Future<Void> deletedFut = waitFor(namespace, name, "deleted", pollingIntervalMs, timeoutMs, (ignore1, ignore2) -> {
                 StatefulSet sts = get(namespace, name);
@@ -372,7 +373,7 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
         vertx.createSharedWorkerExecutor("kubernetes-ops-tool").executeBlocking(
             future -> {
                 try {
-                    Boolean deleted = operation().inNamespace(namespace).withName(name).cascading(cascading).withGracePeriod(-1L).delete();
+                    Boolean deleted = operation().inNamespace(namespace).withName(name).withPropagationPolicy(cascading ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN).withGracePeriod(-1L).delete();
 
                     if (deleted) {
                         log.debug("{} {} in namespace {} has been deleted", resourceKind, name, namespace);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -14,6 +14,7 @@ import io.fabric8.kubernetes.client.dsl.FilterWatchListMultiDeletable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
@@ -147,7 +148,7 @@ public class ClusterOperatorTest {
         }
         when(mockCrds.withName(KafkaConnectS2I.CRD_NAME)).thenReturn(mockResource);
         when(client.customResourceDefinitions()).thenReturn(mockCrds);
-        when(client.customResources(any(), any(), any(), any())).thenReturn(mockCms);
+        when(client.customResources(any(CustomResourceDefinitionContext.class), any(), any(), any())).thenReturn(mockCms);
 
         List<String> namespaceList = asList(namespaces.split(" *,+ *"));
         for (String namespace: namespaceList) {
@@ -229,7 +230,7 @@ public class ClusterOperatorTest {
         }
         when(mockCrds.withName(KafkaConnectS2I.CRD_NAME)).thenReturn(mockResource);
         when(client.customResourceDefinitions()).thenReturn(mockCrds);
-        when(client.customResources(any(), any(), any(), any())).thenReturn(mockCms);
+        when(client.customResources(any(CustomResourceDefinitionContext.class), any(), any(), any())).thenReturn(mockCms);
 
         FilterWatchListMultiDeletable mockFilteredCms = mock(FilterWatchListMultiDeletable.class);
         when(mockFilteredCms.withLabels(any())).thenReturn(mockFilteredCms);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -442,7 +442,8 @@ public class ResourceUtils {
                     .withNamespace(namespace)
                     .withLabels(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
                             "my-user-label", "cromulent"))
-                    .build())
+                    .withAnnotations(emptyMap())
+                .build())
                 .withNewSpec()
                 .endSpec()
                 .build();
@@ -458,6 +459,7 @@ public class ResourceUtils {
                         .withNamespace(namespace)
                         .withLabels(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
                                 "my-user-label", "cromulent"))
+                        .withAnnotations(emptyMap())
                         .build())
                 .withNewSpec()
                 .endSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -358,7 +358,7 @@ public class EntityOperatorTest {
         EntityOperator eo = EntityOperator.fromCrd(resource, VERSIONS);
 
         Deployment dep = eo.generateDeployment(true, Collections.EMPTY_MAP, null, null);
-        assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().size(), is(0));
+        assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -525,7 +525,7 @@ public class KafkaBridgeClusterTest {
         KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(resource, VERSIONS);
 
         Deployment dep = kbc.generateDeployment(emptyMap(), true, null, null);
-        assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().size(), is(0));
+        assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -347,7 +347,7 @@ public class KafkaClusterTest {
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
         StatefulSet sts = kc.generateStatefulSet(false, null, null);
-        assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit().getAmount(), is(sizeLimit));
+        assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit(), is(new Quantity("1", "Gi")));
     }
 
     @Test
@@ -1586,15 +1586,15 @@ public class KafkaClusterTest {
 
         List<NetworkPolicyIngressRule> rules = np.getSpec().getIngress().stream().filter(ing -> ing.getPorts().get(0).getPort().equals(new IntOrString(KafkaCluster.CLIENT_PORT))).collect(Collectors.toList());
         assertThat(rules.size(), is(1));
-        assertThat(rules.get(0).getFrom().size(), is(0));
+        assertThat(rules.get(0).getFrom(), is(nullValue()));
 
         rules = np.getSpec().getIngress().stream().filter(ing -> ing.getPorts().get(0).getPort().equals(new IntOrString(KafkaCluster.CLIENT_TLS_PORT))).collect(Collectors.toList());
         assertThat(rules.size(), is(1));
-        assertThat(rules.get(0).getFrom().size(), is(0));
+        assertThat(rules.get(0).getFrom(), is(nullValue()));
 
         rules = np.getSpec().getIngress().stream().filter(ing -> ing.getPorts().get(0).getPort().equals(new IntOrString(KafkaCluster.EXTERNAL_PORT))).collect(Collectors.toList());
         assertThat(rules.size(), is(1));
-        assertThat(rules.get(0).getFrom().size(), is(0));
+        assertThat(rules.get(0).getFrom(), is(nullValue()));
     }
 
     @Test
@@ -1705,7 +1705,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
         StatefulSet sts = kc.generateStatefulSet(true, null, null);
-        assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().size(), is(0));
+        assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -893,7 +893,7 @@ public class KafkaConnectClusterTest {
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(resource, VERSIONS);
 
         Deployment dep = kc.generateDeployment(emptyMap(), true, null, null);
-        assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().size(), is(0));
+        assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
     @Test
@@ -1333,7 +1333,7 @@ public class KafkaConnectClusterTest {
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(0).getPodSelector().getMatchLabels(), is(kc.getSelectorLabels().toMap()));
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(0).getNamespaceSelector(), is(nullValue()));
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getPodSelector().getMatchLabels(), is(singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator")));
-        assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getNamespaceSelector().getMatchLabels(), is(emptyMap()));
+        assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getNamespaceSelector().getMatchLabels(), is(nullValue()));
         assertThat(np.getSpec().getIngress().get(1).getPorts().size(), is(1));
         assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -281,7 +281,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(bc.getSpec().getSuccessfulBuildsHistoryLimit(), is(new Integer(5)));
         assertThat(bc.getSpec().getFailedBuildsHistoryLimit(), is(new Integer(5)));
         assertThat(bc.getSpec().getResources().getLimits().get("cpu").getAmount(), is("42"));
-        assertThat(bc.getSpec().getResources().getRequests().get("mem").getAmount(), is("4Gi"));
+        assertThat(bc.getSpec().getResources().getRequests().get("mem"), is(new Quantity("4", "Gi")));
         checkOwnerReference(kc.createOwnerReference(), bc);
     }
 
@@ -869,7 +869,7 @@ public class KafkaConnectS2IClusterTest {
         KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(resource, VERSIONS);
 
         DeploymentConfig dep = kc.generateDeploymentConfig(Collections.EMPTY_MAP, true, null, null);
-        assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().size(), is(0));
+        assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
     @Test
@@ -1274,7 +1274,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(0).getPodSelector().getMatchLabels(), is(kc.getSelectorLabels().toMap()));
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(0).getNamespaceSelector(), is(nullValue()));
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getPodSelector().getMatchLabels(), is(singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator")));
-        assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getNamespaceSelector().getMatchLabels(), is(emptyMap()));
+        assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getNamespaceSelector().getMatchLabels(), is(nullValue()));
         assertThat(np.getSpec().getIngress().get(1).getPorts().size(), is(1));
         assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -1002,7 +1002,7 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(resource, VERSIONS);
 
         Deployment dep = kmm2.generateDeployment(emptyMap(), true, null, null);
-        assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().size(), is(0));
+        assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
     @Test
@@ -1441,7 +1441,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(0).getPodSelector().getMatchLabels(), is(kc.getSelectorLabels().toMap()));
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(0).getNamespaceSelector(), is(nullValue()));
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getPodSelector().getMatchLabels(), is(singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator")));
-        assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getNamespaceSelector().getMatchLabels(), is(emptyMap()));
+        assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getNamespaceSelector().getMatchLabels(), is(nullValue()));
         assertThat(np.getSpec().getIngress().get(1).getPorts().size(), is(1));
         assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -601,7 +601,7 @@ public class KafkaMirrorMakerClusterTest {
         KafkaMirrorMakerCluster mmc = KafkaMirrorMakerCluster.fromCrd(resource, VERSIONS);
 
         Deployment dep = mmc.generateDeployment(emptyMap(), true, null, null);
-        assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().size(), is(0));
+        assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/VolumeUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/VolumeUtilsTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.fabric8.kubernetes.api.model.Quantity;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.Volume;
@@ -17,7 +18,7 @@ public class VolumeUtilsTest {
     @Test
     public void testCreateEmptyDirVolumeWithSizeLimit() {
         Volume volume = VolumeUtils.createEmptyDirVolume("bar", "1Gi");
-        assertThat(volume.getEmptyDir().getSizeLimit().getAmount(), is("1Gi"));
+        assertThat(volume.getEmptyDir().getSizeLimit(), is(new Quantity("1", "Gi")));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -558,7 +558,7 @@ public class ZookeeperClusterTest {
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(kafkaAssembly, VERSIONS);
 
         StatefulSet sts = zc.generateStatefulSet(true, null, null);
-        assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().size(), is(0));
+        assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
     @Test
@@ -930,7 +930,7 @@ public class ZookeeperClusterTest {
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(ka, VERSIONS);
 
         StatefulSet sts = zc.generateStatefulSet(false, null, null);
-        assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit().getAmount(), is(sizeLimit));
+        assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit(), is(new Quantity("1", "Gi")));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -139,7 +139,7 @@ public class ZookeeperClusterTest {
         assertThat(headful.getSpec().getPorts().get(0).getName(), is(ZookeeperCluster.CLIENT_TLS_PORT_NAME));
         assertThat(headful.getSpec().getPorts().get(0).getPort(), is(new Integer(ZookeeperCluster.CLIENT_TLS_PORT)));
         assertThat(headful.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
-        assertThat(headful.getMetadata().getAnnotations().size(), is(0));
+        assertThat(headful.getMetadata().getAnnotations(), is(nullValue()));
 
         checkOwnerReference(zc.createOwnerReference(), headful);
     }
@@ -163,9 +163,7 @@ public class ZookeeperClusterTest {
         assertThat(headful.getSpec().getPorts().get(0).getPort(), is(new Integer(ZookeeperCluster.CLIENT_TLS_PORT)));
         assertThat(headful.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
 
-        assertThat(headful.getMetadata().getAnnotations().containsKey("prometheus.io/port"), is(false));
-        assertThat(headful.getMetadata().getAnnotations().containsKey("prometheus.io/scrape"), is(false));
-        assertThat(headful.getMetadata().getAnnotations().containsKey("prometheus.io/path"), is(false));
+        assertThat(headful.getMetadata().getAnnotations(), is(nullValue()));
 
         checkOwnerReference(zc.createOwnerReference(), headful);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
@@ -18,6 +19,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSetSpec;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetStatus;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaList;
 import io.strimzi.api.kafka.model.DoneableKafka;
@@ -356,7 +358,7 @@ public class KafkaAssemblyOperatorMockTest {
         initialReconcile(context)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 for (String secret: secrets) {
-                    client.secrets().inNamespace(NAMESPACE).withName(secret).cascading(true).delete();
+                    client.secrets().inNamespace(NAMESPACE).withName(secret).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
                     assertThat("Expected secret " + secret + " to not exist",
                             client.secrets().inNamespace(NAMESPACE).withName(secret).get(), is(nullValue()));
                 }
@@ -381,7 +383,7 @@ public class KafkaAssemblyOperatorMockTest {
         initialReconcile(context)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 for (String service : services) {
-                    client.services().inNamespace(NAMESPACE).withName(service).cascading(true).delete();
+                    client.services().inNamespace(NAMESPACE).withName(service).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
                     assertThat("Expected service " + service + " to be not exist",
                             client.services().inNamespace(NAMESPACE).withName(service).get(), is(nullValue()));
                 }
@@ -440,7 +442,7 @@ public class KafkaAssemblyOperatorMockTest {
 
         initialReconcile(context)
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                client.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSet).cascading(true).delete();
+                client.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSet).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
                 assertThat("Expected sts " + statefulSet + " should not exist",
                         client.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSet).get(), is(nullValue()));
 
@@ -494,7 +496,7 @@ public class KafkaAssemblyOperatorMockTest {
 
     private Resource<Kafka, DoneableKafka> kafkaAssembly(String namespace, String name) {
         CustomResourceDefinition crd = client.customResourceDefinitions().withName(Kafka.CRD_NAME).get();
-        return client.customResources(crd, Kafka.class, KafkaList.class, DoneableKafka.class)
+        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd), Kafka.class, KafkaList.class, DoneableKafka.class)
                 .inNamespace(namespace).withName(name);
     }
 
@@ -667,7 +669,7 @@ public class KafkaAssemblyOperatorMockTest {
                                     .getMetadata().getAnnotations(),
                             hasEntry(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM, String.valueOf(!originalKafkaDeleteClaim.get())));
                 }
-                kafkaAssembly(NAMESPACE, CLUSTER_NAME).cascading(true).delete();
+                kafkaAssembly(NAMESPACE, CLUSTER_NAME).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
                 LOGGER.info("Reconciling again -> delete");
             })))
             .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)))

--- a/crd-generator/pom.xml
+++ b/crd-generator/pom.xml
@@ -40,7 +40,7 @@
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-model</artifactId>
+      <artifactId>kubernetes-model-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Crd.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Crd.java
@@ -4,8 +4,6 @@
  */
 package io.strimzi.crdgenerator.annotations;
 
-import io.fabric8.kubernetes.api.model.extensions.Scale;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -1260,6 +1260,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -1296,6 +1298,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
@@ -1761,6 +1765,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the Kafka broker container.
                     tlsSidecarContainer:
@@ -1824,6 +1830,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the Kafka broker TLS sidecar container.
                     initContainer:
@@ -1886,6 +1894,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Kafka init container.
@@ -2330,6 +2340,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -2366,6 +2378,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
@@ -2725,6 +2739,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the ZooKeeper container.
                     tlsSidecarContainer:
@@ -2787,6 +2803,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Zookeeper server TLS sidecar container. The TLS sidecar is not used anymore and this option will be ignored.
@@ -3838,6 +3856,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -3874,6 +3894,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
@@ -4173,6 +4195,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the Entity Operator TLS sidecar container.
                     topicOperatorContainer:
@@ -4236,6 +4260,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the Entity Topic Operator container.
                     userOperatorContainer:
@@ -4298,6 +4324,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Entity User Operator container.
@@ -4561,6 +4589,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -4597,6 +4627,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
@@ -4928,6 +4960,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the Cruise Control container.
                     tlsSidecarContainer:
@@ -4990,6 +5024,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Cruise Control TLS sidecar container.
@@ -5134,6 +5170,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -5170,6 +5208,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
@@ -5469,6 +5509,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for JmxTrans container.
                   description: Template for JmxTrans resources.
@@ -5545,6 +5587,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -5581,6 +5625,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
@@ -5893,6 +5939,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Kafka Exporter container.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -580,6 +580,8 @@ spec:
                       properties:
                         fsGroup:
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         runAsGroup:
                           type: integer
                         runAsNonRoot:
@@ -616,6 +618,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
@@ -928,6 +932,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Security context for the container.
                   description: Template for the Kafka Connect container.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -406,6 +406,8 @@ spec:
                       properties:
                         fsGroup:
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         runAsGroup:
                           type: integer
                         runAsNonRoot:
@@ -442,6 +444,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
@@ -754,6 +758,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Security context for the container.
                   description: Template for the Kafka Connect container.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -719,6 +719,8 @@ spec:
                       properties:
                         fsGroup:
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         runAsGroup:
                           type: integer
                         runAsNonRoot:
@@ -755,6 +757,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
@@ -1053,6 +1057,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Security context for the container.
                   description: Template for Kafka MirrorMaker container.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -380,6 +380,8 @@ spec:
                       properties:
                         fsGroup:
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         runAsGroup:
                           type: integer
                         runAsNonRoot:
@@ -416,6 +418,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
@@ -728,6 +732,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Security context for the container.
                   description: Template for the Kafka Bridge container.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -662,6 +662,8 @@ spec:
                       properties:
                         fsGroup:
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         runAsGroup:
                           type: integer
                         runAsNonRoot:
@@ -698,6 +700,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
@@ -1010,6 +1014,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Security context for the container.
                   description: Template for the Kafka Connect container.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1256,6 +1256,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -1292,6 +1294,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
@@ -1757,6 +1761,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the Kafka broker container.
                     tlsSidecarContainer:
@@ -1820,6 +1826,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the Kafka broker TLS sidecar container.
                     initContainer:
@@ -1882,6 +1890,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Kafka init container.
@@ -2326,6 +2336,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -2362,6 +2374,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
@@ -2721,6 +2735,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the ZooKeeper container.
                     tlsSidecarContainer:
@@ -2783,6 +2799,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Zookeeper server TLS sidecar container. The TLS sidecar is not used anymore and this option will be ignored.
@@ -3834,6 +3852,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -3870,6 +3890,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
@@ -4169,6 +4191,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the Entity Operator TLS sidecar container.
                     topicOperatorContainer:
@@ -4232,6 +4256,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the Entity Topic Operator container.
                     userOperatorContainer:
@@ -4294,6 +4320,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Entity User Operator container.
@@ -4557,6 +4585,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -4593,6 +4623,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
@@ -4924,6 +4956,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the Cruise Control container.
                     tlsSidecarContainer:
@@ -4986,6 +5020,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Cruise Control TLS sidecar container.
@@ -5130,6 +5166,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -5166,6 +5204,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
@@ -5465,6 +5505,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for JmxTrans container.
                   description: Template for JmxTrans resources.
@@ -5541,6 +5583,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -5577,6 +5621,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
@@ -5889,6 +5935,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Kafka Exporter container.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -576,6 +576,8 @@ spec:
                       properties:
                         fsGroup:
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         runAsGroup:
                           type: integer
                         runAsNonRoot:
@@ -612,6 +614,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
@@ -924,6 +928,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Security context for the container.
                   description: Template for the Kafka Connect container.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -402,6 +402,8 @@ spec:
                       properties:
                         fsGroup:
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         runAsGroup:
                           type: integer
                         runAsNonRoot:
@@ -438,6 +440,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
@@ -750,6 +754,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Security context for the container.
                   description: Template for the Kafka Connect container.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -715,6 +715,8 @@ spec:
                       properties:
                         fsGroup:
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         runAsGroup:
                           type: integer
                         runAsNonRoot:
@@ -751,6 +753,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
@@ -1049,6 +1053,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Security context for the container.
                   description: Template for Kafka MirrorMaker container.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -376,6 +376,8 @@ spec:
                       properties:
                         fsGroup:
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         runAsGroup:
                           type: integer
                         runAsNonRoot:
@@ -412,6 +414,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
@@ -724,6 +728,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Security context for the container.
                   description: Template for the Kafka Bridge container.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -658,6 +658,8 @@ spec:
                       properties:
                         fsGroup:
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         runAsGroup:
                           type: integer
                         runAsNonRoot:
@@ -694,6 +696,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
@@ -1006,6 +1010,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Security context for the container.
                   description: Template for the Kafka Connect container.

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1576,6 +1576,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -1612,6 +1614,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and
                             common container settings.
@@ -2167,6 +2171,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the Kafka broker container.
                     tlsSidecarContainer:
@@ -2231,6 +2237,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the Kafka broker TLS sidecar container.
                     initContainer:
@@ -2294,6 +2302,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Kafka init container.
@@ -2791,6 +2801,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -2827,6 +2839,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and
                             common container settings.
@@ -3223,6 +3237,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the ZooKeeper container.
                     tlsSidecarContainer:
@@ -3286,6 +3302,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Zookeeper server TLS sidecar container.
@@ -4440,6 +4458,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -4476,6 +4496,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and
                             common container settings.
@@ -4790,6 +4812,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the Entity Operator TLS sidecar container.
                     topicOperatorContainer:
@@ -4854,6 +4878,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the Entity Topic Operator container.
                     userOperatorContainer:
@@ -4917,6 +4943,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Entity User Operator container.
@@ -5246,6 +5274,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -5282,6 +5312,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and
                             common container settings.
@@ -5642,6 +5674,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for the Cruise Control container.
                     tlsSidecarContainer:
@@ -5705,6 +5739,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Cruise Control TLS sidecar container.
@@ -5899,6 +5935,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -5935,6 +5973,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and
                             common container settings.
@@ -6249,6 +6289,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                runAsUserName:
+                                  type: string
                           description: Security context for the container.
                       description: Template for JmxTrans container.
                   description: Template for JmxTrans resources.
@@ -6347,6 +6389,8 @@ spec:
                           properties:
                             fsGroup:
                               type: integer
+                            fsGroupChangePolicy:
+                              type: string
                             runAsGroup:
                               type: integer
                             runAsNonRoot:
@@ -6383,6 +6427,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Configures pod-level security attributes and
                             common container settings.
@@ -6714,6 +6760,8 @@ spec:
                                 gmsaCredentialSpec:
                                   type: string
                                 gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Kafka Exporter container.

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -642,6 +642,8 @@ spec:
                       properties:
                         fsGroup:
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         runAsGroup:
                           type: integer
                         runAsNonRoot:
@@ -678,6 +680,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Configures pod-level security attributes and common
                         container settings.
@@ -1008,6 +1012,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Security context for the container.
                   description: Template for the Kafka Connect container.

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -430,6 +430,8 @@ spec:
                       properties:
                         fsGroup:
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         runAsGroup:
                           type: integer
                         runAsNonRoot:
@@ -466,6 +468,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Configures pod-level security attributes and common
                         container settings.
@@ -796,6 +800,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Security context for the container.
                   description: Template for the Kafka Connect container.

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -814,6 +814,8 @@ spec:
                       properties:
                         fsGroup:
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         runAsGroup:
                           type: integer
                         runAsNonRoot:
@@ -850,6 +852,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Configures pod-level security attributes and common
                         container settings.
@@ -1162,6 +1166,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Security context for the container.
                   description: Template for Kafka MirrorMaker container.

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -442,6 +442,8 @@ spec:
                       properties:
                         fsGroup:
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         runAsGroup:
                           type: integer
                         runAsNonRoot:
@@ -478,6 +480,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Configures pod-level security attributes and common
                         container settings.
@@ -808,6 +812,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Security context for the container.
                   description: Template for the Kafka Bridge container.

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -748,6 +748,8 @@ spec:
                       properties:
                         fsGroup:
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         runAsGroup:
                           type: integer
                         runAsNonRoot:
@@ -784,6 +786,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Configures pod-level security attributes and common
                         container settings.
@@ -1114,6 +1118,8 @@ spec:
                             gmsaCredentialSpec:
                               type: string
                             gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
                               type: string
                       description: Security context for the container.
                   description: Template for the Kafka Connect container.

--- a/kafka-init/pom.xml
+++ b/kafka-init/pom.xml
@@ -28,7 +28,7 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model</artifactId>
+            <artifactId>kubernetes-model-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/kafka-init/src/main/java/io/strimzi/kafka/init/Main.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/Main.java
@@ -6,7 +6,6 @@ package io.strimzi.kafka.init;
 
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.strimzi.operator.common.Util;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -18,12 +17,6 @@ public class Main {
 
         log.info("Init-kafka {} is starting", Main.class.getPackage().getImplementationVersion());
         InitWriterConfig config = InitWriterConfig.fromMap(System.getenv());
-
-        // Workaround for https://github.com/fabric8io/kubernetes-client/issues/2212
-        // Can be removed after upgrade to Fabric8 4.10.2 or higher or to Java 11
-        if (Util.shouldDisableHttp2()) {
-            System.setProperty("http2.disable", "true");
-        }
 
         KubernetesClient client = new DefaultKubernetesClient();
 

--- a/mockkube/pom.xml
+++ b/mockkube/pom.xml
@@ -23,7 +23,31 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model</artifactId>
+            <artifactId>kubernetes-model-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-rbac</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-policy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apps</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-networking</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apiextensions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-model</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/DeploymentMockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/DeploymentMockBuilder.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.test.mockkube;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.DoneablePod;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
@@ -41,7 +42,7 @@ class DeploymentMockBuilder extends MockBuilder<Deployment, DeploymentList, Done
 
     @Override
     protected void mockCreate(String resourceName, RollableScalableResource<Deployment, DoneableDeployment> resource) {
-        when(resource.create(any())).thenAnswer(invocation -> {
+        when(resource.create(any(Deployment.class))).thenAnswer(invocation -> {
             checkNotExists(resourceName);
             Deployment deployment = invocation.getArgument(0);
             LOGGER.debug("create {} {} -> {}", resourceType, resourceName, deployment);
@@ -115,7 +116,7 @@ class DeploymentMockBuilder extends MockBuilder<Deployment, DeploymentList, Done
                 // delete the first "old" Pod if there is one still remaining
                 if (podsForDeployments.get(deploymentName).size() > 0) {
                     String podToDelete = podsForDeployments.get(deploymentName).remove(0);
-                    mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(podToDelete).cascading(true).delete();
+                    mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(podToDelete).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
                 }
 
             }

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
@@ -361,7 +361,7 @@ public class MockKube {
         return crdc.getGroup() + "##" + crdc.getVersion() + "##" + crdc.getKind();
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "deprecation"})
     public void mockCrs(KubernetesClient mockClient) {
         when(mockClient.customResources(any(CustomResourceDefinitionContext.class),
                 any(Class.class),
@@ -369,6 +369,19 @@ public class MockKube {
                 any(Class.class))).thenAnswer(invocation -> {
                     CustomResourceDefinitionContext crdArg = invocation.getArgument(0);
                     String key = crdKey(crdArg);
+                    CreateOrReplaceable createOrReplaceable = crdMixedOps.get(key);
+                    if (createOrReplaceable == null) {
+                        throw new RuntimeException("Unknown CRD " + invocation.getArgument(0));
+                    }
+                    return createOrReplaceable;
+                });
+
+        when(mockClient.customResources(any(CustomResourceDefinition.class),
+                any(Class.class),
+                any(Class.class),
+                any(Class.class))).thenAnswer(invocation -> {
+                    CustomResourceDefinition crdArg = invocation.getArgument(0);
+                    String key = crdKey(CustomResourceDefinitionContext.fromCrd(crdArg));
                     CreateOrReplaceable createOrReplaceable = crdMixedOps.get(key);
                     if (createOrReplaceable == null) {
                         throw new RuntimeException("Unknown CRD " + invocation.getArgument(0));

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
@@ -62,6 +62,7 @@ import io.fabric8.kubernetes.client.dsl.PolicyAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.RbacAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.openshift.api.model.DoneableRoute;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteList;
@@ -306,7 +307,7 @@ public class MockKube {
                 Resource crdResource = mock(Resource.class);
                 when(crdResource.get()).thenReturn(crd);
                 when(crds.withName(crd.getMetadata().getName())).thenReturn(crdResource);
-                String key = crdKey(crd);
+                String key = crdKey(CustomResourceDefinitionContext.fromCrd(crd));
                 CreateOrReplaceable crdMixedOp = crdMixedOps.get(key);
                 if (crdMixedOp == null) {
                     CustomResourceMockBuilder customResourceMockBuilder = addMockBuilder(crd.getSpec().getNames().getPlural(), new CustomResourceMockBuilder<>((MockedCrd) mockedCrd));
@@ -356,17 +357,17 @@ public class MockKube {
         return mockClient;
     }
 
-    public String crdKey(CustomResourceDefinition crd) {
-        return crd.getSpec().getGroup() + "##" + crd.getSpec().getVersion() + "##" + crd.getSpec().getNames().getKind();
+    public String crdKey(CustomResourceDefinitionContext crdc) {
+        return crdc.getGroup() + "##" + crdc.getVersion() + "##" + crdc.getKind();
     }
 
     @SuppressWarnings("unchecked")
     public void mockCrs(KubernetesClient mockClient) {
-        when(mockClient.customResources(any(CustomResourceDefinition.class),
+        when(mockClient.customResources(any(CustomResourceDefinitionContext.class),
                 any(Class.class),
                 any(Class.class),
                 any(Class.class))).thenAnswer(invocation -> {
-                    CustomResourceDefinition crdArg = invocation.getArgument(0);
+                    CustomResourceDefinitionContext crdArg = invocation.getArgument(0);
                     String key = crdKey(crdArg);
                     CreateOrReplaceable createOrReplaceable = crdMixedOps.get(key);
                     if (createOrReplaceable == null) {

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/ServiceMockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/ServiceMockBuilder.java
@@ -31,7 +31,7 @@ class ServiceMockBuilder extends MockBuilder<Service, ServiceList, DoneableServi
     /** Override Service creation to also create Endpoints */
     @Override
     protected void mockCreate(String resourceName, ServiceResource<Service, DoneableService> resource) {
-        when(resource.create(any())).thenAnswer(i -> {
+        when(resource.create(any(Service.class))).thenAnswer(i -> {
             Service argument = i.getArgument(0);
             db.put(resourceName, copyResource(argument));
             LOGGER.debug("create {} (and endpoint) {} ", resourceType, resourceName);

--- a/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeRegressionTest.java
+++ b/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeRegressionTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.test.io.strimzi.test.mockkube;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -73,7 +74,7 @@ public class MockKubeRegressionTest {
 
             }
         });
-        client.pods().inNamespace("ns").withName(ns.get(0).getMetadata().getName()).cascading(true).delete();
+        client.pods().inNamespace("ns").withName(ns.get(0).getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
 
         assertThat(deleted.get(), is(true));
         assertThat(recreated.get(), is(true));
@@ -82,7 +83,7 @@ public class MockKubeRegressionTest {
         ns = client.pods().inNamespace("ns").list().getItems();
         assertThat(ns, hasSize(3));
 
-        client.apps().statefulSets().inNamespace("ns").withName("foo").cascading(true).delete();
+        client.apps().statefulSets().inNamespace("ns").withName("foo").withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
 
     }
 }

--- a/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeTest.java
+++ b/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.test.io.strimzi.test.mockkube;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
@@ -236,7 +237,7 @@ public class MockKubeTest<RT extends HasMetadata, LT extends KubernetesResource 
         // TODO assertNull(gotResource);
 
         // Delete
-        assertThat(mixedOp.apply(client).withName(pod.getMetadata().getName()).cascading(true).delete(), is(true));
+        assertThat(mixedOp.apply(client).withName(pod.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete(), is(true));
         assertThat(w.lastEvent().action, is(Watcher.Action.DELETED));
         RT resource = (RT) w.lastEvent().resource;
         resource.getMetadata().setResourceVersion(null);
@@ -249,7 +250,7 @@ public class MockKubeTest<RT extends HasMetadata, LT extends KubernetesResource 
         gotResource = mixedOp.apply(client).withName(pod.getMetadata().getName()).get();
         assertThat(gotResource, is(nullValue()));
 
-        assertThat(mixedOp.apply(client).withName(pod.getMetadata().getName()).cascading(true).delete(), is(false));
+        assertThat(mixedOp.apply(client).withName(pod.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete(), is(false));
 
         // TODO Delete off a withLabels query, delete off a inNamespace
         // TODO inAnyNamespace()

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -39,7 +39,39 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model</artifactId>
+            <artifactId>kubernetes-model-extensions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apps</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-storageclass</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apiextensions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-rbac</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-policy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-networking</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-model</artifactId>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/operator-common/src/main/java/io/strimzi/operator/PlatformFeaturesAvailability.java
+++ b/operator-common/src/main/java/io/strimzi/operator/PlatformFeaturesAvailability.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.text.ParseException;
+import java.util.Map;
 
 /**
  * Gives a info about certain features availability regarding to kubernetes version
@@ -103,7 +104,7 @@ public class PlatformFeaturesAvailability {
 
         if (kubernetesVersion != null) {
             try {
-                futureVersion = Future.succeededFuture(new VersionInfo(Util.parseMap(kubernetesVersion)));
+                futureVersion = Future.succeededFuture(parseVersionInfo(kubernetesVersion));
             } catch (ParseException e) {
                 throw new RuntimeException("Failed to parse the Kubernetes version information provided through STRIMZI_KUBERNETES_VERSION environment variable", e);
             }
@@ -112,6 +113,33 @@ public class PlatformFeaturesAvailability {
         }
 
         return futureVersion;
+    }
+
+    static VersionInfo parseVersionInfo(String str) throws ParseException {
+        Map<String, String> map = Util.parseMap(str);
+        VersionInfo.Builder vib = new VersionInfo.Builder();
+        for (Map.Entry<String, String> entry: map.entrySet()) {
+            if (entry.getKey().equals("major")) {
+                vib.withMajor(map.get(entry.getKey()));
+            } else if (entry.getKey().equals("minor")) {
+                vib.withMinor(map.get(entry.getKey()));
+            } else if (entry.getKey().equals("gitVersion")) {
+                vib.withGitVersion(map.get(entry.getKey()));
+            } else if (entry.getKey().equals("gitCommit")) {
+                vib.withGitCommit(map.get(entry.getKey()));
+            } else if (entry.getKey().equals("gitTreeState")) {
+                vib.withGitTreeState(map.get(entry.getKey()));
+            } else if (entry.getKey().equals("buildDate")) {
+                vib.withBuildDate(map.get(entry.getKey()));
+            } else if (entry.getKey().equals("goVersion")) {
+                vib.withGoVersion(map.get(entry.getKey()));
+            } else if (entry.getKey().equals("compiler")) {
+                vib.withCompiler(map.get(entry.getKey()));
+            } else if (entry.getKey().equals("platform")) {
+                vib.withPlatform(map.get(entry.getKey()));
+            }
+        }
+        return vib.build();
     }
 
     private static Future<VersionInfo> getVersionInfoFromKubernetes(Vertx vertx, KubernetesClient client)   {

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -285,19 +285,6 @@ public class Util {
     }
 
     /**
-     * OkHttp wrongfully detects JDK8u251 and higher as JDK9 which enables Http2 unsupported for JDK8.
-     * This method is used as workaround as described in https://github.com/fabric8io/kubernetes-client/issues/2212
-     *
-     * This should be removed after migrating to Fabric8 4.10.2 or higher or after migration to Java 11.
-     *
-     * @return true if JDK8 is detected and the environment variable HTTP2_DISABLE is not set
-     */
-    public static boolean shouldDisableHttp2() {
-        return System.getProperty("java.version", "").startsWith("1.8")
-                    && System.getenv("HTTP2_DISABLE") == null;
-    }
-
-    /**
      * Merge two or more Maps together, should be used for merging multiple collections of Kubernetes labels or annotations
      *
      * @param base The base set of key value pairs that will be merged, if no overrides are present this will be returned.

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -173,7 +174,7 @@ public abstract class AbstractNonNamespacedResourceOperator<C extends Kubernetes
 
     protected Future<ReconcileResult<T>> internalPatch(String name, T current, T desired, boolean cascading) {
         try {
-            T result = operation().withName(name).cascading(cascading).patch(desired);
+            T result = operation().withName(name).withPropagationPolicy(cascading ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN).patch(desired);
             log.debug("{} {} has been patched", resourceKind, name);
             return Future.succeededFuture(wasChanged(current, result) ?
                     ReconcileResult.patched(result) : ReconcileResult.noop(result));

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -145,7 +146,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
 
     protected Future<ReconcileResult<T>> internalDelete(String namespace, String name, boolean cascading) {
         try {
-            operation().inNamespace(namespace).withName(name).cascading(cascading).withGracePeriod(-1L).delete();
+            operation().inNamespace(namespace).withName(name).withPropagationPolicy(cascading ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN).withGracePeriod(-1L).delete();
             log.debug("{} {} in namespace {} has been deleted", resourceKind, name, namespace);
             return Future.succeededFuture(ReconcileResult.deleted());
         } catch (Exception e) {
@@ -164,7 +165,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
 
     protected Future<ReconcileResult<T>> internalPatch(String namespace, String name, T current, T desired, boolean cascading) {
         try {
-            T result = operation().inNamespace(namespace).withName(name).cascading(cascading).patch(desired);
+            T result = operation().inNamespace(namespace).withName(name).withPropagationPolicy(cascading ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN).patch(desired);
             log.debug("{} {} in namespace {} has been patched", resourceKind, name, namespace);
             return Future.succeededFuture(wasChanged(current, result) ? ReconcileResult.patched(result) : ReconcileResult.noop(result));
         } catch (Exception e) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.common.operator.resource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
@@ -14,6 +15,7 @@ import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.vertx.core.Future;
@@ -63,7 +65,7 @@ public class CrdOperator<C extends KubernetesClient,
 
     @Override
     protected MixedOperation<T, L, D, Resource<T, D>> operation() {
-        return client.customResources(crd, cls, listCls, doneableCls);
+        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd), cls, listCls, doneableCls);
     }
 
     public Future<T> patchAsync(T resource) {
@@ -77,7 +79,7 @@ public class CrdOperator<C extends KubernetesClient,
             String namespace = resource.getMetadata().getNamespace();
             String name = resource.getMetadata().getName();
             try {
-                T result = operation().inNamespace(namespace).withName(name).cascading(cascading).patch(resource);
+                T result = operation().inNamespace(namespace).withName(name).withPropagationPolicy(cascading ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN).patch(resource);
                 log.debug("{} {} in namespace {} has been patched", resourceKind, name, namespace);
                 future.complete(result);
             } catch (Exception e) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperator.java
@@ -10,8 +10,6 @@ import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudgetList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 
 public class PodDisruptionBudgetOperator extends AbstractResourceOperator<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, DoneablePodDisruptionBudget, Resource<PodDisruptionBudget, DoneablePodDisruptionBudget>> {
@@ -25,23 +23,4 @@ public class PodDisruptionBudgetOperator extends AbstractResourceOperator<Kubern
         return client.policy().podDisruptionBudget();
     }
 
-    @Override
-    protected Future<ReconcileResult<PodDisruptionBudget>> internalPatch(String namespace, String name, PodDisruptionBudget current, PodDisruptionBudget desired, boolean cascading) {
-        Promise<ReconcileResult<PodDisruptionBudget>> promise = Promise.promise();
-        internalDelete(namespace, name).onComplete(delRes -> {
-            if (delRes.succeeded())    {
-                internalCreate(namespace, name, desired).onComplete(createRes -> {
-                    if (createRes.succeeded())  {
-                        promise.complete(createRes.result());
-                    } else {
-                        promise.fail(createRes.cause());
-                    }
-                });
-            } else {
-                promise.fail(delRes.cause());
-            }
-        });
-
-        return promise.future();
-    }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
@@ -7,7 +7,6 @@ package io.strimzi.operator;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.VersionInfo;
-import io.strimzi.operator.common.Util;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
@@ -185,7 +184,7 @@ public class PlatformFeaturesAvailabilityTest {
                 "compiler=gc\n" +
                 "platform=linux/amd64";
 
-        VersionInfo vi = new VersionInfo(Util.parseMap(version));
+        VersionInfo vi = PlatformFeaturesAvailability.parseVersionInfo(version);
 
         context.verify(() -> {
             assertThat(vi.getMajor(), is("1"));

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractCustomResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractCustomResourceOperatorIT.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -68,7 +69,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
     protected abstract CrdOperator<C, T, L, D> operator();
     protected abstract CustomResourceDefinition getCrd();
     protected abstract String getNamespace();
-    protected abstract T getResource();
+    protected abstract T getResource(String name);
     protected abstract T getResourceWithModifications(T resourceInCluster);
     protected abstract T getResourceWithNewReadyStatus(T resourceInCluster);
     protected abstract void assertReady(VertxTestContext context, T modifiedCustomResource);
@@ -113,6 +114,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
 
     @Test
     public void testUpdateStatus(VertxTestContext context) {
+        String resourceName = getResourceName(RESOURCE_NAME);
         Checkpoint async = context.checkpoint();
         String namespace = getNamespace();
 
@@ -127,7 +129,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
 
                 .compose(pfa -> {
                     log.info("Creating resource");
-                    return op.reconcile(namespace, RESOURCE_NAME, getResource());
+                    return op.reconcile(namespace, resourceName, getResource(resourceName));
                 })
                 .onComplete(context.succeeding())
                 .compose(rrCreated -> {
@@ -138,14 +140,14 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
                 })
                 .onComplete(context.succeeding())
 
-                .compose(rrModified -> op.getAsync(namespace, RESOURCE_NAME))
+                .compose(rrModified -> op.getAsync(namespace, resourceName))
                 .onComplete(context.succeeding(modifiedCustomResource -> context.verify(() -> {
                     assertReady(context, modifiedCustomResource);
                 })))
 
                 .compose(rrModified -> {
                     log.info("Deleting resource");
-                    return op.reconcile(namespace, RESOURCE_NAME, null);
+                    return op.reconcile(namespace, resourceName, null);
                 })
                 .onComplete(context.succeeding(rrDeleted ->  async.flag()));
     }
@@ -158,6 +160,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
      */
     @Test
     public void testUpdateStatusAfterResourceDeletedThrowsKubernetesClientException(VertxTestContext context) {
+        String resourceName = getResourceName(RESOURCE_NAME);
         Checkpoint async = context.checkpoint();
         String namespace = getNamespace();
 
@@ -173,15 +176,15 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
                 })))
                 .compose(pfa -> {
                     log.info("Creating resource");
-                    return op.reconcile(namespace, RESOURCE_NAME, getResource());
+                    return op.reconcile(namespace, resourceName, getResource(resourceName));
                 })
                 .onComplete(context.succeeding())
 
                 .compose(rr -> {
                     log.info("Saving resource with status change prior to deletion");
-                    newStatus.set(getResourceWithNewReadyStatus(op.get(namespace, RESOURCE_NAME)));
+                    newStatus.set(getResourceWithNewReadyStatus(op.get(namespace, resourceName)));
                     log.info("Deleting resource");
-                    return op.reconcile(namespace, RESOURCE_NAME, null);
+                    return op.reconcile(namespace, resourceName, null);
                 })
                 .onComplete(context.succeeding())
 
@@ -202,6 +205,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
      */
     @Test
     public void testUpdateStatusAfterResourceUpdatedThrowsKubernetesClientException(VertxTestContext context) {
+        String resourceName = getResourceName(RESOURCE_NAME);
         Checkpoint async = context.checkpoint();
         String namespace = getNamespace();
 
@@ -217,7 +221,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
                 })))
                 .compose(pfa -> {
                     log.info("Creating resource");
-                    return op.reconcile(namespace, RESOURCE_NAME, getResource());
+                    return op.reconcile(namespace, resourceName, getResource(resourceName));
                 })
                 .onComplete(context.succeeding())
                 .compose(rrCreated -> {
@@ -225,7 +229,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
                     T newStatus = getResourceWithNewReadyStatus(rrCreated.resource());
 
                     log.info("Updating resource (mocking an update due to some other reason)");
-                    op.operation().inNamespace(namespace).withName(RESOURCE_NAME).patch(updated);
+                    op.operation().inNamespace(namespace).withName(resourceName).patch(updated);
 
                     log.info("Updating resource status after underlying resource has changed");
                     return op.updateStatusAsync(newStatus);
@@ -238,9 +242,13 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
 
         updateFailed.future().compose(v -> {
             log.info("Deleting resource");
-            return op.reconcile(namespace, RESOURCE_NAME, null);
+            return op.reconcile(namespace, resourceName, null);
         })
         .onComplete(context.succeeding(v -> async.flag()));
+    }
+
+    protected String getResourceName(String name) {
+        return name + "-" + new Random().nextInt(Integer.MAX_VALUE);
     }
 }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorIT.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.strimzi.operator.common.Util;
 import io.strimzi.test.k8s.cluster.KubeCluster;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -16,8 +17,11 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Random;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -34,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 @ExtendWith(VertxExtension.class)
 public abstract class AbstractNonNamespacedResourceOperatorIT<C extends KubernetesClient, T extends HasMetadata, L extends KubernetesResourceList/*<T>*/, D, R extends Resource<T, D>> {
     public static final String RESOURCE_NAME = "my-resource";
+    protected String resourceName;
     protected static Vertx vertx;
     protected static KubernetesClient client;
 
@@ -42,6 +47,11 @@ public abstract class AbstractNonNamespacedResourceOperatorIT<C extends Kubernet
         assertDoesNotThrow(() -> KubeCluster.bootstrap(), "Could not bootstrap server");
         vertx = Vertx.vertx();
         client = new DefaultKubernetesClient();
+    }
+
+    @BeforeEach
+    public void renameResource() {
+        resourceName = getResourceName(RESOURCE_NAME);
     }
 
     @AfterAll
@@ -62,27 +72,37 @@ public abstract class AbstractNonNamespacedResourceOperatorIT<C extends Kubernet
         T newResource = getOriginal();
         T modResource = getModified();
 
-        op.reconcile(RESOURCE_NAME, newResource)
+        op.reconcile(resourceName, newResource)
             .onComplete(context.succeeding(rrCreate -> context.verify(() -> {
-                T created = op.get(RESOURCE_NAME);
+                T created = op.get(resourceName);
 
                 assertThat("Failed to get created Resource", created, is(notNullValue()));
                 assertResources(context, newResource, created);
             })))
-            .compose(rr -> op.reconcile(RESOURCE_NAME, modResource))
+            .compose(rr -> op.reconcile(resourceName, modResource))
             .onComplete(context.succeeding(rrModified -> context.verify(() -> {
-                T modified = (T) op.get(RESOURCE_NAME);
+                T modified = (T) op.get(resourceName);
 
                 assertThat("Failed to get modified Resource", modified, is(notNullValue()));
                 assertResources(context, modResource, modified);
             })))
-            .compose(rr -> op.reconcile(RESOURCE_NAME, null))
+            .compose(rr -> op.reconcile(resourceName, null))
             .onComplete(context.succeeding(rrDelete -> context.verify(() -> {
-                T deleted = (T) op.get(RESOURCE_NAME);
-
-                assertThat("Failed to get modified Resource", deleted, is(nullValue()));
-                async.flag();
+                // it seems the resource is cached for some time so we need wait for it to be null
+                context.verify(() -> {
+                        Util.waitFor(vertx, "resource deletion " + resourceName, "deleted", 1000,
+                                30_000, () -> op.get(resourceName) == null)
+                                .onComplete(del -> {
+                                    assertThat(op.get(resourceName), is(nullValue()));
+                                    async.flag();
+                                });
+                    }
+                );
             })));
+    }
+
+    protected String getResourceName(String name) {
+        return name + "-" + new Random().nextInt(Integer.MAX_VALUE);
     }
 }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
@@ -151,7 +151,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         T resource = resource();
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(null);
-        when(mockResource.create(any())).thenReturn(resource);
+        when(mockResource.create((T) any())).thenReturn(resource);
 
         NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
         when(mockNameable.withName(matches(resource.getMetadata().getName()))).thenReturn(mockResource);
@@ -186,7 +186,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
 
         MixedOperation mockCms = mock(MixedOperation.class);
         when(mockCms.withName(matches(RESOURCE_NAME))).thenReturn(mockResource);
-        when(mockResource.create(any())).thenThrow(ex);
+        when(mockResource.create((T) any())).thenThrow(ex);
 
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -92,7 +93,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         T resource = resource();
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
-        when(mockResource.cascading(cascade)).thenReturn(mockResource);
+        when(mockResource.withPropagationPolicy(cascade ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN)).thenReturn(mockResource);
         when(mockResource.patch(any())).thenReturn(resource);
 
         NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorIT.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.strimzi.operator.common.Util;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.cluster.KubeCluster;
 import io.vertx.core.Vertx;
@@ -19,8 +20,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Random;
 
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -40,11 +44,17 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 public abstract class AbstractResourceOperatorIT<C extends KubernetesClient, T extends HasMetadata, L extends KubernetesResourceList/*<T>*/, D, R extends Resource<T, D>> {
     protected static final Logger log = LogManager.getLogger(AbstractResourceOperatorIT.class);
     public static final String RESOURCE_NAME = "my-test-resource";
+    protected String resourceName;
     protected static Vertx vertx;
     protected static KubernetesClient client;
     protected static String namespace = "resource-operator-it-namespace";
 
     private static KubeClusterResource cluster;
+
+    @BeforeEach
+    public void renameResource() {
+        this.resourceName = getResourceName(RESOURCE_NAME);
+    }
 
     @BeforeAll
     public static void before() {
@@ -89,27 +99,37 @@ public abstract class AbstractResourceOperatorIT<C extends KubernetesClient, T e
         T newResource = getOriginal();
         T modResource = getModified();
 
-        op.reconcile(namespace, RESOURCE_NAME, newResource)
+        op.reconcile(namespace, resourceName, newResource)
             .onComplete(context.succeeding(rrCreated -> {
-                T created = op.get(namespace, RESOURCE_NAME);
+                T created = op.get(namespace, resourceName);
 
                 context.verify(() -> assertThat(created, is(notNullValue())));
                 assertResources(context, newResource, created);
             }))
-            .compose(rr -> op.reconcile(namespace, RESOURCE_NAME, modResource))
+            .compose(rr -> op.reconcile(namespace, resourceName, modResource))
             .onComplete(context.succeeding(rrModified -> {
-                T modified = op.get(namespace, RESOURCE_NAME);
+                T modified = op.get(namespace, resourceName);
 
                 context.verify(() -> assertThat(modified, is(notNullValue())));
                 assertResources(context, modResource, modified);
             }))
-            .compose(rr -> op.reconcile(namespace, RESOURCE_NAME, null))
+            .compose(rr -> op.reconcile(namespace, resourceName, null))
             .onComplete(context.succeeding(rrDeleted -> {
-                T deleted = op.get(namespace, RESOURCE_NAME);
-
-                context.verify(() -> assertThat(deleted, is(nullValue())));
-                async.flag();
+                // it seems the resource is cached for some time so we need wait for it to be null
+                context.verify(() -> {
+                        Util.waitFor(vertx, "resource deletion " + resourceName, "deleted", 1000,
+                                30_000, () -> op.get(namespace, resourceName) == null)
+                                .onComplete(del -> {
+                                    assertThat(op.get(namespace, resourceName), is(nullValue()));
+                                    async.flag();
+                                });
+                    }
+                );
             }));
+    }
+
+    protected String getResourceName(String name) {
+        return name + "-" + new Random().nextInt(Integer.MAX_VALUE);
     }
 }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorTest.java
@@ -4,10 +4,10 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.Deletable;
 import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
@@ -88,7 +88,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         T resource = resource();
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
-        when(mockResource.cascading(cascade)).thenReturn(mockResource);
+        when(mockResource.withPropagationPolicy(cascade ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN)).thenReturn(mockResource);
         when(mockResource.patch(any())).thenReturn(resource);
 
         NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
@@ -145,7 +145,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         T resource = resource();
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(null);
-        when(mockResource.create(any())).thenReturn(resource);
+        when(mockResource.create((T) any())).thenReturn(resource);
 
         NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
         when(mockNameable.withName(matches(resource.getMetadata().getName()))).thenReturn(mockResource);
@@ -179,7 +179,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
 
         MixedOperation mockCms = mock(MixedOperation.class);
         when(mockCms.inNamespace(matches(resource.getMetadata().getNamespace()))).thenReturn(mockNameable);
-        when(mockResource.create(any())).thenThrow(ex);
+        when(mockResource.create((T) any())).thenThrow(ex);
 
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
@@ -220,15 +220,14 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
 
     @Test
     public void testReconcileDeleteWhenResourceExistsStillDeletes(VertxTestContext context) {
-        Deletable mockDeletable = mock(Deletable.class);
-
-        EditReplacePatchDeletable mockERPD = mock(EditReplacePatchDeletable.class);
-        when(mockERPD.withGracePeriod(anyLong())).thenReturn(mockDeletable);
+        EditReplacePatchDeletable mockDeletable = mock(EditReplacePatchDeletable.class);
+        EditReplacePatchDeletable mockDeletableGrace = mock(EditReplacePatchDeletable.class);
 
         T resource = resource();
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
-        when(mockResource.cascading(eq(true))).thenReturn(mockERPD);
+        when(mockResource.withPropagationPolicy(eq(DeletionPropagation.FOREGROUND))).thenReturn(mockDeletableGrace);
+        when(mockDeletableGrace.withGracePeriod(anyLong())).thenReturn(mockDeletable);
 
         NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
         when(mockNameable.withName(matches(RESOURCE_NAME))).thenReturn(mockResource);
@@ -251,15 +250,14 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
 
     @Test
     public void testReconcileDeletionSuccessfullyDeletes(VertxTestContext context) {
-        Deletable mockDeletable = mock(Deletable.class);
-
-        EditReplacePatchDeletable mockERPD = mock(EditReplacePatchDeletable.class);
-        when(mockERPD.withGracePeriod(anyLong())).thenReturn(mockDeletable);
+        EditReplacePatchDeletable mockDeletable = mock(EditReplacePatchDeletable.class);
+        EditReplacePatchDeletable mockDeletableGrace = mock(EditReplacePatchDeletable.class);
 
         T resource = resource();
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
-        when(mockResource.cascading(eq(true))).thenReturn(mockERPD);
+        when(mockResource.withPropagationPolicy(eq(DeletionPropagation.FOREGROUND))).thenReturn(mockDeletableGrace);
+        when(mockDeletableGrace.withGracePeriod(anyLong())).thenReturn(mockDeletable);
 
         NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
         when(mockNameable.withName(matches(RESOURCE_NAME))).thenReturn(mockResource);
@@ -283,7 +281,8 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
     @Test
     public void testReconcileDeleteThrowsWhenDeletionThrows(VertxTestContext context) {
         RuntimeException ex = new RuntimeException("Testing this exception is handled correctly");
-        Deletable mockDeletable = mock(Deletable.class);
+        EditReplacePatchDeletable mockDeletable = mock(EditReplacePatchDeletable.class);
+        EditReplacePatchDeletable mockDeletableGrace = mock(EditReplacePatchDeletable.class);
         when(mockDeletable.delete()).thenThrow(ex);
 
         EditReplacePatchDeletable mockERPD = mock(EditReplacePatchDeletable.class);
@@ -292,7 +291,8 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         T resource = resource();
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
-        when(mockResource.cascading(eq(true))).thenReturn(mockERPD);
+        when(mockResource.withPropagationPolicy(eq(DeletionPropagation.FOREGROUND))).thenReturn(mockDeletableGrace);
+        when(mockDeletableGrace.withGracePeriod(anyLong())).thenReturn(mockDeletable);
 
         NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
         when(mockNameable.withName(matches(RESOURCE_NAME))).thenReturn(mockResource);

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ClusterRoleBindingOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ClusterRoleBindingOperatorIT.java
@@ -49,9 +49,10 @@ public class ClusterRoleBindingOperatorIT extends AbstractNonNamespacedResourceO
                 .withKind("ClusterRole")
                 .build();
 
+
         return new ClusterRoleBindingBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(resourceName)
                     .withLabels(singletonMap("state", "new"))
                 .endMetadata()
                     .withSubjects(ks)
@@ -76,7 +77,7 @@ public class ClusterRoleBindingOperatorIT extends AbstractNonNamespacedResourceO
 
         return new ClusterRoleBindingBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(resourceName)
                     .withLabels(singletonMap("state", "modified"))
                 .endMetadata()
                 .withSubjects(ks)

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ClusterRoleOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ClusterRoleOperatorIT.java
@@ -43,7 +43,7 @@ public class ClusterRoleOperatorIT extends AbstractNonNamespacedResourceOperator
 
         return new ClusterRoleBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(resourceName)
                     .withLabels(singletonMap("state", "new"))
                 .endMetadata()
                 .withRules(rule)
@@ -60,7 +60,7 @@ public class ClusterRoleOperatorIT extends AbstractNonNamespacedResourceOperator
 
         return new ClusterRoleBuilder()
                 .withNewMetadata()
-                .withName(RESOURCE_NAME)
+                .withName(resourceName)
                 .withLabels(singletonMap("state", "modified"))
                 .endMetadata()
                 .withRules(rule)

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaBridgeCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaBridgeCrdOperatorIT.java
@@ -48,11 +48,12 @@ public class KafkaBridgeCrdOperatorIT extends AbstractCustomResourceOperatorIT<K
         return "bridge-crd-it-namespace";
     }
 
-    protected KafkaBridge getResource() {
+    @Override
+    protected KafkaBridge getResource(String resourceName) {
         return new KafkaBridgeBuilder()
                 .withApiVersion(KafkaBridge.RESOURCE_GROUP + "/" + KafkaBridge.V1ALPHA1)
                 .withNewMetadata()
-                .withName(RESOURCE_NAME)
+                .withName(resourceName)
                 .withNamespace(getNamespace())
                 .endMetadata()
                 .withNewSpec()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectCrdOperatorIT.java
@@ -46,11 +46,11 @@ public class KafkaConnectCrdOperatorIT extends AbstractCustomResourceOperatorIT<
     }
 
     @Override
-    protected KafkaConnect getResource() {
+    protected KafkaConnect getResource(String resourceName) {
         return new KafkaConnectBuilder()
                 .withApiVersion(KafkaConnect.RESOURCE_GROUP + "/" + KafkaConnect.V1BETA1)
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(resourceName)
                     .withNamespace(getNamespace())
                 .endMetadata()
                 .withNewSpec()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectS2ICrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectS2ICrdOperatorIT.java
@@ -46,11 +46,12 @@ public class KafkaConnectS2ICrdOperatorIT extends AbstractCustomResourceOperator
         return "kafka-connects2i-crd-it-namespace";
     }
 
-    protected KafkaConnectS2I getResource() {
+    @Override
+    protected KafkaConnectS2I getResource(String resourceName) {
         return new KafkaConnectS2IBuilder()
                 .withApiVersion(KafkaConnectS2I.RESOURCE_GROUP + "/" + KafkaConnectS2I.V1BETA1)
                 .withNewMetadata()
-                .withName(RESOURCE_NAME)
+                .withName(resourceName)
                 .withNamespace(getNamespace())
                 .endMetadata()
                 .withNewSpec()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectorCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectorCrdOperatorIT.java
@@ -46,11 +46,11 @@ public class KafkaConnectorCrdOperatorIT extends AbstractCustomResourceOperatorI
     }
 
     @Override
-    protected KafkaConnector getResource() {
+    protected KafkaConnector getResource(String resourceName) {
         return new KafkaConnectorBuilder()
                 .withApiVersion(KafkaConnector.RESOURCE_GROUP + "/" + KafkaConnector.V1ALPHA1)
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(resourceName)
                     .withNamespace(getNamespace())
                 .endMetadata()
                 .withNewSpec()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorIT.java
@@ -45,11 +45,12 @@ public class KafkaCrdOperatorIT extends AbstractCustomResourceOperatorIT<Kuberne
         return "kafka-crd-it-namespace";
     }
 
-    protected Kafka getResource() {
+    @Override
+    protected Kafka getResource(String resourceName) {
         return new KafkaBuilder()
                 .withApiVersion(Kafka.RESOURCE_GROUP + "/" + Kafka.V1BETA1)
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(resourceName)
                     .withNamespace(getNamespace())
                 .endMetadata()
                 .withNewSpec()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaList;
@@ -79,7 +80,7 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
 
     @Override
     protected void mocker(KubernetesClient mockClient, MixedOperation op) {
-        when(mockClient.customResources(any(), any(), any(), any())).thenReturn(op);
+        when(mockClient.customResources(any(CustomResourceDefinitionContext.class), any(), any(), any())).thenReturn(op);
     }
 
     @Override

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMaker2CrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMaker2CrdOperatorIT.java
@@ -45,11 +45,12 @@ public class KafkaMirrorMaker2CrdOperatorIT extends AbstractCustomResourceOperat
         return "kafka-mirror-maker-2-crd-it-namespace";
     }
 
-    protected KafkaMirrorMaker2 getResource() {
+    @Override
+    protected KafkaMirrorMaker2 getResource(String resourceName) {
         return new KafkaMirrorMaker2Builder()
                 .withApiVersion(KafkaMirrorMaker2.RESOURCE_GROUP + "/" + KafkaMirrorMaker2.V1ALPHA1)
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(resourceName)
                     .withNamespace(getNamespace())
                 .endMetadata()
                 .withNewSpec()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMakerCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMakerCrdOperatorIT.java
@@ -43,14 +43,15 @@ public class KafkaMirrorMakerCrdOperatorIT extends AbstractCustomResourceOperato
 
     @Override
     protected String getNamespace() {
-        return "kafka-mirror-make-2-crd-it-namespace";
+        return "kafka-mirror-maker-2-crd-it-namespace";
     }
 
-    protected KafkaMirrorMaker getResource() {
+    @Override
+    protected KafkaMirrorMaker getResource(String resourceName) {
         return new KafkaMirrorMakerBuilder()
                 .withApiVersion(KafkaMirrorMaker.RESOURCE_GROUP + "/" + KafkaMirrorMaker.V1BETA1)
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(resourceName)
                     .withNamespace(getNamespace())
                 .endMetadata()
                 .withNewSpec()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaUserCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaUserCrdOperatorIT.java
@@ -45,11 +45,12 @@ public class KafkaUserCrdOperatorIT extends AbstractCustomResourceOperatorIT<Kub
         return "kafka-user-crd-it-namespace";
     }
 
-    protected KafkaUser getResource() {
+    @Override
+    protected KafkaUser getResource(String resourceName) {
         return new KafkaUserBuilder()
                 .withApiVersion(KafkaUser.RESOURCE_GROUP + "/" + KafkaUser.V1BETA1)
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(resourceName)
                     .withNamespace(getNamespace())
                 .endMetadata()
                 .withNewSpec()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/NodeOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/NodeOperatorIT.java
@@ -34,7 +34,7 @@ public class NodeOperatorIT extends AbstractNonNamespacedResourceOperatorIT<Kube
     protected Node getOriginal()  {
         return new NodeBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(resourceName)
                     .withLabels(singletonMap("foo", "bar"))
                 .endMetadata()
                 .withNewSpec()
@@ -47,7 +47,7 @@ public class NodeOperatorIT extends AbstractNonNamespacedResourceOperatorIT<Kube
     protected Node getModified()  {
         return new NodeBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(resourceName)
                     .withLabels(singletonMap("bar", "foo"))
                 .endMetadata()
                 .withNewSpec()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperatorTest.java
@@ -4,32 +4,18 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
-import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.policy.DoneablePodDisruptionBudget;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudgetBuilder;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudgetList;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.Deletable;
-import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PolicyAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.junit5.Checkpoint;
-import io.vertx.junit5.VertxTestContext;
 
 import static java.util.Collections.singletonMap;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class PodDisruptionBudgetOperatorTest extends AbstractResourceOperatorTest<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, DoneablePodDisruptionBudget, Resource<PodDisruptionBudget, DoneablePodDisruptionBudget>> {
@@ -70,43 +56,4 @@ public class PodDisruptionBudgetOperatorTest extends AbstractResourceOperatorTes
                 .build();
     }
 
-    @Override
-    public void createWhenExistsIsAPatch(VertxTestContext context, boolean cascade) {
-        PodDisruptionBudget resource = resource();
-        Resource mockResource = mock(resourceType());
-        when(mockResource.get()).thenReturn(resource);
-        when(mockResource.create(any(PodDisruptionBudget.class))).thenReturn(resource);
-
-        Deletable mockDeletable = mock(Deletable.class);
-        EditReplacePatchDeletable mockGrace = mock(EditReplacePatchDeletable.class);
-        when(mockResource.withPropagationPolicy(cascade ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN)).thenReturn(mockGrace);
-        when(mockGrace.withGracePeriod(anyLong())).thenReturn(mockDeletable);
-
-        NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
-        when(mockNameable.withName(matches(resource.getMetadata().getName()))).thenReturn(mockResource);
-
-        MixedOperation mockCms = mock(MixedOperation.class);
-        when(mockCms.inNamespace(matches(resource.getMetadata().getNamespace()))).thenReturn(mockNameable);
-
-        KubernetesClient mockClient = mock(clientType());
-        mocker(mockClient, mockCms);
-
-        AbstractResourceOperator<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, DoneablePodDisruptionBudget, Resource<PodDisruptionBudget, DoneablePodDisruptionBudget>> op = createResourceOperations(vertx, mockClient);
-
-        Checkpoint async = context.checkpoint();
-        Future<ReconcileResult<PodDisruptionBudget>> fut = op.createOrUpdate(resource());
-        fut.onComplete(ar -> {
-            if (!ar.succeeded()) {
-                ar.cause().printStackTrace();
-            }
-            assertThat(ar.succeeded(), is(true));
-            verify(mockResource).get();
-            verify(mockDeletable).delete();
-            verify(mockResource).create(any(PodDisruptionBudget.class));
-            verify(mockResource, never()).patch(any());
-            verify(mockResource, never()).createNew();
-            verify(mockResource, never()).createOrReplace(any());
-            async.flag();
-        });
-    }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleBindingOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleBindingOperatorIT.java
@@ -49,7 +49,7 @@ public class RoleBindingOperatorIT extends AbstractResourceOperatorIT<Kubernetes
 
         return new RoleBindingBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(resourceName)
                     .withNamespace(namespace)
                     .withLabels(singletonMap("state", "new"))
                 .endMetadata()
@@ -75,7 +75,7 @@ public class RoleBindingOperatorIT extends AbstractResourceOperatorIT<Kubernetes
 
         return new RoleBindingBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(resourceName)
                     .withNamespace(namespace)
                     .withLabels(singletonMap("state", "modified"))
                 .endMetadata()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
@@ -72,7 +73,7 @@ public class ServiceAccountOperatorTest extends AbstractResourceOperatorTest<Kub
         ServiceAccount resource = resource();
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
-        when(mockResource.cascading(cascade)).thenReturn(mockResource);
+        when(mockResource.withPropagationPolicy(cascade ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN)).thenReturn(mockResource);
 
         NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
         when(mockNameable.withName(matches(resource.getMetadata().getName()))).thenReturn(mockResource);

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/StorageClassOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/StorageClassOperatorIT.java
@@ -31,7 +31,7 @@ public class StorageClassOperatorIT extends AbstractNonNamespacedResourceOperato
     protected StorageClass getOriginal()  {
         return new StorageClassBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(resourceName)
                     .withLabels(singletonMap("state", "new"))
                 .endMetadata()
                 .withReclaimPolicy("Delete")
@@ -46,7 +46,7 @@ public class StorageClassOperatorIT extends AbstractNonNamespacedResourceOperato
         // Most of the fields seem to be immutable, we patch only labels
         return new StorageClassBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(resourceName)
                     .withLabels(singletonMap("state", "modified"))
                 .endMetadata()
                 .withReclaimPolicy("Delete")

--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,9 @@
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
         <sundrio.version>0.19.0</sundrio.version>
 
-        <fabric8.kubernetes-client.version>4.6.4</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>4.6.4</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>4.6.4</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>4.10.3</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>4.10.3</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>4.10.3</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <okhttp.version>3.12.6</okhttp.version>
         <okio.version>1.15.0</okio.version>
@@ -238,8 +238,58 @@
             </dependency>
             <dependency>
                 <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-model-extensions</artifactId>
+                <version>${fabric8.kubernetes-model.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-model-core</artifactId>
+                <version>${fabric8.kubernetes-model.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-model-rbac</artifactId>
+                <version>${fabric8.kubernetes-model.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-model-apps</artifactId>
+                <version>${fabric8.kubernetes-model.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-model-apiextensions</artifactId>
+                <version>${fabric8.kubernetes-model.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-model-networking</artifactId>
+                <version>${fabric8.kubernetes-model.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-model-policy</artifactId>
+                <version>${fabric8.kubernetes-model.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-model-storageclass</artifactId>
+                <version>${fabric8.kubernetes-model.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-model-batch</artifactId>
+                <version>${fabric8.kubernetes-model.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>openshift-model</artifactId>
+                <version>${fabric8.kubernetes-model.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
                 <artifactId>openshift-client</artifactId>
-                <version>${fabric8.kubernetes-client.version}</version>
+                <version>${fabric8.openshift-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.fabric8</groupId>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -70,10 +70,6 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model-apiextensions</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-model-core</artifactId>
         </dependency>
         <dependency>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -58,7 +58,39 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model</artifactId>
+            <artifactId>kubernetes-model-extensions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apps</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-storageclass</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apiextensions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-rbac</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-networking</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-batch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-model</artifactId>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.resources;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -132,7 +133,7 @@ public class ResourceManager {
                             resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
                     operation.inNamespace(resource.getMetadata().getNamespace())
                             .withName(resource.getMetadata().getName())
-                            .cascading(true)
+                            .withPropagationPolicy(DeletionPropagation.FOREGROUND)
                             .delete();
                     waitForDeletion((Kafka) resource);
                 });
@@ -143,7 +144,7 @@ public class ResourceManager {
                             resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
                     operation.inNamespace(resource.getMetadata().getNamespace())
                             .withName(resource.getMetadata().getName())
-                            .cascading(true)
+                            .withPropagationPolicy(DeletionPropagation.FOREGROUND)
                             .delete();
                     waitForDeletion((KafkaConnect) resource);
                 });
@@ -154,7 +155,7 @@ public class ResourceManager {
                             resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
                     operation.inNamespace(resource.getMetadata().getNamespace())
                             .withName(resource.getMetadata().getName())
-                            .cascading(true)
+                            .withPropagationPolicy(DeletionPropagation.FOREGROUND)
                             .delete();
                     waitForDeletion((KafkaConnectS2I) resource);
                 });
@@ -165,7 +166,7 @@ public class ResourceManager {
                             resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
                     operation.inNamespace(resource.getMetadata().getNamespace())
                             .withName(resource.getMetadata().getName())
-                            .cascading(true)
+                            .withPropagationPolicy(DeletionPropagation.FOREGROUND)
                             .delete();
                     waitForDeletion((KafkaMirrorMaker) resource);
                 });
@@ -176,7 +177,7 @@ public class ResourceManager {
                             resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
                     operation.inNamespace(resource.getMetadata().getNamespace())
                             .withName(resource.getMetadata().getName())
-                            .cascading(true)
+                            .withPropagationPolicy(DeletionPropagation.FOREGROUND)
                             .delete();
                     waitForDeletion((KafkaMirrorMaker2) resource);
                 });
@@ -187,7 +188,7 @@ public class ResourceManager {
                             resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
                     operation.inNamespace(resource.getMetadata().getNamespace())
                             .withName(resource.getMetadata().getName())
-                            .cascading(true)
+                            .withPropagationPolicy(DeletionPropagation.FOREGROUND)
                             .delete();
                     waitForDeletion((KafkaBridge) resource);
                 });
@@ -226,7 +227,7 @@ public class ResourceManager {
                             resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
                     operation.inNamespace(resource.getMetadata().getNamespace())
                             .withName(resource.getMetadata().getName())
-                            .cascading(true)
+                            .withPropagationPolicy(DeletionPropagation.FOREGROUND)
                             .delete();
                     kubeClient().deleteIngress((Ingress) resource);
                 });
@@ -237,7 +238,7 @@ public class ResourceManager {
                             resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
                     operation.inNamespace(resource.getMetadata().getNamespace())
                             .withName(resource.getMetadata().getName())
-                            .cascading(true)
+                            .withPropagationPolicy(DeletionPropagation.FOREGROUND)
                             .delete();
                 });
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.resources.crd;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -125,7 +126,7 @@ public class KafkaBridgeResource {
     }
 
     public static void deleteKafkaBridgeWithoutWait(String resourceName) {
-        kafkaBridgeClient().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(resourceName).cascading(true).delete();
+        kafkaBridgeClient().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(resourceName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
 
     private static KafkaBridge getKafkaBridgeFromYaml(String yamlPath) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.resources.crd;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -110,7 +111,7 @@ public class KafkaConnectResource {
     }
 
     public static void deleteKafkaConnectWithoutWait(String resourceName) {
-        kafkaConnectClient().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(resourceName).cascading(true).delete();
+        kafkaConnectClient().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(resourceName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
 
     private static KafkaConnect getKafkaConnectFromYaml(String yamlPath) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.resources.crd;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -94,7 +95,7 @@ public class KafkaConnectS2IResource {
     }
 
     public static void deleteKafkaConnectS2IWithoutWait(String resourceName) {
-        kafkaConnectS2IClient().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(resourceName).cascading(true).delete();
+        kafkaConnectS2IClient().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(resourceName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
 
     private static KafkaConnectS2I getKafkaConnectS2IFromYaml(String yamlPath) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.resources.crd;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -65,7 +66,7 @@ public class KafkaConnectorResource {
     }
 
     public static void deleteKafkaConnectorWithoutWait(String connectorName) {
-        kafkaConnectorClient().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(connectorName).cascading(true).delete();
+        kafkaConnectorClient().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(connectorName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
 
     private static DoneableKafkaConnector deployKafkaConnector(KafkaConnector kafkaConnector) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.resources.crd;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -127,7 +128,7 @@ public class KafkaMirrorMaker2Resource {
     }
 
     public static void deleteKafkaMirrorMaker2WithoutWait(String resourceName) {
-        kafkaMirrorMaker2Client().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(resourceName).cascading(true).delete();
+        kafkaMirrorMaker2Client().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(resourceName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
 
     private static KafkaMirrorMaker2 getKafkaMirrorMaker2FromYaml(String yamlPath) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.resources.crd;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -104,7 +105,7 @@ public class KafkaMirrorMakerResource {
     }
 
     public static void deleteKafkaMirrorMakerWithoutWait(String resourceName) {
-        kafkaMirrorMakerClient().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(resourceName).cascading(true).delete();
+        kafkaMirrorMakerClient().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(resourceName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
 
     private static KafkaMirrorMaker getKafkaMirrorMakerFromYaml(String yamlPath) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaRebalanceResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaRebalanceResource.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.resources.crd;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -69,7 +70,7 @@ public class KafkaRebalanceResource {
     }
 
     public static void deleteKafkaRebalanceWithoutWait(String resourceName) {
-        kafkaRebalanceClient().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(resourceName).cascading(true).delete();
+        kafkaRebalanceClient().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(resourceName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
 
     private static KafkaRebalance getKafkaRebalanceFromYaml(String yamlPath) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.resources.crd;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -235,7 +236,7 @@ public class KafkaResource {
      * @param resourceName kafka cluster name
      */
     public static void deleteKafkaWithoutWait(String resourceName) {
-        kafkaClient().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(resourceName).cascading(true).delete();
+        kafkaClient().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(resourceName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
 
     private static Kafka getKafkaFromYaml(String yamlPath) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.connect;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -342,7 +343,7 @@ class ConnectS2IST extends AbstractST {
         TestUtils.waitFor("build status: Pending", Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_AVAILABILITY_TEST,
             () -> kubeClient().getClient().adapt(OpenShiftClient.class).builds().inNamespace(NAMESPACE).withName(kafkaConnectS2IName + "-connect-1").get().getStatus().getPhase().equals("Pending"));
 
-        kubeClient().getClient().adapt(OpenShiftClient.class).builds().inNamespace(NAMESPACE).withName(kafkaConnectS2IName + "-connect-1").cascading(true).delete();
+        kubeClient().getClient().adapt(OpenShiftClient.class).builds().inNamespace(NAMESPACE).withName(kafkaConnectS2IName + "-connect-1").withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
 
         KafkaConnectS2IResource.replaceConnectS2IResource(kafkaConnectS2IName, kc -> {
             kc.getSpec().setBuildResources(new ResourceRequirementsBuilder()

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.connect;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.strimzi.api.kafka.Crds;
@@ -249,7 +250,7 @@ class ConnectST extends AbstractST {
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "99");
 
-        KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(CONNECT_TOPIC_NAME).cascading(true).delete();
+        KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(CONNECT_TOPIC_NAME).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
         LOGGER.info("Topic {} deleted", CONNECT_TOPIC_NAME);
         KafkaTopicUtils.waitForKafkaTopicDeletion(CONNECT_TOPIC_NAME);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -13,6 +13,7 @@ import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.DoneableKafkaTopic;
@@ -1972,7 +1973,7 @@ class KafkaST extends AbstractST {
     @Override
     protected void tearDownEnvironmentAfterEach() throws Exception {
         super.tearDownEnvironmentAfterEach();
-        kubeClient().getClient().customResources(Crds.kafkaTopic(), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class).inNamespace(NAMESPACE).delete();
+        kubeClient().getClient().customResources(CustomResourceDefinitionContext.fromCrd(Crds.kafkaTopic()), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class).inNamespace(NAMESPACE).delete();
         kubeClient().getClient().persistentVolumeClaims().inNamespace(NAMESPACE).delete();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.operators;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.Service;
@@ -316,7 +317,7 @@ class CustomResourceStatusST extends AbstractST {
 
         KafkaConnectorUtils.waitForConnectorNotReady(CLUSTER_NAME);
 
-        KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).cascading(true).delete();
+        KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.operators.topic;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
@@ -253,7 +254,7 @@ public class TopicST extends AbstractST {
 
         String topicUid = KafkaTopicUtils.topicSnapshot(topicName);
         LOGGER.info("Going to delete topic {}", topicName);
-        KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(topicName).cascading(true).delete();
+        KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(topicName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
         LOGGER.info("Topic {} deleted", topicName);
 
         KafkaTopicUtils.waitTopicHasRolled(topicName, topicUid);

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.rollingupdate;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.operator.common.Annotations;
@@ -96,7 +97,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
         LOGGER.info("Annotate Kafka StatefulSet {} with manual rolling update annotation", kafkaName);
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.ROLLING_UPDATE));
         // set annotation to trigger Kafka rolling update
-        kubeClient().statefulSet(kafkaName).cascading(false).edit()
+        kubeClient().statefulSet(kafkaName).withPropagationPolicy(DeletionPropagation.ORPHAN).edit()
             .editMetadata()
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
             .endMetadata()
@@ -121,7 +122,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
         assertThat(received, is(sent));
 
         // set annotation to trigger Zookeeper rolling update
-        kubeClient().statefulSet(zkName).cascading(false).edit()
+        kubeClient().statefulSet(zkName).withPropagationPolicy(DeletionPropagation.ORPHAN).edit()
             .editMetadata()
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
             .endMetadata()

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.rollingupdate;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Event;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.operator.common.Annotations;
@@ -87,7 +88,7 @@ class KafkaRollerST extends AbstractST {
         kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
 
         // set annotation to trigger Kafka rolling update
-        kubeClient().statefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).cascading(false).edit()
+        kubeClient().statefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).withPropagationPolicy(DeletionPropagation.ORPHAN).edit()
             .editMetadata()
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
             .endMetadata()
@@ -111,7 +112,7 @@ class KafkaRollerST extends AbstractST {
         LOGGER.info("Annotate Kafka StatefulSet {} with manual rolling update annotation", kafkaName);
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.ROLLING_UPDATE));
         // set annotation to trigger Kafka rolling update
-        kubeClient().statefulSet(kafkaName).cascading(false).edit()
+        kubeClient().statefulSet(kafkaName).withPropagationPolicy(DeletionPropagation.ORPHAN).edit()
             .editMetadata()
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
             .endMetadata()

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -67,7 +67,27 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model</artifactId>
+            <artifactId>kubernetes-model-extensions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-rbac</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apps</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apiextensions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-model</artifactId>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -28,7 +28,7 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model</artifactId>
+            <artifactId>kubernetes-model-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>kubernetes-model-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apiextensions</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
@@ -4,11 +4,13 @@
  */
 package io.strimzi.operator.topic;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.DoneableKafkaTopic;
@@ -90,7 +92,7 @@ public class K8sImpl implements K8s {
         vertx.executeBlocking(future -> {
             try {
                 // Delete the resource by the topic name, because neither ZK nor Kafka know the resource name
-                if (!Boolean.TRUE.equals(operation().inNamespace(namespace).withName(resourceName.toString()).cascading(true).delete())) {
+                if (!Boolean.TRUE.equals(operation().inNamespace(namespace).withName(resourceName.toString()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete())) {
                     LOGGER.warn("KafkaTopic {} could not be deleted, since it doesn't seem to exist", resourceName.toString());
                     future.complete();
                 } else {
@@ -109,7 +111,7 @@ public class K8sImpl implements K8s {
     }
 
     private MixedOperation<KafkaTopic, KafkaTopicList, DoneableKafkaTopic, Resource<KafkaTopic, DoneableKafkaTopic>> operation() {
-        return client.customResources(Crds.kafkaTopic(), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
+        return client.customResources(CustomResourceDefinitionContext.fromCrd(Crds.kafkaTopic()), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
     }
 
     @Override
@@ -125,6 +127,7 @@ public class K8sImpl implements K8s {
     /**
      * Create the given k8s event
      */
+    @SuppressWarnings("deprecation")
     @Override
     public Future<Void> createEvent(Event event) {
         Promise<Void> handler = Promise.promise();

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Main.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Main.java
@@ -6,7 +6,6 @@ package io.strimzi.operator.topic;
 
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.strimzi.api.kafka.Crds;
-import io.strimzi.operator.common.Util;
 import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,12 +40,6 @@ public class Main {
     }
 
     private void deploy(Config config) {
-        // Workaround for https://github.com/fabric8io/kubernetes-client/issues/2212
-        // Can be removed after upgrade to Fabric8 4.10.2 or higher or to Java 11
-        if (Util.shouldDisableHttp2()) {
-            System.setProperty("http2.disable", "true");
-        }
-
         DefaultKubernetesClient kubeClient = new DefaultKubernetesClient();
         Crds.registerCustomKinds();
         VertxOptions options = new VertxOptions().setMetricsOptions(

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.topic;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.DoneableKafkaTopic;
@@ -193,7 +194,7 @@ public class Session extends AbstractVerticle {
                     try {
                         LOGGER.debug("Watching KafkaTopics matching {}", labels.labels());
 
-                        Session.this.topicWatch = kubeClient.customResources(Crds.kafkaTopic(), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class)
+                        Session.this.topicWatch = kubeClient.customResources(CustomResourceDefinitionContext.fromCrd(Crds.kafkaTopic()), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class)
                                 .inNamespace(namespace).withLabels(labels.labels()).watch(watcher);
                         LOGGER.debug("Watching setup");
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -6,7 +6,6 @@ package io.strimzi.operator.topic;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.DoneableKafkaTopic;
@@ -131,6 +130,7 @@ public class Session extends AbstractVerticle {
         }, stop);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void start(Promise<Void> start) {
         LOGGER.info("Starting");
@@ -194,7 +194,7 @@ public class Session extends AbstractVerticle {
                     try {
                         LOGGER.debug("Watching KafkaTopics matching {}", labels.labels());
 
-                        Session.this.topicWatch = kubeClient.customResources(CustomResourceDefinitionContext.fromCrd(Crds.kafkaTopic()), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class)
+                        Session.this.topicWatch = kubeClient.customResources(Crds.kafkaTopic(), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class)
                                 .inNamespace(namespace).withLabels(labels.labels()).watch(watcher);
                         LOGGER.debug("Watching setup");
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -95,7 +95,7 @@ class TopicOperator {
 
         @Override
         public void handle(Void v) {
-            EventBuilder evtb = new EventBuilder().withApiVersion("v1");
+            EventBuilder evtb = new EventBuilder();
             final String eventTime = ZonedDateTime.now().format(DateTimeFormatter.ofPattern("YYYY-MM-dd'T'HH:mm:ss'Z'"));
             
             if (involvedObject != null) {
@@ -424,10 +424,6 @@ class TopicOperator {
 
     public Counter getPeriodicReconciliationsCounter() {
         return this.periodicReconciliationsCounter;
-    }
-
-    public void setTopicCount(int topics) {
-        this.topicCounter.set(topics);
     }
 
     /**

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -426,6 +426,10 @@ class TopicOperator {
         return this.periodicReconciliationsCounter;
     }
 
+    public void setTopicCount(int topics) {
+        this.topicCounter.set(topics);
+    }
+
     /**
      * Run the given {@code action} on the context thread,
      * immediately if there are currently no other actions with the given {@code key},

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.topic;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -58,6 +59,7 @@ public class K8sImplTest {
         KubernetesClient mockClient = mock(KubernetesClient.class);
         MixedOperation<KafkaTopic, KafkaTopicList, TopicOperator.DeleteKafkaTopic, Resource<KafkaTopic, TopicOperator.DeleteKafkaTopic>> mockResources = mock(MixedOperation.class);
         when(mockClient.customResources(any(CustomResourceDefinitionContext.class), any(Class.class), any(Class.class), any(Class.class))).thenReturn(mockResources);
+        when(mockClient.customResources(any(CustomResourceDefinition.class), any(Class.class), any(Class.class), any(Class.class))).thenReturn(mockResources);
         when(mockResources.withLabels(any())).thenReturn(mockResources);
         when(mockResources.inNamespace(any())).thenReturn(mockResources);
         when(mockResources.list()).thenAnswer(invocation -> {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
@@ -5,10 +5,10 @@
 package io.strimzi.operator.topic;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
@@ -57,7 +57,7 @@ public class K8sImplTest {
 
         KubernetesClient mockClient = mock(KubernetesClient.class);
         MixedOperation<KafkaTopic, KafkaTopicList, TopicOperator.DeleteKafkaTopic, Resource<KafkaTopic, TopicOperator.DeleteKafkaTopic>> mockResources = mock(MixedOperation.class);
-        when(mockClient.customResources(any(CustomResourceDefinition.class), any(Class.class), any(Class.class), any(Class.class))).thenReturn(mockResources);
+        when(mockClient.customResources(any(CustomResourceDefinitionContext.class), any(Class.class), any(Class.class), any(Class.class))).thenReturn(mockResources);
         when(mockResources.withLabels(any())).thenReturn(mockResources);
         when(mockResources.inNamespace(any())).thenReturn(mockResources);
         when(mockResources.list()).thenAnswer(invocation -> {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -27,12 +27,10 @@ import java.util.stream.Collectors;
 
 import io.debezium.kafka.KafkaCluster;
 import io.debezium.kafka.ZookeeperServer;
-import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.DoneableKafkaTopic;
@@ -214,7 +212,7 @@ public abstract class TopicOperatorBaseIT {
                 // Wait for the operator to delete all the existing topics in Kafka
                 for (KafkaTopic item : items) {
                     LOGGER.info("Deleting {} from Kube", item.getMetadata().getName());
-                    operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+                    operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).cascading(true).delete();
                     LOGGER.info("Awaiting deletion of {} in Kafka", item.getMetadata().getName());
                     waitForTopicInKafka(new TopicName(item).toString(), false);
                     waitForTopicInKube(item.getMetadata().getName(), false);
@@ -229,7 +227,7 @@ public abstract class TopicOperatorBaseIT {
 
                 // Wait for the operator to delete all the existing topics in Kafka
                 for (KafkaTopic item : items) {
-                    operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+                    operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).cascading(true).delete();
                     waitForTopicInKube(item.getMetadata().getName(), false);
                 }
             }
@@ -583,7 +581,7 @@ public abstract class TopicOperatorBaseIT {
     }
 
     protected MixedOperation<KafkaTopic, KafkaTopicList, DoneableKafkaTopic, Resource<KafkaTopic, DoneableKafkaTopic>> operation() {
-        return kubeClient.customResources(CustomResourceDefinitionContext.fromCrd(Crds.kafkaTopic()), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
+        return kubeClient.customResources(Crds.kafkaTopic(), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
     }
 
     protected void waitForTopicInKafka(String topicName) throws InterruptedException, ExecutionException, TimeoutException {
@@ -631,7 +629,7 @@ public abstract class TopicOperatorBaseIT {
 
     protected void deleteInKube(String resourceName) throws InterruptedException, ExecutionException, TimeoutException {
         // can now delete the topicResource
-        operation().inNamespace(NAMESPACE).withName(resourceName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+        operation().inNamespace(NAMESPACE).withName(resourceName).cascading(true).delete();
         waitFor(() -> {
             return operation().inNamespace(NAMESPACE).withName(resourceName).get() == null;
         }, "verified deletion of KafkaTopic " + resourceName);

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -31,7 +31,7 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model</artifactId>
+            <artifactId>kubernetes-model-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -61,12 +61,6 @@ public class Main {
                         .setEnabled(true));
         Vertx vertx = Vertx.vertx(options);
 
-        // Workaround for https://github.com/fabric8io/kubernetes-client/issues/2212
-        // Can be removed after upgrade to Fabric8 4.10.2 or higher or to Java 11
-        if (Util.shouldDisableHttp2()) {
-            System.setProperty("http2.disable", "true");
-        }
-
         KubernetesClient client = new DefaultKubernetesClient();
         AdminClientProvider adminClientProvider = new DefaultAdminClientProvider();
 


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix
- Enhancement

### Description
Upgrade fabric8 dependency.

Memory resource changes in tests: It seems getting `getSizeLimit().getAmount()` was fixed in fabric8 because it was returning (e.g.) `4Gi`. It is obvious the amount is `4` (not `4Gi` as before, `Gi` is the format (`getSizeLimit().getFormat()`).

The bug with detecting java and enabling http2 has been fixed.

I had to do some changes (random resource name) in ITs because of caching resources which caused some flakiness.

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

