### PR TITLE
[DOC] Standalone User Operator deployment environment variables

### DIFF
--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -23,8 +23,8 @@ For more information about the environment variables used to configure the Topic
 .. `STRIMZI_KAFKA_BOOTSTRAP_SERVERS` to list the bootstrap brokers in your Kafka cluster, given as a comma-separated list of `_hostname_:‍_port_` pairs.
 .. `STRIMZI_ZOOKEEPER_CONNECT` to list the ZooKeeper nodes, given as a comma-separated list of `_hostname_:‍_port_` pairs. This should be the same ZooKeeper cluster that your Kafka cluster is using.
 .. `STRIMZI_NAMESPACE` to the Kubernetes namespace in which you want the operator to watch for  `KafkaTopic` resources.
-.. `STRIMZI_JAVA_OPTS` to the Java options used for the JVM running Topic Operator. An example is `-Xmx=512M -Xms=256M`.
-.. `STRIMZI_JAVA_SYSTEM_PROPERTIES` to list the `-D` options which are set to the Topic Operator. An example is `-Djavax.net.debug=verbose -DpropertyName=value`.
+.. `STRIMZI_JAVA_OPTS` _(optional)_ to the Java options used for the JVM running Topic Operator. An example is `-Xmx=512M -Xms=256M`.
+.. `STRIMZI_JAVA_SYSTEM_PROPERTIES` _(optional)_ to list the `-D` options which are set to the Topic Operator. An example is `-Djavax.net.debug=verbose -DpropertyName=value`.
 
 . Deploy the Topic Operator:
 +

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -31,8 +31,8 @@ This environment variable is optional and should be set only if the communicatio
 .. `STRIMZI_EO_KEY_SECRET_NAME` to point to a Kubernetes `Secret` containing the private key and related certificate for TLS client authentication against the Kafka cluster.
 The `Secret` must contain the keystore with the private key and certificate under the key `entity-operator.p12`, and the related password under the key `entity-operator.password`.
 This environment variable is optional and should be set only if TLS client authentication is needed when the communication with the Kafka cluster is TLS based.
-.. `STRIMZI_JAVA_OPTS` to the Java options used for the JVM running User Operator. An example is `-Xmx=512M -Xms=256M`.
-.. `STRIMZI_JAVA_SYSTEM_PROPERTIES` to list the `-D` options which are set to the User Operator. An example is `-Djavax.net.debug=verbose -DpropertyName=value`.
+.. `STRIMZI_JAVA_OPTS` _(optional)_ to the Java options used for the JVM running User Operator. An example is `-Xmx=512M -Xms=256M`.
+.. `STRIMZI_JAVA_SYSTEM_PROPERTIES` _(optional)_ to list the `-D` options which are set to the User Operator. An example is `-Djavax.net.debug=verbose -DpropertyName=value`.
 
 . Deploy the User Operator:
 +

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -18,21 +18,21 @@ a standalone deployment is more flexible as the User Operator can operate with _
 
 . Edit the following `Deployment.spec.template.spec.containers[0].env` properties in the `install/user-operator/05-Deployment-strimzi-user-operator.yaml` file by setting:
 +
+.. `STRIMZI_KAFKA_BOOTSTRAP_SERVERS` to list the Kafka brokers, given as a comma-separated list of `_hostname_:‍_port_` pairs.
+.. `STRIMZI_ZOOKEEPER_CONNECT` to list the ZooKeeper nodes, given as a comma-separated list of `_hostname_:‍_port_` pairs. This must be the same ZooKeeper cluster that your Kafka cluster is using.
+.. `STRIMZI_NAMESPACE` to the Kubernetes namespace in which you want the operator to watch for `KafkaUser` resources.
 .. `STRIMZI_CA_CERT_NAME` to point to a Kubernetes `Secret` that contains the public key of the Certificate Authority for signing new user certificates for TLS client authentication.
 The `Secret` must contain the public key of the Certificate Authority under the key `ca.crt`.
 .. `STRIMZI_CA_KEY_NAME` to point to a Kubernetes `Secret` that contains the private key of the Certificate Authority for signing new user certificates for TLS client authentication.
 The `Secret` must contain the private key of the Certificate Authority under the key `ca.key`.
-.. `STRIMZI_ZOOKEEPER_CONNECT` to list the ZooKeeper nodes, given as a comma-separated list of `_hostname_:‍_port_` pairs. This must be the same ZooKeeper cluster that your Kafka cluster is using.
-.. `STRIMZI_NAMESPACE` to the Kubernetes namespace in which you want the operator to watch for `KafkaUser` resources.
-.. `STRIMZI_JAVA_OPTS` to the Java options used for the JVM running User Operator. An example is `-Xmx=512M -Xms=256M`.
-.. `STRIMZI_JAVA_SYSTEM_PROPERTIES` to list the `-D` options which are set to the User Operator. An example is `-Djavax.net.debug=verbose -DpropertyName=value`.
-.. `STRIMZI_KAFKA_BOOTSTRAP_SERVERS` to list the Kafka brokers, given as a comma-separated list of `_hostname_:‍_port_` pairs.
-.. `STRIMZI_CLUSTER_CA_CERT_SECRET_NAME` to point to a Kubernetes `Secret` containing the public key of the Certificate Authority used for signing Kafka brokers certificates for enabling TLS based communication.
+.. `STRIMZI_CLUSTER_CA_CERT_SECRET_NAME` to point to a Kubernetes `Secret` containing the public key of the Certificate Authority used for signing Kafka brokers certificates for enabling TLS-based communication.
 The `Secret` must contain the public key of the Certificate Authority under the key `ca.crt`.
 This environment variable is optional and should be set only if the communication with the Kafka cluster is TLS based.
 .. `STRIMZI_EO_KEY_SECRET_NAME` to point to a Kubernetes `Secret` containing the private key and related certificate for TLS client authentication against the Kafka cluster.
 The `Secret` must contain the keystore with the private key and certificate under the key `entity-operator.p12`, and the related password under the key `entity-operator.password`.
 This environment variable is optional and should be set only if TLS client authentication is needed when the communication with the Kafka cluster is TLS based.
+.. `STRIMZI_JAVA_OPTS` to the Java options used for the JVM running User Operator. An example is `-Xmx=512M -Xms=256M`.
+.. `STRIMZI_JAVA_SYSTEM_PROPERTIES` to list the `-D` options which are set to the User Operator. An example is `-Djavax.net.debug=verbose -DpropertyName=value`.
 
 . Deploy the User Operator:
 +

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.systemtest;
 
-import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
+import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
@@ -67,7 +67,7 @@ public abstract class AbstractNamespaceST extends BaseST {
         KafkaMirrorMakerResource.kafkaMirrorMaker(CLUSTER_NAME, kafkaSourceName, kafkaTargetName, "my-group", 1, false).done();
 
         LOGGER.info("Waiting for creation {} in namespace {}", CLUSTER_NAME + "-mirror-maker", SECOND_NAMESPACE);
-        DeploymentUtils.waitForDeploymentAndPodsReady(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME), 1);
+        DeploymentUtils.waitForDeploymentAndPodsReady(KafkaMirrorMakerResources.deploymentName(CLUSTER_NAME), 1);
         cluster.setNamespace(previousNamespace);
     }
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Following feedback, a small update to the _Deploying the standalone User Operator_ procedure in the _Deploying Guide_, to change the order of priority of the environment variables listed. Also makes the order consistent with the variables listed in _Deploying the standalone Topic Operator_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

