### PR TITLE
Increase the default memory for the Strimzi cluster operator to 384Mi

### DIFF
--- a/helm-charts/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/strimzi-kafka-operator/values.yaml
@@ -104,10 +104,10 @@ tlsSidecarCruiseControl:
     tagPrefix: latest
 resources:
   limits:
-    memory: 256Mi
+    memory: 384Mi
     cpu: 1000m
   requests:
-    memory: 256Mi
+    memory: 384Mi
     cpu: 200m
 livenessProbe:
   initialDelaySeconds: 10

--- a/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
@@ -96,9 +96,9 @@ spec:
         resources:
           limits:
             cpu: 1000m
-            memory: 256Mi
+            memory: 384Mi
           requests:
             cpu: 200m
-            memory: 256Mi
+            memory: 384Mi
   strategy:
     type: Recreate


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

For a long time, we have been adding new features while still running with the same 256 of default memeory request. But lately, the operator is often running out of memeory and being killed by the OOM killer. The operator restarting because of memeory is not a big issue -> it just recovers and continues. But it is unnecessary disruption to monitoring, log collectors etc. and we should in general try to avoid it.

In PR #2977 I did some optimizations to the map and list sizes, but it didn't seem to help completely. So this PR increases the memeory reuest for a start to 384Mi. In my tests, that seemed to be stable. In the future we might get back to this and increase the memeory more or do further analysis and tuning. But this should make it more stable at least for the 0.18.0 release.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally