### PR TITLE
[systemtest] KafkaConnect/ConnectS2I - scaling to zero replicas

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -63,6 +63,10 @@ public class PodUtils {
         AtomicInteger count = new AtomicInteger();
         TestUtils.waitFor("All pods matching " + selector + "to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS, () -> {
             List<Pod> pods = kubeClient().listPods(selector);
+            if (pods.isEmpty() && expectPods == 0) {
+                LOGGER.debug("Expected pods are ready");
+                return true;
+            }
             if (pods.isEmpty()) {
                 LOGGER.debug("Not ready (no pods matching {})", selector);
                 return false;

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -20,6 +20,7 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.api.kafka.model.status.KafkaConnectS2IStatus;
+import io.strimzi.api.kafka.model.status.KafkaConnectorStatus;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
@@ -615,6 +616,74 @@ class ConnectS2IST extends BaseST {
             .withName(CONNECT_S2I_CLUSTER_NAME).get().getSpec().getTls().getTrustedCertificates();
 
         assertThat(trustedCertificates.stream().anyMatch(cert -> cert.getSecretName().equals("my-secret")), is(true));
+    }
+
+    @Test
+    void testScaleConnectS2IWithoutConnectorToZero() {
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
+
+        KafkaConnectS2IResource.kafkaConnectS2I(CONNECT_S2I_CLUSTER_NAME, CLUSTER_NAME, 2)
+            .editMetadata()
+                .addToLabels("type", "kafka-connect-s2i")
+            .endMetadata()
+            .done();
+
+        String deploymentConfigName = KafkaConnectS2IResources.deploymentName(CONNECT_S2I_CLUSTER_NAME);
+        List<String> connectS2IPods = kubeClient().listPodNames("type", "kafka-connect-s2i");
+
+        assertThat(connectS2IPods.size(), Matchers.is(2));
+        //scale down
+        LOGGER.info("Scaling KafkaConnect down to zero");
+        KafkaConnectS2IResource.replaceConnectS2IResource(CONNECT_S2I_CLUSTER_NAME, kafkaConnectS2I -> kafkaConnectS2I.getSpec().setReplicas(0));
+
+        DeploymentUtils.waitForDeploymentConfigReady(deploymentConfigName, 0);
+
+        connectS2IPods = kubeClient().listPodNames("type", "kafka-connect-s2i");
+        KafkaConnectS2IStatus connectS2IStatus = KafkaConnectS2IResource.kafkaConnectS2IClient().inNamespace(NAMESPACE).withName(CONNECT_S2I_CLUSTER_NAME).get().getStatus();
+
+        assertThat(connectS2IPods.size(), Matchers.is(0));
+        assertThat(connectS2IStatus.getConditions().get(0).getType(), is("Ready"));
+    }
+
+    @Test
+    void testScaleConnectS2IWithConnectorToZero() {
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
+
+        KafkaConnectS2IResource.kafkaConnectS2I(CONNECT_S2I_CLUSTER_NAME, CLUSTER_NAME, 2)
+            .editMetadata()
+                .addToLabels("type", "kafka-connect-s2i")
+                .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+            .endMetadata()
+            .done();
+
+        KafkaConnectorResource.kafkaConnector(CONNECT_S2I_CLUSTER_NAME)
+            .editSpec()
+                .withClassName("org.apache.kafka.connect.file.FileStreamSinkConnector")
+                .addToConfig("file", Constants.DEFAULT_SINK_FILE_PATH)
+                .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
+                .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
+                .addToConfig("topics", TOPIC_NAME)
+            .endSpec()
+            .done();
+
+        String deploymentConfigName = KafkaConnectS2IResources.deploymentName(CONNECT_S2I_CLUSTER_NAME);
+        List<String> connectS2IPods = kubeClient().listPodNames("type", "kafka-connect-s2i");
+
+        assertThat(connectS2IPods.size(), Matchers.is(2));
+        //scale down
+        LOGGER.info("Scaling KafkaConnect down to zero");
+        KafkaConnectS2IResource.replaceConnectS2IResource(CONNECT_S2I_CLUSTER_NAME, kafkaConnectS2I -> kafkaConnectS2I.getSpec().setReplicas(0));
+
+        DeploymentUtils.waitForDeploymentConfigReady(deploymentConfigName, 0);
+
+        connectS2IPods = kubeClient().listPodNames("type", "kafka-connect-s2i");
+        KafkaConnectS2IStatus connectS2IStatus = KafkaConnectS2IResource.kafkaConnectS2IClient().inNamespace(NAMESPACE).withName(CONNECT_S2I_CLUSTER_NAME).get().getStatus();
+        KafkaConnectorStatus connectorStatus = KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CONNECT_S2I_CLUSTER_NAME).get().getStatus();
+
+        assertThat(connectS2IPods.size(), Matchers.is(0));
+        assertThat(connectS2IStatus.getConditions().get(0).getType(), is("Ready"));
+        assertThat(connectorStatus.getConditions().stream().anyMatch(condition -> condition.getType().equals("NotReady")), Matchers.is(true));
+        assertThat(connectorStatus.getConditions().stream().anyMatch(condition -> condition.getMessage().contains("has 0 replicas")), Matchers.is(true));
     }
 
     private void deployConnectS2IWithMongoDb(String kafkaConnectS2IName, boolean useConnectorOperator) throws IOException {

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -682,8 +682,8 @@ class ConnectS2IST extends BaseST {
 
         assertThat(connectS2IPods.size(), Matchers.is(0));
         assertThat(connectS2IStatus.getConditions().get(0).getType(), is("Ready"));
-        assertThat(connectorStatus.getConditions().stream().anyMatch(condition -> condition.getType().equals("NotReady")), Matchers.is(true));
-        assertThat(connectorStatus.getConditions().stream().anyMatch(condition -> condition.getMessage().contains("has 0 replicas")), Matchers.is(true));
+        assertThat(connectorStatus.getConditions().stream().anyMatch(condition -> condition.getType().equals("NotReady")), is(true));
+        assertThat(connectorStatus.getConditions().stream().anyMatch(condition -> condition.getMessage().contains("has 0 replicas")), is(true));
     }
 
     private void deployConnectS2IWithMongoDb(String kafkaConnectS2IName, boolean useConnectorOperator) throws IOException {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New tests

### Description

In this PR I'm testing new feature - ability to scale KafkaConnect/KafkaConnectS2I to zero replicas - with and without KafkaConnector - so I added new tests for it. In the past, if we wanted to scale replicas to zero, the CR was failing.

It checks:
- ability to scale KafkaConnect/KafkaConnectS2I to zero replicas
- if statuses are correct

### Checklist

- [x] Write tests
- [x] Make sure all tests pass


