### PR TITLE
Use batch mode in the Maven builds on Azure

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -64,6 +64,7 @@ jobs:
         env:
           DOCKER_USER: $(DOCKER_USER)
           DOCKER_PASS: $(DOCKER_PASS_SECRET)
+          MVN_ARGS: '-B'
         displayName: "Build images"
 
       - task: PublishTestResults@2

--- a/.azure/pull-request-pipeline.yaml
+++ b/.azure/pull-request-pipeline.yaml
@@ -49,7 +49,7 @@ jobs:
           make docker_build
           make docker_tag
         env:
-          MVN_ARGS: '-DskipTests'
+          MVN_ARGS: '-B -DskipTests'
         displayName: "Build Strimzi images locally"
 
       - task: Maven@3


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Thw Travis builds are using quiet Maven builds because Travis has limited size of the output log. That is not needed on Azure, so we disabled the quiet builds there. That is in general useful. However, it is not pulling the dependnecies in interactive mode and sometimes you andup scrolling through pages and pages of progress of downloading various dependencies. Using the batch mode should make it easier to read these logs.