### PR TITLE
[systemtest][kafkatopic] Decrease topic partitions and min.insync.replicas tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
@@ -124,7 +124,8 @@ public class KafkaMirrorMaker2Resource {
     }
 
     public static void deleteKafkaMirrorMaker2WithoutWait(KafkaMirrorMaker2 kafkaMirrorMaker2) {
-        kafkaMirrorMaker2Client().inNamespace(ResourceManager.kubeClient().getNamespace()).delete(kafkaMirrorMaker2);
+        String clusterName = kafkaMirrorMaker2.getMetadata().getName();
+        kafkaMirrorMaker2Client().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(clusterName).cascading(true).delete();
     }
 
     private static KafkaMirrorMaker2 getKafkaMirrorMaker2FromYaml(String yamlPath) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -309,7 +309,7 @@ class CustomResourceStatusST extends BaseST {
 
         KafkaConnectorUtils.waitForConnectorNotReady(CLUSTER_NAME);
 
-        KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).delete();
+        KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).cascading(true).delete();
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -87,7 +87,7 @@ class CustomResourceStatusST extends BaseST {
     static final String NAMESPACE = "status-cluster-test";
     private static final Logger LOGGER = LogManager.getLogger(CustomResourceStatusST.class);
     private static final String CONNECTS2I_CLUSTER_NAME = CLUSTER_NAME + "-s2i";
-    private static int TO_RECONCILIATION_INTERVAL;
+    private static int topicOperatorReconciliationInterval;
 
     @Test
     @Tag(NODEPORT_SUPPORTED)
@@ -315,7 +315,6 @@ class CustomResourceStatusST extends BaseST {
     @Test
     void testKafkaTopicStatus() {
         KafkaTopicUtils.waitForKafkaTopicReady(TOPIC_NAME);
-        // The reason why we have there Observed Generation = 2 cause Kafka sync message.format.version when topic is created
         assertKafkaTopicStatus(1, TOPIC_NAME);
     }
 
@@ -385,8 +384,8 @@ class CustomResourceStatusST extends BaseST {
         assertKafkaTopicDecreasePartitionsStatus(TEST_TOPIC_NAME);
 
         // Wait some time to check if error is still present in KafkaTopic status
-        LOGGER.info("Wait {} ms for next reconciliation", TO_RECONCILIATION_INTERVAL);
-        Thread.sleep(TO_RECONCILIATION_INTERVAL);
+        LOGGER.info("Wait {} ms for next reconciliation", topicOperatorReconciliationInterval);
+        Thread.sleep(topicOperatorReconciliationInterval);
         assertKafkaTopicDecreasePartitionsStatus(TEST_TOPIC_NAME);
     }
 
@@ -402,8 +401,8 @@ class CustomResourceStatusST extends BaseST {
         assertKafkaTopicWrongMinInSyncReplicasStatus(TEST_TOPIC_NAME, invalidValue);
 
         // Wait some time to check if error is still present in KafkaTopic status
-        LOGGER.info("Wait {} ms for next reconciliation", TO_RECONCILIATION_INTERVAL);
-        Thread.sleep(TO_RECONCILIATION_INTERVAL);
+        LOGGER.info("Wait {} ms for next reconciliation", topicOperatorReconciliationInterval);
+        Thread.sleep(topicOperatorReconciliationInterval);
         assertKafkaTopicWrongMinInSyncReplicasStatus(TEST_TOPIC_NAME, invalidValue);
     }
 
@@ -441,7 +440,7 @@ class CustomResourceStatusST extends BaseST {
         KafkaTopicResource.topic(CLUSTER_NAME, TOPIC_NAME).done();
         KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).done();
 
-        TO_RECONCILIATION_INTERVAL = KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get()
+        topicOperatorReconciliationInterval = KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get()
             .getSpec().getEntityOperator().getTopicOperator().getReconciliationIntervalSeconds();
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -441,7 +441,7 @@ class CustomResourceStatusST extends BaseST {
         KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).done();
 
         topicOperatorReconciliationInterval = KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get()
-            .getSpec().getEntityOperator().getTopicOperator().getReconciliationIntervalSeconds();
+            .getSpec().getEntityOperator().getTopicOperator().getReconciliationIntervalSeconds() * 1_000 * 2 + 5_000;
     }
 
     void assertKafkaStatus(long expectedObservedGeneration, String internalAddress) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -316,7 +316,7 @@ class CustomResourceStatusST extends BaseST {
     void testKafkaTopicStatus() {
         KafkaTopicUtils.waitForKafkaTopicReady(TOPIC_NAME);
         // The reason why we have there Observed Generation = 2 cause Kafka sync message.format.version when topic is created
-        assertKafkaTopicStatus(2, TOPIC_NAME);
+        assertKafkaTopicStatus(1, TOPIC_NAME);
     }
 
     @Test
@@ -380,6 +380,7 @@ class CustomResourceStatusST extends BaseST {
         LOGGER.info("Decreasing number of partitions to {}", decreaseTo);
         KafkaTopicResource.replaceTopicResource(TEST_TOPIC_NAME, kafkaTopic -> kafkaTopic.getSpec().setPartitions(decreaseTo));
         KafkaTopicUtils.waitForKafkaTopicPartitionChange(TEST_TOPIC_NAME, decreaseTo);
+        KafkaTopicUtils.waitForKafkaTopicNotReady(TEST_TOPIC_NAME);
 
         assertKafkaTopicDecreasePartitionsStatus(TEST_TOPIC_NAME);
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New tests

### Description

Our new tests will check functionality of our new features:

1) - earlier when we wanted to decrease KafkaTopic partitions, CR status was saying, that topic is `Ready` but in TO there was error that KafkaTopic cannot be reconcile because of exception: `Number of partitions cannot be decreased`
Now in status of KafkaTopic is proper error and reason with message.

2) - second feature is also about KafkaTopic status - when we changed `min.insync.replicas` to some random character (like `x`) we get proper error, but after a while the status changed to `Ready` even if the `min.insync.replicas` was still set to `x`.
 
Checklist:

Decrease topic partitions test:

- create topic with x partitions
- decrease it to 1 partition
- assert KafkaTopic status 

Min.insync.replicas test:
- create topic
- change `min.insync.replicas` to `x`
- assert KafkaTopic status
- wait some time
- assert KafkaTopic status again

--------------------------------------------------------------------
+ fix one failing test ->  problem here was in `observedGeneration` - in original test we had gen 2 - cause of this was that Kafka sync `message.format.version` on topic creation. But after #2930 is behaviour of KafkaTopic changed

+ other problem was in deletion of KafkaMirrorMaker2 without wait -> I added cascading deletion to CR resource - now should be deleted correctly

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

