### PR TITLE
[systemtest] Fix nightlies

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
@@ -59,8 +59,8 @@ class AllNamespaceST extends AbstractNamespaceST {
         List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(CLUSTER_NAME, 0);
         assertThat(topics, not(hasItems(TOPIC_NAME)));
 
-        deployNewTopic(SECOND_NAMESPACE, THIRD_NAMESPACE, TOPIC_NAME);
-        deleteNewTopic(SECOND_NAMESPACE, TOPIC_NAME);
+        deployNewTopic(SECOND_NAMESPACE, THIRD_NAMESPACE, EXAMPLE_TOPIC_NAME);
+        deleteNewTopic(SECOND_NAMESPACE, EXAMPLE_TOPIC_NAME);
         cluster.setNamespace(previousNamespace);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
@@ -107,6 +107,8 @@ public abstract class BaseST implements TestSeparator {
 
     public static final int MESSAGE_COUNT = 100;
     public static final String TOPIC_NAME = KafkaTopicUtils.generateRandomNameOfTopic();
+    public static final String EXAMPLE_TOPIC_NAME = "my-topic";
+
     public static final String USER_NAME = KafkaUserUtils.generateRandomNameOfKafkaUser();
 
     private HelmClient helmClient() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -503,7 +503,7 @@ class ConnectS2IST extends BaseST {
                 "curl", "-X", "GET", "http://localhost:8083/connectors/" + CLUSTER_NAME + "/status").out()
         );
         String podIP = connectStatus.getJsonObject("connector").getString("worker_id").split(":")[0];
-        String connectorPodName = kubeClient().listPods().stream().filter(pod ->
+        String connectorPodName = kubeClient().listPods("type", "kafka-connect-s2i").stream().filter(pod ->
                 pod.getStatus().getPodIP().equals(podIP)).findFirst().get().getMetadata().getName();
 
         internalKafkaClient.assertSentAndReceivedMessages(

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -455,7 +455,9 @@ class ConnectS2IST extends BaseST {
         KafkaConnectorUtils.waitForConnectorCreation(connectS2IPodName, connectorName);
         KafkaConnectorUtils.waitForConnectorStability(connectorName, connectS2IPodName);
         KafkaConnectUtils.waitForConnectNotReady(CLUSTER_NAME);
+
         KafkaConnectResource.kafkaConnectClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).delete();
+        DeploymentUtils.waitForDeploymentDeletion(KafkaConnectResources.deploymentName(CLUSTER_NAME));
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
+import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.PasswordSecretSourceBuilder;
@@ -683,7 +684,9 @@ class ConnectST extends BaseST {
         KafkaConnectorUtils.waitForConnectorCreation(connectPodName, connectorName);
         KafkaConnectorUtils.waitForConnectorStability(connectorName, connectPodName);
         KafkaConnectS2IUtils.waitForConnectS2INotReady(CLUSTER_NAME);
+
         KafkaConnectS2IResource.kafkaConnectS2IClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).delete();
+        DeploymentUtils.waitForDeploymentConfigDeletion(KafkaConnectS2IResources.deploymentName(CLUSTER_NAME));
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
+import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.api.kafka.model.status.Condition;
@@ -49,6 +50,7 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaMirrorMakerUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -305,6 +307,8 @@ class CustomResourceStatusST extends BaseST {
             .build());
 
         KafkaConnectorUtils.waitForConnectorNotReady(CLUSTER_NAME);
+
+        KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).delete();
     }
 
     @Test
@@ -364,6 +368,7 @@ class CustomResourceStatusST extends BaseST {
         KafkaMirrorMaker2Utils.waitForKafkaMirrorMaker2NotReady(CLUSTER_NAME);
 
         KafkaMirrorMaker2Resource.deleteKafkaMirrorMaker2WithoutWait(kafkaMirrorMaker2);
+        DeploymentUtils.waitForDeploymentDeletion(KafkaMirrorMakerResources.deploymentName(CLUSTER_NAME));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
@@ -35,10 +35,10 @@ class MultipleNamespaceST extends AbstractNamespaceST {
         LOGGER.info("Deploying TO to watch a different namespace that it is deployed in");
         cluster.setNamespace(SECOND_NAMESPACE);
         List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(CLUSTER_NAME, 0);
-        assertThat(topics, not(hasItems(TOPIC_NAME)));
+        assertThat(topics, not(hasItems(EXAMPLE_TOPIC_NAME)));
 
-        deployNewTopic(CO_NAMESPACE, SECOND_NAMESPACE, TOPIC_NAME);
-        deleteNewTopic(CO_NAMESPACE, TOPIC_NAME);
+        deployNewTopic(CO_NAMESPACE, SECOND_NAMESPACE, EXAMPLE_TOPIC_NAME);
+        deleteNewTopic(CO_NAMESPACE, EXAMPLE_TOPIC_NAME);
         cluster.setNamespace(CO_NAMESPACE);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
@@ -1085,6 +1085,8 @@ public class ListenersST extends BaseST {
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(clusterName), 1);
 
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(clusterName, NAMESPACE, "Secret " + nonExistingCertName + ".*does not exist.*");
+
+        KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(clusterName).delete();
     }
 
     @Test
@@ -1113,6 +1115,8 @@ public class ListenersST extends BaseST {
 
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(clusterName, NAMESPACE,
                 "Secret " + customCertServer1 + ".*does not contain certificate under the key " + nonExistingCertName + ".*");
+
+        KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(clusterName).delete();
     }
 
     @Test
@@ -1141,6 +1145,8 @@ public class ListenersST extends BaseST {
 
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(clusterName, NAMESPACE,
                 "Secret " + customCertServer1 + ".*does not contain.*private key under the key " + nonExistingCertKey + ".*");
+
+        KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(clusterName).delete();
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -167,7 +167,7 @@ public class MetricsST extends BaseST {
             assertThat("Value from collected metric should be non-empty", !value.isEmpty());
             assertThat("Metrics doesn't contain specific values", value.contains("kafka_consumergroup_current_offset"));
             assertThat("Metrics doesn't contain specific values", value.contains("kafka_consumergroup_lag"));
-            assertThat("Metrics doesn't contain specific values", value.contains("kafka_topic_partitions{topic=\"" + TEST_TOPIC_NAME + "\"} 7"));
+            assertThat("Metrics doesn't contain specific values", value.contains("kafka_topic_partitions{topic=\"" + TEST_TOPIC_NAME + "\"}"));
         });
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -11,7 +11,6 @@ import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
 import io.strimzi.systemtest.resources.crd.KafkaMirrorMaker2Resource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.specific.MetricsUtils;
@@ -167,7 +166,7 @@ public class MetricsST extends BaseST {
             assertThat("Value from collected metric should be non-empty", !value.isEmpty());
             assertThat("Metrics doesn't contain specific values", value.contains("kafka_consumergroup_current_offset"));
             assertThat("Metrics doesn't contain specific values", value.contains("kafka_consumergroup_lag"));
-            assertThat("Metrics doesn't contain specific values", value.contains("kafka_topic_partitions{topic=\"" + TEST_TOPIC_NAME + "\"}"));
+            assertThat("Metrics doesn't contain specific values", value.contains("kafka_topic_partitions{topic=\"" + TEST_TOPIC_NAME + "\"} 7"));
         });
     }
 
@@ -325,7 +324,7 @@ public class MetricsST extends BaseST {
         KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).done();
         KafkaConnectResource.kafkaConnectWithMetrics(CLUSTER_NAME, 1).done();
         KafkaMirrorMaker2Resource.kafkaMirrorMaker2WithMetrics(MIRROR_MAKER_CLUSTER, CLUSTER_NAME, SECOND_CLUSTER, 1).done();
-        KafkaTopicResource.topic(CLUSTER_NAME, KafkaTopicUtils.generateRandomNameOfTopic(), 7, 2).done();
+        KafkaTopicResource.topic(CLUSTER_NAME, TEST_TOPIC_NAME, 7, 2).done();
 
         KafkaUserResource.tlsUser(CLUSTER_NAME, KafkaUserUtils.generateRandomNameOfKafkaUser()).done();
         KafkaUserResource.tlsUser(CLUSTER_NAME, KafkaUserUtils.generateRandomNameOfKafkaUser()).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -11,6 +11,7 @@ import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
 import io.strimzi.systemtest.resources.crd.KafkaMirrorMaker2Resource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.specific.MetricsUtils;
@@ -324,7 +325,7 @@ public class MetricsST extends BaseST {
         KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).done();
         KafkaConnectResource.kafkaConnectWithMetrics(CLUSTER_NAME, 1).done();
         KafkaMirrorMaker2Resource.kafkaMirrorMaker2WithMetrics(MIRROR_MAKER_CLUSTER, CLUSTER_NAME, SECOND_CLUSTER, 1).done();
-        KafkaTopicResource.topic(CLUSTER_NAME, TEST_TOPIC_NAME, 7, 2).done();
+        KafkaTopicResource.topic(CLUSTER_NAME, KafkaTopicUtils.generateRandomNameOfTopic(), 7, 2).done();
 
         KafkaUserResource.tlsUser(CLUSTER_NAME, KafkaUserUtils.generateRandomNameOfKafkaUser()).done();
         KafkaUserResource.tlsUser(CLUSTER_NAME, KafkaUserUtils.generateRandomNameOfKafkaUser()).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.CertificateAuthorityBuilder;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
+import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
@@ -877,6 +878,7 @@ class SecurityST extends BaseST {
         assertThat("KafkaConnect status should be " + "Ready", kafkaStatus.getConditions().get(0).getType(), is("Ready"));
 
         KafkaConnectResource.deleteKafkaConnectWithoutWait(kafkaConnect);
+        DeploymentUtils.waitForDeploymentDeletion(KafkaConnectResources.deploymentName(CLUSTER_NAME));
     }
 
     @Test
@@ -949,6 +951,7 @@ class SecurityST extends BaseST {
         assertThat("KafkaMirrorMaker status should be " + "Ready", kafkaMirrorMakerStatus.getConditions().get(0).getType(), is("Ready"));
 
         KafkaMirrorMakerResource.deleteKafkaMirrorMakerWithoutWait(kafkaMirrorMaker);
+        DeploymentUtils.waitForDeploymentDeletion(KafkaMirrorMakerResources.deploymentName(CLUSTER_NAME));
     }
 
     @Test
@@ -1326,6 +1329,9 @@ class SecurityST extends BaseST {
         LOGGER.info("Verifying that Kafka Connect status is Ready because of same TLS version");
 
         KafkaConnectUtils.waitForConnectStatus(CLUSTER_NAME, "Ready");
+
+        KafkaConnectResource.kafkaConnectClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME);
+        DeploymentUtils.waitForDeploymentDeletion(KafkaConnectResources.deploymentName(CLUSTER_NAME));
     }
 
     @Test
@@ -1386,6 +1392,9 @@ class SecurityST extends BaseST {
         LOGGER.info("Verifying that Kafka Connect status is Ready because of the same cipher suites complexity of algorithm");
 
         KafkaConnectUtils.waitForConnectStatus(CLUSTER_NAME, "Ready");
+
+        KafkaConnectResource.kafkaConnectClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME);
+        DeploymentUtils.waitForDeploymentDeletion(KafkaConnectResources.deploymentName(CLUSTER_NAME));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -175,6 +175,8 @@ public class SpecificST extends BaseST {
 
         KafkaUtils.waitUntilKafkaCRIsNotReady(CLUSTER_NAME);
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(CLUSTER_NAME, NAMESPACE, nonExistingVersionMessage);
+
+        KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).delete();
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR gonna fix failing tests from our nightly builds.

`AllNamespaceST&MultipleNamespaceST` - here was two problems - first one was same like in `TopicST` - there was problem in using `cmd` - already fixed by different PR, the second problem was in naming of topic - after refactor we waited for topic that had randomly generated name, but in our `examples` KafkaTopic yaml we have `my-topic` name -> so the randomly named topic wasn't never created

`ConnectS2IST` - here was problem in getting the right pod where KafkaConnector is receiving messages to sink -> the `connectorPod` had KafkaConnect build pod name, so the test failed because no messages was received to sink-file 

I also added deletion of all CR that are created without wait to prevent future problems

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

