### PR TITLE
[systemtest] Edit ClientUtils receive method

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -23,20 +23,19 @@ public class ClientUtils {
     // ensuring that object can not be created outside of class
     private ClientUtils() {}
 
-    public static void waitUntilClientReceivedMessagesTls(KafkaClientOperations kafkaClient, int exceptedMessages) throws Throwable {
-        int receivedMessages;
-        int tries = 3;
-
-        for (; tries > 0; tries--) {
-            receivedMessages = kafkaClient.receiveMessagesTls(Constants.GLOBAL_CLIENTS_TIMEOUT);
+    public static void waitUntilClientReceivedMessagesTls(KafkaClientOperations kafkaClient, int exceptedMessages) throws Exception {
+        for (int tries = 1; ; tries++) {
+            int receivedMessages = kafkaClient.receiveMessagesTls(Constants.GLOBAL_CLIENTS_TIMEOUT);
 
             if (receivedMessages == exceptedMessages) {
-                LOGGER.info("Consumer successfully consumed {} messages", exceptedMessages);
+                LOGGER.info("Consumer successfully consumed {} messages for the {} time", exceptedMessages, tries);
                 break;
             }
-        }
-        if (tries == 0) {
-            throw new Throwable(String.format("Consumer wasn't able to consume %s messages for 3 times", exceptedMessages));
+            LOGGER.warn("Client not received excepted messages {}, instead received only {}!", exceptedMessages, receivedMessages);
+
+            if (tries == 3) {
+                throw new RuntimeException(String.format("Consumer wasn't able to consume %s messages for 3 times", exceptedMessages));
+            }
         }
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -6,7 +6,6 @@ package io.strimzi.systemtest.utils;
 
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.KafkaClientOperations;
-import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -24,18 +23,21 @@ public class ClientUtils {
     // ensuring that object can not be created outside of class
     private ClientUtils() {}
 
-    public static void waitUntilClientReceivedMessagesTls(KafkaClientOperations kafkaClient, int exceptedMessages) {
-        TestUtils.waitFor("Kafka " + kafkaClient.toString() + " client received messages", Constants.GLOBAL_CLIENTS_POLL, Constants.GLOBAL_TIMEOUT,
-            () -> {
-                int receivedMessages = 0;
-                try {
-                    receivedMessages = kafkaClient.receiveMessagesTls(Constants.GLOBAL_CLIENTS_TIMEOUT);
-                    return receivedMessages == exceptedMessages;
-                } catch (Exception e) {
-                    LOGGER.warn("Client not received excepted messages {}, instead received only {}!", exceptedMessages, receivedMessages);
-                    return false;
-                }
-            });
+    public static void waitUntilClientReceivedMessagesTls(KafkaClientOperations kafkaClient, int exceptedMessages) throws Throwable {
+        int receivedMessages;
+        int tries = 3;
+
+        for (; tries > 0; tries--) {
+            receivedMessages = kafkaClient.receiveMessagesTls(Constants.GLOBAL_CLIENTS_TIMEOUT);
+
+            if (receivedMessages == exceptedMessages) {
+                LOGGER.info("Consumer successfully consumed {} messages", exceptedMessages);
+                break;
+            }
+        }
+        if (tries == 0) {
+            throw new Throwable(String.format("Consumer wasn't able to consume %s messages for 3 times", exceptedMessages));
+        }
     }
 }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -86,7 +86,7 @@ class RollingUpdateST extends BaseST {
     private static final Pattern ZK_SERVER_STATE = Pattern.compile("zk_server_state\\s+(leader|follower)");
 
     @Test
-    void testRecoveryDuringZookeeperRollingUpdate() throws Throwable {
+    void testRecoveryDuringZookeeperRollingUpdate() throws Exception {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
         KafkaResource.kafkaPersistent(CLUSTER_NAME, 3).done();
@@ -173,7 +173,7 @@ class RollingUpdateST extends BaseST {
     }
 
     @Test
-    void testRecoveryDuringKafkaRollingUpdate() throws Throwable {
+    void testRecoveryDuringKafkaRollingUpdate() throws Exception {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
         KafkaResource.kafkaPersistent(CLUSTER_NAME, 3)

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -86,7 +86,7 @@ class RollingUpdateST extends BaseST {
     private static final Pattern ZK_SERVER_STATE = Pattern.compile("zk_server_state\\s+(leader|follower)");
 
     @Test
-    void testRecoveryDuringZookeeperRollingUpdate() {
+    void testRecoveryDuringZookeeperRollingUpdate() throws Throwable {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
         KafkaResource.kafkaPersistent(CLUSTER_NAME, 3).done();
@@ -173,7 +173,7 @@ class RollingUpdateST extends BaseST {
     }
 
     @Test
-    void testRecoveryDuringKafkaRollingUpdate() {
+    void testRecoveryDuringKafkaRollingUpdate() throws Throwable {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
         KafkaResource.kafkaPersistent(CLUSTER_NAME, 3)


### PR DESCRIPTION
### Type of change

- Edit

### Description

This PR gonna edit our wait for receive messages method in `ClientUtils` to try only 3 times if consumer will receive messages. The `receiveMessagesTls()` have `waitFor` inside it, so there is no need to have it in our method and that's why I change it. Other than that -> if consumer won't receive messages on 3 tries, it will not receive it in the timeout.

### Checklist

- [ ] Make sure all tests pass

