### PR TITLE
Try to optimize sizes of some maps and arrays

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractConnectorSpec.java
@@ -73,7 +73,7 @@ public abstract class AbstractConnectorSpec implements Serializable, UnknownProp
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/CertSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CertSecretSource.java
@@ -60,7 +60,7 @@ public class CertSecretSource implements UnknownPropertyPreserving, Serializable
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/GenericSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/GenericSecretSource.java
@@ -59,7 +59,7 @@ public class GenericSecretSource implements UnknownPropertyPreserving, Serializa
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/InlineLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/InlineLogging.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/api/src/main/java/io/strimzi/api/kafka/model/InlineLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/InlineLogging.java
@@ -27,7 +27,7 @@ public class InlineLogging extends Logging {
 
     public static final String TYPE_INLINE = "inline";
 
-    private Map<String, String> loggers = new HashMap<>();
+    private Map<String, String> loggers = new HashMap<>(0);
 
     @Description("Must be `" + TYPE_INLINE + "`")
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/InlineLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/InlineLogging.java
@@ -27,7 +27,7 @@ public class InlineLogging extends Logging {
 
     public static final String TYPE_INLINE = "inline";
 
-    private Map<String, String> loggers = new HashMap<>(0);
+    private Map<String, String> loggers = null;
 
     @Description("Must be `" + TYPE_INLINE + "`")
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorization.java
@@ -44,7 +44,7 @@ public abstract class KafkaAuthorization implements UnknownPropertyPreserving, S
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
@@ -149,7 +149,7 @@ public class KafkaBridge extends CustomResource implements UnknownPropertyPreser
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeClientSpec.java
@@ -44,7 +44,7 @@ public abstract class KafkaBridgeClientSpec implements UnknownPropertyPreserving
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeTls.java
@@ -48,7 +48,7 @@ public class KafkaBridgeTls implements UnknownPropertyPreserving, Serializable {
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectTls.java
@@ -48,7 +48,7 @@ public class KafkaConnectTls implements UnknownPropertyPreserving, Serializable 
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
@@ -132,7 +132,7 @@ public class KafkaConnector extends CustomResource implements UnknownPropertyPre
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
@@ -162,7 +162,7 @@ public class KafkaMirrorMaker extends CustomResource implements UnknownPropertyP
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ClusterSpec.java
@@ -100,7 +100,7 @@ public class KafkaMirrorMaker2ClusterSpec implements UnknownPropertyPreserving, 
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2MirrorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2MirrorSpec.java
@@ -130,7 +130,7 @@ public class KafkaMirrorMaker2MirrorSpec implements Serializable, UnknownPropert
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2Tls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2Tls.java
@@ -48,7 +48,7 @@ public class KafkaMirrorMaker2Tls implements UnknownPropertyPreserving, Serializ
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerClientSpec.java
@@ -79,7 +79,7 @@ public class KafkaMirrorMakerClientSpec implements UnknownPropertyPreserving, Se
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerTls.java
@@ -50,7 +50,7 @@ public class KafkaMirrorMakerTls implements UnknownPropertyPreserving, Serializa
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
@@ -154,7 +154,7 @@ public class KafkaTopic extends CustomResource implements UnknownPropertyPreserv
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopicSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopicSpec.java
@@ -96,7 +96,7 @@ public class KafkaTopicSpec implements UnknownPropertyPreserving, Serializable {
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -153,7 +153,7 @@ public class KafkaUser extends CustomResource implements UnknownPropertyPreservi
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthentication.java
@@ -40,7 +40,7 @@ public abstract class KafkaUserAuthentication implements UnknownPropertyPreservi
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthorization.java
@@ -41,7 +41,7 @@ public abstract class KafkaUserAuthorization implements UnknownPropertyPreservin
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserQuotas.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserQuotas.java
@@ -75,7 +75,7 @@ public class KafkaUserQuotas implements UnknownPropertyPreserving, Serializable 
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserSpec.java
@@ -72,7 +72,7 @@ public class KafkaUserSpec  implements UnknownPropertyPreserving, Serializable {
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/PasswordSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/PasswordSecretSource.java
@@ -60,7 +60,7 @@ public class PasswordSecretSource implements UnknownPropertyPreserving, Serializ
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/TlsClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TlsClientAuthentication.java
@@ -32,7 +32,7 @@ public class TlsClientAuthentication implements UnknownPropertyPreserving, Seria
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthentication.java
@@ -51,7 +51,7 @@ public abstract class KafkaClientAuthentication implements UnknownPropertyPreser
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/ExternalListenerBrokerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/ExternalListenerBrokerOverride.java
@@ -75,7 +75,7 @@ public class ExternalListenerBrokerOverride implements Serializable, UnknownProp
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthentication.java
@@ -54,7 +54,7 @@ public abstract class KafkaListenerAuthentication implements UnknownPropertyPres
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternal.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternal.java
@@ -70,7 +70,7 @@ public abstract class KafkaListenerExternal implements UnknownPropertyPreserving
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalConfiguration.java
@@ -54,7 +54,7 @@ public class KafkaListenerExternalConfiguration implements Serializable, Unknown
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerPlain.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerPlain.java
@@ -72,7 +72,7 @@ public class KafkaListenerPlain implements UnknownPropertyPreserving, Serializab
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerTls.java
@@ -81,7 +81,7 @@ public class KafkaListenerTls implements UnknownPropertyPreserving, Serializable
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListeners.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListeners.java
@@ -74,7 +74,7 @@ public class KafkaListeners implements UnknownPropertyPreserving, Serializable {
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerOverride.java
@@ -64,7 +64,7 @@ public class LoadBalancerListenerOverride implements UnknownPropertyPreserving, 
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBootstrapOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBootstrapOverride.java
@@ -61,7 +61,7 @@ public class NodePortListenerBootstrapOverride extends ExternalListenerBootstrap
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerOverride.java
@@ -64,7 +64,7 @@ public class NodePortListenerOverride implements Serializable, UnknownPropertyPr
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/RouteListenerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/RouteListenerOverride.java
@@ -64,7 +64,7 @@ public class RouteListenerOverride implements UnknownPropertyPreserving, Seriali
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/TlsListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/TlsListenerConfiguration.java
@@ -53,7 +53,7 @@ public class TlsListenerConfiguration implements Serializable, UnknownPropertyPr
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/Condition.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/Condition.java
@@ -92,7 +92,7 @@ public class Condition implements UnknownPropertyPreserving, Serializable {
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaMirrorMaker2Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaMirrorMaker2Status.java
@@ -31,7 +31,7 @@ import lombok.ToString;
 public class KafkaMirrorMaker2Status extends KafkaConnectStatus {
     private static final long serialVersionUID = 1L;
 
-    private List<Map<String, Object>> connectors = new ArrayList<>();
+    private List<Map<String, Object>> connectors = new ArrayList<>(3);
 
     @Description("List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerAddress.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerAddress.java
@@ -63,7 +63,7 @@ public class ListenerAddress implements UnknownPropertyPreserving, Serializable 
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
@@ -87,7 +87,7 @@ public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/Status.java
@@ -47,7 +47,7 @@ public abstract class Status implements UnknownPropertyPreserving, Serializable 
 
     private List<Condition> prepareConditionsUpdate() {
         List<Condition> oldConditions = getConditions();
-        List<Condition> newConditions = oldConditions != null ? new ArrayList<>(oldConditions) : new ArrayList<>();
+        List<Condition> newConditions = oldConditions != null ? new ArrayList<>(oldConditions) : new ArrayList<>(0);
         return newConditions;
     }
 
@@ -81,7 +81,7 @@ public abstract class Status implements UnknownPropertyPreserving, Serializable 
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/storage/PersistentClaimStorageOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/storage/PersistentClaimStorageOverride.java
@@ -64,7 +64,7 @@ public class PersistentClaimStorageOverride  implements Serializable, UnknownPro
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/tracing/Tracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/tracing/Tracing.java
@@ -43,7 +43,7 @@ public abstract class Tracing implements UnknownPropertyPreserving, Serializable
     @Override
     public void setAdditionalProperty(String name, Object value) {
         if (this.additionalProperties == null) {
-            this.additionalProperties = new HashMap<>();
+            this.additionalProperties = new HashMap<>(1);
         }
         this.additionalProperties.put(name, value);
     }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect.out.yaml
@@ -20,7 +20,6 @@ spec:
     value: "value2"
   logging:
     type: "inline"
-    loggers: {}
   externalConfiguration:
     env:
     - name: "SOME_VARIABLE"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-invalid-external-configuration.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-invalid-external-configuration.yaml
@@ -15,7 +15,7 @@ spec:
   - sourceCluster: source
     targetCluster: target
     sourceConnector: {}
-    topics: my-topic
+    topicsPattern: my-topic
   externalConfiguration:
     env:
     - name: SOME_VARIABLE

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-invalid-replicas.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-invalid-replicas.yaml
@@ -15,6 +15,6 @@ spec:
   - sourceCluster: source
     targetCluster: target
     sourceConnector: {}
-    topics: my-topic
+    topicsPattern: my-topic
   config:
     name: bar

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-missing-required-property.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-missing-required-property.yaml
@@ -35,8 +35,8 @@ spec:
         tasksMax: 2
         config:
           checkpoints.topic.replication.factor: 1
-      # topics is missing
-      groups: my-group
+      # topicsPattern is missing
+      groupsPattern: my-group
     - sourceConnector:
         config:
           replication.factor: 1

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-scram-sha-512-auth.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-scram-sha-512-auth.yaml
@@ -27,5 +27,5 @@ spec:
   - sourceCluster: source
     targetCluster: target
     sourceConnector: {}
-    topics: my-topic
+    topicsPattern: my-topic
   

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-template.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-template.yaml
@@ -15,7 +15,7 @@ spec:
   - sourceCluster: source
     targetCluster: target
     sourceConnector: {}
-    topics: my-topic
+    topicsPattern: my-topic
   template:
     deployment:
       metadata:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-tls-auth-with-missing-required.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-tls-auth-with-missing-required.yaml
@@ -37,7 +37,7 @@ spec:
   - sourceCluster: source
     targetCluster: target
     sourceConnector: {}
-    topics: my-topic
+    topicsPattern: my-topic
   tolerations:
     - key: "key1"
       operator: "Equal"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-tls-auth.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-tls-auth.yaml
@@ -39,7 +39,7 @@ spec:
   - sourceCluster: source
     targetCluster: target
     sourceConnector: {}
-    topics: my-topic
+    topicsPattern: my-topic
   tolerations:
     - key: "key1"
       operator: "Equal"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-tls.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-tls.yaml
@@ -31,7 +31,7 @@ spec:
   - sourceCluster: source
     targetCluster: target
     sourceConnector: {}
-    topics: my-topic
+    topicsPattern: my-topic
   tolerations:
     - key: "key1"
       operator: "Equal"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.out.yaml
@@ -43,7 +43,6 @@ spec:
     value: "value2"
   logging:
     type: "inline"
-    loggers: {}
   externalConfiguration:
     env:
     - name: "SOME_VARIABLE"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.out.yaml
@@ -30,8 +30,8 @@ spec:
       tasksMax: 2
       config:
         heartbeats.topic.replication.factor: 1
-    topics: "my-topic"
-    groups: "my-group"
+    topicsPattern: "my-topic"
+    groupsPattern: "my-group"
   tolerations:
   - effect: "NoSchedule"
     key: "key1"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.yaml
@@ -69,5 +69,5 @@ spec:
       tasksMax: 2
       config:
         checkpoints.topic.replication.factor: 1
-    topics: my-topic
-    groups: my-group
+    topicsPattern: my-topic
+    groupsPattern: my-group

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2V1alpha1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2V1alpha1.yaml
@@ -31,8 +31,8 @@ spec:
       tasksMax: 2
       config:
         checkpoints.topic.replication.factor: 1
-    topics: my-topic
-    groups: my-group
+    topicsPattern: my-topic
+    groupsPattern: my-group
   tolerations:
     - key: "key1"
       operator: "Equal"

--- a/certificate-manager/src/main/java/io/strimzi/certs/SecretCertProvider.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/SecretCertProvider.java
@@ -88,7 +88,7 @@ public class SecretCertProvider {
                                byte[] store, byte[] storePassword,
                                Map<String, String> labels, Map<String, String> annotations,
                                OwnerReference ownerReference) {
-        Map<String, String> data = new HashMap<>();
+        Map<String, String> data = new HashMap<>(4);
 
         Base64.Encoder encoder = Base64.getEncoder();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -103,7 +103,7 @@ public class ClusterOperator extends AbstractVerticle {
         // Configure the executor here, but it is used only in other places
         getVertx().createSharedWorkerExecutor("kubernetes-ops-pool", 10, TimeUnit.SECONDS.toNanos(120));
 
-        List<Future> watchFutures = new ArrayList<>();
+        List<Future> watchFutures = new ArrayList<>(8);
         List<AbstractOperator<?, ?>> operators = new ArrayList<>(asList(
                 kafkaAssemblyOperator, kafkaMirrorMakerAssemblyOperator,
                 kafkaConnectAssemblyOperator, kafkaBridgeAssemblyOperator, kafkaMirrorMaker2AssemblyOperator));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -127,7 +127,7 @@ public class Main {
         KafkaBridgeAssemblyOperator kafkaBridgeAssemblyOperator =
                 new KafkaBridgeAssemblyOperator(vertx, pfa, certManager, passwordGenerator, resourceOperatorSupplier, config);
 
-        List<Future> futures = new ArrayList<>();
+        List<Future> futures = new ArrayList<>(config.getNamespaces().size());
         for (String namespace : config.getNamespaces()) {
             Promise<String> prom = Promise.promise();
             futures.add(prom.future());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -587,7 +587,7 @@ public abstract class AbstractModel {
     }
 
     protected PersistentVolumeClaim createPersistentVolumeClaim(int podNumber, String name, PersistentClaimStorage storage) {
-        Map<String, Quantity> requests = new HashMap<>();
+        Map<String, Quantity> requests = new HashMap<>(1);
         requests.put("storage", new Quantity(storage.getSize(), null));
 
         LabelSelector selector = null;
@@ -1092,7 +1092,6 @@ public abstract class AbstractModel {
 
     @SafeVarargs
     protected static Map<String, String> mergeLabelsOrAnnotations(Map<String, String> internal, Map<String, String>... templates) {
-        
         Map<String, String> merged = new HashMap<>();
 
         if (internal != null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -351,8 +351,14 @@ public abstract class AbstractModel {
      */
     public String parseLogging(Logging logging, ConfigMap externalCm) {
         if (logging instanceof InlineLogging) {
+            InlineLogging inlineLogging = (InlineLogging) logging;
             OrderedProperties newSettings = getDefaultLogConfig();
-            newSettings.addMapPairs(((InlineLogging) logging).getLoggers());
+
+            if (inlineLogging.getLoggers() != null) {
+                // Inline logging as specified and some loggers are configured
+                newSettings.addMapPairs(inlineLogging.getLoggers());
+            }
+
             return createPropertiesString(newSettings);
         } else if (logging instanceof ExternalLogging) {
             if (externalCm != null && externalCm.getData() != null && externalCm.getData().containsKey(getAncillaryConfigMapKeyLogConfig())) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
@@ -242,7 +242,7 @@ public class AuthenticationUtils {
      * @return Map of name/value pairs
      */
     public static Map<String, String> getClientAuthenticationProperties(KafkaClientAuthentication authentication) {
-        Map<String, String> properties = new HashMap<>();
+        Map<String, String> properties = new HashMap<>(3);
         
         if (authentication != null) {
             if (authentication instanceof KafkaClientAuthenticationTls) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -126,7 +126,7 @@ public class ClusterCa extends Ca {
         String cluster = kafka.getMetadata().getName();
         String namespace = kafka.getMetadata().getNamespace();
         Function<Integer, Subject> subjectFn = i -> {
-            Map<String, String> sbjAltNames = new HashMap<>();
+            Map<String, String> sbjAltNames = new HashMap<>(6);
             sbjAltNames.put("DNS.1", ZookeeperCluster.serviceName(cluster));
             sbjAltNames.put("DNS.2", String.format("%s.%s", ZookeeperCluster.serviceName(cluster), namespace));
             sbjAltNames.put("DNS.3", String.format("%s.%s.svc", ZookeeperCluster.serviceName(cluster), namespace));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -358,7 +358,7 @@ public class CruiseControl extends AbstractModel {
 
     @Override
     protected List<Container> getContainers(ImagePullPolicy imagePullPolicy) {
-        List<Container> containers = new ArrayList<>();
+        List<Container> containers = new ArrayList<>(2);
         Container container = new ContainerBuilder()
                 .withName(CRUISE_CONTROL_CONTAINER_NAME)
                 .withImage(getImage())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
@@ -49,7 +49,7 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
     private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
 
     static {
-        CC_DEFAULT_PROPERTIES_MAP = new HashMap<>();
+        CC_DEFAULT_PROPERTIES_MAP = new HashMap<>(7);
         CC_DEFAULT_PROPERTIES_MAP.put("partition.metrics.window.ms", Integer.toString(300_000));
         CC_DEFAULT_PROPERTIES_MAP.put("num.partition.metrics.windows", "1");
         CC_DEFAULT_PROPERTIES_MAP.put("broker.metrics.window.ms", Integer.toString(300_000));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -253,7 +253,7 @@ public class EntityOperator extends AbstractModel {
 
     @Override
     protected List<Container> getContainers(ImagePullPolicy imagePullPolicy) {
-        List<Container> containers = new ArrayList<>();
+        List<Container> containers = new ArrayList<>(3);
 
         if (topicOperator != null) {
             containers.addAll(topicOperator.getContainers(imagePullPolicy));
@@ -300,7 +300,7 @@ public class EntityOperator extends AbstractModel {
     }
 
     private List<Volume> getVolumes(boolean isOpenShift) {
-        List<Volume> volumeList = new ArrayList<>();
+        List<Volume> volumeList = new ArrayList<>(4);
         if (topicOperator != null) {
             volumeList.addAll(topicOperator.getVolumes());
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
@@ -211,7 +211,7 @@ public class JmxTrans extends AbstractModel {
      * @throws JsonProcessingException when JmxTrans config can't be created properly
      */
     public ConfigMap generateJmxTransConfigMap(JmxTransSpec spec, int numOfBrokers) throws JsonProcessingException {
-        Map<String, String> data = new HashMap<>();
+        Map<String, String> data = new HashMap<>(1);
         String jmxConfig = generateJMXConfig(spec, numOfBrokers);
         data.put(JMXTRANS_CONFIGMAP_KEY, jmxConfig);
         configMapName = jmxTransConfigName(clusterName);
@@ -219,14 +219,14 @@ public class JmxTrans extends AbstractModel {
     }
 
     public List<Volume> getVolumes() {
-        List<Volume> volumes = new ArrayList<>();
+        List<Volume> volumes = new ArrayList<>(2);
         volumes.add(VolumeUtils.createConfigMapVolume(JMXTRANS_VOLUME_NAME, configMapName));
         volumes.add(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, KafkaCluster.metricAndLogConfigsName(clusterName)));
         return volumes;
     }
 
     private List<VolumeMount> getVolumeMounts() {
-        List<VolumeMount> volumeMountList = new ArrayList<>();
+        List<VolumeMount> volumeMountList = new ArrayList<>(2);
 
         volumeMountList.add(VolumeUtils.createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath));
         volumeMountList.add(VolumeUtils.createVolumeMount(JMXTRANS_VOLUME_NAME, JMX_FILE_PATH));
@@ -235,7 +235,7 @@ public class JmxTrans extends AbstractModel {
 
     @Override
     protected List<Container> getContainers(ImagePullPolicy imagePullPolicy) {
-        List<Container> containers = new ArrayList<>();
+        List<Container> containers = new ArrayList<>(1);
         Container container = new ContainerBuilder()
                 .withName(name)
                 .withImage(getImage())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -337,7 +337,7 @@ public class KafkaBridgeCluster extends AbstractModel {
     @Override
     protected List<Container> getContainers(ImagePullPolicy imagePullPolicy) {
 
-        List<Container> containers = new ArrayList<>();
+        List<Container> containers = new ArrayList<>(1);
 
         Container container = new ContainerBuilder()
                 .withName(name)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConsumerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConsumerConfiguration.java
@@ -25,7 +25,7 @@ public class KafkaBridgeConsumerConfiguration extends AbstractConfiguration {
     static {
         FORBIDDEN_PREFIXES = asList(KafkaBridgeConsumerSpec.FORBIDDEN_PREFIXES.split(", "));
         FORBIDDEN_PREFIX_EXCEPTIONS = asList(KafkaBridgeConsumerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
-        DEFAULTS = new HashMap<>();
+        DEFAULTS = new HashMap<>(0);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeProducerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeProducerConfiguration.java
@@ -25,7 +25,7 @@ public class KafkaBridgeProducerConfiguration extends AbstractConfiguration {
     static {
         FORBIDDEN_PREFIXES = asList(KafkaBridgeProducerSpec.FORBIDDEN_PREFIXES.split(", "));
         FORBIDDEN_PREFIX_EXCEPTIONS = asList(KafkaBridgeProducerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
-        DEFAULTS = new HashMap<>();
+        DEFAULTS = new HashMap<>(0);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1349,7 +1349,7 @@ public class KafkaCluster extends AbstractModel {
      */
     public Secret generateBrokersSecret() {
 
-        Map<String, String> data = new HashMap<>();
+        Map<String, String> data = new HashMap<>(replicas * 4);
         for (int i = 0; i < replicas; i++) {
             CertAndKey cert = brokerCerts.get(KafkaCluster.kafkaPodName(cluster, i));
             data.put(KafkaCluster.kafkaPodName(cluster, i) + ".key", cert.keyAsBase64String());
@@ -1366,7 +1366,7 @@ public class KafkaCluster extends AbstractModel {
      * @return The generated Secret
      */
     public Secret generateJmxSecret() {
-        Map<String, String> data = new HashMap<>();
+        Map<String, String> data = new HashMap<>(2);
         String[] keys = {SECRET_JMX_USERNAME_KEY, SECRET_JMX_PASSWORD_KEY};
         PasswordGenerator passwordGenerator = new PasswordGenerator(16);
         for (String key : keys) {
@@ -1695,7 +1695,7 @@ public class KafkaCluster extends AbstractModel {
 
     @Override
     protected List<Container> getInitContainers(ImagePullPolicy imagePullPolicy) {
-        List<Container> initContainers = new ArrayList<>();
+        List<Container> initContainers = new ArrayList<>(1);
 
         if (rack != null || isExposedWithNodePort()) {
             ResourceRequirements resources = new ResourceRequirementsBuilder()
@@ -1725,7 +1725,7 @@ public class KafkaCluster extends AbstractModel {
     @Override
     protected List<Container> getContainers(ImagePullPolicy imagePullPolicy) {
 
-        List<Container> containers = new ArrayList<>();
+        List<Container> containers = new ArrayList<>(2);
 
         Container container = new ContainerBuilder()
                 .withName(KAFKA_NAME)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -437,7 +437,7 @@ public class KafkaConnectCluster extends AbstractModel {
     @Override
     protected List<Container> getContainers(ImagePullPolicy imagePullPolicy) {
 
-        List<Container> containers = new ArrayList<>();
+        List<Container> containers = new ArrayList<>(1);
 
         Container container = new ContainerBuilder()
                 .withName(name)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
@@ -25,7 +25,7 @@ public class KafkaConnectConfiguration extends AbstractConfiguration {
         FORBIDDEN_PREFIXES = asList(KafkaConnectSpec.FORBIDDEN_PREFIXES.split(", "));
         FORBIDDEN_PREFIX_EXCEPTIONS = asList(KafkaConnectSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
 
-        DEFAULTS = new HashMap<>();
+        DEFAULTS = new HashMap<>(6);
         DEFAULTS.put("group.id", "connect-cluster");
         DEFAULTS.put("offset.storage.topic", "connect-cluster-offsets");
         DEFAULTS.put("config.storage.topic", "connect-cluster-configs");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -218,7 +218,7 @@ public class KafkaExporter extends AbstractModel {
 
     @Override
     protected List<Container> getContainers(ImagePullPolicy imagePullPolicy) {
-        List<Container> containers = new ArrayList<>();
+        List<Container> containers = new ArrayList<>(1);
 
         Container container = new ContainerBuilder()
                 .withName(name)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Configuration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Configuration.java
@@ -25,7 +25,7 @@ public class KafkaMirrorMaker2Configuration extends AbstractConfiguration {
         FORBIDDEN_PREFIXES = asList(KafkaMirrorMaker2ClusterSpec.FORBIDDEN_PREFIXES.split(", "));
         FORBIDDEN_PREFIX_EXCEPTIONS = asList(KafkaMirrorMaker2ClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
 
-        DEFAULTS = new HashMap<>();
+        DEFAULTS = new HashMap<>(8);
         DEFAULTS.put("group.id", "mirrormaker2-cluster");
         DEFAULTS.put("offset.storage.topic", "mirrormaker2-cluster-offsets");
         DEFAULTS.put("config.storage.topic", "mirrormaker2-cluster-configs");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -316,7 +316,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
     @Override
     protected List<Container> getContainers(ImagePullPolicy imagePullPolicy) {
 
-        List<Container> containers = new ArrayList<>();
+        List<Container> containers = new ArrayList<>(1);
 
         Container container = new ContainerBuilder()
                 .withName(name)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerConsumerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerConsumerConfiguration.java
@@ -24,7 +24,7 @@ public class KafkaMirrorMakerConsumerConfiguration extends AbstractConfiguration
     static {
         FORBIDDEN_PREFIXES = asList(KafkaMirrorMakerConsumerSpec.FORBIDDEN_PREFIXES.split(", "));
         FORBIDDEN_PREFIX_EXCEPTIONS = asList(KafkaMirrorMakerConsumerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
-        DEFAULTS = new HashMap<>();
+        DEFAULTS = new HashMap<>(0);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerProducerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerProducerConfiguration.java
@@ -24,7 +24,7 @@ public class KafkaMirrorMakerProducerConfiguration extends AbstractConfiguration
     static {
         FORBIDDEN_PREFIXES = asList(KafkaMirrorMakerProducerSpec.FORBIDDEN_PREFIXES.split(", "));
         FORBIDDEN_PREFIX_EXCEPTIONS = asList(KafkaMirrorMakerProducerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
-        DEFAULTS = new HashMap<>();
+        DEFAULTS = new HashMap<>(0);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -225,7 +225,7 @@ public class ModelUtils {
 
     public static Secret buildSecret(ClusterCa clusterCa, Secret secret, String namespace, String secretName,
             String commonName, String keyCertName, Labels labels, OwnerReference ownerReference, boolean isMaintenanceTimeWindowsSatisfied) {
-        Map<String, String> data = new HashMap<>();
+        Map<String, String> data = new HashMap<>(4);
         CertAndKey certAndKey = null;
         boolean shouldBeRegenerated = false;
         List<String> reasons = new ArrayList<>(2);
@@ -428,7 +428,7 @@ public class ModelUtils {
         if (javaSystemProperties == null) {
             return null;
         }
-        List<String> javaSystemPropertiesList = new ArrayList<>();
+        List<String> javaSystemPropertiesList = new ArrayList<>(javaSystemProperties.size());
         for (SystemProperty property: javaSystemProperties) {
             javaSystemPropertiesList.add("-D" + property.getName() + "=" + property.getValue());
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -272,7 +272,7 @@ public class TopicOperator extends AbstractModel {
 
     @Override
     protected List<Container> getContainers(ImagePullPolicy imagePullPolicy) {
-        List<Container> containers = new ArrayList<>();
+        List<Container> containers = new ArrayList<>(2);
 
         Container container = new ContainerBuilder()
                 .withName(TOPIC_OPERATOR_NAME)
@@ -313,7 +313,7 @@ public class TopicOperator extends AbstractModel {
 
     @Override
     protected List<EnvVar> getEnvVars() {
-        List<EnvVar> varList = new ArrayList<>();
+        List<EnvVar> varList = new ArrayList<>(9);
         varList.add(buildEnvVar(ENV_VAR_RESOURCE_LABELS, topicConfigMapLabels));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_BOOTSTRAP_SERVERS, kafkaBootstrapServers));
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_CONNECT, String.format("%s:%d", "localhost", io.strimzi.api.kafka.model.TopicOperatorSpec.DEFAULT_ZOOKEEPER_PORT)));
@@ -377,7 +377,7 @@ public class TopicOperator extends AbstractModel {
     }
 
     private List<Volume> getVolumes(boolean isOpenShift) {
-        List<Volume> volumeList = new ArrayList<>();
+        List<Volume> volumeList = new ArrayList<>(3);
         volumeList.add(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
         volumeList.add(VolumeUtils.createSecretVolume(TLS_SIDECAR_EO_CERTS_VOLUME_NAME, TopicOperator.secretName(cluster), isOpenShift));
         volumeList.add(VolumeUtils.createSecretVolume(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, AbstractModel.clusterCaCertSecretName(cluster), isOpenShift));
@@ -385,7 +385,7 @@ public class TopicOperator extends AbstractModel {
     }
 
     private List<VolumeMount> getVolumeMounts() {
-        List<VolumeMount> volumeMountList = new ArrayList<>();
+        List<VolumeMount> volumeMountList = new ArrayList<>(3);
         volumeMountList.add(VolumeUtils.createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath));
         volumeMountList.add(VolumeUtils.createVolumeMount(TLS_SIDECAR_EO_CERTS_VOLUME_NAME, TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT));
         volumeMountList.add(VolumeUtils.createVolumeMount(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
@@ -172,7 +172,7 @@ public class VolumeUtils {
      * @return The PVC created
      */
     public static PersistentVolumeClaim createPersistentVolumeClaimTemplate(String name, PersistentClaimStorage storage) {
-        Map<String, Quantity> requests = new HashMap<>();
+        Map<String, Quantity> requests = new HashMap<>(1);
         requests.put("storage", new Quantity(storage.getSize(), null));
 
         LabelSelector selector = null;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -378,7 +378,7 @@ public class ZookeeperCluster extends AbstractModel {
 
         NetworkPolicyPeer zookeeperClusterPeer = new NetworkPolicyPeer();
         LabelSelector labelSelector2 = new LabelSelector();
-        Map<String, String> expressions2 = new HashMap<>();
+        Map<String, String> expressions2 = new HashMap<>(1);
         expressions2.put(Labels.STRIMZI_NAME_LABEL, zookeeperClusterName(cluster));
         labelSelector2.setMatchLabels(expressions2);
         zookeeperClusterPeer.setPodSelector(labelSelector2);
@@ -400,21 +400,21 @@ public class ZookeeperCluster extends AbstractModel {
         if (namespaceAndPodSelectorNetworkPolicySupported) {
             NetworkPolicyPeer kafkaClusterPeer = new NetworkPolicyPeer();
             LabelSelector labelSelector = new LabelSelector();
-            Map<String, String> expressions = new HashMap<>();
+            Map<String, String> expressions = new HashMap<>(1);
             expressions.put(Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(cluster));
             labelSelector.setMatchLabels(expressions);
             kafkaClusterPeer.setPodSelector(labelSelector);
 
             NetworkPolicyPeer entityOperatorPeer = new NetworkPolicyPeer();
             LabelSelector labelSelector3 = new LabelSelector();
-            Map<String, String> expressions3 = new HashMap<>();
+            Map<String, String> expressions3 = new HashMap<>(1);
             expressions3.put(Labels.STRIMZI_NAME_LABEL, EntityOperator.entityOperatorName(cluster));
             labelSelector3.setMatchLabels(expressions3);
             entityOperatorPeer.setPodSelector(labelSelector3);
 
             NetworkPolicyPeer clusterOperatorPeer = new NetworkPolicyPeer();
             LabelSelector labelSelector4 = new LabelSelector();
-            Map<String, String> expressions4 = new HashMap<>();
+            Map<String, String> expressions4 = new HashMap<>(1);
             expressions4.put(Labels.STRIMZI_KIND_LABEL, "cluster-operator");
             labelSelector4.setMatchLabels(expressions4);
             clusterOperatorPeer.setPodSelector(labelSelector4);
@@ -422,7 +422,7 @@ public class ZookeeperCluster extends AbstractModel {
 
             NetworkPolicyPeer cruiseControlPeer = new NetworkPolicyPeer();
             LabelSelector labelSelector5 = new LabelSelector();
-            Map<String, String> expressions5 = new HashMap<>();
+            Map<String, String> expressions5 = new HashMap<>(1);
             expressions5.put(Labels.STRIMZI_NAME_LABEL, CruiseControl.cruiseControlName(cluster));
             labelSelector5.setMatchLabels(expressions5);
             cruiseControlPeer.setPodSelector(labelSelector5);
@@ -500,7 +500,7 @@ public class ZookeeperCluster extends AbstractModel {
      */
     public Secret generateNodesSecret(ClusterCa clusterCa, Kafka kafka, boolean isMaintenanceTimeWindowsSatisfied) {
 
-        Map<String, String> data = new HashMap<>();
+        Map<String, String> data = new HashMap<>(replicas * 4);
 
         log.debug("Generating certificates");
         Map<String, CertAndKey> certs;
@@ -526,7 +526,7 @@ public class ZookeeperCluster extends AbstractModel {
     @Override
     protected List<Container> getContainers(ImagePullPolicy imagePullPolicy) {
 
-        List<Container> containers = new ArrayList<>();
+        List<Container> containers = new ArrayList<>(1);
 
         Container container = new ContainerBuilder()
                 .withName(ZOOKEEPER_NAME)
@@ -567,7 +567,7 @@ public class ZookeeperCluster extends AbstractModel {
     }
 
     private List<ServicePort> getServicePortList() {
-        List<ServicePort> portList = new ArrayList<>();
+        List<ServicePort> portList = new ArrayList<>(3);
         portList.add(createServicePort(CLIENT_TLS_PORT_NAME, CLIENT_TLS_PORT, CLIENT_TLS_PORT, "TCP"));
         portList.add(createServicePort(CLUSTERING_PORT_NAME, CLUSTERING_PORT, CLUSTERING_PORT, "TCP"));
         portList.add(createServicePort(LEADER_ELECTION_PORT_NAME, LEADER_ELECTION_PORT, LEADER_ELECTION_PORT, "TCP"));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
@@ -27,7 +27,7 @@ public class ZookeeperConfiguration extends AbstractConfiguration {
         FORBIDDEN_PREFIXES = asList(ZookeeperClusterSpec.FORBIDDEN_PREFIXES.split(", "));
         FORBIDDEN_PREFIX_EXCEPTIONS = asList(ZookeeperClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
 
-        Map<String, String> config = new HashMap<>();
+        Map<String, String> config = new HashMap<>(4);
         config.put("tickTime", "2000");
         config.put("initLimit", "5");
         config.put("syncLimit", "2");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -2579,7 +2579,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                                     .filter(pvc -> pvc.getMetadata().getName().endsWith(podName))
                                                     .collect(Collectors.toList());
                                         } else {
-                                            deletePvcs = new ArrayList<>();
+                                            deletePvcs = new ArrayList<>(0);
                                         }
 
                                         List<PersistentVolumeClaim> createPvcs = desiredPvcs
@@ -2906,7 +2906,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                 configAnnotation += this.userOperatorMetricsAndLogsConfigMap.getData().get("log4j2.properties");
                             }
 
-                            Map<String, String> annotations = new HashMap<>();
+                            Map<String, String> annotations = new HashMap<>(1);
                             annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, configAnnotation);
 
                             this.eoDeployment = entityOperator.generateDeployment(pfa.isOpenshift(), annotations, imagePullPolicy, imagePullSecrets);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
@@ -88,7 +88,7 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
                 configMapOperations.get(namespace, ((ExternalLogging) bridge.getLogging()).getName()) :
                 null);
 
-        Map<String, String> annotations = new HashMap<>();
+        Map<String, String> annotations = new HashMap<>(1);
         annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, logAndMetricsConfigMap.getData().get(bridge.ANCILLARY_CM_KEY_LOG_CONFIG));
 
         log.debug("{}: Updating Kafka Bridge cluster", reconciliation);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -111,7 +111,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                 configMapOperations.get(namespace, ((ExternalLogging) connect.getLogging()).getName()) :
                 null);
 
-        Map<String, String> annotations = new HashMap<>();
+        Map<String, String> annotations = new HashMap<>(1);
         annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, logAndMetricsConfigMap.getData().get(connect.ANCILLARY_CM_KEY_LOG_CONFIG));
 
         log.debug("{}: Updating Kafka Connect cluster", reconciliation);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -116,7 +116,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<Ope
                 configMapOperations.get(namespace, ((ExternalLogging) connect.getLogging()).getName()) :
                 null);
 
-        HashMap<String, String> annotations = new HashMap<>();
+        HashMap<String, String> annotations = new HashMap<>(1);
         annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, logAndMetricsConfigMap.getData().get(connect.ANCILLARY_CM_KEY_LOG_CONFIG));
 
         boolean connectHasZeroReplicas = connect.getReplicas() == 0;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -77,7 +77,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
     public static final String MIRRORMAKER2_SOURCE_CONNECTOR_SUFFIX = ".MirrorSourceConnector";
     public static final String MIRRORMAKER2_CHECKPOINT_CONNECTOR_SUFFIX = ".MirrorCheckpointConnector";
     public static final String MIRRORMAKER2_HEARTBEAT_CONNECTOR_SUFFIX = ".MirrorHeartbeatConnector";
-    private static final Map<String, Function<KafkaMirrorMaker2MirrorSpec, KafkaMirrorMaker2ConnectorSpec>> MIRRORMAKER2_CONNECTORS = new HashMap<>();
+    private static final Map<String, Function<KafkaMirrorMaker2MirrorSpec, KafkaMirrorMaker2ConnectorSpec>> MIRRORMAKER2_CONNECTORS = new HashMap<>(3);
 
     static {
         MIRRORMAKER2_CONNECTORS.put(MIRRORMAKER2_SOURCE_CONNECTOR_SUFFIX, KafkaMirrorMaker2MirrorSpec::getSourceConnector);
@@ -140,7 +140,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                 configMapOperations.get(namespace, ((ExternalLogging) mirrorMaker2Cluster.getLogging()).getName()) :
                 null);
 
-        Map<String, String> annotations = new HashMap<>();
+        Map<String, String> annotations = new HashMap<>(1);
         annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, logAndMetricsConfigMap.getData().get(mirrorMaker2Cluster.ANCILLARY_CM_KEY_LOG_CONFIG));
 
         log.debug("{}: Updating Kafka MirrorMaker 2.0 cluster", reconciliation);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -91,7 +91,7 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
                 configMapOperations.get(namespace, ((ExternalLogging) mirror.getLogging()).getName()) :
                 null);
 
-        Map<String, String> annotations = new HashMap<>();
+        Map<String, String> annotations = new HashMap<>(1);
         annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, logAndMetricsConfigMap.getData().get(mirror.ANCILLARY_CM_KEY_LOG_CONFIG));
 
         log.debug("{}: Updating Kafka Mirror Maker cluster", reconciliation);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
@@ -74,7 +74,7 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
         log.debug("Considering rolling update of {}/{}", namespace, name);
 
         boolean zkRoll = false;
-        ArrayList<Pod> pods = new ArrayList<>();
+        ArrayList<Pod> pods = new ArrayList<>(replicas);
         String cluster = sts.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
         for (int i = 0; i < replicas; i++) {
             Pod pod = podOperations.get(sts.getMetadata().getNamespace(), KafkaResources.zookeeperPodName(cluster, i));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -84,12 +84,12 @@ public class KafkaConnectClusterTest {
     private final String bootstrapServers = "foo-kafka:9092";
     private final String kafkaHeapOpts = "-Xms" + AbstractModel.DEFAULT_JVM_XMS;
     private final OrderedProperties defaultConfiguration = new OrderedProperties()
-            .addPair("config.storage.topic", "connect-cluster-configs")
-            .addPair("group.id", "connect-cluster")
-            .addPair("status.storage.topic", "connect-cluster-status")
             .addPair("offset.storage.topic", "connect-cluster-offsets")
             .addPair("value.converter", "org.apache.kafka.connect.json.JsonConverter")
-            .addPair("key.converter", "org.apache.kafka.connect.json.JsonConverter");
+            .addPair("config.storage.topic", "connect-cluster-configs")
+            .addPair("key.converter", "org.apache.kafka.connect.json.JsonConverter")
+            .addPair("group.id", "connect-cluster")
+            .addPair("status.storage.topic", "connect-cluster-status");
     private final OrderedProperties expectedConfiguration = new OrderedProperties()
             .addMapPairs(defaultConfiguration.asMap())
             .addPair("foo", "bar");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -84,12 +84,12 @@ public class KafkaConnectS2IClusterTest {
     private final String bootstrapServers = "foo-kafka:9092";
     private final String kafkaHeapOpts = "-Xms" + AbstractModel.DEFAULT_JVM_XMS;
     private final OrderedProperties defaultConfiguration = new OrderedProperties()
-            .addPair("config.storage.topic", "connect-cluster-configs")
-            .addPair("group.id", "connect-cluster")
-            .addPair("status.storage.topic", "connect-cluster-status")
             .addPair("offset.storage.topic", "connect-cluster-offsets")
             .addPair("value.converter", "org.apache.kafka.connect.json.JsonConverter")
-            .addPair("key.converter", "org.apache.kafka.connect.json.JsonConverter");
+            .addPair("config.storage.topic", "connect-cluster-configs")
+            .addPair("key.converter", "org.apache.kafka.connect.json.JsonConverter")
+            .addPair("group.id", "connect-cluster")
+            .addPair("status.storage.topic", "connect-cluster-status");
     private final OrderedProperties expectedConfiguration = new OrderedProperties()
             .addMapPairs(defaultConfiguration.asMap())
             .addPair("foo", "bar");

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -352,12 +352,12 @@ public abstract class Ca {
         File brokerCertFile = File.createTempFile("tls", "broker-cert");
         File brokerKeyStoreFile = File.createTempFile("tls", "broker-p12");
 
-        int replicasInMewSecret = Math.min(replicasInSecret, replicas);
-        Map<String, CertAndKey> certs = new HashMap<>(replicasInMewSecret);
+        int replicasInNewSecret = Math.min(replicasInSecret, replicas);
+        Map<String, CertAndKey> certs = new HashMap<>(replicasInNewSecret);
         // copying the minimum number of certificates already existing in the secret
         // scale up -> it will copy all certificates
         // scale down -> it will copy just the requested number of replicas
-        for (int i = 0; i < replicasInMewSecret; i++) {
+        for (int i = 0; i < replicasInNewSecret; i++) {
             String podName = podNameFn.apply(i);
             log.debug("Certificate for {} already exists", podName);
             Subject subject = subjectFn.apply(i);

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -352,11 +352,12 @@ public abstract class Ca {
         File brokerCertFile = File.createTempFile("tls", "broker-cert");
         File brokerKeyStoreFile = File.createTempFile("tls", "broker-p12");
 
-        Map<String, CertAndKey> certs = new HashMap<>();
+        int replicasInMewSecret = Math.min(replicasInSecret, replicas);
+        Map<String, CertAndKey> certs = new HashMap<>(replicasInMewSecret);
         // copying the minimum number of certificates already existing in the secret
         // scale up -> it will copy all certificates
         // scale down -> it will copy just the requested number of replicas
-        for (int i = 0; i < Math.min(replicasInSecret, replicas); i++) {
+        for (int i = 0; i < replicasInMewSecret; i++) {
             String podName = podNameFn.apply(i);
             log.debug("Certificate for {} already exists", podName);
             Subject subject = subjectFn.apply(i);
@@ -512,12 +513,12 @@ public abstract class Ca {
             log.debug("{} renewalType {}", this, renewalType);
             switch (renewalType) {
                 case CREATE:
-                    keyData = new HashMap<>();
-                    certData = new HashMap<>();
+                    keyData = new HashMap<>(1);
+                    certData = new HashMap<>(3);
                     generateCaKeyAndCert(nextCaSubject(caKeyGeneration), keyData, certData);
                     break;
                 case REPLACE_KEY:
-                    keyData = new HashMap<>();
+                    keyData = new HashMap<>(1);
                     certData = new HashMap<>(caCertSecret.getData());
                     if (certData.containsKey(CA_CRT)) {
                         String notAfterDate = DATE_TIME_FORMATTER.format(currentCert.getNotAfter().toInstant().atZone(ZoneId.of("Z")));
@@ -529,7 +530,7 @@ public abstract class Ca {
                     break;
                 case RENEW_CERT:
                     keyData = caKeySecret.getData();
-                    certData = new HashMap<>();
+                    certData = new HashMap<>(3);
                     ++caCertGeneration;
                     renewCaCert(nextCaSubject(caKeyGeneration), certData);
                     break;

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -134,7 +134,7 @@ public class KafkaUserModel {
      */
     public Secret generateSecret()  {
         if (authentication instanceof KafkaUserTlsClientAuthentication) {
-            Map<String, String> data = new HashMap<>();
+            Map<String, String> data = new HashMap<>(5);
             data.put("ca.crt", caCert);
             data.put("user.key", userCertAndKey.keyAsBase64String());
             data.put("user.crt", userCertAndKey.certAsBase64String());
@@ -142,7 +142,7 @@ public class KafkaUserModel {
             data.put("user.password", userCertAndKey.storePasswordAsBase64String());
             return createSecret(data);
         } else if (authentication instanceof KafkaUserScramSha512ClientAuthentication) {
-            Map<String, String> data = new HashMap<>();
+            Map<String, String> data = new HashMap<>(1);
             data.put(KafkaUserModel.KEY_PASSWORD, Base64.getEncoder().encodeToString(scramSha512Password.getBytes(StandardCharsets.US_ASCII)));
             return createSecret(data);
         } else {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In many cases, we create HaskMaps and ArrayLists with the default settings, although they are going to be used for a smaller / predefined number of items. This RP tries to optimize the sizes in the places where obvious by using the initial size in the constructor.

This also fixes some `api` tests for MM2 which used wrong field names and were failing.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally