### PR TITLE
Added Cruise Control, resource and operator to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Use Strimzi Kafka Bridge 0.18.0
 * Add support for CORS in the HTTP Kafka Bridge
 * Pass HTTP Proxy configuration from operator to operands
+* Add Cruise Control support, KafkaRebalance resource and rebalance operator
 
 ## 0.17.0
 


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

This PR adds Cruise Control support to the changelog. Maybe we shouldn't have it at the bottom because it's really a new addition to highlight but I am fine if you want to leave it there.
To be cherry-picked when merged to master.