### PR TITLE
Disable the HTTP2 protocol as a workaround for Java 1.8.0-252 issues

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -69,6 +69,13 @@ public class Main {
                         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
                         .setEnabled(true));
         Vertx vertx = Vertx.vertx(options);
+
+        // Workaround for https://github.com/fabric8io/kubernetes-client/issues/2212
+        // Can be removed after upgrade to Fabric8 4.10.2 or higher or to Java 11
+        if (Util.shouldDisableHttp2()) {
+            System.setProperty("http2.disable", "true");
+        }
+        
         KubernetesClient client = new DefaultKubernetesClient();
 
         maybeCreateClusterRoles(vertx, config, client).setHandler(crs -> {

--- a/kafka-init/src/main/java/io/strimzi/kafka/init/Main.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/Main.java
@@ -6,6 +6,7 @@ package io.strimzi.kafka.init;
 
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.operator.common.Util;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -17,6 +18,13 @@ public class Main {
 
         log.info("Init-kafka {} is starting", Main.class.getPackage().getImplementationVersion());
         InitWriterConfig config = InitWriterConfig.fromMap(System.getenv());
+
+        // Workaround for https://github.com/fabric8io/kubernetes-client/issues/2212
+        // Can be removed after upgrade to Fabric8 4.10.2 or higher or to Java 11
+        if (Util.shouldDisableHttp2()) {
+            System.setProperty("http2.disable", "true");
+        }
+
         KubernetesClient client = new DefaultKubernetesClient();
 
         log.info("Init-kafka started with config: {}", config);

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -251,6 +251,18 @@ public class Util {
         } else {
             return value;
         }
+    }
 
+    /**
+     * OkHttp wrongfully detects JDK8u251 and higher as JDK9 which enables Http2 unsupported for JDK8.
+     * This method is used as workaround as described in https://github.com/fabric8io/kubernetes-client/issues/2212
+     *
+     * Thsi shoud be removed after migrating to Fabric8 4.10.2 or higher or after migration to Java 11.
+     *
+     * @return true if JDK8 is detected and the environment variable HTTP2_DISABLE is not set
+     */
+    public static boolean shouldDisableHttp2() {
+        return System.getProperty("java.version", "").startsWith("1.8")
+                    && System.getenv("HTTP2_DISABLE") == null;
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -257,7 +257,7 @@ public class Util {
      * OkHttp wrongfully detects JDK8u251 and higher as JDK9 which enables Http2 unsupported for JDK8.
      * This method is used as workaround as described in https://github.com/fabric8io/kubernetes-client/issues/2212
      *
-     * Thsi shoud be removed after migrating to Fabric8 4.10.2 or higher or after migration to Java 11.
+     * This should be removed after migrating to Fabric8 4.10.2 or higher or after migration to Java 11.
      *
      * @return true if JDK8 is detected and the environment variable HTTP2_DISABLE is not set
      */

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Main.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Main.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.topic;
 
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.strimzi.api.kafka.Crds;
+import io.strimzi.operator.common.Util;
 import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -40,6 +41,12 @@ public class Main {
     }
 
     private void deploy(Config config) {
+        // Workaround for https://github.com/fabric8io/kubernetes-client/issues/2212
+        // Can be removed after upgrade to Fabric8 4.10.2 or higher or to Java 11
+        if (Util.shouldDisableHttp2()) {
+            System.setProperty("http2.disable", "true");
+        }
+
         DefaultKubernetesClient kubeClient = new DefaultKubernetesClient();
         Crds.registerCustomKinds();
         VertxOptions options = new VertxOptions().setMetricsOptions(

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -59,6 +59,13 @@ public class Main {
                         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
                         .setEnabled(true));
         Vertx vertx = Vertx.vertx(options);
+
+        // Workaround for https://github.com/fabric8io/kubernetes-client/issues/2212
+        // Can be removed after upgrade to Fabric8 4.10.2 or higher or to Java 11
+        if (Util.shouldDisableHttp2()) {
+            System.setProperty("http2.disable", "true");
+        }
+
         KubernetesClient client = new DefaultKubernetesClient();
         AdminClientProvider adminClientProvider = new DefaultAdminClientProvider();
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Java 8-252 introduces some issues to the okhttp library because it backpotrs some JDK9 parts and confuses okhttp to think it is running on JDK9. This PR introduces a workaround based on https://github.com/fabric8io/kubernetes-client/issues/2212 - it deisables HTTP2 support when running on Java 8.

My tests have confirmed this to solve the issues on environments which had issues with this in the past.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally