### PR TITLE
[systemtest] Fix tests in ListenersST and KafkaST

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -144,28 +144,9 @@ public class PodUtils {
     public static void waitForPodDeletion(String name) {
         LOGGER.info("Waiting when Pod {} will be deleted", name);
 
-        if (kubeClient().listPodsByPrefixInName(name).size() != 0) {
-            TestUtils.waitFor("Pod " + name + " could not be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.TIMEOUT_FOR_POD_DELETION,
-                () -> {
-                    Pod pod = kubeClient().getPod(name);
-                    if (pod == null) {
-                        return true;
-                    } else {
-                        LOGGER.debug("Deleting pod {}", pod.getMetadata().getName());
-                        cmdKubeClient().deleteByName("pod", pod.getMetadata().getName());
-                        return false;
-                    }
-                });
-        }
-        LOGGER.info("Pod {} deleted", name);
-    }
-
-    public static void waitForPodDeletionByPrefix(String podPrefix) {
-        LOGGER.info("Waiting for Pods with prefix {} will be deleted", podPrefix);
-
-        TestUtils.waitFor("Pods with prefix" + podPrefix + "will be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.TIMEOUT_FOR_POD_DELETION,
+        TestUtils.waitFor("Pod " + name + " could not be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.TIMEOUT_FOR_POD_DELETION,
             () -> {
-                List<Pod> pods = kubeClient().listPodsByPrefixInName(podPrefix);
+                List<Pod> pods = kubeClient().listPodsByPrefixInName(name);
                 if (pods.size() != 0) {
                     for (Pod pod : pods) {
                         LOGGER.debug("Deleting pod {}", pod.getMetadata().getName());
@@ -173,10 +154,10 @@ public class PodUtils {
                     }
                     return false;
                 } else {
-                    return !kubeClient().listPodsByPrefixInName(podPrefix).stream().anyMatch(pod -> pod.getStatus().getPhase().equals("Terminating"));
+                    return true;
                 }
             });
-        LOGGER.info("All pods with prefix {} deleted", podPrefix);
+        LOGGER.info("Pod {} deleted", name);
     }
 
     public static void waitUntilPodsCountIsPresent(String podNamePrefix, int numberOfPods) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -1021,7 +1021,6 @@ class KafkaST extends BaseST {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
 
         String eoDeploymentName = KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME);
-        String eoPodName = kubeClient().listPodsByPrefixInName(eoDeploymentName).get(0).getMetadata().getName();
 
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, k -> {
             k.getSpec().getEntityOperator().setTopicOperator(null);
@@ -1031,7 +1030,7 @@ class KafkaST extends BaseST {
         //Waiting when EO pod will be deleted
         DeploymentUtils.waitForDeploymentDeletion(eoDeploymentName);
         ReplicaSetUtils.waitForReplicaSetDeletion(eoDeploymentName);
-        PodUtils.waitForPodDeletion(eoPodName);
+        PodUtils.waitForPodDeletionByPrefix(eoDeploymentName);
 
         //Checking that EO was removed
         assertThat(kubeClient().listPodsByPrefixInName(eoDeploymentName).size(), is(0));

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -1030,7 +1030,7 @@ class KafkaST extends BaseST {
         //Waiting when EO pod will be deleted
         DeploymentUtils.waitForDeploymentDeletion(eoDeploymentName);
         ReplicaSetUtils.waitForReplicaSetDeletion(eoDeploymentName);
-        PodUtils.waitForPodDeletionByPrefix(eoDeploymentName);
+        PodUtils.waitForPodDeletion(eoDeploymentName);
 
         //Checking that EO was removed
         assertThat(kubeClient().listPodsByPrefixInName(eoDeploymentName).size(), is(0));

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
@@ -14,7 +14,6 @@ import io.strimzi.systemtest.BaseST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
 import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
-import io.strimzi.systemtest.kafkaclients.KafkaClientProperties;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -28,7 +27,6 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -170,7 +168,6 @@ public class ListenersST extends BaseST {
 
         KafkaUser aliceUser = KafkaUserResource.tlsUser(CLUSTER_NAME, userName).done();
 
-
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(topicName)
             .withNamespaceName(NAMESPACE)
@@ -180,16 +177,7 @@ public class ListenersST extends BaseST {
             .withConsumerGroupName(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
             .withCertificateAuthorityCertificateName(customRootCA1)
             .withSecurityProtocol(SecurityProtocol.SSL)
-            .withKafkaClientProperties(
-                new KafkaClientProperties.KafkaClientPropertiesBuilder()
-                    .withNamespaceName(NAMESPACE)
-                    .withClusterName(CLUSTER_NAME)
-                    .withBootstrapServerConfig(KafkaResources.externalBootstrapServiceName(CLUSTER_NAME))
-                    .withKeySerializerConfig(StringSerializer.class)
-                    .withValueSerializerConfig(StringSerializer.class)
-                    .withClientIdConfig("kafka-user-producer")
-                    .build()
-            ).build();
+            .build();
 
         LOGGER.info("This is client configuration {}", basicExternalKafkaClient.getClientProperties());
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR gonna fix some of our failing tests from nightly builds.

First one was in `KafkaST` -> this problem I tried to fix on different PR, but it was wrong -> problem here is when before we are deleting TO and UO from EO, we got EO pod name and after it's deletion we've waited for **pod** with name to be deleted. Bad thing is, that after terminating the original EO pod, another one reappeared and terminated, but we already checked that EO pods are on 0. Here was race condition. 

The last one was in `ListenersST` and sending messages -> when we tried to send messages with external bootstrap server, it failed. I removed it as we have it in every ST with external services
### Checklist

- [x] Write tests
- [x] Make sure all tests pass


