### PR TITLE
[systemtest] Generic waitForDeletion and fix tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.KafkaBridgeList;
 import io.strimzi.api.kafka.model.DoneableKafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridgeBuilder;
+import io.strimzi.api.kafka.model.KafkaBridgeResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.test.TestUtils;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -78,6 +79,7 @@ public class KafkaBridgeResource {
 
     public static void deleteKafkaBridgeWithoutWait(KafkaBridge kafkaBridge) {
         kafkaBridgeClient().inNamespace(ResourceManager.kubeClient().getNamespace()).delete(kafkaBridge);
+        ResourceManager.waitForResourceDeletion(kafkaBridge, KafkaBridgeResources.deploymentName(kafkaBridge.getMetadata().getName()));
     }
 
     private static KafkaBridge getKafkaBridgeFromYaml(String yamlPath) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -109,6 +109,7 @@ public class KafkaConnectResource {
 
     public static void deleteKafkaConnectWithoutWait(KafkaConnect kafkaConnect) {
         kafkaConnectClient().inNamespace(ResourceManager.kubeClient().getNamespace()).delete(kafkaConnect);
+        ResourceManager.waitForResourceDeletion(kafkaConnect, KafkaConnectResources.deploymentName(kafkaConnect.getMetadata().getName()));
     }
 
     private static KafkaConnect getKafkaConnectFromYaml(String yamlPath) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
@@ -93,6 +93,7 @@ public class KafkaConnectS2IResource {
 
     public static void deleteKafkaConnectS2IWithoutWait(KafkaConnectS2I kafkaConnectS2I) {
         kafkaConnectS2IClient().inNamespace(ResourceManager.kubeClient().getNamespace()).delete(kafkaConnectS2I);
+        ResourceManager.waitForResourceDeletion(kafkaConnectS2I, KafkaConnectS2IResources.deploymentName(kafkaConnectS2I.getMetadata().getName()));
     }
 
     private static KafkaConnectS2I getKafkaConnectS2IFromYaml(String yamlPath) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
@@ -14,7 +14,6 @@ import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.systemtest.resources.ResourceManager;
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
@@ -14,6 +14,7 @@ import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.systemtest.resources.ResourceManager;
 
@@ -59,7 +60,6 @@ public class KafkaConnectorResource {
     public static KafkaConnector kafkaConnectorWithoutWait(KafkaConnector kafkaConnector) {
         kafkaConnectorClient().inNamespace(ResourceManager.kubeClient().getNamespace()).createOrReplace(kafkaConnector);
         return kafkaConnector;
-
     }
 
     private static DoneableKafkaConnector deployKafkaConnector(KafkaConnector kafkaConnector) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Builder;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpecBuilder;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
@@ -125,6 +126,7 @@ public class KafkaMirrorMaker2Resource {
 
     public static void deleteKafkaMirrorMaker2WithoutWait(KafkaMirrorMaker2 kafkaMirrorMaker2) {
         kafkaMirrorMaker2Client().inNamespace(ResourceManager.kubeClient().getNamespace()).delete(kafkaMirrorMaker2);
+        ResourceManager.waitForResourceDeletion(kafkaMirrorMaker2, KafkaMirrorMaker2Resources.deploymentName(kafkaMirrorMaker2.getMetadata().getName()));
     }
 
     private static KafkaMirrorMaker2 getKafkaMirrorMaker2FromYaml(String yamlPath) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.KafkaMirrorMakerList;
 import io.strimzi.api.kafka.model.DoneableKafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerBuilder;
+import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
@@ -102,6 +103,7 @@ public class KafkaMirrorMakerResource {
 
     public static void deleteKafkaMirrorMakerWithoutWait(KafkaMirrorMaker kafkaMirrorMaker) {
         kafkaMirrorMakerClient().inNamespace(ResourceManager.kubeClient().getNamespace()).delete(kafkaMirrorMaker);
+        ResourceManager.waitForResourceDeletion(kafkaMirrorMaker, KafkaMirrorMakerResources.deploymentName(kafkaMirrorMaker.getMetadata().getName()));
     }
 
     private static KafkaMirrorMaker getKafkaMirrorMakerFromYaml(String yamlPath) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -204,6 +204,7 @@ public class KafkaResource {
      */
     public static void deleteKafkaWithoutWait(Kafka kafka) {
         kafkaClient().inNamespace(ResourceManager.kubeClient().getNamespace()).delete(kafka);
+        ResourceManager.waitForKafkaDeletion(kafka);
     }
 
     private static Kafka getKafkaFromYaml(String yamlPath) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.DoneableKafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -70,6 +71,11 @@ public class KafkaTopicResource {
     public static KafkaTopic topicWithoutWait(KafkaTopic kafkaTopic) {
         kafkaTopicClient().inNamespace(ResourceManager.kubeClient().getNamespace()).createOrReplace(kafkaTopic);
         return kafkaTopic;
+    }
+
+    public static void deleteKafkaTopicWithoutWait(KafkaTopic kafkaTopic) {
+        kafkaTopicClient().inNamespace(ResourceManager.kubeClient().getNamespace()).delete(kafkaTopic);
+        KafkaTopicUtils.waitForKafkaTopicDeletion(kafkaTopic.getMetadata().getName());
     }
 
     private static KafkaTopic getKafkaTopicFromYaml(String yamlPath) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.DoneableKafkaUser;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserBuilder;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -64,6 +65,11 @@ public class KafkaUserResource {
     public static KafkaUser kafkaUserWithoutWait(KafkaUser user) {
         kafkaUserClient().inNamespace(ResourceManager.kubeClient().getNamespace()).createOrReplace(user);
         return user;
+    }
+
+    public static void deleteKafkaUserWithoutWait(KafkaUser user) {
+        kafkaUserClient().inNamespace(ResourceManager.kubeClient().getNamespace()).delete(user);
+        KafkaUserUtils.waitForKafkaUserDeletion(user.getMetadata().getName());
     }
 
     private static KafkaUser waitFor(KafkaUser kafkaUser) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -11,11 +11,11 @@ import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.strimzi.api.kafka.model.CertSecretSource;
 import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
+import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
 import io.strimzi.api.kafka.model.KafkaConnectTlsBuilder;
-import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
@@ -376,7 +376,6 @@ class ConnectS2IST extends BaseST {
         });
 
         KafkaConnectS2IResource.deleteKafkaConnectS2IWithoutWait(kafkaConnectS2I);
-        DeploymentUtils.waitForDeploymentDeletion(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME));
     }
 
     @Test
@@ -402,7 +401,7 @@ class ConnectS2IST extends BaseST {
             .endSpec().done();
 
         // Create connect cluster with default connect image
-        KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.defaultKafkaConnect(CLUSTER_NAME, CLUSTER_NAME, 1)
+        KafkaConnect kafkaConnect = KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.defaultKafkaConnect(CLUSTER_NAME, CLUSTER_NAME, 1)
             .editMetadata()
                 .addToLabels("type", "kafka-connect")
                 .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
@@ -455,7 +454,7 @@ class ConnectS2IST extends BaseST {
         KafkaConnectorUtils.waitForConnectorCreation(connectS2IPodName, connectorName);
         KafkaConnectorUtils.waitForConnectorStability(connectorName, connectS2IPodName);
         KafkaConnectUtils.waitForConnectNotReady(CLUSTER_NAME);
-        KafkaConnectResource.kafkaConnectClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).delete();
+        KafkaConnectResource.deleteKafkaConnectWithoutWait(kafkaConnect);
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
+import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.PasswordSecretSourceBuilder;
@@ -630,7 +631,7 @@ class ConnectST extends BaseST {
             .endSpec().done();
 
         // Create different connect cluster via S2I resources
-        KafkaConnectS2IResource.kafkaConnectS2IWithoutWait(KafkaConnectS2IResource.defaultKafkaConnectS2I(CLUSTER_NAME, CLUSTER_NAME, 1)
+        KafkaConnectS2I kafkaConnectS2I = KafkaConnectS2IResource.kafkaConnectS2IWithoutWait(KafkaConnectS2IResource.defaultKafkaConnectS2I(CLUSTER_NAME, CLUSTER_NAME, 1)
             .editMetadata()
                 .addToLabels("type", "kafka-connect-s2i")
                 .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
@@ -683,7 +684,7 @@ class ConnectST extends BaseST {
         KafkaConnectorUtils.waitForConnectorCreation(connectPodName, connectorName);
         KafkaConnectorUtils.waitForConnectorStability(connectorName, connectPodName);
         KafkaConnectS2IUtils.waitForConnectS2INotReady(CLUSTER_NAME);
-        KafkaConnectS2IResource.kafkaConnectS2IClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).delete();
+        KafkaConnectS2IResource.deleteKafkaConnectS2IWithoutWait(kafkaConnectS2I);
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -13,6 +13,8 @@ import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.status.KafkaBridgeStatus;
@@ -142,7 +144,7 @@ class CustomResourceStatusST extends BaseST {
     void testKafkaUserStatusNotReady() {
         // Simulate NotReady state with userName longer than 64 characters
         String userName = "sasl-use-rabcdefghijklmnopqrstuvxyzabcdefghijklmnopqrstuvxyzabcdef";
-        KafkaUserResource.kafkaUserWithoutWait(KafkaUserResource.defaultUser(CLUSTER_NAME, userName).build());
+        KafkaUser kafkaUser = KafkaUserResource.kafkaUserWithoutWait(KafkaUserResource.defaultUser(CLUSTER_NAME, userName).build());
 
         KafkaUserUtils.waitForKafkaUserNotReady(userName);
 
@@ -155,7 +157,7 @@ class CustomResourceStatusST extends BaseST {
         assertThat("KafkaUser is in wrong state!", kafkaCondition.getType(), is("NotReady"));
         LOGGER.info("KafkaUser {} is in desired state: {}", userName, kafkaCondition.getType());
 
-        KafkaUserResource.kafkaUserClient().inNamespace(NAMESPACE).withName(userName).delete();
+        KafkaUserResource.deleteKafkaUserWithoutWait(kafkaUser);
     }
 
     @Test
@@ -317,9 +319,10 @@ class CustomResourceStatusST extends BaseST {
     @Test
     void testKafkaTopicStatusNotReady() {
         String topicName = "my-topic";
-        KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME, topicName, 1, 10, 10).build());
+        KafkaTopic kafkaTopic = KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME, topicName, 1, 10, 10).build());
         KafkaTopicUtils.waitForKafkaTopicNotReady(topicName);
         assertKafkaTopicStatus(1, topicName);
+        KafkaTopicResource.deleteKafkaTopicWithoutWait(kafkaTopic);
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -1093,7 +1093,7 @@ class KafkaST extends BaseST {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
 
         // Creating topic without any label
-        KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME, "topic-without-labels", 1, 1, 1)
+        KafkaTopic kafkaTopic = KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME, "topic-without-labels", 1, 1, 1)
             .editMetadata()
                 .withLabels(null)
             .endMetadata()
@@ -1116,6 +1116,8 @@ class KafkaST extends BaseST {
         //Checking all topics were deleted
         List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(CLUSTER_NAME, 0);
         assertThat(topics, not(hasItems("topic-without-labels")));
+
+        KafkaTopicResource.deleteKafkaTopicWithoutWait(kafkaTopic);
     }
 
     @Test
@@ -2085,7 +2087,7 @@ class KafkaST extends BaseST {
 
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(CLUSTER_NAME, NAMESPACE,
                 "Kafka configuration option .* should be set to " + replicas + " or less because 'spec.kafka.replicas' is " + replicas);
-        KafkaResource.kafkaClient().inNamespace(NAMESPACE).delete(kafka);
+        KafkaResource.deleteKafkaWithoutWait(kafka);
     }
 
     protected void checkKafkaConfiguration(String podNamePrefix, Map<String, Object> config, String clusterName) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
@@ -64,7 +64,7 @@ class UserST extends BaseST {
         // Create sasl user with long name, shouldn't fail
         KafkaUserResource.scramShaUser(CLUSTER_NAME, saslUserWithLongName).done();
 
-        KafkaUserResource.kafkaUserWithoutWait(KafkaUserResource.defaultUser(CLUSTER_NAME, userWithLongName)
+        KafkaUser kafkaUser = KafkaUserResource.kafkaUserWithoutWait(KafkaUserResource.defaultUser(CLUSTER_NAME, userWithLongName)
             .withNewSpec()
                 .withNewKafkaUserTlsClientAuthentication()
                 .endKafkaUserTlsClientAuthentication()
@@ -80,6 +80,8 @@ class UserST extends BaseST {
                 "InvalidResourceException",
                 "True",
                 "NotReady");
+
+        KafkaUserResource.deleteKafkaUserWithoutWait(kafkaUser);
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.kafka;
 
+import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.listener.KafkaListenerExternalLoadBalancerBuilder;
@@ -1065,7 +1066,7 @@ public class ListenersST extends BaseST {
         String nonExistingCertName = "non-existing-certificate";
         String clusterName = "broken-cluster";
 
-        KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(clusterName, 1, 1)
+        Kafka kafka = KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(clusterName, 1, 1)
             .editSpec()
                 .editKafka()
                     .editListeners()
@@ -1085,6 +1086,7 @@ public class ListenersST extends BaseST {
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(clusterName), 1);
 
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(clusterName, NAMESPACE, "Secret " + nonExistingCertName + ".*does not exist.*");
+        KafkaResource.deleteKafkaWithoutWait(kafka);
     }
 
     @Test
@@ -1092,7 +1094,7 @@ public class ListenersST extends BaseST {
         String nonExistingCertName = "non-existing-crt";
         String clusterName = "broken-cluster";
 
-        KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(clusterName, 1, 1)
+        Kafka kafka = KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(clusterName, 1, 1)
             .editSpec()
                 .editKafka()
                     .editListeners()
@@ -1113,6 +1115,7 @@ public class ListenersST extends BaseST {
 
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(clusterName, NAMESPACE,
                 "Secret " + customCertServer1 + ".*does not contain certificate under the key " + nonExistingCertName + ".*");
+        KafkaResource.deleteKafkaWithoutWait(kafka);
     }
 
     @Test
@@ -1120,7 +1123,7 @@ public class ListenersST extends BaseST {
         String nonExistingCertKey = "non-existing-key";
         String clusterName = "broken-cluster";
 
-        KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(clusterName, 1, 1)
+        Kafka kafka = KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(clusterName, 1, 1)
             .editSpec()
                 .editKafka()
                     .editListeners()
@@ -1141,6 +1144,7 @@ public class ListenersST extends BaseST {
 
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(clusterName, NAMESPACE,
                 "Secret " + customCertServer1 + ".*does not contain.*private key under the key " + nonExistingCertKey + ".*");
+        KafkaResource.deleteKafkaWithoutWait(kafka);
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -1296,7 +1296,7 @@ class SecurityST extends BaseST {
 
         KafkaClientsResource.deployKafkaClients(KAFKA_CLIENTS_NAME).done();
 
-        KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.defaultKafkaConnect(CLUSTER_NAME, CLUSTER_NAME, 1)
+        KafkaConnect kafkaConnect = KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.defaultKafkaConnect(CLUSTER_NAME, CLUSTER_NAME, 1)
                 .editSpec()
                 .withConfig(configWithLowestVersionOfTls)
                 .endSpec()
@@ -1308,7 +1308,7 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Replacing Kafka Connect config to the newest(TLSv1.2) one same as the Kafka broker has.");
 
-        KafkaConnectResource.replaceKafkaConnectResource(CLUSTER_NAME, kafkaConnect -> kafkaConnect.getSpec().setConfig(configWithNewestVersionOfTls));
+        KafkaConnectResource.replaceKafkaConnectResource(CLUSTER_NAME, kafkaConnectReplace -> kafkaConnectReplace.getSpec().setConfig(configWithNewestVersionOfTls));
 
         LOGGER.info("Verifying that Kafka Connect has the accepted configuration:\n {} -> {}\n {} -> {}",
                 SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG,
@@ -1326,6 +1326,7 @@ class SecurityST extends BaseST {
         LOGGER.info("Verifying that Kafka Connect status is Ready because of same TLS version");
 
         KafkaConnectUtils.waitForConnectStatus(CLUSTER_NAME, "Ready");
+        KafkaConnectResource.deleteKafkaConnectWithoutWait(kafkaConnect);
     }
 
     @Test
@@ -1360,7 +1361,7 @@ class SecurityST extends BaseST {
 
         KafkaClientsResource.deployKafkaClients(KAFKA_CLIENTS_NAME).done();
 
-        KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.defaultKafkaConnect(CLUSTER_NAME, CLUSTER_NAME, 1)
+        KafkaConnect kafkaConnect = KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.defaultKafkaConnect(CLUSTER_NAME, CLUSTER_NAME, 1)
                 .editSpec()
                 .withConfig(configWithCipherSuitesSha256)
                 .endSpec()
@@ -1372,7 +1373,7 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Replacing Kafka Connect config to the cipher suites same as the Kafka broker has.");
 
-        KafkaConnectResource.replaceKafkaConnectResource(CLUSTER_NAME, kafkaConnect -> kafkaConnect.getSpec().setConfig(configWithCipherSuitesSha384));
+        KafkaConnectResource.replaceKafkaConnectResource(CLUSTER_NAME, kafkaConnectReplace -> kafkaConnectReplace.getSpec().setConfig(configWithCipherSuitesSha384));
 
         LOGGER.info("Verifying that Kafka Connect has the accepted configuration:\n {} -> {}",
                 SslConfigs.SSL_CIPHER_SUITES_CONFIG, configsFromKafkaCustomResource.get(SslConfigs.SSL_CIPHER_SUITES_CONFIG));
@@ -1386,6 +1387,7 @@ class SecurityST extends BaseST {
         LOGGER.info("Verifying that Kafka Connect status is Ready because of the same cipher suites complexity of algorithm");
 
         KafkaConnectUtils.waitForConnectStatus(CLUSTER_NAME, "Ready");
+        KafkaConnectResource.deleteKafkaConnectWithoutWait(kafkaConnect);
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.NodeSelectorRequirement;
 import io.fabric8.kubernetes.api.model.PodAffinityTerm;
+import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.listener.LoadBalancerListenerBootstrapOverride;
 import io.strimzi.api.kafka.model.listener.LoadBalancerListenerBootstrapOverrideBuilder;
@@ -164,7 +165,7 @@ public class SpecificST extends BaseST {
         String nonExistingVersion = "6.6.6";
         String nonExistingVersionMessage = "Unsupported Kafka.spec.kafka.version: " + nonExistingVersion + ". Supported versions are.*";
 
-        KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(CLUSTER_NAME, 1, 1)
+        Kafka kafka = KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(CLUSTER_NAME, 1, 1)
             .editSpec()
                 .editKafka()
                     .withVersion(nonExistingVersion)
@@ -175,6 +176,7 @@ public class SpecificST extends BaseST {
 
         KafkaUtils.waitUntilKafkaCRIsNotReady(CLUSTER_NAME);
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(CLUSTER_NAME, NAMESPACE, nonExistingVersionMessage);
+        KafkaResource.deleteKafkaWithoutWait(kafka);
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicST.java
@@ -93,6 +93,8 @@ public class TopicST extends BaseST {
 
         assertThat("Topic exists in Kafka itself", hasTopicInKafka(newTopicName));
         assertThat("Topic exists in Kafka CR (Kubernetes)", hasTopicInCRK8s(kafkaTopic, newTopicName));
+
+        KafkaTopicResource.deleteKafkaTopicWithoutWait(kafkaTopic);
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

This PR gonna edit our `waitForDeletion` methods from `ResourceManager` to be done generic way (for CRs) and solve problems that can happen in tests.

The problem was that if we run some ST that had resource made with `withoutWait` method and it wasn't deleted, the next test failed because there was some conflict **or** the CR cannot be updated with new resources. I added `waitForResourceDeletion` to all `delete.*WithoutWait` methods in resources classes so we can't prevent this fault will happen in future runs. I add it everywhere for prevention.

### Checklist

- [ ] Make sure all tests pass

