### PR TITLE
Make sure all examples end up in the distribution archives

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -13,8 +13,12 @@ release:
 	$(CP) -r ./kafka-mirror-maker $(RELEASE_PATH)/
 	$(CP) -r ./kafka-mirror-maker-2 $(RELEASE_PATH)/
 	$(CP) -r ./kafka-bridge $(RELEASE_PATH)/
+	$(CP) -r ./connector $(RELEASE_PATH)/
+	$(CP) -r ./cruise-control $(RELEASE_PATH)/
+	$(CP) -r ./security $(RELEASE_PATH)/
 	$(CP) -r ./user $(RELEASE_PATH)/
 	$(CP) -r ./topic $(RELEASE_PATH)/
 	$(CP) -r ./metrics $(RELEASE_PATH)/
+	$(CP) -r ./README.md $(RELEASE_PATH)/
 
 .PHONY: all build clean docker_build docker_push docker_tag spotbugs

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -7,18 +7,6 @@ RELEASE_PATH ?= ../strimzi-$(RELEASE_VERSION)/$(PROJECT_NAME)
 
 release:
 	mkdir -p $(RELEASE_PATH)
-	$(CP) -r ./templates $(RELEASE_PATH)/
-	$(CP) -r ./kafka $(RELEASE_PATH)/
-	$(CP) -r ./kafka-connect $(RELEASE_PATH)/
-	$(CP) -r ./kafka-mirror-maker $(RELEASE_PATH)/
-	$(CP) -r ./kafka-mirror-maker-2 $(RELEASE_PATH)/
-	$(CP) -r ./kafka-bridge $(RELEASE_PATH)/
-	$(CP) -r ./connector $(RELEASE_PATH)/
-	$(CP) -r ./cruise-control $(RELEASE_PATH)/
-	$(CP) -r ./security $(RELEASE_PATH)/
-	$(CP) -r ./user $(RELEASE_PATH)/
-	$(CP) -r ./topic $(RELEASE_PATH)/
-	$(CP) -r ./metrics $(RELEASE_PATH)/
-	$(CP) -r ./README.md $(RELEASE_PATH)/
+	$(CP) -r $$(ls | $(GREP) -Ev '^Makefile$$') $(RELEASE_PATH)/
 
 .PHONY: all build clean docker_build docker_push docker_tag spotbugs


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We added some new examples to the `examples` folder. But nobody adjusted the release Makefiles for it. So the new files are missing there. Thsi includes Kafka Connector examples, CruiseControl examples and the new security examples. This PR adds them to the archives.