### PR TITLE
ST: Fix typos in several tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
@@ -32,9 +32,10 @@ import static io.strimzi.systemtest.Constants.SCALABILITY;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.valid4j.matchers.jsonpath.JsonPathMatchers.hasJsonPath;
 
@@ -181,7 +182,7 @@ class UserST extends BaseST {
         KafkaUserUtils.waitForKafkaUserDeletion(user.getMetadata().getName());
 
         ExecResult resultAfterDelete = cmdKubeClient().execInPod(KafkaResources.kafkaPodName(CLUSTER_NAME, 0), "/bin/bash", "-c", command);
-        assertThat(resultAfterDelete.out(), emptyString());
+        assertThat(resultAfterDelete.out(), not(containsString(userName)));
 
         TestUtils.waitFor("user " + userName + " will be deleted from Zookeeper", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
             ExecResult zkResult = cmdKubeClient().execInPod(KafkaResources.kafkaPodName(CLUSTER_NAME, 0), "/bin/bash", "-c", zkListCommand);

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.networking.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.systemtest.BaseST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
@@ -737,9 +738,9 @@ public class TracingST extends BaseST {
         TracingUtils.verify(JAEGER_CONSUMER_SERVICE, kafkaClientsPodName);
         TracingUtils.verify(JAEGER_KAFKA_CONNECT_S2I_SERVICE, kafkaClientsPodName);
 
-        LOGGER.info("Deleting topic {} from CR", TOPIC_NAME);
-        cmdKubeClient().deleteByName("kafkatopic", TOPIC_NAME);
-        KafkaTopicUtils.waitForKafkaTopicDeletion(TOPIC_NAME);
+        LOGGER.info("Deleting topic {} from CR", TEST_TOPIC_NAME);
+        cmdKubeClient().deleteByName(KafkaTopic.RESOURCE_KIND, TEST_TOPIC_NAME);
+        KafkaTopicUtils.waitForKafkaTopicDeletion(TEST_TOPIC_NAME);
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

_Select the type of your PR_

- Bugfix

### Description

This PR fix or slightly refactor the following tests:

- KafkaST#testJvmAndResources
- KafkaST#testCustomAndUpdatedValues
- KafkaST#testForTopicOperator
- KafkaST#testMessagesAreStoredInDis
- UserST#Quotas tests
- TracingST#testConnectS2IService

Most of the failures was caused by wrong topic name after https://github.com/strimzi/strimzi-kafka-operator/pull/2904 or by wrong commands for collecting data from zookeeper tls sidecar which was removed by https://github.com/strimzi/strimzi-kafka-operator/pull/2915

### Checklist

- [x] Make sure all tests pass

