### PR TITLE
Fix the cross book links linking to it self

### DIFF
--- a/documentation/deploying/master.adoc
+++ b/documentation/deploying/master.adoc
@@ -2,7 +2,6 @@
 include::shared/attributes.adoc[]
 
 :context: str
-:BookURLUsing: ./using.html
 
 [id="deploying-book_{context}"]
 = Deploying and Upgrading {ProductName}

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -164,3 +164,7 @@
 
 //Latest Strimzi version
 :ProductVersion: 0.17.x
+
+// Links to other Strimzi documentation books
+:BookURLDeploying: ./deploying.html
+:BookURLUsing: ./using.html

--- a/documentation/using/master.adoc
+++ b/documentation/using/master.adoc
@@ -2,7 +2,6 @@ include::shared/version-dependent-attrs.adoc[]
 include::shared/attributes.adoc[]
 
 :context: str
-:BookURLDeploying: ./deploying.html
 
 = Using {ProductLongName}
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The variables used for linking between books do to not work well when they are used in the same book (which easily happens when the module is re-included). This PR moves them from the `master.adoc` files into `attributes.adoc` to have them defined everywhere and fixes #2982.
