### PR TITLE
[systemtest][rollingupdate] Test - replication factor lower than min.insync.replicas

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -992,10 +992,6 @@ class RollingUpdateST extends BaseST {
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
             .endMetadata().done();
 
-        // check annotation to trigger rolling update
-        assertThat(Boolean.parseBoolean(kubeClient().getStatefulSet(kafkaName)
-            .getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE)), is(true));
-
         StatefulSetUtils.waitTillSsHasRolled(kafkaName, 2, kafkaPods);
         assertThat(StatefulSetUtils.ssSnapshot(kafkaName), is(not(kafkaPods)));
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -972,6 +972,34 @@ class RollingUpdateST extends BaseST {
         zkMetricsOutput.values().forEach(value -> assertThat(value, is("")));
     }
 
+    @Test
+    void testKafkaTopicRFLowerThanMinInSyncReplicas() {
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 2).done();
+        KafkaTopicResource.topic(CLUSTER_NAME, TOPIC_NAME, 1, 1).done();
+
+        String kafkaName = KafkaResources.kafkaStatefulSetName(CLUSTER_NAME);
+        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaName);
+
+        LOGGER.info("Setting KafkaTopic's min.insync.replicas to be higher than replication factor");
+        KafkaTopicResource.replaceTopicResource(TOPIC_NAME, kafkaTopic -> kafkaTopic.getSpec().getConfig().replace("min.insync.replicas", 2));
+
+        // rolling update for kafka
+        LOGGER.info("Annotate Kafka StatefulSet {} with manual rolling update annotation", kafkaName);
+        timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.ROLLING_UPDATE));
+        // set annotation to trigger Kafka rolling update
+        kubeClient().statefulSet(kafkaName).cascading(false).edit()
+            .editMetadata()
+                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
+            .endMetadata().done();
+
+        // check annotation to trigger rolling update
+        assertThat(Boolean.parseBoolean(kubeClient().getStatefulSet(kafkaName)
+            .getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE)), is(true));
+
+        StatefulSetUtils.waitTillSsHasRolled(kafkaName, 2, kafkaPods);
+        assertThat(StatefulSetUtils.ssSnapshot(kafkaName), is(not(kafkaPods)));
+    }
+
     @Override
     protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
         super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_SHORT);


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test

### Description

In this PR I added test about KafkaRoller/rolling update - earlier when we changed `min.insync.replicas` to be higher than replication factor, KafkaRoller didn't rolled Kafka pods (even when we trigger rolling update manually). Now when we do this change, the pods should be rolled even if KafkaTopic will not be available.

Closed issue: #2964 
PR with fix: #2968 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

