### PR TITLE
Synchronize configuration constant names

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
@@ -27,12 +27,12 @@ public abstract class AbstractConfiguration {
      *
      * @param configuration     Configuration in String format. Should contain zero or more lines with with key=value
      *                          pairs.
-     * @param forbiddenOptions   List with configuration keys which are not allowed. All keys which start with one of
-     *                           these keys will be ignored.
+     * @param forbiddenPrefixes List with configuration key prefixes which are not allowed. All keys which start with one of
+     *                          these prefixes will be ignored.
      */
-    public AbstractConfiguration(String configuration, List<String> forbiddenOptions) {
+    public AbstractConfiguration(String configuration, List<String> forbiddenPrefixes) {
         options.addStringPairs(configuration);
-        filterForbidden(forbiddenOptions);
+        filterForbidden(forbiddenPrefixes);
     }
 
     /**
@@ -41,14 +41,14 @@ public abstract class AbstractConfiguration {
      *
      * @param configuration     Configuration in String format. Should contain zero or more lines with with key=value
      *                          pairs.
-     * @param forbiddenOptions  List with configuration keys which are not allowed. All keys which start with one of
-     *                          these keys will be ignored.
+     * @param forbiddenPrefixes List with configuration key prefixes which are not allowed. All keys which start with one of
+     *                          these prefixes will be ignored.
      * @param defaults          Properties object with default options
      */
-    public AbstractConfiguration(String configuration, List<String> forbiddenOptions, Map<String, String> defaults) {
+    public AbstractConfiguration(String configuration, List<String> forbiddenPrefixes, Map<String, String> defaults) {
         options.addMapPairs(defaults);
         options.addStringPairs(configuration);
-        filterForbidden(forbiddenOptions);
+        filterForbidden(forbiddenPrefixes);
     }
 
     /**
@@ -56,12 +56,12 @@ public abstract class AbstractConfiguration {
      * ConfigMap / CRD.
      *
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
-     * @param forbiddenOptions   List with configuration keys which are not allowed. All keys which start with one of
-     *                           these keys will be ignored.
+     * @param forbiddenPrefixes   List with configuration key prefixes which are not allowed. All keys which start with one of
+     *                           these prefixes will be ignored.
      */
-    public AbstractConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenOptions) {
+    public AbstractConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenPrefixes) {
         options.addIterablePairs(jsonOptions);
-        filterForbidden(forbiddenOptions);
+        filterForbidden(forbiddenPrefixes);
     }
 
     /**
@@ -69,13 +69,13 @@ public abstract class AbstractConfiguration {
      * ConfigMap / CRD.
      *
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
-     * @param forbiddenOptions   List with configuration keys which are not allowed. All keys which start with one of
-     *                           these keys will be ignored.
-     * @param exceptions        Exceptions excluded from forbidden options checking
+     * @param forbiddenPrefixes  List with configuration key prefixes which are not allowed. All keys which start with one of
+     *                           these prefixes will be ignored.
+     * @param forbiddenPrefixExceptions Exceptions excluded from forbidden prefix options checking
      */
-    public AbstractConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenOptions, List<String> exceptions) {
+    public AbstractConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenPrefixes, List<String> forbiddenPrefixExceptions) {
         options.addIterablePairs(jsonOptions);
-        filterForbidden(forbiddenOptions, exceptions);
+        filterForbidden(forbiddenPrefixes, forbiddenPrefixExceptions);
     }
 
     /**
@@ -83,14 +83,14 @@ public abstract class AbstractConfiguration {
      * ConfigMap / CRD.
      *
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
-     * @param forbiddenOptions   List with configuration keys which are not allowed. All keys which start with one of
-     *                           these keys will be ignored.
+     * @param forbiddenPrefixes   List with configuration key prefixes which are not allowed. All keys which start with one of
+     *                           these prefixes will be ignored.
      * @param defaults          Properties object with default options
      */
-    public AbstractConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenOptions, Map<String, String> defaults) {
+    public AbstractConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenPrefixes, Map<String, String> defaults) {
         options.addMapPairs(defaults);
         options.addIterablePairs(jsonOptions);
-        filterForbidden(forbiddenOptions);
+        filterForbidden(forbiddenPrefixes);
     }
 
     /**
@@ -98,29 +98,29 @@ public abstract class AbstractConfiguration {
      * ConfigMap / CRD.
      *
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
-     * @param forbiddenOptions   List with configuration keys which are not allowed. All keys which start with one of
-     *                           these keys will be ignored.
-     * @param exceptions        Exceptions excluded from forbidden options checking
+     * @param forbiddenPrefixes  List with configuration key prefixes which are not allowed. All keys which start with one of
+     *                           these prefixes will be ignored.
+     * @param forbiddenPrefixExceptions  Exceptions excluded from forbidden prefix options checking
      * @param defaults          Properties object with default options
      */
-    public AbstractConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenOptions, List<String> exceptions, Map<String, String> defaults) {
+    public AbstractConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenPrefixes, List<String> forbiddenPrefixExceptions, Map<String, String> defaults) {
         options.addMapPairs(defaults);
         options.addIterablePairs(jsonOptions);
-        filterForbidden(forbiddenOptions, exceptions);
+        filterForbidden(forbiddenPrefixes, forbiddenPrefixExceptions);
     }
 
     /**
      * Filters forbidden values from the configuration.
      *
-     * @param forbiddenOptions  List with configuration keys which are not allowed. All keys which start with one of
-     *                          these keys will be ignored.
-     * @param exceptions        Exceptions excluded from forbidden options checking
+     * @param forbiddenPrefixes List with configuration key prefixes which are not allowed. All keys which start with one of
+     *                          these prefixes will be ignored.
+     * @param forbiddenPrefixExceptions Exceptions excluded from forbidden prefix options checking
      */
-    private void filterForbidden(List<String> forbiddenOptions, List<String> exceptions)   {
-        options.filter(k -> forbiddenOptions.stream().anyMatch(s -> {
+    private void filterForbidden(List<String> forbiddenPrefixes, List<String> forbiddenPrefixExceptions)   {
+        options.filter(k -> forbiddenPrefixes.stream().anyMatch(s -> {
             boolean forbidden = k.toLowerCase(Locale.ENGLISH).startsWith(s);
             if (forbidden) {
-                if (exceptions.contains(k))
+                if (forbiddenPrefixExceptions.contains(k))
                     forbidden = false;
             }
             if (forbidden) {
@@ -132,8 +132,8 @@ public abstract class AbstractConfiguration {
         }));
     }
 
-    private void filterForbidden(List<String> forbiddenOptions)   {
-        this.filterForbidden(forbiddenOptions, Collections.emptyList());
+    private void filterForbidden(List<String> forbiddenPrefixes)   {
+        this.filterForbidden(forbiddenPrefixes, Collections.emptyList());
     }
 
     public String getConfigOption(String configOption) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
@@ -45,8 +45,8 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
     */
     private static final Map<String, String> CC_DEFAULT_PROPERTIES_MAP;
 
-    private static final List<String> FORBIDDEN_OPTIONS;
-    private static final List<String> EXCEPTIONS;
+    private static final List<String> FORBIDDEN_PREFIXES;
+    private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
 
     static {
         CC_DEFAULT_PROPERTIES_MAP = new HashMap<>();
@@ -58,8 +58,8 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
         CC_DEFAULT_PROPERTIES_MAP.put("default.goals", DEFAULT_GOALS);
         CC_DEFAULT_PROPERTIES_MAP.put("goals", DEFAULT_GOALS);
 
-        FORBIDDEN_OPTIONS = asList(CruiseControlSpec.FORBIDDEN_PREFIXES.split(", *"));
-        EXCEPTIONS = asList(CruiseControlSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", *"));
+        FORBIDDEN_PREFIXES = asList(CruiseControlSpec.FORBIDDEN_PREFIXES.split(", *"));
+        FORBIDDEN_PREFIX_EXCEPTIONS = asList(CruiseControlSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", *"));
     }
 
     /**
@@ -69,7 +69,7 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public CruiseControlConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS, EXCEPTIONS);
+        super(jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS);
     }
 
     private CruiseControlConfiguration(String configuration, List<String> forbiddenOptions) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
@@ -72,8 +72,8 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
         super(jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS);
     }
 
-    private CruiseControlConfiguration(String configuration, List<String> forbiddenOptions) {
-        super(configuration, forbiddenOptions);
+    private CruiseControlConfiguration(String configuration, List<String> forbiddenPrefixes) {
+        super(configuration, forbiddenPrefixes);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConsumerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConsumerConfiguration.java
@@ -18,13 +18,13 @@ import static java.util.Arrays.asList;
  */
 public class KafkaBridgeConsumerConfiguration extends AbstractConfiguration {
 
-    private static final List<String> FORBIDDEN_OPTIONS;
-    private static final List<String> EXCEPTIONS;
+    private static final List<String> FORBIDDEN_PREFIXES;
+    private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
     private static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_OPTIONS = asList(KafkaBridgeConsumerSpec.FORBIDDEN_PREFIXES.split(", "));
-        EXCEPTIONS = asList(KafkaBridgeConsumerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
+        FORBIDDEN_PREFIXES = asList(KafkaBridgeConsumerSpec.FORBIDDEN_PREFIXES.split(", "));
+        FORBIDDEN_PREFIX_EXCEPTIONS = asList(KafkaBridgeConsumerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
         DEFAULTS = new HashMap<>();
     }
 
@@ -35,6 +35,6 @@ public class KafkaBridgeConsumerConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaBridgeConsumerConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS, EXCEPTIONS, DEFAULTS);
+        super(jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeProducerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeProducerConfiguration.java
@@ -18,13 +18,13 @@ import static java.util.Arrays.asList;
  */
 public class KafkaBridgeProducerConfiguration extends AbstractConfiguration {
 
-    private static final List<String> FORBIDDEN_OPTIONS;
-    private static final List<String> EXCEPTIONS;
+    private static final List<String> FORBIDDEN_PREFIXES;
+    private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
     private static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_OPTIONS = asList(KafkaBridgeProducerSpec.FORBIDDEN_PREFIXES.split(", "));
-        EXCEPTIONS = asList(KafkaBridgeProducerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
+        FORBIDDEN_PREFIXES = asList(KafkaBridgeProducerSpec.FORBIDDEN_PREFIXES.split(", "));
+        FORBIDDEN_PREFIX_EXCEPTIONS = asList(KafkaBridgeProducerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
         DEFAULTS = new HashMap<>();
     }
 
@@ -35,6 +35,6 @@ public class KafkaBridgeProducerConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaBridgeProducerConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS, EXCEPTIONS, DEFAULTS);
+        super(jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -49,8 +49,8 @@ public class KafkaConfiguration extends AbstractConfiguration {
         super(jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS);
     }
 
-    private KafkaConfiguration(String configuration, List<String> forbiddenOptions) {
-        super(configuration, forbiddenOptions);
+    private KafkaConfiguration(String configuration, List<String> forbiddenPrefixes) {
+        super(configuration, forbiddenPrefixes);
     }
 
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -31,12 +31,12 @@ public class KafkaConfiguration extends AbstractConfiguration {
     public static final String INTERBROKER_PROTOCOL_VERSION = "inter.broker.protocol.version";
     public static final String LOG_MESSAGE_FORMAT_VERSION = "log.message.format.version";
 
-    private static final List<String> FORBIDDEN_OPTIONS;
-    private static final List<String> EXCEPTIONS;
+    private static final List<String> FORBIDDEN_PREFIXES;
+    private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
 
     static {
-        FORBIDDEN_OPTIONS = asList(KafkaClusterSpec.FORBIDDEN_PREFIXES.split(", "));
-        EXCEPTIONS = asList(KafkaClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
+        FORBIDDEN_PREFIXES = asList(KafkaClusterSpec.FORBIDDEN_PREFIXES.split(", "));
+        FORBIDDEN_PREFIX_EXCEPTIONS = asList(KafkaClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
     }
 
     /**
@@ -46,7 +46,7 @@ public class KafkaConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS, EXCEPTIONS);
+        super(jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS);
     }
 
     private KafkaConfiguration(String configuration, List<String> forbiddenOptions) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
@@ -17,13 +17,13 @@ import static java.util.Arrays.asList;
  * Class for handling Kafka Connect configuration passed by the user
  */
 public class KafkaConnectConfiguration extends AbstractConfiguration {
-    private static final List<String> FORBIDDEN_OPTIONS;
-    private static final List<String> EXCEPTIONS;
+    private static final List<String> FORBIDDEN_PREFIXES;
+    private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
     private static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_OPTIONS = asList(KafkaConnectSpec.FORBIDDEN_PREFIXES.split(", "));
-        EXCEPTIONS = asList(KafkaConnectSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
+        FORBIDDEN_PREFIXES = asList(KafkaConnectSpec.FORBIDDEN_PREFIXES.split(", "));
+        FORBIDDEN_PREFIX_EXCEPTIONS = asList(KafkaConnectSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
 
         DEFAULTS = new HashMap<>();
         DEFAULTS.put("group.id", "connect-cluster");
@@ -41,6 +41,6 @@ public class KafkaConnectConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaConnectConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS, EXCEPTIONS, DEFAULTS);
+        super(jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Configuration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Configuration.java
@@ -17,13 +17,13 @@ import static java.util.Arrays.asList;
  * Class for handling Kafka MirrorMaker 2.0 connect configuration passed by the user
  */
 public class KafkaMirrorMaker2Configuration extends AbstractConfiguration {
-    private static final List<String> FORBIDDEN_OPTIONS;
-    private static final List<String> EXCEPTIONS;
+    private static final List<String> FORBIDDEN_PREFIXES;
+    private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
     private static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_OPTIONS = asList(KafkaMirrorMaker2ClusterSpec.FORBIDDEN_PREFIXES.split(", "));
-        EXCEPTIONS = asList(KafkaMirrorMaker2ClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
+        FORBIDDEN_PREFIXES = asList(KafkaMirrorMaker2ClusterSpec.FORBIDDEN_PREFIXES.split(", "));
+        FORBIDDEN_PREFIX_EXCEPTIONS = asList(KafkaMirrorMaker2ClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
 
         DEFAULTS = new HashMap<>();
         DEFAULTS.put("group.id", "mirrormaker2-cluster");
@@ -44,6 +44,6 @@ public class KafkaMirrorMaker2Configuration extends AbstractConfiguration {
      *                    pairs.
      */
     public KafkaMirrorMaker2Configuration(Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS, EXCEPTIONS, DEFAULTS);
+        super(jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerConsumerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerConsumerConfiguration.java
@@ -17,13 +17,13 @@ import static java.util.Arrays.asList;
  * Class for handling Kafka Mirror Maker consumer configuration passed by the user
  */
 public class KafkaMirrorMakerConsumerConfiguration extends AbstractConfiguration {
-    private static final List<String> FORBIDDEN_OPTIONS;
-    private static final List<String> EXCEPTIONS;
+    private static final List<String> FORBIDDEN_PREFIXES;
+    private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
     private static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_OPTIONS = asList(KafkaMirrorMakerConsumerSpec.FORBIDDEN_PREFIXES.split(", "));
-        EXCEPTIONS = asList(KafkaMirrorMakerConsumerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
+        FORBIDDEN_PREFIXES = asList(KafkaMirrorMakerConsumerSpec.FORBIDDEN_PREFIXES.split(", "));
+        FORBIDDEN_PREFIX_EXCEPTIONS = asList(KafkaMirrorMakerConsumerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
         DEFAULTS = new HashMap<>();
     }
 
@@ -34,6 +34,6 @@ public class KafkaMirrorMakerConsumerConfiguration extends AbstractConfiguration
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaMirrorMakerConsumerConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS, EXCEPTIONS, DEFAULTS);
+        super(jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerProducerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerProducerConfiguration.java
@@ -17,13 +17,13 @@ import static java.util.Arrays.asList;
  * Class for handling Kafka Mirror Maker producer configuration passed by the user
  */
 public class KafkaMirrorMakerProducerConfiguration extends AbstractConfiguration {
-    private static final List<String> FORBIDDEN_OPTIONS;
-    private static final List<String> EXCEPTIONS;
+    private static final List<String> FORBIDDEN_PREFIXES;
+    private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
     private static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_OPTIONS = asList(KafkaMirrorMakerProducerSpec.FORBIDDEN_PREFIXES.split(", "));
-        EXCEPTIONS = asList(KafkaMirrorMakerProducerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
+        FORBIDDEN_PREFIXES = asList(KafkaMirrorMakerProducerSpec.FORBIDDEN_PREFIXES.split(", "));
+        FORBIDDEN_PREFIX_EXCEPTIONS = asList(KafkaMirrorMakerProducerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
         DEFAULTS = new HashMap<>();
     }
 
@@ -34,6 +34,6 @@ public class KafkaMirrorMakerProducerConfiguration extends AbstractConfiguration
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaMirrorMakerProducerConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS, EXCEPTIONS, DEFAULTS);
+        super(jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
@@ -19,13 +19,13 @@ import static java.util.Arrays.asList;
  */
 public class ZookeeperConfiguration extends AbstractConfiguration {
 
-    private static final List<String> FORBIDDEN_OPTIONS;
-    private static final List<String> EXCEPTIONS;
+    private static final List<String> FORBIDDEN_PREFIXES;
+    private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
     protected static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_OPTIONS = asList(ZookeeperClusterSpec.FORBIDDEN_PREFIXES.split(", "));
-        EXCEPTIONS = asList(ZookeeperClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
+        FORBIDDEN_PREFIXES = asList(ZookeeperClusterSpec.FORBIDDEN_PREFIXES.split(", "));
+        FORBIDDEN_PREFIX_EXCEPTIONS = asList(ZookeeperClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
 
         Map<String, String> config = new HashMap<>();
         config.put("tickTime", "2000");
@@ -42,6 +42,6 @@ public class ZookeeperConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public ZookeeperConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS, EXCEPTIONS, DEFAULTS);
+        super(jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractConfigurationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractConfigurationTest.java
@@ -292,11 +292,11 @@ public class AbstractConfigurationTest {
 }
 
 class TestConfiguration extends AbstractConfiguration {
-    private static final List<String> FORBIDDEN_OPTIONS;
+    private static final List<String> FORBIDDEN_PREFIXES;
     private static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_OPTIONS = asList(
+        FORBIDDEN_PREFIXES = asList(
                 "forbidden.option");
 
         DEFAULTS = new HashMap<>();
@@ -311,7 +311,7 @@ class TestConfiguration extends AbstractConfiguration {
      *                      pairs.
      */
     public TestConfiguration(String configuration) {
-        super(configuration, FORBIDDEN_OPTIONS, DEFAULTS);
+        super(configuration, FORBIDDEN_PREFIXES, DEFAULTS);
     }
 
     /**
@@ -321,15 +321,15 @@ class TestConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public TestConfiguration(JsonObject jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS, DEFAULTS);
+        super(jsonOptions, FORBIDDEN_PREFIXES, DEFAULTS);
     }
 }
 
 class TestConfigurationWithoutDefaults extends AbstractConfiguration {
-    private static final List<String> FORBIDDEN_OPTIONS;
+    private static final List<String> FORBIDDEN_PREFIXES;
 
     static {
-        FORBIDDEN_OPTIONS = asList(
+        FORBIDDEN_PREFIXES = asList(
                 "forbidden.option");
     }
 
@@ -341,7 +341,7 @@ class TestConfigurationWithoutDefaults extends AbstractConfiguration {
      *                      pairs.
      */
     public TestConfigurationWithoutDefaults(String configuration) {
-        super(configuration, FORBIDDEN_OPTIONS);
+        super(configuration, FORBIDDEN_PREFIXES);
     }
 
     /**
@@ -351,6 +351,6 @@ class TestConfigurationWithoutDefaults extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public TestConfigurationWithoutDefaults(JsonObject jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS);
+        super(jsonOptions, FORBIDDEN_PREFIXES);
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Addresses https://github.com/strimzi/strimzi-kafka-operator/issues/2927

Renames the `FORBIDDEN_OPTIONS` and `EXCEPTIONS` constants in *Configuration classes of the the _cluster-operator_ module _model_ package to `FORBIDDEN_PREFIXES` and `FORBIDDEN_PREFIX_EXCEPTIONS` to be consistent with their sources in the api module.

Updates the corresponding parameter names in `AbstractConfiguration` constructors from `forbiddenOptions` and `exceptions` to `forbiddenPrefixes` and `forbiddenPrefixExceptions` for consistency.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Reference relevant issue(s) and close them after merging

