### PR TITLE
Fix typo in the Bridge version in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * Add support for Kafka 2.5.0
 * Remove TLS sidecars from ZooKeeper pods, using native ZooKeeper TLS support instead
 * Add metrics for Topic Operator
-* Use Strimzi Kafka Bridge 0.18.0
+* Use Strimzi Kafka Bridge 0.16.0
 * Add support for CORS in the HTTP Kafka Bridge
 * Pass HTTP Proxy configuration from operator to operands
 


### PR DESCRIPTION
It looks like I did a mistake when adding the Kafka Bridge update to the CHNAGELOG.md and mentioned Bridge version 0.18.0. The correct one is of course 0.16.0. This PR fixes it.

This should be picked for the 0.18.0 release branch to fix it there as well.