### PR TITLE
Fixed HttpBridge STs due to a JSON decode exception

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/Producer.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/Producer.java
@@ -64,7 +64,7 @@ public class Producer extends ClientHandlerBase<Integer> implements AutoCloseabl
         if (msgCntPredicate.negate().test(numSent.get())) {
 
             KafkaProducerRecord<String, String> record =
-                    KafkaProducerRecord.create(topic, "\"Sending messages\": \"Hello-world - " + numSent.get() + "\"");
+                    KafkaProducerRecord.create(topic, "\"Hello-world - " + numSent.get() + "\"");
 
             producer.send(record, done -> {
                 if (done.succeeded()) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
@@ -55,7 +55,7 @@ public class KafkaConnectUtils {
 
     public static void waitForMessagesInKafkaConnectFileSink(String kafkaConnectPodName, String sinkFileName) {
         waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, sinkFileName,
-                "\"Sending messages\": \"Hello-world - 99\"");
+                "\"Hello-world - 99\"");
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Bugfix

### Description

With the new HTTP bridge, there is a new Jackson version that has better decoding raising an exception if a string like this `"foo" : "bar"` is sent because it's not a JSON string and it's not a structured JSON (missing the curly brackets). Previously, it was working thanks to bad behavior of the JSON decoder which just returned "foo" (truncating) while now it returns `Failed to decode:Unexpected character (':' (code 58)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false')`.
This PR changes the message produced during the test to use a valid one.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

