### PR TITLE
 Enable CO to access CC service across namespaces + bump to CC 2.0.103

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlResources.java
@@ -38,6 +38,17 @@ public class CruiseControlResources {
     }
 
     /**
+     * Returns qualified name of the service which works across different namespaces.
+     *
+     * @param clusterName   The {@code metadata.name} of the {@code Kafka} resource.
+     * @param namespace     Namespace of the Cruise Control deployment
+     * @return              qualified namespace in the format "&lt;service-name&gt;.&lt;namespace&gt;.svc"
+     */
+    public static String qualifiedServiceName(String clusterName, String namespace) {
+        return serviceName(clusterName) + "." + namespace + ".svc";
+    }
+
+    /**
      * Returns the name of the Cruise Control {@code Secret} for a {@code Kafka} cluster of the given name.
      * This {@code Secret} will only exist if {@code Kafka.spec.cruiseControl} is configured in the
      * {@code Kafka} resource with the given name.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -845,7 +845,7 @@ public class KafkaRebalanceAssemblyOperator
                                             }
                                             // check annotation
                                             RebalanceAnnotation rebalanceAnnotation = rebalanceAnnotation(fetchedKafkaRebalance);
-                                            return reconcile(reconciliation, ccHost == null ? CruiseControlResources.serviceName(clusterName) : ccHost, apiClient, fetchedKafkaRebalance, currentState, rebalanceAnnotation).mapEmpty();
+                                            return reconcile(reconciliation, ccHost == null ? CruiseControlResources.qualifiedServiceName(clusterName, clusterNamespace) : ccHost, apiClient, fetchedKafkaRebalance, currentState, rebalanceAnnotation).mapEmpty();
                                         }, exception -> Future.failedFuture(exception).mapEmpty());
 
                             } else {

--- a/docker-images/kafka/kafka-thirdparty-libs/2.4.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.4.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.4.0</strimzi-oauth.version>
-        <cruise-control.version>2.0.101</cruise-control.version>
+        <cruise-control.version>2.0.103</cruise-control.version>
     </properties>
 
     <repositories>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.4.0</strimzi-oauth.version>
-        <cruise-control.version>2.0.101</cruise-control.version>
+        <cruise-control.version>2.0.103</cruise-control.version>
     </properties>
 
     <repositories>

--- a/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.0.101</cruise-control.version>
+        <cruise-control.version>2.0.103</cruise-control.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

- Enable CO to access CC service across namespaces
- Bump to CC 2.0.103 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

