### PR TITLE
Pass HTTP Proxy configuration from Cluster Operator to operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add support for Kafka 2.5.0
 * Remove TLS sidecars from ZooKeeper pods, using native ZooKeeper TLS support instead
 * Add metrics for Topic Operator
+* Pass HTTP Proxy configuration from operator to operands
 
 ## 0.17.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -127,7 +127,7 @@ public abstract class AbstractModel {
         if (envVars.size() > 0) {
             PROXY_ENV_VARS = Collections.unmodifiableList(envVars);
         } else {
-            PROXY_ENV_VARS = Collections.unmodifiableList(new ArrayList<>(0));
+            PROXY_ENV_VARS = Collections.emptyList();
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -107,6 +107,30 @@ public abstract class AbstractModel {
     public static final String ANNO_STRIMZI_CM_GENERATION = Annotations.STRIMZI_DOMAIN + "cm-generation";
     public static final String ANNO_STRIMZI_LOGGING_HASH = Annotations.STRIMZI_DOMAIN + "logging-hash";
 
+    protected static final List<EnvVar> PROXY_ENV_VARS;
+
+    static {
+        List<EnvVar> envVars = new ArrayList<>(3);
+
+        if (System.getenv("HTTP_PROXY") != null)    {
+            envVars.add(buildEnvVar("HTTP_PROXY", System.getenv("HTTP_PROXY")));
+        }
+
+        if (System.getenv("HTTPS_PROXY") != null)    {
+            envVars.add(buildEnvVar("HTTPS_PROXY", System.getenv("HTTPS_PROXY")));
+        }
+
+        if (System.getenv("NO_PROXY") != null)    {
+            envVars.add(buildEnvVar("NO_PROXY", System.getenv("NO_PROXY")));
+        }
+
+        if (envVars.size() > 0) {
+            PROXY_ENV_VARS = envVars;
+        } else {
+            PROXY_ENV_VARS = new ArrayList<>(0);
+        }
+    }
+
     protected final String cluster;
     protected final String namespace;
 
@@ -407,6 +431,17 @@ public abstract class AbstractModel {
      */
     public String getAncillaryConfigName() {
         return ancillaryConfigName;
+    }
+
+    /**
+     * Returns a lit of environment variables which should be shared by all containers.
+     * Currently contains the mirrored HTTP Proxy environment variables
+     *
+     * @return  List with environment variables
+     */
+    protected List<EnvVar> getSharedEnvVars() {
+        // HTTP Proxy configuration should be passed to all images
+        return PROXY_ENV_VARS;
     }
 
     protected List<EnvVar> getEnvVars() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -125,9 +125,9 @@ public abstract class AbstractModel {
         }
 
         if (envVars.size() > 0) {
-            PROXY_ENV_VARS = envVars;
+            PROXY_ENV_VARS = Collections.unmodifiableList(envVars);
         } else {
-            PROXY_ENV_VARS = new ArrayList<>(0);
+            PROXY_ENV_VARS = Collections.unmodifiableList(new ArrayList<>(0));
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -485,6 +485,10 @@ public class CruiseControl extends AbstractModel {
         if (configuration != null && !configuration.getConfiguration().isEmpty()) {
             varList.add(buildEnvVar(ENV_VAR_CRUISE_CONTROL_CONFIGURATION, configuration.getConfiguration()));
         }
+
+        // Add shared environment variables used for all containers
+        varList.addAll(getSharedEnvVars());
+
         addContainerEnvsToExistingEnvs(varList, templateCruiseControlContainerEnvVars);
 
         return varList;
@@ -522,6 +526,9 @@ public class CruiseControl extends AbstractModel {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(ModelUtils.tlsSidecarLogEnvVar(tlsSidecar));
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_CONNECT, zookeeperConnect));
+
+        // Add shared environment variables used for all containers
+        varList.addAll(getSharedEnvVars());
 
         addContainerEnvsToExistingEnvs(varList, templateTlsSidecarContainerEnvVars);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -294,6 +294,9 @@ public class EntityOperator extends AbstractModel {
         varList.add(ModelUtils.tlsSidecarLogEnvVar(tlsSidecar));
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_CONNECT, zookeeperConnect));
 
+        // Add shared environment variables used for all containers
+        varList.addAll(getSharedEnvVars());
+
         addContainerEnvsToExistingEnvs(varList, templateTlsSidecarContainerEnvVars);
 
         return varList;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -264,6 +264,9 @@ public class EntityTopicOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
         EntityOperator.javaOptions(varList, getJvmOptions(), javaSystemProperties);
 
+        // Add shared environment variables used for all containers
+        varList.addAll(getSharedEnvVars());
+
         addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
 
         return varList;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -283,6 +283,9 @@ public class EntityUserOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
         EntityOperator.javaOptions(varList, getJvmOptions(), javaSystemProperties);
 
+        // Add shared environment variables used for all containers
+        varList.addAll(getSharedEnvVars());
+
         addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
 
         return varList;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
@@ -262,6 +262,9 @@ public class JmxTrans extends AbstractModel {
         }
         varList.add(buildEnvVar(ENV_VAR_JMXTRANS_LOGGING_LEVEL, loggingLevel));
 
+        // Add shared environment variables used for all containers
+        varList.addAll(getSharedEnvVars());
+
         addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
 
         return varList;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -403,6 +403,9 @@ public class KafkaBridgeCluster extends AbstractModel {
             varList.add(buildEnvVar(ENV_VAR_STRIMZI_TRACING, tracing.getType()));
         }
 
+        // Add shared environment variables used for all containers
+        varList.addAll(getSharedEnvVars());
+
         addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
 
         return varList;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1687,6 +1687,9 @@ public class KafkaCluster extends AbstractModel {
             }
         }
 
+        // Add shared environment variables used for all containers
+        varList.addAll(getSharedEnvVars());
+
         addContainerEnvsToExistingEnvs(varList, templateInitContainerEnvVars);
 
         return varList;
@@ -1842,6 +1845,9 @@ public class KafkaCluster extends AbstractModel {
             }
         }
 
+        // Add shared environment variables used for all containers
+        varList.addAll(getSharedEnvVars());
+
         // Add user defined environment variables to the Kafka broker containers
         addContainerEnvsToExistingEnvs(varList, templateKafkaContainerEnvVars);
 
@@ -1910,6 +1916,9 @@ public class KafkaCluster extends AbstractModel {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(ENV_VAR_KAFKA_ZOOKEEPER_CONNECT, zookeeperConnect));
         varList.add(ModelUtils.tlsSidecarLogEnvVar(tlsSidecar));
+
+        // Add shared environment variables used for all containers
+        varList.addAll(getSharedEnvVars());
 
         addContainerEnvsToExistingEnvs(varList, templateTlsSidecarContainerEnvVars);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -501,6 +501,9 @@ public class KafkaConnectCluster extends AbstractModel {
             varList.add(buildEnvVar(ENV_VAR_STRIMZI_TRACING, tracing.getType()));
         }
 
+        // Add shared environment variables used for all containers
+        varList.addAll(getSharedEnvVars());
+
         varList.addAll(getExternalConfigurationEnvVars());
 
         addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -251,6 +251,9 @@ public class KafkaExporter extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_KAFKA_EXPORTER_KAFKA_SERVER, KafkaCluster.serviceName(cluster) + ":" + KafkaCluster.REPLICATION_PORT));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_EXPORTER_ENABLE_SARAMA, String.valueOf(saramaLoggingEnabled)));
 
+        // Add shared environment variables used for all containers
+        varList.addAll(getSharedEnvVars());
+
         addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
 
         return varList;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -408,6 +408,9 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_READINESS_PERIOD,
                 String.valueOf(readinessProbeOptions.getPeriodSeconds() != null ? readinessProbeOptions.getPeriodSeconds() : DEFAULT_HEALTHCHECK_PERIOD)));
 
+        // Add shared environment variables used for all containers
+        varList.addAll(getSharedEnvVars());
+
         addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
 
         return varList;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -324,6 +324,9 @@ public class TopicOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_TLS_ENABLED, Boolean.toString(true)));
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
 
+        // Add shared environment variables used for all containers
+        varList.addAll(getSharedEnvVars());
+
         return varList;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -560,6 +560,9 @@ public class ZookeeperCluster extends AbstractModel {
         jvmPerformanceOptions(varList);
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_CONFIGURATION, configuration.getConfiguration()));
 
+        // Add shared environment variables used for all containers
+        varList.addAll(getSharedEnvVars());
+
         addContainerEnvsToExistingEnvs(varList, templateZookeeperContainerEnvVars);
 
         return varList;


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In some situation, the Kafka cluster might be runnign behing a HTTP proxy. In geenral that should not be a problem since the compoenents in general don't communicate with open internet. But there are some cases it might be useful to support such environments for example:
* Kafka Connect running connectors which pull/push data from/to outside through the proxy
* Maybe also JMXTrans pushing the data or OAuth authentication talking with OAuth server from behind the proxy

With this PR, the usual environment variables - `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` can be passed to the Cluster operator which will in turn set them on all created containers. This is also in sync with OpenShift Operator Hub which sets these environment variables automatically when proxy is configured in the cluster.

This PR is hard to test because environment variables cannot be easily changed from within the unit tests. And without support for things such as Dependency Injection it is hard to deal with it in a way when we can easily test it but also don't go through the environment variables every single reconciliation. So there are currently no tests. But the functionality is very primitive, so I hope this should be fine.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md