### PR TITLE
docs: Add missing JmxTrans Documentation

### DIFF
--- a/documentation/assemblies/assembly-deployment-configuration-kafka.adoc
+++ b/documentation/assemblies/assembly-deployment-configuration-kafka.adoc
@@ -53,6 +53,8 @@ include::assembly-prometheus-metrics.adoc[leveloffset=+1]
 
 include::assembly-kafka-jmx-options.adoc[leveloffset=+1]
 
+include::assembly-jmxtrans.adoc[leveloffset=+1]
+
 include::assembly-jvm-options.adoc[leveloffset=+1]
 
 include::assembly-configuring-container-images.adoc[leveloffset=+1]


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

Add missing JmxTrans documentation that was added earlier but not
added in the Kafka deployment assembly.

Closes: strimzi/strimzi-kafka-operator#3026

Signed-off-by: Julian Goh <juliangohsl@gmail.com>

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Update/write design documentation in `./design`
- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

