### PR TITLE
Add more security examples with authentication and authorization

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,23 @@
+# Examples
+
+This folder contains different examples of Strimzi custom resources and demonstrates how they can be used.
+
+* [Kafka cluster examples](./kafka)
+    * Examples of Kafka deployments with different types of storage
+* [Kafka Connect examples](./kafka-connect)
+* [Kafka Connect Connector examples](./connector)
+* [Kafka Mirror Maker examples](./kafka-mirror-maker)
+* [Kafka Mirror Maker 2 examples](./kafka-mirror-maker2)
+* [Kafka Bridge examples](./kafka-bridge)
+* [Cruise Control and Kafka Rebalance examples](./cruise-control)
+* [User examples](./user)
+* [Topic examples](./topic)
+* [Prometheus metric examples](./metrics)
+    * Examples of Kafka components with enabled Prometheus metrics
+    * Grafana dashboards
+    * Prometheus Alert examples
+    * Sample Prometheus installation files
+    * Sample Grafana installation files
+    * JMX Trans examples
+* [Security examples](./security)
+    * Example deployments of Kafka, Kafka Connect and HTTP Bridge using TLS encryption, authentication and authorization

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,22 +2,22 @@
 
 This folder contains different examples of Strimzi custom resources and demonstrates how they can be used.
 
-* [Kafka cluster examples](./kafka)
-    * Examples of Kafka deployments with different types of storage
-* [Kafka Connect examples](./kafka-connect)
-* [Kafka Connect Connector examples](./connector)
-* [Kafka Mirror Maker examples](./kafka-mirror-maker)
-* [Kafka Mirror Maker 2 examples](./kafka-mirror-maker2)
-* [Kafka Bridge examples](./kafka-bridge)
-* [Cruise Control and Kafka Rebalance examples](./cruise-control)
-* [User examples](./user)
-* [Topic examples](./topic)
-* [Prometheus metric examples](./metrics)
+* [Kafka cluster](./kafka)
+    * Kafka deployments with different types of storage
+* [Kafka Connect](./kafka-connect)
+* [Kafka Connect Connector](./connector)
+* [Kafka Mirror Maker](./kafka-mirror-maker)
+* [Kafka Mirror Maker 2](./kafka-mirror-maker2)
+* [Kafka Bridge](./kafka-bridge)
+* [Cruise Control and Kafka Rebalance](./cruise-control)
+* [Kafka users](./user)
+* [Kafka topics](./topic)
+* [Prometheus metric](./metrics)
     * Examples of Kafka components with enabled Prometheus metrics
     * Grafana dashboards
-    * Prometheus Alert examples
+    * Prometheus Alert
     * Sample Prometheus installation files
     * Sample Grafana installation files
-    * JMX Trans examples
-* [Security examples](./security)
-    * Example deployments of Kafka, Kafka Connect and HTTP Bridge using TLS encryption, authentication and authorization
+    * JMX Trans deployment
+* [Security](./security)
+    * Deployments of Kafka, Kafka Connect and HTTP Bridge using TLS encryption, authentication and authorization

--- a/examples/security/scram-sha-512-auth/bridge.yaml
+++ b/examples/security/scram-sha-512-auth/bridge.yaml
@@ -1,0 +1,56 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaUser
+metadata:
+  name: my-bridge
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+    # Topics and groups used by the HTTP clients through the HTTP Bridge
+    # Change to match the topics used by your HTTP clients
+    - resource:
+        type: group
+        name: my-group
+      operation: Read
+    - resource:
+        type: topic
+        name: my-topic
+      operation: Read
+    - resource:
+        type: topic
+        name: my-topic
+      operation: Describe
+    - resource:
+        type: topic
+        name: my-topic
+      operation: Write
+    - resource:
+        type: topic
+        name: my-topic
+      operation: Create
+---
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaBridge
+metadata:
+  name: my-bridge
+spec:
+  replicas: 1
+  bootstrapServers: my-cluster-kafka-bootstrap:9093
+  tls:
+    trustedCertificates:
+    - secretName: my-cluster-cluster-ca-cert
+      certificate: ca.crt
+  authentication:
+    type: scram-sha-512
+    username: my-bridge
+    passwordSecret:
+      secretName: my-bridge
+      password: password
+  http:
+    port: 8080
+ 
+

--- a/examples/security/scram-sha-512-auth/connect.yaml
+++ b/examples/security/scram-sha-512-auth/connect.yaml
@@ -1,0 +1,116 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaUser
+metadata:
+  name: my-connect
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+    # Kafka Connects internal topics used to store configuration, offsets or status
+    - resource:
+        type: group
+        name: connect-cluster
+      operation: Read
+    - resource:
+        type: topic
+        name: connect-cluster-configs
+      operation: Read
+    - resource:
+        type: topic
+        name: connect-cluster-configs
+      operation: Describe
+    - resource:
+        type: topic
+        name: connect-cluster-configs
+      operation: Write
+    - resource:
+        type: topic
+        name: connect-cluster-configs
+      operation: Create
+    - resource:
+        type: topic
+        name: connect-cluster-status
+      operation: Read
+    - resource:
+        type: topic
+        name: connect-cluster-status
+      operation: Describe
+    - resource:
+        type: topic
+        name: connect-cluster-status
+      operation: Write
+    - resource:
+        type: topic
+        name: connect-cluster-status
+      operation: Create
+    - resource:
+        type: topic
+        name: connect-cluster-offsets
+      operation: Read
+    - resource:
+        type: topic
+        name: connect-cluster-offsets
+      operation: Write
+    - resource:
+        type: topic
+        name: connect-cluster-offsets
+      operation: Describe
+    - resource:
+        type: topic
+        name: connect-cluster-offsets
+      operation: Create
+    # Additional topics and groups used by connectors
+    # Change to match the topics used by your connectors
+    - resource:
+        type: group
+        name: connect-cluster
+      operation: Read
+    - resource:
+        type: topic
+        name: my-topic
+      operation: Read
+    - resource:
+        type: topic
+        name: my-topic
+      operation: Describe
+    - resource:
+        type: topic
+        name: my-topic
+      operation: Write
+    - resource:
+        type: topic
+        name: my-topic
+      operation: Create
+---
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaConnect
+metadata:
+  name: my-connect
+#  annotations:
+#  # use-connector-resources configures this KafkaConnect
+#  # to use KafkaConnector resources to avoid
+#  # needing to call the Connect REST API directly
+#    strimzi.io/use-connector-resources: "true"
+spec:
+  version: 2.5.0
+  replicas: 1
+  bootstrapServers: my-cluster-kafka-bootstrap:9093
+  tls:
+    trustedCertificates:
+      - secretName: my-cluster-cluster-ca-cert
+        certificate: ca.crt
+  authentication:
+    type: scram-sha-512
+    username: my-connect
+    passwordSecret:
+      secretName: my-connect
+      password: password
+  config:
+    group.id: connect-cluster
+    offset.storage.topic: connect-cluster-offsets
+    config.storage.topic: connect-cluster-configs
+    status.storage.topic: connect-cluster-status

--- a/examples/security/scram-sha-512-auth/kafka.yaml
+++ b/examples/security/scram-sha-512-auth/kafka.yaml
@@ -1,0 +1,36 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    version: 2.5.0
+    replicas: 3
+    listeners:
+      tls:
+        authentication:
+          type: scram-sha-512
+    authorization:
+      type: simple
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      log.message.format.version: "2.5"
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+  zookeeper:
+    replicas: 3
+    storage:
+      type: persistent-claim
+      size: 100Gi
+      deleteClaim: false
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+

--- a/examples/security/scram-sha-512-auth/topic.yaml
+++ b/examples/security/scram-sha-512-auth/topic.yaml
@@ -1,0 +1,14 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  name: my-topic
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 10
+  replicas: 3
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824
+ 
+

--- a/examples/security/scram-sha-512-auth/user.yaml
+++ b/examples/security/scram-sha-512-auth/user.yaml
@@ -1,0 +1,50 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaUser
+metadata:
+  name: my-user
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      # Example ACL rules for consuming from my-topic using consumer group my-group
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Read
+        host: "*"
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Describe
+        host: "*"
+      - resource:
+          type: group
+          name: my-group
+          patternType: literal
+        operation: Read
+        host: "*"
+      # Example ACL rules for producing to topic my-topic
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Write
+        host: "*"
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Create
+        host: "*"
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Describe
+        host: "*"

--- a/examples/security/tls-auth/bridge.yaml
+++ b/examples/security/tls-auth/bridge.yaml
@@ -1,0 +1,56 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaUser
+metadata:
+  name: my-bridge
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+    # Topics and groups used by the HTTP clients through the HTTP Bridge
+    # Change to match the topics used by your HTTP clients
+    - resource:
+        type: group
+        name: my-group
+      operation: Read
+    - resource:
+        type: topic
+        name: my-topic
+      operation: Read
+    - resource:
+        type: topic
+        name: my-topic
+      operation: Describe
+    - resource:
+        type: topic
+        name: my-topic
+      operation: Write
+    - resource:
+        type: topic
+        name: my-topic
+      operation: Create
+---
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaBridge
+metadata:
+  name: my-bridge
+spec:
+  replicas: 1
+  bootstrapServers: my-cluster-kafka-bootstrap:9093
+  tls:
+    trustedCertificates:
+    - secretName: my-cluster-cluster-ca-cert
+      certificate: ca.crt
+  authentication:
+    type: tls
+    certificateAndKey:
+      secretName: my-bridge
+      certificate: user.crt
+      key: user.key
+  http:
+    port: 8080
+ 
+

--- a/examples/security/tls-auth/connect.yaml
+++ b/examples/security/tls-auth/connect.yaml
@@ -1,0 +1,116 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaUser
+metadata:
+  name: my-connect
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+    # Kafka Connects internal topics used to store configuration, offsets or status
+    - resource:
+        type: group
+        name: connect-cluster
+      operation: Read
+    - resource:
+        type: topic
+        name: connect-cluster-configs
+      operation: Read
+    - resource:
+        type: topic
+        name: connect-cluster-configs
+      operation: Describe
+    - resource:
+        type: topic
+        name: connect-cluster-configs
+      operation: Write
+    - resource:
+        type: topic
+        name: connect-cluster-configs
+      operation: Create
+    - resource:
+        type: topic
+        name: connect-cluster-status
+      operation: Read
+    - resource:
+        type: topic
+        name: connect-cluster-status
+      operation: Describe
+    - resource:
+        type: topic
+        name: connect-cluster-status
+      operation: Write
+    - resource:
+        type: topic
+        name: connect-cluster-status
+      operation: Create
+    - resource:
+        type: topic
+        name: connect-cluster-offsets
+      operation: Read
+    - resource:
+        type: topic
+        name: connect-cluster-offsets
+      operation: Write
+    - resource:
+        type: topic
+        name: connect-cluster-offsets
+      operation: Describe
+    - resource:
+        type: topic
+        name: connect-cluster-offsets
+      operation: Create
+    # Additional topics and groups used by connectors
+    # Change to match the topics used by your connectors
+    - resource:
+        type: group
+        name: connect-cluster
+      operation: Read
+    - resource:
+        type: topic
+        name: my-topic
+      operation: Read
+    - resource:
+        type: topic
+        name: my-topic
+      operation: Describe
+    - resource:
+        type: topic
+        name: my-topic
+      operation: Write
+    - resource:
+        type: topic
+        name: my-topic
+      operation: Create
+---
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaConnect
+metadata:
+  name: my-connect
+#  annotations:
+#  # use-connector-resources configures this KafkaConnect
+#  # to use KafkaConnector resources to avoid
+#  # needing to call the Connect REST API directly
+#    strimzi.io/use-connector-resources: "true"
+spec:
+  version: 2.5.0
+  replicas: 1
+  bootstrapServers: my-cluster-kafka-bootstrap:9093
+  tls:
+    trustedCertificates:
+      - secretName: my-cluster-cluster-ca-cert
+        certificate: ca.crt
+  authentication:
+    type: tls
+    certificateAndKey:
+      secretName: my-connect
+      certificate: user.crt
+      key: user.key
+  config:
+    group.id: connect-cluster
+    offset.storage.topic: connect-cluster-offsets
+    config.storage.topic: connect-cluster-configs
+    status.storage.topic: connect-cluster-status

--- a/examples/security/tls-auth/kafka.yaml
+++ b/examples/security/tls-auth/kafka.yaml
@@ -1,0 +1,36 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    version: 2.5.0
+    replicas: 3
+    listeners:
+      tls:
+        authentication:
+          type: tls
+    authorization:
+      type: simple
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      log.message.format.version: "2.5"
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+  zookeeper:
+    replicas: 3
+    storage:
+      type: persistent-claim
+      size: 100Gi
+      deleteClaim: false
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+

--- a/examples/security/tls-auth/topic.yaml
+++ b/examples/security/tls-auth/topic.yaml
@@ -1,0 +1,14 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  name: my-topic
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 10
+  replicas: 3
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824
+ 
+

--- a/examples/security/tls-auth/user.yaml
+++ b/examples/security/tls-auth/user.yaml
@@ -1,0 +1,50 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaUser
+metadata:
+  name: my-user
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      # Example ACL rules for consuming from my-topic using consumer group my-group
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Read
+        host: "*"
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Describe
+        host: "*"
+      - resource:
+          type: group
+          name: my-group
+          patternType: literal
+        operation: Read
+        host: "*"
+      # Example ACL rules for producing to topic my-topic
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Write
+        host: "*"
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Create
+        host: "*"
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Describe
+        host: "*"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

One of the things users have sometimes problem with is to setup everything with full security - TLS encryption, authentication and authorization. They also often ask for examples. This PR adds two sets of examples. The both provide:
* Kafka Cluster
* Kafka Connect
* Kafka Bridge

They are each configured to connect with each with TLS encryption, authentication and authorization. One set is using TLS authentication and other one is using SASL SCRAM-SHA-512. They aslo contain the topic used in the examples and a separate user.

Additionally, a small README.md file is added here describing the different examples.
