### PR TITLE
Context succeeding - Part 8

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LoadBalancerIngressBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
@@ -756,5 +757,15 @@ public class ResourceUtils {
 
     public static ClusterOperatorConfig dummyClusterOperatorConfig() {
         return dummyClusterOperatorConfig(new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap()));
+    }
+
+    /**
+     * Find the first resource in the given resources with the given name.
+     * @param resources The secrets to search.
+     * @param name The secret name.
+     * @return The secret with that name.
+     */
+    public static <T extends HasMetadata> T findResourceWithName(List<T> resources, String name) {
+        return resources.stream().filter(s -> s.getMetadata().getName().equals(name)).findFirst().orElse(null);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -63,12 +63,10 @@ import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetDiff;
 import io.strimzi.operator.cluster.operator.resource.ZookeeperSetOperator;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.MockCertManager;
-import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
@@ -78,10 +76,8 @@ import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
-import io.strimzi.operator.common.operator.resource.RoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.RouteOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
-import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.test.TestUtils;
 import io.vertx.core.Future;
@@ -107,7 +103,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -121,7 +116,8 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -304,7 +300,7 @@ public class KafkaAssemblyOperatorTest {
      * @return The secret with that name.
      */
     public static Secret findSecretWithName(List<Secret> secrets, String sname) {
-        return secrets.stream().filter(s -> s.getMetadata().getName().equals(sname)).findFirst().orElse(null);
+        return ResourceUtils.findResourceWithName(secrets, sname);
     }
 
     public static void setFields(Params params) {
@@ -329,6 +325,8 @@ public class KafkaAssemblyOperatorTest {
     @AfterAll
     public static void after() {
         vertx.close();
+        ResourceUtils.cleanUpTemporaryTLSFiles();
+
     }
 
     @ParameterizedTest
@@ -350,8 +348,8 @@ public class KafkaAssemblyOperatorTest {
         createCluster(context, kafka,
                 Collections.singletonList(new SecretBuilder()
                         .withNewMetadata()
-                        .withName(KafkaCluster.jmxSecretName("foo"))
-                        .withNamespace("test")
+                            .withName(KafkaCluster.jmxSecretName("foo"))
+                            .withNamespace("test")
                         .endMetadata()
                         .withData(Collections.singletonMap("foo", "bar"))
                         .build()
@@ -414,9 +412,6 @@ public class KafkaAssemblyOperatorTest {
     }
 
     private void createCluster(VertxTestContext context, Kafka clusterCm, List<Secret> secrets) {
-        ClusterCa clusterCa = new ClusterCa(new MockCertManager(), new PasswordGenerator(10, "a", "a"), clusterCm.getMetadata().getName(),
-                findSecretWithName(secrets, AbstractModel.clusterCaCertSecretName(clusterCm.getMetadata().getName())),
-                findSecretWithName(secrets, AbstractModel.clusterCaKeySecretName(clusterCm.getMetadata().getName())));
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(clusterCm, VERSIONS);
         ZookeeperCluster zookeeperCluster = ZookeeperCluster.fromCrd(clusterCm, VERSIONS);
         TopicOperator topicOperator = TopicOperator.fromCrd(clusterCm, VERSIONS);
@@ -503,9 +498,7 @@ public class KafkaAssemblyOperatorTest {
                 });
 
         when(mockPvcOps.listAsync(eq(clusterCmNamespace), ArgumentMatchers.any(Labels.class)))
-                .thenAnswer(invocation -> {
-                    return Future.succeededFuture(Collections.EMPTY_LIST);
-                });
+                .thenAnswer(invocation -> Future.succeededFuture(Collections.EMPTY_LIST));
 
         Set<String> expectedPvcs = new HashSet<>(zkPvcs.keySet());
         expectedPvcs.addAll(kafkaPvcs.keySet());
@@ -624,78 +617,75 @@ public class KafkaAssemblyOperatorTest {
 
         // Now try to create a KafkaCluster based on this CM
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            if (createResult.failed()) {
-                createResult.cause().printStackTrace();
-            }
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
 
-            // No metrics config  => no CMs created
-            Set<String> logsAndMetricsNames = new HashSet<>();
-            logsAndMetricsNames.add(KafkaCluster.metricAndLogConfigsName(clusterCmName));
+                // No metrics config  => no CMs created
+                Set<String> logsAndMetricsNames = new HashSet<>();
+                logsAndMetricsNames.add(KafkaCluster.metricAndLogConfigsName(clusterCmName));
 
-            // We expect a headless and headful service
-            Set<String> expectedServices = set(
-                    ZookeeperCluster.headlessServiceName(clusterCmName),
-                    ZookeeperCluster.serviceName(clusterCmName),
-                    KafkaCluster.serviceName(clusterCmName),
-                    KafkaCluster.headlessServiceName(clusterCmName));
+                // We expect a headless and headful service
+                Set<String> expectedServices = set(
+                        ZookeeperCluster.headlessServiceName(clusterCmName),
+                        ZookeeperCluster.serviceName(clusterCmName),
+                        KafkaCluster.serviceName(clusterCmName),
+                        KafkaCluster.headlessServiceName(clusterCmName));
 
-            if (metrics)    {
-                expectedServices.add(KafkaExporterResources.serviceName(clusterCmName));
-            }
-
-            if (kafkaListeners != null && kafkaListeners.getExternal() != null) {
-                expectedServices.add(KafkaCluster.externalBootstrapServiceName(clusterCmName));
-
-                for (int i = 0; i < kafkaCluster.getReplicas(); i++) {
-                    expectedServices.add(KafkaCluster.externalServiceName(clusterCmName, i));
-                }
-            }
-
-            List<Service> capturedServices = serviceCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedServices.stream().filter(svc -> svc != null).map(svc -> svc.getMetadata().getName()).collect(Collectors.toSet()).size(),
-                    is(expectedServices.size())));
-            context.verify(() -> assertThat(capturedServices.stream().filter(svc -> svc != null).map(svc -> svc.getMetadata().getName()).collect(Collectors.toSet()),
-                    is(expectedServices)));
-
-            // Assertions on the statefulset
-            List<StatefulSet> capturedSs = ssCaptor.getAllValues();
-            // We expect a statefulSet for kafka and zookeeper...
-            context.verify(() -> assertThat(capturedSs.stream().map(sts -> sts.getMetadata().getName()).collect(Collectors.toSet()),
-                    is(set(KafkaCluster.kafkaClusterName(clusterCmName), ZookeeperCluster.zookeeperClusterName(clusterCmName)))));
-
-            // expected Secrets with certificates
-            context.verify(() -> assertThat(new TreeSet(createdOrUpdatedSecrets), is(new TreeSet(expectedSecrets))));
-
-            // Check PDBs
-            context.verify(() -> assertThat(pdbCaptor.getAllValues().size(), is(2)));
-            context.verify(() -> assertThat(pdbCaptor.getAllValues().stream().map(sts -> sts.getMetadata().getName()).collect(Collectors.toSet()),
-                    is(set(KafkaCluster.kafkaClusterName(clusterCmName), ZookeeperCluster.zookeeperClusterName(clusterCmName)))));
-
-            // Check PVCs
-            context.verify(() -> assertThat(pvcCaptor.getAllValues().size(), is(expectedPvcs.size())));
-            context.verify(() -> assertThat(pvcCaptor.getAllValues().stream().map(pvc -> pvc.getMetadata().getName()).collect(Collectors.toSet()),
-                    is(expectedPvcs)));
-            for (PersistentVolumeClaim pvc : pvcCaptor.getAllValues()) {
-                context.verify(() -> assertThat(Annotations.hasAnnotation(pvc, AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is(true)));
-            }
-
-            // Verify deleted routes
-            if (openShift) {
-                Set<String> expectedRoutes = set(KafkaCluster.serviceName(clusterCmName));
-
-                for (int i = 0; i < kafkaCluster.getReplicas(); i++)    {
-                    expectedRoutes.add(KafkaCluster.externalServiceName(clusterCmName, i));
+                if (metrics)    {
+                    expectedServices.add(KafkaExporterResources.serviceName(clusterCmName));
                 }
 
-                context.verify(() -> assertThat(captured(routeNameCaptor), is(expectedRoutes)));
-            } else {
-                context.verify(() -> assertThat(routeNameCaptor.getAllValues().size(), is(0)));
-            }
+                if (kafkaListeners != null && kafkaListeners.getExternal() != null) {
+                    expectedServices.add(KafkaCluster.externalBootstrapServiceName(clusterCmName));
 
-            async.flag();
-        });
+                    for (int i = 0; i < kafkaCluster.getReplicas(); i++) {
+                        expectedServices.add(KafkaCluster.externalServiceName(clusterCmName, i));
+                    }
+                }
+
+                List<Service> capturedServices = serviceCaptor.getAllValues();
+                assertThat(capturedServices.stream().filter(svc -> svc != null).map(svc -> svc.getMetadata().getName()).collect(Collectors.toSet()).size(),
+                        is(expectedServices.size()));
+                assertThat(capturedServices.stream().filter(svc -> svc != null).map(svc -> svc.getMetadata().getName()).collect(Collectors.toSet()),
+                        is(expectedServices));
+
+                // Assertions on the statefulset
+                List<StatefulSet> capturedSs = ssCaptor.getAllValues();
+                // We expect a statefulSet for kafka and zookeeper...
+                assertThat(capturedSs.stream().map(sts -> sts.getMetadata().getName()).collect(Collectors.toSet()),
+                        is(set(KafkaCluster.kafkaClusterName(clusterCmName), ZookeeperCluster.zookeeperClusterName(clusterCmName))));
+
+                // expected Secrets with certificates
+                assertThat(new TreeSet(createdOrUpdatedSecrets), is(new TreeSet(expectedSecrets)));
+
+                // Check PDBs
+                assertThat(pdbCaptor.getAllValues(), hasSize(2));
+                assertThat(pdbCaptor.getAllValues().stream().map(sts -> sts.getMetadata().getName()).collect(Collectors.toSet()),
+                        is(set(KafkaCluster.kafkaClusterName(clusterCmName), ZookeeperCluster.zookeeperClusterName(clusterCmName))));
+
+                // Check PVCs
+                assertThat(pvcCaptor.getAllValues(), hasSize(expectedPvcs.size()));
+                assertThat(pvcCaptor.getAllValues().stream().map(pvc -> pvc.getMetadata().getName()).collect(Collectors.toSet()),
+                        is(expectedPvcs));
+                for (PersistentVolumeClaim pvc : pvcCaptor.getAllValues()) {
+                    assertThat(pvc.getMetadata().getAnnotations(), hasKey(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM));
+                }
+
+                // Verify deleted routes
+                if (openShift) {
+                    Set<String> expectedRoutes = set(KafkaCluster.serviceName(clusterCmName));
+
+                    for (int i = 0; i < kafkaCluster.getReplicas(); i++)    {
+                        expectedRoutes.add(KafkaCluster.externalServiceName(clusterCmName, i));
+                    }
+
+                    assertThat(captured(routeNameCaptor), is(expectedRoutes));
+                } else {
+                    assertThat(routeNameCaptor.getAllValues(), hasSize(0));
+                }
+
+                async.flag();
+            })));
     }
 
     private Kafka getKafkaAssembly(String clusterName) {
@@ -722,15 +712,16 @@ public class KafkaAssemblyOperatorTest {
         return kafka;
     }
 
-    private List<Secret> getInitialCertificates(String clusterName) {
-        String clusterCmNamespace = "test";
-        return ResourceUtils.createKafkaClusterInitialSecrets(clusterCmNamespace, clusterName);
-    }
-
-    private List<Secret> getClusterCertificates(String clusterCmName, int kafkaReplicas, int zkReplicas) {
-        String clusterCmNamespace = "test";
-        return ResourceUtils.createKafkaClusterSecretsWithReplicas(clusterCmNamespace, clusterCmName, kafkaReplicas, zkReplicas);
-    }
+    // TODO unused
+//    private List<Secret> getInitialCertificates(String clusterName) {
+//        String clusterCmNamespace = "test";
+//        return ResourceUtils.createKafkaClusterInitialSecrets(clusterCmNamespace, clusterName);
+//    }
+//
+//    private List<Secret> getClusterCertificates(String clusterCmName, int kafkaReplicas, int zkReplicas) {
+//        String clusterCmNamespace = "test";
+//        return ResourceUtils.createKafkaClusterSecretsWithReplicas(clusterCmNamespace, clusterCmName, kafkaReplicas, zkReplicas);
+//    }
 
     private static <T> Set<T> captured(ArgumentCaptor<T> captor) {
         return new HashSet<>(captor.getAllValues());
@@ -878,10 +869,6 @@ public class KafkaAssemblyOperatorTest {
         SecretOperator mockSecretOps = supplier.secretOperations;
         NetworkPolicyOperator mockPolicyOps = supplier.networkPolicyOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
-        ServiceAccountOperator mockSao = supplier.serviceAccountOperations;
-        RoleBindingOperator mockRbo = supplier.roleBindingOperations;
-        ClusterRoleBindingOperator mockCrbo = supplier.clusterRoleBindingOperator;
-        RouteOperator mockRouteOps = supplier.routeOperations;
         NodeOperator mockNodeOps = supplier.nodeOperator;
 
         String clusterName = updatedAssembly.getMetadata().getName();
@@ -931,9 +918,9 @@ public class KafkaAssemblyOperatorTest {
                 .thenAnswer(invocation -> {
                     Labels labels = invocation.getArgument(1);
                     if (labels.toMap().get(Labels.STRIMZI_NAME_LABEL).contains("kafka")) {
-                        return Future.succeededFuture(new ArrayList<PersistentVolumeClaim>(kafkaPvcs.values()));
+                        return Future.succeededFuture(new ArrayList<>(kafkaPvcs.values()));
                     } else if (labels.toMap().get(Labels.STRIMZI_NAME_LABEL).contains("zookeeper")) {
-                        return Future.succeededFuture(new ArrayList<PersistentVolumeClaim>(zkPvcs.values()));
+                        return Future.succeededFuture(new ArrayList<>(zkPvcs.values()));
                     }
                     return Future.succeededFuture(Collections.EMPTY_LIST);
                 });
@@ -1181,56 +1168,45 @@ public class KafkaAssemblyOperatorTest {
 
         // Now try to update a KafkaCluster based on this CM
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, clusterNamespace, clusterName) {
+        ops.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, clusterNamespace, clusterName),
+                updatedAssembly)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                // rolling restart
+                Set<String> expectedRollingRestarts = set();
+                if (KafkaSetOperator.needsRollingUpdate(
+                        new StatefulSetDiff(originalKafkaCluster.generateStatefulSet(openShift, null, null),
+                        updatedKafkaCluster.generateStatefulSet(openShift, null, null)))) {
+                    expectedRollingRestarts.add(originalKafkaCluster.getName());
+                }
+                if (ZookeeperSetOperator.needsRollingUpdate(
+                        new StatefulSetDiff(originalZookeeperCluster.generateStatefulSet(openShift, null, null),
+                                updatedZookeeperCluster.generateStatefulSet(openShift, null, null)))) {
+                    expectedRollingRestarts.add(originalZookeeperCluster.getName());
+                }
 
-        }, updatedAssembly).setHandler(createResult -> {
-            if (createResult.failed()) createResult.cause().printStackTrace();
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+                // Check that ZK scale-up happens when it should
+                boolean zkScaledUp = updatedAssembly.getSpec().getZookeeper().getReplicas() > originalAssembly.getSpec().getZookeeper().getReplicas();
+                verify(mockZsOps, times(zkScaledUp ? 1 : 0)).scaleUp(anyString(), scaledUpCaptor.capture(), anyInt());
 
-            int steps = updatedAssembly.getSpec().getZookeeper().getReplicas();
-            // rolling restart
-            Set<String> expectedRollingRestarts = set();
-            if (KafkaSetOperator.needsRollingUpdate(
-                    new StatefulSetDiff(originalKafkaCluster.generateStatefulSet(openShift, null, null),
-                    updatedKafkaCluster.generateStatefulSet(openShift, null, null)))) {
-                expectedRollingRestarts.add(originalKafkaCluster.getName());
-            }
-            if (ZookeeperSetOperator.needsRollingUpdate(
-                    new StatefulSetDiff(originalZookeeperCluster.generateStatefulSet(openShift, null, null),
-                            updatedZookeeperCluster.generateStatefulSet(openShift, null, null)))) {
-                expectedRollingRestarts.add(originalZookeeperCluster.getName());
-            }
+                // No metrics config  => no CMs created
+                verify(mockCmOps, never()).createOrUpdate(any());
 
-            // Check that ZK scale-up happens when it should
-            verify(mockZsOps, times(updatedAssembly.getSpec().getZookeeper().getReplicas() > originalAssembly.getSpec().getZookeeper().getReplicas() ? 1 : 0)).scaleUp(anyString(), scaledUpCaptor.capture(), anyInt());
-
-            // No metrics config  => no CMs created
-            verify(mockCmOps, never()).createOrUpdate(any());
-
-            async.flag();
-        });
+                async.flag();
+            })));
     }
 
     @ParameterizedTest
     @MethodSource("data")
     @Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
-    public void testReconcile(Params params, VertxTestContext context) throws InterruptedException {
+    public void testReconcile(Params params, VertxTestContext context) {
         setFields(params);
 
         // create CM, Service, headless service, statefulset
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(openShift);
         ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);
         CrdOperator mockKafkaOps = supplier.kafkaOperator;
-        ConfigMapOperator mockCmOps = supplier.configMapOperations;
-        ServiceOperator mockServiceOps = supplier.serviceOperations;
-        ZookeeperSetOperator mockZsOps = supplier.zkSetOperations;
         KafkaSetOperator mockKsOps = supplier.kafkaSetOperations;
-        PvcOperator mockPvcOps = supplier.pvcOperations;
-        DeploymentOperator mockDepOps = supplier.deploymentOperations;
         SecretOperator mockSecretOps = supplier.secretOperations;
-        ServiceAccountOperator mockSao = supplier.serviceAccountOperations;
-        RoleBindingOperator mockRbo = supplier.roleBindingOperations;
-        ClusterRoleBindingOperator mockCrbo = supplier.clusterRoleBindingOperator;
         String clusterCmNamespace = "test";
 
         Kafka foo = getKafkaAssembly("foo");
@@ -1285,8 +1261,8 @@ public class KafkaAssemblyOperatorTest {
         when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.clusterCaCertSecretName(bar.getMetadata().getName())))).thenReturn(barSecrets.get(0));
         when(mockSecretOps.reconcile(eq(clusterCmNamespace), eq(AbstractModel.clusterCaCertSecretName(bar.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());
 
-        CountDownLatch fooLatch = new CountDownLatch(1);
-        CountDownLatch barLatch = new CountDownLatch(1);
+        Checkpoint fooAsync = context.checkpoint();
+        Checkpoint barAsync = context.checkpoint();
 
         KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, kubernetesVersion),
                 certManager,
@@ -1297,9 +1273,9 @@ public class KafkaAssemblyOperatorTest {
             public Future<Void> createOrUpdate(Reconciliation reconciliation, Kafka kafkaAssembly) {
                 String name = kafkaAssembly.getMetadata().getName();
                 if ("foo".equals(name)) {
-                    fooLatch.countDown();
+                    fooAsync.flag();
                 } else if ("bar".equals(name)) {
-                    barLatch.countDown();
+                    barAsync.flag();
                 } else {
                     context.failNow(new AssertionError("Unexpected name " + name));
                 }
@@ -1307,26 +1283,15 @@ public class KafkaAssemblyOperatorTest {
             }
         };
 
+        Checkpoint async = context.checkpoint();
         // Now try to reconcile all the Kafka clusters
-        ops.reconcileAll("test", clusterCmNamespace, context.succeeding());
-
-        if (!fooLatch.await(2, TimeUnit.MINUTES)) {
-            if (barLatch.getCount() > 0) {
-                fail("Neither foo nor bar seen");
-            } else {
-                fail("foo not seen");
-            }
-        }
-        if (!barLatch.await(2, TimeUnit.MINUTES)) {
-            fail("bar not seen");
-        }
-        context.completeNow();
+        ops.reconcileAll("test", clusterCmNamespace, context.succeeding(v -> async.flag()));
     }
 
     @ParameterizedTest
     @MethodSource("data")
     @Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
-    public void testReconcileAllNamespaces(Params params, VertxTestContext context) throws InterruptedException {
+    public void testReconcileAllNamespaces(Params params, VertxTestContext context) {
         setFields(params);
 
         // create CM, Service, headless service, statefulset
@@ -1382,8 +1347,8 @@ public class KafkaAssemblyOperatorTest {
                     barClusterCa.caCertSecret()))
         );
 
-        CountDownLatch fooLatch = new CountDownLatch(1);
-        CountDownLatch barLatch = new CountDownLatch(1);
+        Checkpoint fooAsync = context.checkpoint();
+        Checkpoint barAsync = context.checkpoint();
         KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, kubernetesVersion),
                 certManager,
                 passwordGenerator,
@@ -1393,9 +1358,9 @@ public class KafkaAssemblyOperatorTest {
             public Future<Void> createOrUpdate(Reconciliation reconciliation, Kafka kafkaAssembly) {
                 String name = kafkaAssembly.getMetadata().getName();
                 if ("foo".equals(name)) {
-                    fooLatch.countDown();
+                    fooAsync.flag();
                 } else if ("bar".equals(name)) {
-                    barLatch.countDown();
+                    barAsync.flag();
                 } else {
                     context.failNow(new AssertionError("Unexpected name " + name));
                 }
@@ -1403,24 +1368,9 @@ public class KafkaAssemblyOperatorTest {
             }
         };
 
+        Checkpoint async = context.checkpoint();
         // Now try to reconcile all the Kafka clusters
-        ops.reconcileAll("test", "*", context.succeeding());
-
-        if (!fooLatch.await(2, TimeUnit.MINUTES)) {
-            if (barLatch.getCount() > 0) {
-                fail("Neither foo nor bar seen");
-            } else {
-                fail("foo not seen");
-            }
-        }
-        if (!barLatch.await(2, TimeUnit.MINUTES)) {
-            fail("bar not seen");
-        }
-        context.completeNow();
+        ops.reconcileAll("test", "*", context.succeeding(v -> async.flag()));
     }
 
-    @AfterAll
-    public static void cleanUp() {
-        ResourceUtils.cleanUpTemporaryTLSFiles();
-    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.KafkaBridge;
+import io.strimzi.api.kafka.model.KafkaBridgeBuilder;
 import io.strimzi.api.kafka.model.KafkaBridgeConsumerSpec;
 import io.strimzi.api.kafka.model.KafkaBridgeHttpConfig;
 import io.strimzi.api.kafka.model.KafkaBridgeProducerSpec;
@@ -36,6 +37,7 @@ import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.test.TestUtils;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
@@ -54,14 +56,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -101,7 +100,7 @@ public class KafkaBridgeAssemblyOperatorTest {
     }
 
     @Test
-    public void testCreateCluster(VertxTestContext context) {
+    public void testCreateOrUpdateCreatesCluster(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockBridgeOps = supplier.kafkaBridgeOperator;
         DeploymentOperator mockDcOps = supplier.deploymentOperations;
@@ -146,50 +145,49 @@ public class KafkaBridgeAssemblyOperatorTest {
                 VERSIONS);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                // Verify service
+                List<Service> capturedServices = serviceCaptor.getAllValues();
+                assertThat(capturedServices, hasSize(1));
+                Service service = capturedServices.get(0);
+                assertThat(service.getMetadata().getName(), is(bridge.getServiceName()));
+                assertThat(service, is(bridge.generateService()));
 
-            // Verify service
-            List<Service> capturedServices = serviceCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedServices.size(), is(1)));
-            Service service = capturedServices.get(0);
-            context.verify(() -> assertThat(service.getMetadata().getName(), is(bridge.getServiceName())));
-            context.verify(() -> assertThat("Services are not equal", service, is(bridge.generateService())));
+                // No metrics config  => no CMs created
+                Set<String> metricsNames = new HashSet<>();
+                if (bridge.isMetricsEnabled()) {
+                    metricsNames.add(KafkaBridgeResources.metricsAndLogConfigMapName(clusterCmName));
+                }
 
-            // No metrics config  => no CMs created
-            Set<String> metricsNames = new HashSet<>();
-            if (bridge.isMetricsEnabled()) {
-                metricsNames.add(KafkaBridgeResources.metricsAndLogConfigMapName(clusterCmName));
-            }
+                // Verify Deployment
+                List<Deployment> capturedDc = dcCaptor.getAllValues();
+                assertThat(capturedDc, hasSize(1));
+                Deployment dc = capturedDc.get(0);
+                assertThat(dc.getMetadata().getName(), is(bridge.getName()));
+                Map annotations = new HashMap();
+                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
+                assertThat(dc, is(bridge.generateDeployment(annotations, true, null, null)));
 
-            // Verify Deployment
-            List<Deployment> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
-            Deployment dc = capturedDc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(bridge.getName())));
-            Map annotations = new HashMap();
-            annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
-            context.verify(() -> assertThat("Deployments are not equal", dc, is(bridge.generateDeployment(annotations, true, null, null))));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                assertThat(capturedPdb.size(), is(1));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                assertThat(pdb.getMetadata().getName(), is(bridge.getName()));
+                assertThat(pdb, is(bridge.generatePodDisruptionBudget()));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(bridge.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(bridge.generatePodDisruptionBudget())));
+                // Verify status
+                List<KafkaBridge> capturedStatuses = bridgeCaptor.getAllValues();
+                assertThat(capturedStatuses.get(0).getStatus().getUrl(), is("http://foo-bridge-service.test.svc:8080"));
+                assertThat(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), is("True"));
+                assertThat(capturedStatuses.get(0).getStatus().getConditions().get(0).getType(), is("Ready"));
 
-            // Verify status
-            List<KafkaBridge> capturedStatuses = bridgeCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedStatuses.get(0).getStatus().getUrl(), is("http://foo-bridge-service.test.svc:8080")));
-            context.verify(() -> assertThat(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
-            context.verify(() -> assertThat(capturedStatuses.get(0).getStatus().getConditions().get(0).getType(), is("Ready")));
-
-            async.flag();
-        });
+                async.flag();
+            })));
     }
 
     @Test
-    public void testUpdateClusterNoDiff(VertxTestContext context) {
+    public void testCreateOrUpdateWithNoDiffCausesNoChanges(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockBridgeOps = supplier.kafkaBridgeOperator;
         DeploymentOperator mockDcOps = supplier.deploymentOperations;
@@ -242,34 +240,34 @@ public class KafkaBridgeAssemblyOperatorTest {
                 ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
 
-            // Verify service
-            List<Service> capturedServices = serviceCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedServices.size(), is(1)));
+                // Verify service
+                List<Service> capturedServices = serviceCaptor.getAllValues();
+                assertThat(capturedServices, hasSize(1));
 
-            // Verify Deployment Config
-            List<Deployment> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
+                // Verify Deployment Config
+                List<Deployment> capturedDc = dcCaptor.getAllValues();
+                assertThat(capturedDc, hasSize(1));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(bridge.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(bridge.generatePodDisruptionBudget())));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                assertThat(capturedPdb, hasSize(1));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                assertThat(pdb.getMetadata().getName(), is(bridge.getName()));
+                assertThat(pdb, is(bridge.generatePodDisruptionBudget()));
 
-            // Verify scaleDown / scaleUp were not called
-            context.verify(() -> assertThat(dcScaleDownNameCaptor.getAllValues().size(), is(1)));
-            context.verify(() -> assertThat(dcScaleUpNameCaptor.getAllValues().size(), is(1)));
+                // Verify scaleDown / scaleUp were not called
+                assertThat(dcScaleDownNameCaptor.getAllValues(), hasSize(1));
+                assertThat(dcScaleUpNameCaptor.getAllValues(), hasSize(1));
 
-            async.flag();
-        });
+                async.flag();
+            })));
     }
 
     @Test
-    public void testUpdateCluster(VertxTestContext context) {
+    public void testCreateOrUpdateUpdatesCluster(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockBridgeOps = supplier.kafkaBridgeOperator;
         DeploymentOperator mockDcOps = supplier.deploymentOperations;
@@ -350,47 +348,47 @@ public class KafkaBridgeAssemblyOperatorTest {
                 ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
 
-            KafkaBridgeCluster compareTo = KafkaBridgeCluster.fromCrd(clusterCm,
-                    VERSIONS);
+                KafkaBridgeCluster compareTo = KafkaBridgeCluster.fromCrd(clusterCm,
+                        VERSIONS);
 
-            // Verify service
-            List<Service> capturedServices = serviceCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedServices.size(), is(1)));
-            Service service = capturedServices.get(0);
-            context.verify(() -> assertThat(service.getMetadata().getName(), is(compareTo.getServiceName())));
-            context.verify(() -> assertThat("Services are not equal", service, is(compareTo.generateService())));
+                // Verify service
+                List<Service> capturedServices = serviceCaptor.getAllValues();
+                assertThat(capturedServices, hasSize(1));
+                Service service = capturedServices.get(0);
+                assertThat(service.getMetadata().getName(), is(compareTo.getServiceName()));
+                assertThat(service, is(compareTo.generateService()));
 
-            // Verify Deployment
-            List<Deployment> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
-            Deployment dc = capturedDc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(compareTo.getName())));
-            Map<String, String> annotations = new HashMap();
-            annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, loggingCm.getData().get(compareTo.ANCILLARY_CM_KEY_LOG_CONFIG));
-            context.verify(() -> assertThat("Deployments are not equal", dc, is(compareTo.generateDeployment(annotations, true, null, null))));
+                // Verify Deployment
+                List<Deployment> capturedDc = dcCaptor.getAllValues();
+                assertThat(capturedDc, hasSize(1));
+                Deployment dc = capturedDc.get(0);
+                assertThat(dc.getMetadata().getName(), is(compareTo.getName()));
+                Map<String, String> annotations = new HashMap();
+                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, loggingCm.getData().get(compareTo.ANCILLARY_CM_KEY_LOG_CONFIG));
+                assertThat(dc, is(compareTo.generateDeployment(annotations, true, null, null)));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(compareTo.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(compareTo.generatePodDisruptionBudget())));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                assertThat(capturedPdb, hasSize(1));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                assertThat(pdb.getMetadata().getName(), is(compareTo.getName()));
+                assertThat(pdb, is(compareTo.generatePodDisruptionBudget()));
 
-            // Verify scaleDown / scaleUp were not called
-            context.verify(() -> assertThat(dcScaleDownNameCaptor.getAllValues().size(), is(1)));
-            context.verify(() -> assertThat(dcScaleUpNameCaptor.getAllValues().size(), is(1)));
+                // Verify scaleDown / scaleUp were not called
+                assertThat(dcScaleDownNameCaptor.getAllValues(), hasSize(1));
+                assertThat(dcScaleUpNameCaptor.getAllValues(), hasSize(1));
 
-            // No metrics config  => no CMs created
-            verify(mockCmOps, never()).createOrUpdate(any());
-            async.flag();
-        });
+                // No metrics config  => no CMs created
+                verify(mockCmOps, never()).createOrUpdate(any());
+                async.flag();
+            })));
     }
 
     @Test
-    public void testUpdateClusterFailure(VertxTestContext context) {
+    public void testCreateOrUpdateThrowsWhenCreateServiceThrows(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockBridgeOps = supplier.kafkaBridgeOperator;
         DeploymentOperator mockDcOps = supplier.deploymentOperations;
@@ -407,7 +405,7 @@ public class KafkaBridgeAssemblyOperatorTest {
                 BOOTSTRAP_SERVERS, KAFKA_BRIDGE_PRODUCER_SPEC, KAFKA_BRIDGE_CONSUMER_SPEC, KAFKA_BRIDGE_HTTP_SPEC, metricsCm);
         KafkaBridgeCluster bridge = KafkaBridgeCluster.fromCrd(clusterCm,
                 VERSIONS);
-        clusterCm.getSpec().setImage("some/different:image"); // Change the image to generate some diff
+        clusterCm.getSpec().setImage("some/different:image"); // Change the image to generate some differences
 
         when(mockBridgeOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         when(mockBridgeOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(clusterCm));
@@ -449,15 +447,12 @@ public class KafkaBridgeAssemblyOperatorTest {
                 ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(false)));
-
-            async.flag();
-        });
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.failing(e -> async.flag()));
     }
 
     @Test
-    public void testUpdateClusterScaleUp(VertxTestContext context) {
+    public void testCreateOrUpdateWithReplicasScaleUpToOne(VertxTestContext context) {
         final int scaleTo = 1;
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
@@ -479,7 +474,7 @@ public class KafkaBridgeAssemblyOperatorTest {
         when(mockBridgeOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(clusterCm));
         when(mockBridgeOps.updateStatusAsync(any(KafkaBridge.class))).thenReturn(Future.succeededFuture());
         when(mockServiceOps.get(clusterCmNamespace, bridge.getName())).thenReturn(bridge.generateService());
-        Deployment dep = bridge.generateDeployment(new HashMap<String, String>(), true, null, null);
+        Deployment dep = bridge.generateDeployment(new HashMap<>(), true, null, null);
         when(mockDcOps.get(clusterCmNamespace, bridge.getName())).thenReturn(dep);
         when(mockDcOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
@@ -502,17 +497,16 @@ public class KafkaBridgeAssemblyOperatorTest {
                 new MockCertManager(), new PasswordGenerator(10, "a", "a"), supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                verify(mockDcOps).scaleUp(clusterCmNamespace, bridge.getName(), scaleTo);
 
-            verify(mockDcOps).scaleUp(clusterCmNamespace, bridge.getName(), scaleTo);
-
-            async.flag();
-        });
+                async.flag();
+            })));
     }
 
     @Test
-    public void testUpdateClusterScaleDown(VertxTestContext context) {
+    public void testCreateOrUpdateWithScaleDown(VertxTestContext context) {
         int scaleTo = 1;
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
@@ -526,15 +520,21 @@ public class KafkaBridgeAssemblyOperatorTest {
         String clusterCmNamespace = "test";
 
         KafkaBridge clusterCm = ResourceUtils.createEmptyKafkaBridgeCluster(clusterCmNamespace, clusterCmName);
-        clusterCm.getSpec().setReplicas(3);
         clusterCm.getSpec().setReplicas(scaleTo); // Change replicas to create ScaleDown
+
+        // Change replicas to create ScaleDown
+        KafkaBridge scaledDownCluster = new KafkaBridgeBuilder(clusterCm)
+                .editOrNewSpec()
+                    .withReplicas(scaleTo)
+                .endSpec()
+                .build();
         KafkaBridgeCluster bridge = KafkaBridgeCluster.fromCrd(clusterCm, VERSIONS);
 
         when(mockBridgeOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         when(mockBridgeOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(clusterCm));
         when(mockBridgeOps.updateStatusAsync(any(KafkaBridge.class))).thenReturn(Future.succeededFuture());
         when(mockServiceOps.get(clusterCmNamespace, bridge.getName())).thenReturn(bridge.generateService());
-        Deployment dep = bridge.generateDeployment(new HashMap<String, String>(), true, null, null);
+        Deployment dep = bridge.generateDeployment(new HashMap<>(), true, null, null);
         when(mockDcOps.get(clusterCmNamespace, bridge.getName())).thenReturn(dep);
         when(mockDcOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
@@ -557,17 +557,16 @@ public class KafkaBridgeAssemblyOperatorTest {
                 new MockCertManager(), new PasswordGenerator(10, "a", "a"), supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
-
-            verify(mockDcOps).scaleUp(clusterCmNamespace, bridge.getName(), scaleTo);
-
-            async.flag();
-        });
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), scaledDownCluster)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                verify(mockDcOps).scaleUp(clusterCmNamespace, bridge.getName(), scaleTo);
+                verify(mockDcOps).scaleDown(clusterCmNamespace, bridge.getName(), scaleTo);
+                async.flag();
+            })));
     }
 
     @Test
-    public void testReconcile(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    public void testReconcileCallsCreateOrUpdate(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockBridgeOps = supplier.kafkaBridgeOperator;
         DeploymentOperator mockDcOps = supplier.deploymentOperations;
@@ -609,7 +608,8 @@ public class KafkaBridgeAssemblyOperatorTest {
 
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
 
-        CountDownLatch async = new CountDownLatch(2);
+        // Should be called twice, once for foo and once for bar
+        Checkpoint asyncCreatedOrUpdated = context.checkpoint(2);
 
         KafkaBridgeAssemblyOperator ops = new KafkaBridgeAssemblyOperator(vertx,
                 new PlatformFeaturesAvailability(true, kubernetesVersion),
@@ -620,18 +620,22 @@ public class KafkaBridgeAssemblyOperatorTest {
             @Override
             public Future<Void> createOrUpdate(Reconciliation reconciliation, KafkaBridge kafkaBridgeAssembly) {
                 createdOrUpdated.add(kafkaBridgeAssembly.getMetadata().getName());
-                async.countDown();
+                asyncCreatedOrUpdated.flag();
                 return Future.succeededFuture();
             }
         };
 
+        Checkpoint async = context.checkpoint();
+        Promise reconciled = Promise.promise();
         // Now try to reconcile all the Kafka Bridge clusters
-        ops.reconcileAll("test", clusterCmNamespace, ignored -> { });
+        ops.reconcileAll("test", clusterCmNamespace, v -> reconciled.complete());
 
-        async.await(60, TimeUnit.SECONDS);
+        reconciled.future().setHandler(context.succeeding(v -> context.verify(() -> {
+            assertThat(createdOrUpdated, is(new HashSet(asList("foo", "bar"))));
+            async.flag();
+        })));
 
-        context.verify(() -> assertThat(createdOrUpdated, is(new HashSet(asList("foo", "bar")))));
-        context.completeNow();
+
     }
 
     @Test
@@ -671,17 +675,16 @@ public class KafkaBridgeAssemblyOperatorTest {
                 ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(false)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.failing(e -> context.verify(() -> {
+                // Verify status
+                List<KafkaBridge> capturedStatuses = bridgeCaptor.getAllValues();
+                assertThat(capturedStatuses.get(0).getStatus().getUrl(), is("http://foo-bridge-service.test.svc:8080"));
+                assertThat(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), is("True"));
+                assertThat(capturedStatuses.get(0).getStatus().getConditions().get(0).getType(), is("NotReady"));
 
-            // Verify status
-            List<KafkaBridge> capturedStatuses = bridgeCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedStatuses.get(0).getStatus().getUrl(), is("http://foo-bridge-service.test.svc:8080")));
-            context.verify(() -> assertThat(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
-            context.verify(() -> assertThat(capturedStatuses.get(0).getStatus().getConditions().get(0).getType(), is("NotReady")));
-
-            async.flag();
-        });
+                async.flag();
+            })));
     }
 
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -13,6 +13,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.connect.cli.ConnectDistributed;
@@ -31,18 +32,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(VertxExtension.class)
 public class KafkaConnectApiTest {
@@ -61,7 +62,9 @@ public class KafkaConnectApiTest {
         cluster.deleteDataUponShutdown(true);
         cluster.usingDirectory(Files.createTempDirectory("operator-integration-test").toFile());
         cluster.startup();
-        cluster.createTopics(getClass().getSimpleName() + "-offsets", getClass().getSimpleName() + "-config", getClass().getSimpleName() + "-status");
+        cluster.createTopics(getClass().getSimpleName() + "-offsets",
+                getClass().getSimpleName() + "-config",
+                getClass().getSimpleName() + "-status");
 
         // Start a N node connect cluster
         Map<String, String> workerProps = new HashMap<>();
@@ -113,29 +116,30 @@ public class KafkaConnectApiTest {
 
     @Test
     @SuppressWarnings({"unchecked", "checkstyle:MethodLength", "checkstyle:NPathComplexity"})
-    public void test(VertxTestContext context) throws InterruptedException {
+    public void test(VertxTestContext context) {
         KafkaConnectApi client = new KafkaConnectApiImpl(vertx);
-        CountDownLatch async = new CountDownLatch(1);
+        Checkpoint async = context.checkpoint();
         client.listConnectorPlugins("localhost", PORT)
-            .compose(connectorPlugins -> {
+            .setHandler(context.succeeding(connectorPlugins -> context.verify(() -> {
                 assertThat(connectorPlugins.size(), greaterThanOrEqualTo(2));
 
-                ConnectorPlugin fileSink = connectorPlugins.stream().filter(connector -> "org.apache.kafka.connect.file.FileStreamSinkConnector".equals(connector.getConnectorClass())).findFirst().orElse(null);
+                ConnectorPlugin fileSink = connectorPlugins.stream()
+                        .filter(connector -> "org.apache.kafka.connect.file.FileStreamSinkConnector".equals(connector.getConnectorClass()))
+                        .findFirst().orElse(null);
                 assertNotNull(fileSink);
-                assertEquals(fileSink.getType(), "sink");
-                assertNotNull(fileSink.getVersion());
-                assertFalse(fileSink.getVersion().isEmpty());
+                assertThat(fileSink.getType(), is("sink"));
+                assertThat(fileSink.getVersion(), is(not(emptyString())));
 
                 ConnectorPlugin fileSource = connectorPlugins.stream().filter(connector -> "org.apache.kafka.connect.file.FileStreamSourceConnector".equals(connector.getConnectorClass())).findFirst().orElse(null);
                 assertNotNull(fileSource);
-                assertEquals(fileSource.getType(), "source");
-                assertNotNull(fileSource.getVersion());
-                assertFalse(fileSource.getVersion().isEmpty());
+                assertThat(fileSource.getType(), is("source"));
+                assertThat(fileSource.getVersion(), is(not(emptyString())));
+            })))
 
-                return client.list("localhost", PORT);
-            })
+            .compose(connectorPlugins -> client.list("localhost", PORT))
+            .setHandler(context.succeeding(connectorNames -> context.verify(() -> assertThat(connectorNames, is(empty())))))
+
             .compose(connectorNames -> {
-                assertEquals(emptyList(), connectorNames);
                 JsonObject o = new JsonObject()
                     .put("connector.class", "FileStreamSource")
                     .put("tasks.max", "1")
@@ -143,8 +147,11 @@ public class KafkaConnectApiTest {
                     .put("topic", "my-topic");
                 return client.createOrUpdatePutRequest("localhost", PORT, "test", o);
             })
+            .setHandler(context.succeeding())
             .compose(created -> {
+
                 Promise<Map<String, Object>> promise = Promise.promise();
+
                 Handler<Long> handler = new Handler<Long>() {
                     @Override
                     public void handle(Long timerId) {
@@ -167,119 +174,82 @@ public class KafkaConnectApiTest {
                 vertx.setTimer(1000, handler);
                 return promise.future();
             })
-            .compose(status -> {
-                try {
-                    assertEquals("test", status.get("name"));
-                    assertEquals("RUNNING", ((Map) status.getOrDefault("connector", emptyMap())).get("state"));
-                    assertEquals("localhost:18083", ((Map) status.getOrDefault("connector", emptyMap())).get("worker_id"));
-                    List<Map> tasks = (List<Map>) status.get("tasks");
-                    for (Map an : tasks) {
-                        assertEquals("RUNNING", an.get("state"));
-                        assertEquals("localhost:18083", an.get("worker_id"));
-                    }
-                    return client.getConnectorConfig(new BackOff(10), "localhost", PORT, "test");
-                } catch (Throwable e) {
-                    return Future.failedFuture(e);
+            .setHandler(context.succeeding(status -> context.verify(() -> {
+                assertThat(status.get("name"), is("test"));
+                Map<String, Object> connectorStatus = ((Map<String, Object>) status.getOrDefault("connector", emptyMap()));
+                assertThat(connectorStatus.get("state"), is("RUNNING"));
+                assertThat(connectorStatus.get("worker_id"), is("localhost:18083"));
+
+                System.out.println("help " + connectorStatus);
+                List<Map> tasks = (List<Map>) status.get("tasks");
+                for (Map an : tasks) {
+                    assertThat(an.get("state"), is("RUNNING"));
+                    assertThat(an.get("worker_id"), is("localhost:18083"));
                 }
-            })
-            .compose(config -> {
-                try {
-                    assertEquals(TestUtils.map("connector.class", "FileStreamSource",
-                            "file", "/dev/null",
-                            "tasks.max", "1",
-                            "name", "test",
-                            "topic", "my-topic"), config);
-                    return client.getConnectorConfig(new BackOff(10), "localhost", PORT, "does-not-exist");
-                } catch (Throwable e) {
-                    return Future.failedFuture(e);
-                }
-            })
-            .recover(error -> {
-                try {
-                    assertTrue(error instanceof ConnectRestException);
-                    assertEquals(404, ((ConnectRestException) error).getStatusCode());
-                    return Future.succeededFuture();
-                } catch (Throwable e) {
-                    return Future.failedFuture(e);
-                }
-            }).compose(ignored -> {
-                return client.pause("localhost", PORT, "test");
-            })
+            })))
+            .compose(status -> client.getConnectorConfig(new BackOff(10), "localhost", PORT, "test"))
+            .setHandler(context.succeeding(config -> context.verify(() -> {
+                assertThat(config, is(TestUtils.map("connector.class", "FileStreamSource",
+                        "file", "/dev/null",
+                        "tasks.max", "1",
+                        "name", "test",
+                        "topic", "my-topic")));
+            })))
+            .compose(config -> client.getConnectorConfig(new BackOff(10), "localhost", PORT, "does-not-exist"))
+            .setHandler(context.failing(error -> context.verify(() -> {
+                assertThat(error, instanceOf(ConnectRestException.class));
+                assertThat(((ConnectRestException) error).getStatusCode(), is(404));
+            })))
+            .recover(error -> Future.succeededFuture())
+
+            .compose(ignored -> client.pause("localhost", PORT, "test"))
+            .setHandler(context.succeeding())
+
+            .compose(ignored -> client.resume("localhost", PORT, "test"))
+            .setHandler(context.succeeding())
+
             .compose(ignored -> {
-                return client.resume("localhost", PORT, "test");
+                JsonObject o = new JsonObject()
+                        .put("connector.class", "ThisConnectorDoesNotExist")
+                        .put("tasks.max", "1")
+                        .put("file", "/dev/null")
+                        .put("topic", "my-topic");
+                return client.createOrUpdatePutRequest("localhost", PORT, "broken", o);
             })
-            .compose(ignored1 -> {
+            .setHandler(context.failing(error -> context.verify(() -> {
+                assertThat(error, instanceOf(ConnectRestException.class));
+
+                assertThat(error.getMessage(),
+                        containsString("Failed to find any class that implements Connector and which name matches ThisConnectorDoesNotExist"));
+            })))
+            .recover(e -> Future.succeededFuture())
+            .compose(ignored -> {
                 JsonObject o = new JsonObject()
-                    .put("connector.class", "ThisConnectorDoesNotExist")
-                    .put("tasks.max", "1")
-                    .put("file", "/dev/null")
-                    .put("topic", "my-topic");
-                return client.createOrUpdatePutRequest("localhost", PORT, "broken", o)
-                    .compose(ignored -> Future.failedFuture(new AssertionError("Should fail")))
-                    .recover(e -> {
-                        if (e instanceof ConnectRestException) {
-                            if (e.getMessage().contains("Failed to find any class that implements Connector and which name matches ThisConnectorDoesNotExist")) {
-                                return Future.succeededFuture();
-                            } else {
-                                return Future.failedFuture(e.getMessage());
-                            }
-                        } else {
-                            return Future.failedFuture(e);
-                        }
-                    });
-            }).compose(created -> {
-                JsonObject o = new JsonObject()
-                    .put("connector.class", "FileStreamSource")
-                    .put("tasks.max", "dog")
-                    .put("file", "/dev/null")
-                    .put("topic", "my-topic");
-                return client.createOrUpdatePutRequest("localhost", PORT, "broken2", o)
-                    .compose(ignored -> Future.failedFuture(new AssertionError("Should fail")))
-                    .recover(e -> {
-                        if (e instanceof ConnectRestException) {
-                            if (e.getMessage().contains("Invalid value dog for configuration tasks.max: Not a number of type INT")) {
-                                return Future.succeededFuture();
-                            } else {
-                                return Future.failedFuture(e.getMessage());
-                            }
-                        } else {
-                            return Future.failedFuture(e);
-                        }
-                    });
-            }).compose(createResponse -> {
-                return client.list("localhost", PORT);
-            }).compose(connectorNames -> {
-                assertEquals(singletonList("test"), connectorNames);
-                return client.delete("localhost", PORT, "test");
-            }).compose(deleteResponse -> {
-                return client.list("localhost", PORT);
-            }).compose(connectorNames -> {
-                assertEquals(emptyList(), connectorNames);
-                return client.delete("localhost", PORT, "never-existed")
-                    .compose(ignored -> Future.failedFuture(new AssertionError("Should fail")))
-                    .recover(e -> {
-                        if (e instanceof ConnectRestException) {
-                            if (e.getMessage().contains("Connector never-existed not found")) {
-                                return Future.succeededFuture();
-                            } else {
-                                return Future.failedFuture(e.getMessage());
-                            }
-                        } else {
-                            return Future.failedFuture(e);
-                        }
-                    });
-            }).compose(ignored -> {
-                async.countDown();
-                return Future.succeededFuture();
-            }).recover(e -> {
-                context.failNow(e);
-                async.countDown();
-                return Future.succeededFuture();
-            });
-        if (async.await(60, TimeUnit.SECONDS)) {
-            context.completeNow();
-        } else {
-            context.failNow(new TimeoutException("Timeout!"));
-        }
+                        .put("connector.class", "FileStreamSource")
+                        .put("tasks.max", "dog")
+                        .put("file", "/dev/null")
+                        .put("topic", "my-topic");
+                return client.createOrUpdatePutRequest("localhost", PORT, "broken2", o);
+            })
+            .setHandler(context.failing(error -> context.verify(() -> {
+                assertThat(error, instanceOf(ConnectRestException.class));
+                assertThat(error.getMessage(),
+                        containsString("Invalid value dog for configuration tasks.max: Not a number of type INT"));
+            })))
+            .recover(e -> Future.succeededFuture())
+            .compose(createResponse -> client.list("localhost", PORT))
+            .setHandler(context.succeeding(connectorNames -> context.verify(() ->
+                    assertThat(connectorNames, is(singletonList("test"))))))
+            .compose(connectorNames -> client.delete("localhost", PORT, "test"))
+            .setHandler(context.succeeding())
+            .compose(deletedConnector -> client.list("localhost", PORT))
+            .setHandler(context.succeeding(connectorNames -> assertThat(connectorNames, is(empty()))))
+            .compose(connectorNames -> client.delete("localhost", PORT, "never-existed"))
+            .setHandler(context.failing(error -> {
+                assertThat(error, instanceOf(ConnectRestException.class));
+                assertThat(error.getMessage(),
+                        containsString("Connector never-existed not found"));
+                async.flag();
+            }));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -176,7 +176,7 @@ public class KafkaConnectApiTest {
             })
             .setHandler(context.succeeding(status -> context.verify(() -> {
                 assertThat(status.get("name"), is("test"));
-                Map<String, Object> connectorStatus = ((Map<String, Object>) status.getOrDefault("connector", emptyMap()));
+                Map<String, Object> connectorStatus = (Map<String, Object>) status.getOrDefault("connector", emptyMap());
                 assertThat(connectorStatus.get("state"), is("RUNNING"));
                 assertThat(connectorStatus.get("worker_id"), is("localhost:18083"));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -19,6 +19,7 @@ import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.api.kafka.model.connect.ConnectorPluginBuilder;
+import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
@@ -40,6 +41,7 @@ import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.test.TestUtils;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
@@ -58,10 +60,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -70,6 +68,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -102,7 +101,7 @@ public class KafkaConnectAssemblyOperatorTest {
         vertx.close();
     }
 
-    public void testCreateCluster(VertxTestContext context, KafkaConnect clusterCm, boolean connectorOperator) {
+    public void createKafkaConnectCluster(VertxTestContext context, KafkaConnect clusterCm, boolean connectorOperator) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
@@ -155,58 +154,60 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnectCluster connect = KafkaConnectCluster.fromCrd(clusterCm, VERSIONS);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCm.getMetadata().getNamespace(), clusterCm.getMetadata().getName()), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCm.getMetadata().getNamespace(), clusterCm.getMetadata().getName()), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                // No metrics config  => no CMs created
+                Set<String> metricsNames = new HashSet<>();
+                if (connect.isMetricsEnabled()) {
+                    metricsNames.add(KafkaConnectResources.metricsAndLogConfigMapName(clusterCm.getMetadata().getName()));
+                }
 
-            // No metrics config  => no CMs created
-            Set<String> metricsNames = new HashSet<>();
-            if (connect.isMetricsEnabled()) {
-                metricsNames.add(KafkaConnectResources.metricsAndLogConfigMapName(clusterCm.getMetadata().getName()));
-            }
+                // Verify service
+                List<Service> capturedServices = serviceCaptor.getAllValues();
+                assertThat(capturedServices, hasSize(1));
+                Service service = capturedServices.get(0);
+                assertThat(service.getMetadata().getName(), is(connect.getServiceName()));
+                assertThat(service, is(connect.generateService()));
 
-            // Verify service
-            List<Service> capturedServices = serviceCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedServices.size(), is(1)));
-            Service service = capturedServices.get(0);
-            context.verify(() -> assertThat(service.getMetadata().getName(), is(connect.getServiceName())));
-            context.verify(() -> assertThat("Services are not equal", service, is(connect.generateService())));
+                // Verify Deployment
+                List<Deployment> capturedDc = dcCaptor.getAllValues();
+                assertThat(capturedDc, hasSize(1));
+                Deployment dc = capturedDc.get(0);
+                assertThat(dc.getMetadata().getName(), is(connect.getName()));
+                Map annotations = new HashMap();
+                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
+                assertThat(dc, is(connect.generateDeployment(annotations, true, null, null)));
 
-            // Verify Deployment
-            List<Deployment> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
-            Deployment dc = capturedDc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(connect.getName())));
-            Map annotations = new HashMap();
-            annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
-            context.verify(() -> assertThat("Deployments are not equal", dc, is(connect.generateDeployment(annotations, true, null, null))));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                assertThat(capturedPdb.size(), is(1));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                assertThat(pdb.getMetadata().getName(), is(connect.getName()));
+                assertThat(pdb, is(connect.generatePodDisruptionBudget()));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(connect.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(connect.generatePodDisruptionBudget())));
+                // Verify status
+                List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                assertThat(capturedConnects, hasSize(1));
+                KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
 
-            // Verify status
-            List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getUrl(), is("http://foo-connect-api.test.svc:8083")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("Ready")));
+                assertThat(connectStatus.getUrl(), is("http://foo-connect-api.test.svc:8083"));
+                assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
 
-            if (connectorOperator) {
-                context.verify(() -> assertThat(npCaptor.getValue(), is(notNullValue())));
+                if (connectorOperator) {
+                    assertThat(npCaptor.getValue(), is(notNullValue()));
 
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().size(), is(1)));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getConnectorClass(), is("io.strimzi.MyClass")));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getType(), is("sink")));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getVersion(), is("1.0.0")));
-            } else {
-                context.verify(() -> assertThat(npCaptor.getValue(), is(nullValue())));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins(), nullValue()));
-            }
+                    assertThat(connectStatus.getConnectorPlugins(), hasSize(1));
+                    assertThat(connectStatus.getConnectorPlugins().get(0).getConnectorClass(), is("io.strimzi.MyClass"));
+                    assertThat(connectStatus.getConnectorPlugins().get(0).getType(), is("sink"));
+                    assertThat(connectStatus.getConnectorPlugins().get(0).getVersion(), is("1.0.0"));
+                } else {
+                    assertThat(npCaptor.getValue(), is(nullValue()));
+                    assertThat(connectStatus.getConnectorPlugins(), nullValue());
+                }
 
-            async.flag();
-        });
+                async.flag();
+            })));
     }
 
     @Test
@@ -215,7 +216,7 @@ public class KafkaConnectAssemblyOperatorTest {
         String clusterCmNamespace = "test";
         KafkaConnect clusterCm = ResourceUtils.createEmptyKafkaConnectCluster(clusterCmNamespace, clusterCmName);
 
-        testCreateCluster(context, clusterCm, false);
+        createKafkaConnectCluster(context, clusterCm, false);
     }
 
     @Test
@@ -223,13 +224,13 @@ public class KafkaConnectAssemblyOperatorTest {
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
         KafkaConnect clusterCm = ResourceUtils.createEmptyKafkaConnectCluster(clusterCmNamespace, clusterCmName);
-        clusterCm.getMetadata().getAnnotations().put("strimzi.io/use-connector-resources", "true");
+        clusterCm.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true");
 
-        testCreateCluster(context, clusterCm, true);
+        createKafkaConnectCluster(context, clusterCm, true);
     }
 
     @Test
-    public void testUpdateClusterNoDiff(VertxTestContext context) {
+    public void testCreateOrUpdateDoesNotUpdateWithNoDiff(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
@@ -292,34 +293,34 @@ public class KafkaConnectAssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
 
-            // Verify service
-            List<Service> capturedServices = serviceCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedServices.size(), is(1)));
+                // Verify service
+                List<Service> capturedServices = serviceCaptor.getAllValues();
+                assertThat(capturedServices, hasSize(1));
 
-            // Verify Deployment Config
-            List<Deployment> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
+                // Verify Deployment Config
+                List<Deployment> capturedDc = dcCaptor.getAllValues();
+                assertThat(capturedDc, hasSize(1));
 
-            // Verify scaleDown / scaleUp were not called
-            context.verify(() -> assertThat(dcScaleDownNameCaptor.getAllValues().size(), is(1)));
-            context.verify(() -> assertThat(dcScaleUpNameCaptor.getAllValues().size(), is(1)));
+                // Verify scaleDown / scaleUp were not called
+                assertThat(dcScaleDownNameCaptor.getAllValues(), hasSize(1));
+                assertThat(dcScaleUpNameCaptor.getAllValues(), hasSize(1));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(connect.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(connect.generatePodDisruptionBudget())));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                assertThat(capturedPdb, hasSize(1));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                assertThat(pdb.getMetadata().getName(), is(connect.getName()));
+                assertThat(pdb, is(connect.generatePodDisruptionBudget()));
 
-            async.flag();
-        });
+                async.flag();
+            })));
     }
 
     @Test
-    public void testUpdateCluster(VertxTestContext context) {
+    public void testCreateOrUpdateUpdatesCluster(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
@@ -409,46 +410,45 @@ public class KafkaConnectAssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                KafkaConnectCluster compareTo = KafkaConnectCluster.fromCrd(clusterCm, VERSIONS);
 
-            KafkaConnectCluster compareTo = KafkaConnectCluster.fromCrd(clusterCm, VERSIONS);
+                // Verify service
+                List<Service> capturedServices = serviceCaptor.getAllValues();
+                assertThat(capturedServices, hasSize(1));
+                Service service = capturedServices.get(0);
+                assertThat(service.getMetadata().getName(), is(compareTo.getServiceName()));
+                assertThat(service, is(compareTo.generateService()));
 
-            // Verify service
-            List<Service> capturedServices = serviceCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedServices.size(), is(1)));
-            Service service = capturedServices.get(0);
-            context.verify(() -> assertThat(service.getMetadata().getName(), is(compareTo.getServiceName())));
-            context.verify(() -> assertThat("Services are not equal", service, is(compareTo.generateService())));
+                // Verify Deployment
+                List<Deployment> capturedDc = dcCaptor.getAllValues();
+                assertThat(capturedDc, hasSize(1));
+                Deployment dc = capturedDc.get(0);
+                assertThat(dc.getMetadata().getName(), is(compareTo.getName()));
+                Map<String, String> annotations = new HashMap();
+                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, loggingCm.getData().get(compareTo.ANCILLARY_CM_KEY_LOG_CONFIG));
+                assertThat(dc, is(compareTo.generateDeployment(annotations, true, null, null)));
 
-            // Verify Deployment
-            List<Deployment> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
-            Deployment dc = capturedDc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(compareTo.getName())));
-            Map<String, String> annotations = new HashMap();
-            annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, loggingCm.getData().get(compareTo.ANCILLARY_CM_KEY_LOG_CONFIG));
-            context.verify(() -> assertThat("Deployments are not equal", dc, is(compareTo.generateDeployment(annotations, true, null, null))));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                assertThat(capturedPdb, hasSize(1));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                assertThat(pdb.getMetadata().getName(), is(connect.getName()));
+                assertThat(pdb, is(connect.generatePodDisruptionBudget()));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(connect.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(connect.generatePodDisruptionBudget())));
+                // Verify scaleDown / scaleUp were not called
+                assertThat(dcScaleDownNameCaptor.getAllValues(), hasSize(1));
+                assertThat(dcScaleUpNameCaptor.getAllValues(), hasSize(1));
 
-            // Verify scaleDown / scaleUp were not called
-            context.verify(() -> assertThat(dcScaleDownNameCaptor.getAllValues().size(), is(1)));
-            context.verify(() -> assertThat(dcScaleUpNameCaptor.getAllValues().size(), is(1)));
-
-            // No metrics config  => no CMs created
-            verify(mockCmOps, never()).createOrUpdate(any());
-            async.flag();
-        });
+                // No metrics config  => no CMs created
+                verify(mockCmOps, never()).createOrUpdate(any());
+                async.flag();
+            })));
     }
 
     @Test
-    public void testUpdateClusterFailure(VertxTestContext context) {
+    public void testCreateOrUpdateFailsWhenDeploymentUpdateFails(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
@@ -503,11 +503,8 @@ public class KafkaConnectAssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(false)));
-
-            async.flag();
-        });
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.failing(v -> async.flag()));
     }
 
     @Test
@@ -570,13 +567,11 @@ public class KafkaConnectAssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
-
-            verify(mockDcOps).scaleUp(clusterCmNamespace, connect.getName(), scaleTo);
-
-            async.flag();
-        });
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                verify(mockDcOps).scaleUp(clusterCmNamespace, connect.getName(), scaleTo);
+                async.flag();
+            })));
     }
 
     @Test
@@ -639,17 +634,16 @@ public class KafkaConnectAssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                verify(mockDcOps).scaleUp(clusterCmNamespace, connect.getName(), scaleTo);
 
-            verify(mockDcOps).scaleUp(clusterCmNamespace, connect.getName(), scaleTo);
-
-            async.flag();
-        });
+                async.flag();
+            })));
     }
 
     @Test
-    public void testReconcile(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    public void testReconcile(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
@@ -688,28 +682,32 @@ public class KafkaConnectAssemblyOperatorTest {
 
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
 
-        CountDownLatch async = new CountDownLatch(2);
+        Checkpoint asyncCreated = context.checkpoint(2);
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS)) {
 
             @Override
             public Future<Void> createOrUpdate(Reconciliation reconciliation, KafkaConnect kafkaConnectAssembly) {
                 createdOrUpdated.add(kafkaConnectAssembly.getMetadata().getName());
-                async.countDown();
+                asyncCreated.flag();
                 return Future.succeededFuture();
             }
         };
 
-        // Now try to reconcile all the Kafka Connect clusters
-        ops.reconcileAll("test", clusterCmNamespace, ignored -> { });
 
-        async.await(60, TimeUnit.SECONDS);
-        context.verify(() -> assertThat(createdOrUpdated, is(new HashSet(asList("foo", "bar")))));
-        context.completeNow();
+        Checkpoint async = context.checkpoint();
+        Promise reconciled = Promise.promise();
+        // Now try to reconcile all the Kafka Connect clusters
+        ops.reconcileAll("test", clusterCmNamespace, ignored -> reconciled.complete());
+
+        reconciled.future().setHandler(context.succeeding(v -> context.verify(() -> {
+            assertThat(createdOrUpdated, is(new HashSet(asList("foo", "bar"))));
+            async.flag();
+        })));
     }
 
     @Test
-    public void testCreateClusterStatusNotReady(VertxTestContext context) {
+    public void testUpdateClusterWithFailedScaleDownSetsStatusNotReady(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
@@ -734,7 +732,8 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockDcOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
-        when(mockNetPolOps.reconcile(eq(clusterCm.getMetadata().getNamespace()), eq(KafkaConnectResources.deploymentName(clusterCm.getMetadata().getName())), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
+        when(mockNetPolOps.reconcile(eq(clusterCm.getMetadata().getNamespace()), eq(KafkaConnectResources.deploymentName(clusterCm.getMetadata().getName())), any()))
+            .thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
         when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture());
 
         ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
@@ -744,20 +743,21 @@ public class KafkaConnectAssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(false)));
-
-            // Verify status
-            List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getUrl(), is("http://foo-connect-api.test.svc:8083")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("NotReady")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getMessage(), is(failureMsg)));
-            async.flag();
-        });
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.failing(v -> context.verify(() -> {
+                // Verify status
+                List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                assertThat(capturedConnects, hasSize(1));
+                KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
+                assertThat(connectStatus.getUrl(), is("http://foo-connect-api.test.svc:8083"));
+                assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                assertThat(connectStatus.getConditions().get(0).getType(), is("NotReady"));
+                assertThat(connectStatus.getConditions().get(0).getMessage(), is(failureMsg));
+                async.flag();
+            })));
     }
 
-    public void testCreateClusterWitDuplicateOlderConnect(VertxTestContext context, KafkaConnect clusterCm, boolean connectorOperator) {
+    public void assertCreateClusterWitDuplicateOlderConnect(VertxTestContext context, KafkaConnect clusterCm, boolean connectorOperator) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
@@ -814,53 +814,54 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnectCluster connect = KafkaConnectCluster.fromCrd(clusterCm, VERSIONS);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCm.getMetadata().getNamespace(), clusterCm.getMetadata().getName()), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCm.getMetadata().getNamespace(), clusterCm.getMetadata().getName()), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
 
-            // No metrics config  => no CMs created
-            Set<String> metricsNames = new HashSet<>();
-            if (connect.isMetricsEnabled()) {
-                metricsNames.add(KafkaConnectResources.metricsAndLogConfigMapName(clusterCm.getMetadata().getName()));
-            }
+                // No metrics config  => no CMs created
+                Set<String> metricsNames = new HashSet<>();
+                if (connect.isMetricsEnabled()) {
+                    metricsNames.add(KafkaConnectResources.metricsAndLogConfigMapName(clusterCm.getMetadata().getName()));
+                }
 
-            // Verify service
-            List<Service> capturedServices = serviceCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedServices.size(), is(1)));
-            Service service = capturedServices.get(0);
-            context.verify(() -> assertThat(service.getMetadata().getName(), is(connect.getServiceName())));
-            context.verify(() -> assertThat("Services are not equal", service, is(connect.generateService())));
+                // Verify service
+                List<Service> capturedServices = serviceCaptor.getAllValues();
+                assertThat(capturedServices.size(), is(1));
+                Service service = capturedServices.get(0);
+                assertThat(service.getMetadata().getName(), is(connect.getServiceName()));
+                assertThat(service, is(connect.generateService()));
 
-            // Verify Deployment
-            List<Deployment> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
-            Deployment dc = capturedDc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(connect.getName())));
-            Map annotations = new HashMap();
-            annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
-            context.verify(() -> assertThat("Deployments are not equal", dc, is(connect.generateDeployment(annotations, true, null, null))));
+                // Verify Deployment
+                List<Deployment> capturedDc = dcCaptor.getAllValues();
+                assertThat(capturedDc.size(), is(1));
+                Deployment dc = capturedDc.get(0);
+                assertThat(dc.getMetadata().getName(), is(connect.getName()));
+                Map annotations = new HashMap();
+                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
+                assertThat(dc, is(connect.generateDeployment(annotations, true, null, null)));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(connect.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(connect.generatePodDisruptionBudget())));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                assertThat(capturedPdb, hasSize(1));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                assertThat(pdb.getMetadata().getName(), is(connect.getName()));
+                assertThat(pdb, is(connect.generatePodDisruptionBudget()));
 
-            // Verify status
-            List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getUrl(), is("http://foo-connect-api.test.svc:8083")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("Ready")));
+                // Verify status
+                List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                assertThat(capturedConnects, hasSize(1));
+                KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
+                assertThat(connectStatus.getUrl(), is("http://foo-connect-api.test.svc:8083"));
+                assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
+                if (connectorOperator) {
+                    assertThat(connectStatus.getConnectorPlugins(), hasSize(1));
+                    assertThat(connectStatus.getConnectorPlugins().get(0).getConnectorClass(), is("io.strimzi.MyClass"));
+                    assertThat(connectStatus.getConnectorPlugins().get(0).getType(), is("sink"));
+                    assertThat(connectStatus.getConnectorPlugins().get(0).getVersion(), is("1.0.0"));
+                }
 
-            if (connectorOperator) {
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().size(), is(1)));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getConnectorClass(), is("io.strimzi.MyClass")));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getType(), is("sink")));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getVersion(), is("1.0.0")));
-            }
-
-            async.flag();
-        });
+                async.flag();
+            })));
     }
 
     @Test
@@ -869,7 +870,7 @@ public class KafkaConnectAssemblyOperatorTest {
         String clusterCmNamespace = "test";
         KafkaConnect clusterCm = ResourceUtils.createEmptyKafkaConnectCluster(clusterCmNamespace, clusterCmName);
 
-        testCreateClusterWitDuplicateOlderConnect(context, clusterCm, false);
+        assertCreateClusterWitDuplicateOlderConnect(context, clusterCm, false);
     }
 
     @Test
@@ -879,11 +880,11 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnect clusterCm = ResourceUtils.createEmptyKafkaConnectCluster(clusterCmNamespace, clusterCmName);
         clusterCm.getMetadata().getAnnotations().put("strimzi.io/use-connector-resources", "true");
 
-        testCreateClusterWitDuplicateOlderConnect(context, clusterCm, true);
+        assertCreateClusterWitDuplicateOlderConnect(context, clusterCm, true);
     }
 
     @Test
-    public void testCreateClusterWitDuplicateNeverConnect(VertxTestContext context) {
+    public void testCreateClusterWitDuplicateNeverConnectHasNotReadyStatus(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
@@ -910,17 +911,17 @@ public class KafkaConnectAssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(false)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.failing(error -> context.verify(() -> {
+                // Verify status
+                List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True"));
+                assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("NotReady"));
+                assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getMessage(),
+                        is("Both KafkaConnect and KafkaConnectS2I exist with the same name. KafkaConnectS2I is older and will be used while this custom resource will be ignored."));
 
-            // Verify status
-            List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("NotReady")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getMessage(), is("Both KafkaConnect and KafkaConnectS2I exist with the same name. KafkaConnectS2I is older and will be used while this custom resource will be ignored.")));
-
-            async.flag();
-        });
+                async.flag();
+            })));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -21,6 +21,7 @@ import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
 import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.api.kafka.model.connect.ConnectorPluginBuilder;
+import io.strimzi.api.kafka.model.status.KafkaConnectS2IStatus;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
@@ -62,10 +63,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -106,7 +103,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         vertx.close();
     }
 
-    public void testCreateCluster(VertxTestContext context, KafkaConnectS2I clusterCm, boolean connectorOperator) {
+    public void createCluster(VertxTestContext context, KafkaConnectS2I clusterCm, boolean connectorOperator) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
         CrdOperator mockConnectOps = supplier.connectOperator;
@@ -173,72 +170,72 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCm.getMetadata().getNamespace(), clusterCm.getMetadata().getName()), clusterCm)
-            .setHandler(context.succeeding(v -> {
+            .setHandler(context.succeeding(v -> context.verify(() -> {
 
                 // Verify service
                 List<Service> capturedServices = serviceCaptor.getAllValues();
-                context.verify(() -> assertThat(capturedServices, hasSize(1)));
+                assertThat(capturedServices, hasSize(1));
                 Service service = capturedServices.get(0);
-                context.verify(() -> assertThat(service.getMetadata().getName(), is(connect.getServiceName())));
-                context.verify(() -> assertThat("Services are not equal", service, is(connect.generateService())));
+                assertThat(service.getMetadata().getName(), is(connect.getServiceName()));
+                assertThat(service, is(connect.generateService()));
 
                 // Verify Deployment Config
                 List<DeploymentConfig> capturedDc = dcCaptor.getAllValues();
-                context.verify(() -> assertThat(capturedDc, hasSize(1)));
+                assertThat(capturedDc, hasSize(1));
                 DeploymentConfig dc = capturedDc.get(0);
-                context.verify(() -> assertThat(dc.getMetadata().getName(), is(connect.getName())));
+                assertThat(dc.getMetadata().getName(), is(connect.getName()));
                 Map annotations = new HashMap();
                 annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
-                context.verify(() -> assertThat("Deployment Configs are not equal", dc, is(connect.generateDeploymentConfig(annotations, true, null, null))));
+                assertThat(dc, is(connect.generateDeploymentConfig(annotations, true, null, null)));
 
                 // Verify Build Config
                 List<BuildConfig> capturedBc = bcCaptor.getAllValues();
-                context.verify(() -> assertThat(capturedBc, hasSize(1)));
+                assertThat(capturedBc, hasSize(1));
                 BuildConfig bc = capturedBc.get(0);
-                context.verify(() -> assertThat(dc.getMetadata().getName(), is(connect.getName())));
-                context.verify(() -> assertThat("Build Configs are not equal", bc, is(connect.generateBuildConfig())));
+                assertThat(dc.getMetadata().getName(), is(connect.getName()));
+                assertThat(bc, is(connect.generateBuildConfig()));
 
                 // Verify PodDisruptionBudget
                 List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-                context.verify(() -> assertThat(capturedPdb, hasSize(1)));
+                assertThat(capturedPdb, hasSize(1));
                 PodDisruptionBudget pdb = capturedPdb.get(0);
-                context.verify(() -> assertThat(pdb.getMetadata().getName(), is(connect.getName())));
-                context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(connect.generatePodDisruptionBudget())));
+                assertThat(pdb.getMetadata().getName(), is(connect.getName()));
+                assertThat(pdb, is(connect.generatePodDisruptionBudget()));
 
                 // Verify Image Streams
                 List<ImageStream> capturedIs = isCaptor.getAllValues();
-                context.verify(() -> assertThat(capturedIs, hasSize(2)));
-                int sisIndex = (KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster())).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
-                int tisIndex = (connect.getName()).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
+                assertThat(capturedIs, hasSize(2));
+                int sourceImageStreamIndex = (KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster())).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
+                int targetImageStreamIndex = (connect.getName()).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
 
-                ImageStream sis = capturedIs.get(sisIndex);
-                context.verify(() -> assertThat(sis.getMetadata().getName(), is(KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster()))));
-                context.verify(() -> assertThat("Source Image Streams are not equal", sis, is(connect.generateSourceImageStream())));
+                ImageStream source = capturedIs.get(sourceImageStreamIndex);
+                assertThat(source.getMetadata().getName(), is(KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster())));
+                assertThat(source, is(connect.generateSourceImageStream()));
 
-                ImageStream tis = capturedIs.get(tisIndex);
-                context.verify(() -> assertThat(tis.getMetadata().getName(), is(connect.getName())));
-                context.verify(() -> assertThat("Target Image Streams are not equal", tis, is(connect.generateTargetImageStream())));
+                ImageStream target = capturedIs.get(targetImageStreamIndex);
+                assertThat(target.getMetadata().getName(), is(connect.getName()));
+                assertThat(target, is(connect.generateTargetImageStream()));
 
                 // Verify status
                 List<KafkaConnectS2I> capturedConnects = connectCaptor.getAllValues();
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getUrl(), is("http://foo-connect-api.test.svc:8083")));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("Ready")));
+                KafkaConnectS2IStatus connectStatus = capturedConnects.get(0).getStatus();
+                assertThat(connectStatus.getUrl(), is("http://foo-connect-api.test.svc:8083"));
+                assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
 
                 if (connectorOperator) {
-                    context.verify(() -> assertThat(npCaptor.getValue(), is(notNullValue())));
-
-                    context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins(), hasSize(1)));
-                    context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getConnectorClass(), is("io.strimzi.MyClass")));
-                    context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getType(), is("sink")));
-                    context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getVersion(), is("1.0.0")));
+                    assertThat(npCaptor.getValue(), is(notNullValue()));
+                    assertThat(connectStatus.getConnectorPlugins(), hasSize(1));
+                    assertThat(connectStatus.getConnectorPlugins().get(0).getConnectorClass(), is("io.strimzi.MyClass"));
+                    assertThat(connectStatus.getConnectorPlugins().get(0).getType(), is("sink"));
+                    assertThat(connectStatus.getConnectorPlugins().get(0).getVersion(), is("1.0.0"));
                 } else {
-                    context.verify(() -> assertThat(npCaptor.getValue(), is(nullValue())));
-                    context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins(), nullValue()));
+                    assertThat(npCaptor.getValue(), is(nullValue()));
+                    assertThat(connectStatus.getConnectorPlugins(), nullValue());
                 }
 
                 async.flag();
-            }));
+            })));
     }
 
     @Test
@@ -247,7 +244,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         String clusterCmNamespace = "test";
         KafkaConnectS2I clusterCm = ResourceUtils.createEmptyKafkaConnectS2ICluster(clusterCmNamespace, clusterCmName);
 
-        testCreateCluster(context, clusterCm, false);
+        createCluster(context, clusterCm, false);
     }
 
     @Test
@@ -255,13 +252,13 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
         KafkaConnectS2I clusterCm = ResourceUtils.createEmptyKafkaConnectS2ICluster(clusterCmNamespace, clusterCmName);
-        clusterCm.getMetadata().getAnnotations().put("strimzi.io/use-connector-resources", "true");
+        clusterCm.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true");
 
-        testCreateCluster(context, clusterCm, true);
+        createCluster(context, clusterCm, true);
     }
 
     @Test
-    public void testUpdateClusterNoDiff(VertxTestContext context) {
+    public void testCreateOrUpdateDoesNotUpdateWithNoDiff(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
         CrdOperator mockConnectOps = supplier.connectOperator;
@@ -347,35 +344,34 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                // Verify service
+                List<Service> capturedServices = serviceCaptor.getAllValues();
+                assertThat(capturedServices, hasSize(1));
 
-            // Verify service
-            List<Service> capturedServices = serviceCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedServices.size(), is(1)));
+                // Verify Deployment Config
+                List<DeploymentConfig> capturedDc = dcCaptor.getAllValues();
+                assertThat(capturedDc, hasSize(1));
 
-            // Verify Deployment Config
-            List<DeploymentConfig> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
+                // Verify Build Config
+                List<BuildConfig> capturedBc = bcCaptor.getAllValues();
+                assertThat(capturedBc, hasSize(1));
 
-            // Verify Build Config
-            List<BuildConfig> capturedBc = bcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedBc.size(), is(1)));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                assertThat(capturedPdb, hasSize(1));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
+                // Verify Image Streams
+                List<ImageStream> capturedIs = isCaptor.getAllValues();
+                assertThat(capturedIs, hasSize(2));
 
-            // Verify Image Streams
-            List<ImageStream> capturedIs = isCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedIs.size(), is(2)));
+                // Verify scaleDown / scaleUp were not called
+                assertThat(dcScaleDownNameCaptor.getAllValues(), hasSize(1));
+                assertThat(dcScaleUpNameCaptor.getAllValues(), hasSize(1));
 
-            // Verify scaleDown / scaleUp were not called
-            context.verify(() -> assertThat(dcScaleDownNameCaptor.getAllValues().size(), is(1)));
-            context.verify(() -> assertThat(dcScaleUpNameCaptor.getAllValues().size(), is(1)));
-
-            async.flag();
-        });
+                async.flag();
+            })));
     }
 
     @SuppressWarnings({"checkstyle:JavaNCSS", "checkstyle:MethodLength"})
@@ -484,61 +480,60 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                KafkaConnectS2ICluster compareTo = KafkaConnectS2ICluster.fromCrd(clusterCm, VERSIONS);
 
-            KafkaConnectS2ICluster compareTo = KafkaConnectS2ICluster.fromCrd(clusterCm, VERSIONS);
+                // Verify service
+                List<Service> capturedServices = serviceCaptor.getAllValues();
+                assertThat(capturedServices, hasSize(1));
+                Service service = capturedServices.get(0);
+                assertThat(service.getMetadata().getName(), is(compareTo.getServiceName()));
+                assertThat(service, is(compareTo.generateService()));
 
-            // Verify service
-            List<Service> capturedServices = serviceCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedServices.size(), is(1)));
-            Service service = capturedServices.get(0);
-            context.verify(() -> assertThat(service.getMetadata().getName(), is(compareTo.getServiceName())));
-            context.verify(() -> assertThat("Services are not equal", service, is(compareTo.generateService())));
+                // Verify Deployment Config
+                List<DeploymentConfig> capturedDc = dcCaptor.getAllValues();
+                assertThat(capturedDc, hasSize(1));
+                DeploymentConfig dc = capturedDc.get(0);
+                assertThat(dc.getMetadata().getName(), is(compareTo.getName()));
+                Map annotations = new HashMap();
+                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
+                assertThat(dc, is(compareTo.generateDeploymentConfig(annotations, true, null, null)));
 
-            // Verify Deployment Config
-            List<DeploymentConfig> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
-            DeploymentConfig dc = capturedDc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(compareTo.getName())));
-            Map annotations = new HashMap();
-            annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
-            context.verify(() -> assertThat("Deployment Configs are not equal", dc, is(compareTo.generateDeploymentConfig(annotations, true, null, null))));
+                // Verify Build Config
+                List<BuildConfig> capturedBc = bcCaptor.getAllValues();
+                assertThat(capturedBc, hasSize(1));
+                BuildConfig bc = capturedBc.get(0);
+                assertThat(bc.getMetadata().getName(), is(compareTo.getName()));
+                assertThat(bc, is(compareTo.generateBuildConfig()));
 
-            // Verify Build Config
-            List<BuildConfig> capturedBc = bcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedBc.size(), is(1)));
-            BuildConfig bc = capturedBc.get(0);
-            context.verify(() -> assertThat(bc.getMetadata().getName(), is(compareTo.getName())));
-            context.verify(() -> assertThat("Build Configs are not equal", bc, is(compareTo.generateBuildConfig())));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                assertThat(capturedPdb, hasSize(1));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                assertThat(pdb.getMetadata().getName(), is(compareTo.getName()));
+                assertThat(pdb, is(compareTo.generatePodDisruptionBudget()));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(compareTo.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(compareTo.generatePodDisruptionBudget())));
+                // Verify Image Streams
+                List<ImageStream> capturedIs = isCaptor.getAllValues();
+                assertThat(capturedIs, hasSize(2));
+                int sourceImageStreamIndex = (KafkaConnectS2IResources.sourceImageStreamName(compareTo.getCluster())).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
+                int targetImageStreamIndex = (compareTo.getName()).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
 
-            // Verify Image Streams
-            List<ImageStream> capturedIs = isCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedIs.size(), is(2)));
-            int sisIndex = (KafkaConnectS2IResources.sourceImageStreamName(compareTo.getCluster())).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
-            int tisIndex = (compareTo.getName()).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
+                ImageStream source = capturedIs.get(sourceImageStreamIndex);
+                assertThat(source.getMetadata().getName(), is(KafkaConnectS2IResources.sourceImageStreamName(compareTo.getCluster())));
+                assertThat(source, is(compareTo.generateSourceImageStream()));
 
-            ImageStream sis = capturedIs.get(sisIndex);
-            context.verify(() -> assertThat(sis.getMetadata().getName(), is(KafkaConnectS2IResources.sourceImageStreamName(compareTo.getCluster()))));
-            context.verify(() -> assertThat("Source Image Streams are not equal", sis, is(compareTo.generateSourceImageStream())));
+                ImageStream target = capturedIs.get(targetImageStreamIndex);
+                assertThat(target.getMetadata().getName(), is(compareTo.getName()));
+                assertThat(target, is(compareTo.generateTargetImageStream()));
 
-            ImageStream tis = capturedIs.get(tisIndex);
-            context.verify(() -> assertThat(tis.getMetadata().getName(), is(compareTo.getName())));
-            context.verify(() -> assertThat("Target Image Streams are not equal", tis, is(compareTo.generateTargetImageStream())));
-
-            async.flag();
-        });
+                async.flag();
+            })));
     }
 
     @Test
-    public void testUpdateClusterFailure(VertxTestContext context) {
+    public void testCreateOrUpdateFailsWhenDeploymentUpdateFails(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
         CrdOperator mockConnectOps = supplier.connectOperator;
@@ -610,11 +605,8 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(false)));
-
-            async.flag();
-        });
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.failing(v -> context.verify(() -> async.flag())));
     }
 
     @Test
@@ -685,13 +677,11 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
-
-            verify(mockDcOps).scaleUp(clusterCmNamespace, connect.getName(), scaleTo);
-
-            async.flag();
-        });
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                verify(mockDcOps).scaleUp(clusterCmNamespace, connect.getName(), scaleTo);
+                async.flag();
+            })));
     }
 
     @Test
@@ -763,18 +753,16 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
-
-            // Verify ScaleDown
-            verify(mockDcOps).scaleDown(clusterCmNamespace, connect.getName(), scaleTo);
-
-            async.flag();
-        });
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                // Verify ScaleDown
+                verify(mockDcOps).scaleDown(clusterCmNamespace, connect.getName(), scaleTo);
+                async.flag();
+            })));
     }
 
     @Test
-    public void testReconcile(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    public void testReconcile(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
         DeploymentConfigOperator mockDcOps = supplier.deploymentConfigOperations;
@@ -808,7 +796,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
 
-        CountDownLatch async = new CountDownLatch(2);
+        Checkpoint createOrUpdateAsync = context.checkpoint(2);
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS)) {
@@ -816,17 +804,19 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             @Override
             public Future<Void> createOrUpdate(Reconciliation reconciliation, KafkaConnectS2I kafkaConnectS2IAssembly) {
                 createdOrUpdated.add(kafkaConnectS2IAssembly.getMetadata().getName());
-                async.countDown();
+                createOrUpdateAsync.flag();
                 return Future.succeededFuture();
             }
         };
 
+        Checkpoint async = context.checkpoint();
         // Now try to reconcile all the Kafka Connect S2I clusters
-        ops.reconcileAll("test", clusterCmNamespace, ignored -> { });
+        ops.reconcileAll("test", clusterCmNamespace,
+            context.succeeding(v -> context.verify(() -> {
+                assertThat(createdOrUpdated, is(new HashSet(asList("foo", "bar"))));
+                async.flag();
+            })));
 
-        async.await(60, TimeUnit.SECONDS);
-        context.verify(() -> assertThat(createdOrUpdated, is(new HashSet(asList("foo", "bar")))));
-        context.completeNow();
     }
 
     @Test
@@ -871,21 +861,20 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(false)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.failing(e -> context.verify(() -> {
+                // Verify status
+                List<KafkaConnectS2I> capturedConnects = connectCaptor.getAllValues();
+                assertThat(capturedConnects.get(0).getStatus().getUrl(), is("http://foo-connect-api.test.svc:8083"));
+                assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True"));
+                assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("NotReady"));
+                assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getMessage(), is(failureMessage));
 
-            // Verify status
-            List<KafkaConnectS2I> capturedConnects = connectCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getUrl(), is("http://foo-connect-api.test.svc:8083")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("NotReady")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getMessage(), is(failureMessage)));
-
-            async.flag();
-        });
+                async.flag();
+            })));
     }
 
-    public void testCreateClusterWithDuplicateOlderConnect(VertxTestContext context, KafkaConnectS2I clusterCm, boolean connectorOperator) {
+    public void createClusterWithDuplicateOlderConnect(VertxTestContext context, KafkaConnectS2I clusterCm, boolean connectorOperator) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
         CrdOperator mockConnectOps = supplier.connectOperator;
@@ -954,68 +943,67 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromCrd(clusterCm, VERSIONS);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCm.getMetadata().getNamespace(), clusterCm.getMetadata().getName()), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCm.getMetadata().getNamespace(), clusterCm.getMetadata().getName()), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                // Verify service
+                List<Service> capturedServices = serviceCaptor.getAllValues();
+                assertThat(capturedServices, hasSize(1));
+                Service service = capturedServices.get(0);
+                assertThat(service.getMetadata().getName(), is(connect.getServiceName()));
+                assertThat(service, is(connect.generateService()));
 
-            // Verify service
-            List<Service> capturedServices = serviceCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedServices.size(), is(1)));
-            Service service = capturedServices.get(0);
-            context.verify(() -> assertThat(service.getMetadata().getName(), is(connect.getServiceName())));
-            context.verify(() -> assertThat("Services are not equal", service, is(connect.generateService())));
+                // Verify Deployment Config
+                List<DeploymentConfig> capturedDc = dcCaptor.getAllValues();
+                assertThat(capturedDc, hasSize(1));
+                DeploymentConfig dc = capturedDc.get(0);
+                assertThat(dc.getMetadata().getName(), is(connect.getName()));
+                Map annotations = new HashMap();
+                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
+                assertThat(dc, is(connect.generateDeploymentConfig(annotations, true, null, null)));
 
-            // Verify Deployment Config
-            List<DeploymentConfig> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
-            DeploymentConfig dc = capturedDc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(connect.getName())));
-            Map annotations = new HashMap();
-            annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
-            context.verify(() -> assertThat("Deployment Configs are not equal", dc, is(connect.generateDeploymentConfig(annotations, true, null, null))));
+                // Verify Build Config
+                List<BuildConfig> capturedBc = bcCaptor.getAllValues();
+                assertThat(capturedBc, hasSize(1));
+                BuildConfig bc = capturedBc.get(0);
+                assertThat(dc.getMetadata().getName(), is(connect.getName()));
+                assertThat(bc, is(connect.generateBuildConfig()));
 
-            // Verify Build Config
-            List<BuildConfig> capturedBc = bcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedBc.size(), is(1)));
-            BuildConfig bc = capturedBc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(connect.getName())));
-            context.verify(() -> assertThat("Build Configs are not equal", bc, is(connect.generateBuildConfig())));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                assertThat(capturedPdb, hasSize(1));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                assertThat(pdb.getMetadata().getName(), is(connect.getName()));
+                assertThat(pdb, is(connect.generatePodDisruptionBudget()));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(connect.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(connect.generatePodDisruptionBudget())));
+                // Verify Image Streams
+                List<ImageStream> capturedIs = isCaptor.getAllValues();
+                assertThat(capturedIs, hasSize(2));
+                int sourceImageStreamIndex = (KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster())).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
+                int targetImageStreamIndex = (connect.getName()).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
 
-            // Verify Image Streams
-            List<ImageStream> capturedIs = isCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedIs.size(), is(2)));
-            int sisIndex = (KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster())).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
-            int tisIndex = (connect.getName()).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
+                ImageStream source = capturedIs.get(sourceImageStreamIndex);
+                assertThat(source.getMetadata().getName(), is(KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster())));
+                assertThat(source, is(connect.generateSourceImageStream()));
 
-            ImageStream sis = capturedIs.get(sisIndex);
-            context.verify(() -> assertThat(sis.getMetadata().getName(), is(KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster()))));
-            context.verify(() -> assertThat("Source Image Streams are not equal", sis, is(connect.generateSourceImageStream())));
+                ImageStream target = capturedIs.get(targetImageStreamIndex);
+                assertThat(target.getMetadata().getName(), is(connect.getName()));
+                assertThat(target, is(connect.generateTargetImageStream()));
 
-            ImageStream tis = capturedIs.get(tisIndex);
-            context.verify(() -> assertThat(tis.getMetadata().getName(), is(connect.getName())));
-            context.verify(() -> assertThat("Target Image Streams are not equal", tis, is(connect.generateTargetImageStream())));
+                // Verify status
+                List<KafkaConnectS2I> capturedConnects = connectCaptor.getAllValues();
+                assertThat(capturedConnects.get(0).getStatus().getUrl(), is("http://foo-connect-api.test.svc:8083"));
+                assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True"));
+                assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("Ready"));
 
-            // Verify status
-            List<KafkaConnectS2I> capturedConnects = connectCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getUrl(), is("http://foo-connect-api.test.svc:8083")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("Ready")));
+                if (connectorOperator) {
+                    assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins(), hasSize(1));
+                    assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getConnectorClass(), is("io.strimzi.MyClass"));
+                    assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getType(), is("sink"));
+                    assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getVersion(), is("1.0.0"));
+                }
 
-            if (connectorOperator) {
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().size(), is(1)));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getConnectorClass(), is("io.strimzi.MyClass")));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getType(), is("sink")));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getVersion(), is("1.0.0")));
-            }
-
-            async.flag();
-        });
+                async.flag();
+            })));
     }
 
     @Test
@@ -1024,7 +1012,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         String clusterCmNamespace = "test";
         KafkaConnectS2I clusterCm = ResourceUtils.createEmptyKafkaConnectS2ICluster(clusterCmNamespace, clusterCmName);
 
-        testCreateClusterWithDuplicateOlderConnect(context, clusterCm, false);
+        createClusterWithDuplicateOlderConnect(context, clusterCm, false);
     }
 
     @Test
@@ -1034,11 +1022,11 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         KafkaConnectS2I clusterCm = ResourceUtils.createEmptyKafkaConnectS2ICluster(clusterCmNamespace, clusterCmName);
         clusterCm.getMetadata().getAnnotations().put("strimzi.io/use-connector-resources", "true");
 
-        testCreateClusterWithDuplicateOlderConnect(context, clusterCm, true);
+        createClusterWithDuplicateOlderConnect(context, clusterCm, true);
     }
 
     @Test
-    public void testCreateClusterWithDuplicateNeverConnect(VertxTestContext context) {
+    public void testCreateClusterWithSameNameAsConnectFails(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
         CrdOperator mockConnectOps = supplier.connectOperator;
@@ -1064,17 +1052,16 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(false)));
-
-            // Verify status
-            List<KafkaConnectS2I> capturedConnects = connectCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("NotReady")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getMessage(), is("Both KafkaConnect and KafkaConnectS2I exist with the same name. KafkaConnect is older and will be used while this custom resource will be ignored.")));
-
-            async.flag();
-        });
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.failing(v -> context.verify(() -> {
+                // Verify status
+                List<KafkaConnectS2I> capturedConnects = connectCaptor.getAllValues();
+                assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True"));
+                assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("NotReady"));
+                assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getMessage(),
+                        is("Both KafkaConnect and KafkaConnectS2I exist with the same name. KafkaConnect is older and will be used while this custom resource will be ignored."));
+                async.flag();
+            })));
     }
 
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -186,8 +186,7 @@ public class KafkaConnectorIT {
                         .withName(connectorName)
                         .patch(createKafkaConnector(namespace, connectorName, config));
                 return operator.reconcileConnectorAndHandleResult(new Reconciliation("test", "KafkaConnect", namespace, "bogus"),
-                        "localhost", connectClient, true, connectorName,
-                        connector);
+                        "localhost", connectClient, true, connectorName, connector);
             })
             .setHandler(context.succeeding(v -> context.verify(() -> {
                 assertConnectorIsRunning(context, client, namespace, connectorName);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -28,7 +28,9 @@ import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -40,16 +42,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -71,6 +68,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
 
     private static Vertx vertx;
     private MockKube mockKube;
+    private KafkaMirrorMaker2AssemblyOperator kco;
 
     @BeforeAll
     public static void before() {
@@ -102,7 +100,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
     }
 
 
-    private KafkaMirrorMaker2AssemblyOperator createMirrorMaker2Cluster(VertxTestContext context, KafkaConnectApi kafkaConnectApi)  throws InterruptedException, ExecutionException, TimeoutException {
+    private Future<Void> createMirrorMaker2Cluster(VertxTestContext context, KafkaConnectApi kafkaConnectApi) {
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
         ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(vertx, this.mockClient,
                 new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, this.mockClient),
@@ -114,34 +112,29 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
                 pfa, 60_000L);
 
         ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);
-        KafkaMirrorMaker2AssemblyOperator kco = new KafkaMirrorMaker2AssemblyOperator(vertx, pfa,
+        kco = new KafkaMirrorMaker2AssemblyOperator(vertx, pfa,
             supplier,
             config,
-            foo -> {
-                return kafkaConnectApi;
-            });
+            foo -> kafkaConnectApi);
 
         LOGGER.info("Reconciling initially -> create");
-        CountDownLatch createAsync = new CountDownLatch(1);
+        Promise created = Promise.promise();
+        Checkpoint async = context.checkpoint();
         kco.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME))
-            .setHandler(context.succeeding(ar -> {
-                context.verify(() -> {
-                    assertThat(mockClient.apps().deployments().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue()));
-                    assertThat(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(CLUSTER_NAME)).get(), is(notNullValue()));
-                    assertThat(mockClient.services().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.serviceName(CLUSTER_NAME)).get(), is(notNullValue()));
-                    assertThat(mockClient.policy().podDisruptionBudget().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue()));
-                });
+            .setHandler(context.succeeding(ar -> context.verify(() -> {
+                assertThat(mockClient.apps().deployments().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue()));
+                assertThat(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(CLUSTER_NAME)).get(), is(notNullValue()));
+                assertThat(mockClient.services().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.serviceName(CLUSTER_NAME)).get(), is(notNullValue()));
+                assertThat(mockClient.policy().podDisruptionBudget().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue()));
 
-                createAsync.countDown();
-            }));
-        if (!createAsync.await(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
-        return kco;
+                async.flag();
+                created.complete();
+            })));
+        return created.future();
     }
 
     @Test
-    public void testCreateUpdate(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    public void testReconcileUpdate(VertxTestContext context) {
         setMirrorMaker2Resource(new KafkaMirrorMaker2Builder()
                 .withMetadata(new ObjectMetaBuilder()
                         .withName(CLUSTER_NAME)
@@ -154,17 +147,15 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
             .build());
         KafkaConnectApi mock = mock(KafkaConnectApi.class);
         when(mock.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        KafkaMirrorMaker2AssemblyOperator kco = createMirrorMaker2Cluster(context,
-                mock);
-        LOGGER.info("Reconciling again -> update");
-        CountDownLatch updateAsync = new CountDownLatch(1);
-        kco.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).setHandler(ar -> {
-            if (ar.failed()) ar.cause().printStackTrace();
-            context.verify(() -> assertTrue(ar.succeeded()));
-            updateAsync.countDown();
-        });
-        updateAsync.await(30, TimeUnit.SECONDS);
-        context.completeNow();
+
+        Checkpoint async = context.checkpoint();
+        createMirrorMaker2Cluster(context, mock)
+            .setHandler(context.succeeding())
+            .compose(v -> {
+                LOGGER.info("Reconciling again -> update");
+                return kco.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME));
+            })
+            .setHandler(context.succeeding(v -> async.flag()));
     }
 
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
@@ -51,15 +51,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -136,45 +133,44 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         KafkaMirrorMaker2Cluster mirrorMaker2 = KafkaMirrorMaker2Cluster.fromCrd(clusterCm, VERSIONS);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                // No metrics config  => no CMs created
+                Set<String> metricsNames = new HashSet<>();
+                if (mirrorMaker2.isMetricsEnabled()) {
+                    metricsNames.add(KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(clusterCmName));
+                }
 
-            // No metrics config  => no CMs created
-            Set<String> metricsNames = new HashSet<>();
-            if (mirrorMaker2.isMetricsEnabled()) {
-                metricsNames.add(KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(clusterCmName));
-            }
+                // Verify service
+                List<Service> capturedServices = serviceCaptor.getAllValues();
+                assertThat(capturedServices, hasSize(1));
+                Service service = capturedServices.get(0);
+                assertThat(service.getMetadata().getName(), is(mirrorMaker2.getServiceName()));
+                assertThat(service, is(mirrorMaker2.generateService()));
 
-            // Verify service
-            List<Service> capturedServices = serviceCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedServices.size(), is(1)));
-            Service service = capturedServices.get(0);
-            context.verify(() -> assertThat(service.getMetadata().getName(), is(mirrorMaker2.getServiceName())));
-            context.verify(() -> assertThat("Services are not equal", service, is(mirrorMaker2.generateService())));
+                // Verify Deployment
+                List<Deployment> capturedDc = dcCaptor.getAllValues();
+                assertThat(capturedDc, hasSize(1));
+                Deployment dc = capturedDc.get(0);
+                assertThat(dc.getMetadata().getName(), is(mirrorMaker2.getName()));
+                Map annotations = new HashMap();
+                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
+                assertThat(dc, is(mirrorMaker2.generateDeployment(annotations, true, null, null)));
 
-            // Verify Deployment
-            List<Deployment> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
-            Deployment dc = capturedDc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(mirrorMaker2.getName())));
-            Map annotations = new HashMap();
-            annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
-            context.verify(() -> assertThat("Deployments are not equal", dc, is(mirrorMaker2.generateDeployment(annotations, true, null, null))));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                assertThat(capturedPdb, hasSize(1));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                assertThat(pdb.getMetadata().getName(), is(mirrorMaker2.getName()));
+                assertThat(pdb, is(mirrorMaker2.generatePodDisruptionBudget()));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(mirrorMaker2.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(mirrorMaker2.generatePodDisruptionBudget())));
-
-            // Verify status
-            List<KafkaMirrorMaker2> capturedMirrorMaker2s = mirrorMaker2Captor.getAllValues();
-            context.verify(() -> assertThat(capturedMirrorMaker2s.get(0).getStatus().getUrl(), is("http://foo-mirrormaker2-api.test.svc:8083")));
-            context.verify(() -> assertThat(capturedMirrorMaker2s.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
-            context.verify(() -> assertThat(capturedMirrorMaker2s.get(0).getStatus().getConditions().get(0).getType(), is("Ready")));
-            async.flag();
-        });
+                // Verify status
+                List<KafkaMirrorMaker2> capturedMirrorMaker2s = mirrorMaker2Captor.getAllValues();
+                assertThat(capturedMirrorMaker2s.get(0).getStatus().getUrl(), is("http://foo-mirrormaker2-api.test.svc:8083"));
+                assertThat(capturedMirrorMaker2s.get(0).getStatus().getConditions().get(0).getStatus(), is("True"));
+                assertThat(capturedMirrorMaker2s.get(0).getStatus().getConditions().get(0).getType(), is("Ready"));
+                async.flag();
+            })));
     }
 
     @Test
@@ -229,30 +225,30 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
 
-            // Verify service
-            List<Service> capturedServices = serviceCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedServices.size(), is(1)));
+                // Verify service
+                List<Service> capturedServices = serviceCaptor.getAllValues();
+                assertThat(capturedServices, hasSize(1));
 
-            // Verify Deployment Config
-            List<Deployment> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
+                // Verify Deployment Config
+                List<Deployment> capturedDc = dcCaptor.getAllValues();
+                assertThat(capturedDc, hasSize(1));
 
-            // Verify scaleDown / scaleUp were not called
-            context.verify(() -> assertThat(dcScaleDownNameCaptor.getAllValues().size(), is(1)));
-            context.verify(() -> assertThat(dcScaleUpNameCaptor.getAllValues().size(), is(1)));
+                // Verify scaleDown / scaleUp were not called
+                assertThat(dcScaleDownNameCaptor.getAllValues(), hasSize(1));
+                assertThat(dcScaleUpNameCaptor.getAllValues(), hasSize(1));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(mirrorMaker2.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(mirrorMaker2.generatePodDisruptionBudget())));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                assertThat(capturedPdb, hasSize(1));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                assertThat(pdb.getMetadata().getName(), is(mirrorMaker2.getName()));
+                assertThat("PodDisruptionBudgets are not equal", pdb, is(mirrorMaker2.generatePodDisruptionBudget()));
 
-            async.flag();
-        });
+                async.flag();
+            })));
     }
 
     @Test
@@ -275,7 +271,8 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockMirrorMaker2Ops.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(clusterCm));
         when(mockMirrorMaker2Ops.updateStatusAsync(any(KafkaMirrorMaker2.class))).thenReturn(Future.succeededFuture());
         when(mockServiceOps.get(clusterCmNamespace, mirrorMaker2.getName())).thenReturn(mirrorMaker2.generateService());
-        when(mockDcOps.get(clusterCmNamespace, mirrorMaker2.getName())).thenReturn(mirrorMaker2.generateDeployment(new HashMap<String, String>(), true, null, null));
+        when(mockDcOps.get(clusterCmNamespace, mirrorMaker2.getName()))
+                .thenReturn(mirrorMaker2.generateDeployment(new HashMap<String, String>(), true, null, null));
         when(mockDcOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
 
@@ -296,7 +293,8 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockDcOps.scaleDown(eq(clusterCmNamespace), dcScaleDownNameCaptor.capture(), dcScaleDownReplicasCaptor.capture())).thenReturn(Future.succeededFuture());
 
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
-        when(mockNetPolOps.reconcile(eq(clusterCm.getMetadata().getNamespace()), eq(KafkaMirrorMaker2Resources.deploymentName(clusterCm.getMetadata().getName())), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
+        when(mockNetPolOps.reconcile(eq(clusterCm.getMetadata().getNamespace()), eq(KafkaMirrorMaker2Resources.deploymentName(clusterCm.getMetadata().getName())), any()))
+                .thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
 
         ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
         when(mockPdbOps.reconcile(anyString(), any(), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
@@ -334,46 +332,45 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                KafkaMirrorMaker2Cluster compareTo = KafkaMirrorMaker2Cluster.fromCrd(clusterCm, VERSIONS);
 
-            KafkaMirrorMaker2Cluster compareTo = KafkaMirrorMaker2Cluster.fromCrd(clusterCm, VERSIONS);
+                // Verify service
+                List<Service> capturedServices = serviceCaptor.getAllValues();
+                assertThat(capturedServices, hasSize(1));
+                Service service = capturedServices.get(0);
+                assertThat(service.getMetadata().getName(), is(compareTo.getServiceName()));
+                assertThat(service, is(compareTo.generateService()));
 
-            // Verify service
-            List<Service> capturedServices = serviceCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedServices.size(), is(1)));
-            Service service = capturedServices.get(0);
-            context.verify(() -> assertThat(service.getMetadata().getName(), is(compareTo.getServiceName())));
-            context.verify(() -> assertThat("Services are not equal", service, is(compareTo.generateService())));
+                // Verify Deployment
+                List<Deployment> capturedDc = dcCaptor.getAllValues();
+                assertThat(capturedDc, hasSize(1));
+                Deployment dc = capturedDc.get(0);
+                assertThat(dc.getMetadata().getName(), is(compareTo.getName()));
+                Map<String, String> annotations = new HashMap();
+                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, loggingCm.getData().get(compareTo.ANCILLARY_CM_KEY_LOG_CONFIG));
+                assertThat(dc, is(compareTo.generateDeployment(annotations, true, null, null)));
 
-            // Verify Deployment
-            List<Deployment> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
-            Deployment dc = capturedDc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(compareTo.getName())));
-            Map<String, String> annotations = new HashMap();
-            annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, loggingCm.getData().get(compareTo.ANCILLARY_CM_KEY_LOG_CONFIG));
-            context.verify(() -> assertThat("Deployments are not equal", dc, is(compareTo.generateDeployment(annotations, true, null, null))));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                assertThat(capturedPdb, hasSize(1));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                assertThat(pdb.getMetadata().getName(), is(mirrorMaker2.getName()));
+                assertThat(pdb, is(mirrorMaker2.generatePodDisruptionBudget()));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(mirrorMaker2.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(mirrorMaker2.generatePodDisruptionBudget())));
+                // Verify scaleDown / scaleUp were not called
+                assertThat(dcScaleDownNameCaptor.getAllValues(), hasSize(1));
+                assertThat(dcScaleUpNameCaptor.getAllValues(), hasSize(1));
 
-            // Verify scaleDown / scaleUp were not called
-            context.verify(() -> assertThat(dcScaleDownNameCaptor.getAllValues().size(), is(1)));
-            context.verify(() -> assertThat(dcScaleUpNameCaptor.getAllValues().size(), is(1)));
-
-            // No metrics config  => no CMs created
-            verify(mockCmOps, never()).createOrUpdate(any());
-            async.flag();
-        });
+                // No metrics config  => no CMs created
+                verify(mockCmOps, never()).createOrUpdate(any());
+                async.flag();
+            })));
     }
 
     @Test
-    public void testUpdateClusterFailure(VertxTestContext context) {
+    public void testUpdateClusterWithFailingDeploymentFailure(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorMaker2Ops = supplier.mirrorMaker2Operator;
         DeploymentOperator mockDcOps = supplier.deploymentOperations;
@@ -426,11 +423,8 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(false)));
-
-            async.flag();
-        });
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.failing(v -> async.flag()));
     }
 
     @Test
@@ -482,13 +476,11 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
-
-            verify(mockDcOps).scaleUp(clusterCmNamespace, mirrorMaker2.getName(), scaleTo);
-
-            async.flag();
-        });
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                verify(mockDcOps).scaleUp(clusterCmNamespace, mirrorMaker2.getName(), scaleTo);
+                async.flag();
+            })));
     }
 
     @Test
@@ -540,17 +532,15 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
-
-            verify(mockDcOps).scaleUp(clusterCmNamespace, mirrorMaker2.getName(), scaleTo);
-
-            async.flag();
-        });
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                verify(mockDcOps).scaleUp(clusterCmNamespace, mirrorMaker2.getName(), scaleTo);
+                async.flag();
+            })));
     }
 
     @Test
-    public void testReconcile(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    public void testReconcile(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorMaker2Ops = supplier.mirrorMaker2Operator;
         DeploymentOperator mockDcOps = supplier.deploymentOperations;
@@ -584,24 +574,26 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
 
-        CountDownLatch async = new CountDownLatch(2);
+        Checkpoint createOrUpdateAsync = context.checkpoint(2);
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS)) {
 
             @Override
             public Future<Void> createOrUpdate(Reconciliation reconciliation, KafkaMirrorMaker2 kafkaMirrorMaker2Assembly) {
                 createdOrUpdated.add(kafkaMirrorMaker2Assembly.getMetadata().getName());
-                async.countDown();
+                createOrUpdateAsync.flag();
                 return Future.succeededFuture();
             }
         };
 
+        Checkpoint async = context.checkpoint();
         // Now try to reconcile all the Kafka MirrorMaker 2.0 clusters
-        ops.reconcileAll("test", clusterCmNamespace, ignored -> { });
+        ops.reconcileAll("test", clusterCmNamespace,
+            context.succeeding(v -> context.verify(() -> {
+                assertThat(createdOrUpdated, is(new HashSet(asList("foo", "bar"))));
+                async.flag();
+            })));
 
-        async.await(60, TimeUnit.SECONDS);
-        context.verify(() -> assertThat(createdOrUpdated, is(new HashSet(asList("foo", "bar")))));
-        context.completeNow();
     }
 
     @Test
@@ -638,17 +630,16 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(false)));
-
-            // Verify status
-            List<KafkaMirrorMaker2> capturedMirrorMaker2s = mirrorMaker2Captor.getAllValues();
-            context.verify(() -> assertThat(capturedMirrorMaker2s.get(0).getStatus().getUrl(), is("http://foo-mirrormaker2-api.test.svc:8083")));
-            context.verify(() -> assertThat(capturedMirrorMaker2s.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
-            context.verify(() -> assertThat(capturedMirrorMaker2s.get(0).getStatus().getConditions().get(0).getType(), is("NotReady")));
-            context.verify(() -> assertThat(capturedMirrorMaker2s.get(0).getStatus().getConditions().get(0).getMessage(), is(failureMsg)));
-            async.flag();
-        });
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.failing(v -> context.verify(() -> {
+                // Verify status
+                List<KafkaMirrorMaker2> capturedMirrorMaker2s = mirrorMaker2Captor.getAllValues();
+                assertThat(capturedMirrorMaker2s.get(0).getStatus().getUrl(), is("http://foo-mirrormaker2-api.test.svc:8083"));
+                assertThat(capturedMirrorMaker2s.get(0).getStatus().getConditions().get(0).getStatus(), is("True"));
+                assertThat(capturedMirrorMaker2s.get(0).getStatus().getConditions().get(0).getType(), is("NotReady"));
+                assertThat(capturedMirrorMaker2s.get(0).getStatus().getConditions().get(0).getMessage(), is(failureMsg));
+                async.flag();
+            })));
     }
 
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -53,14 +53,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -149,8 +146,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(createResult -> {
-
+            .setHandler(context.succeeding(v -> context.verify(() -> {
                 // No metrics config  => no CMs created
                 Set<String> metricsNames = new HashSet<>();
                 if (mirror.isMetricsEnabled()) {
@@ -159,29 +155,29 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
                 // Verify Deployment
                 List<Deployment> capturedDc = dcCaptor.getAllValues();
-                context.verify(() -> assertThat(capturedDc.size(), is(1)));
+                assertThat(capturedDc, hasSize(1));
                 Deployment dc = capturedDc.get(0);
-                context.verify(() -> assertThat(dc.getMetadata().getName(), is(mirror.getName())));
+                assertThat(dc.getMetadata().getName(), is(mirror.getName()));
                 Map annotations = new HashMap();
                 annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
-                context.verify(() -> assertThat("Deployments are not equal", dc, is(mirror.generateDeployment(annotations, true, null, null))));
+                assertThat("Deployments are not equal", dc, is(mirror.generateDeployment(annotations, true, null, null)));
 
                 // Verify PodDisruptionBudget
                 List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-                context.verify(() -> assertThat(capturedPdb.size(), is(1)));
+                assertThat(capturedPdb, hasSize(1));
                 PodDisruptionBudget pdb = capturedPdb.get(0);
-                context.verify(() -> assertThat(pdb.getMetadata().getName(), is(mirror.getName())));
-                context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(mirror.generatePodDisruptionBudget())));
+                assertThat(pdb.getMetadata().getName(), is(mirror.getName()));
+                assertThat("PodDisruptionBudgets are not equal", pdb, is(mirror.generatePodDisruptionBudget()));
 
                 // Verify status
                 List<KafkaMirrorMaker> capturedMM = statusCaptor.getAllValues();
-                context.verify(() -> assertThat(capturedMM.size(), is(1)));
+                assertThat(capturedMM, hasSize(1));
                 KafkaMirrorMaker mm = capturedMM.get(0);
-                context.verify(() -> assertThat(mm.getStatus().getConditions().get(0).getType(), is("Ready")));
-                context.verify(() -> assertThat(mm.getStatus().getConditions().get(0).getStatus(), is("True")));
+                assertThat(mm.getStatus().getConditions().get(0).getType(), is("Ready"));
+                assertThat(mm.getStatus().getConditions().get(0).getStatus(), is("True"));
 
                 async.flag();
-            }));
+            })));
     }
 
     @Test
@@ -239,26 +235,25 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                 ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                // Verify Deployment Config
+                List<Deployment> capturedDc = dcCaptor.getAllValues();
+                assertThat(capturedDc, hasSize(1));
 
-            // Verify Deployment Config
-            List<Deployment> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                assertThat(capturedPdb, hasSize(1));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                assertThat(pdb.getMetadata().getName(), is(mirror.getName()));
+                assertThat("PodDisruptionBudgets are not equal", pdb, is(mirror.generatePodDisruptionBudget()));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(mirror.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(mirror.generatePodDisruptionBudget())));
+                // Verify scaleDown / scaleUp were not called
+                assertThat(dcScaleDownNameCaptor.getAllValues(), hasSize(1));
+                assertThat(dcScaleUpNameCaptor.getAllValues(), hasSize(1));
 
-            // Verify scaleDown / scaleUp were not called
-            context.verify(() -> assertThat(dcScaleDownNameCaptor.getAllValues().size(), is(1)));
-            context.verify(() -> assertThat(dcScaleUpNameCaptor.getAllValues().size(), is(1)));
-
-            async.flag();
-        });
+                async.flag();
+            })));
     }
 
     @Test
@@ -344,36 +339,35 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                 ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                KafkaMirrorMakerCluster compareTo = KafkaMirrorMakerCluster.fromCrd(clusterCm,
+                        VERSIONS);
 
-            KafkaMirrorMakerCluster compareTo = KafkaMirrorMakerCluster.fromCrd(clusterCm,
-                    VERSIONS);
+                // Verify Deployment
+                List<Deployment> capturedDc = dcCaptor.getAllValues();
+                assertThat(capturedDc, hasSize(1));
+                Deployment dc = capturedDc.get(0);
+                assertThat(dc.getMetadata().getName(), is(compareTo.getName()));
+                Map<String, String> annotations = new HashMap();
+                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, loggingCm.getData().get(compareTo.ANCILLARY_CM_KEY_LOG_CONFIG));
+                assertThat("Deployments are not equal", dc, is(compareTo.generateDeployment(annotations, true, null, null)));
 
-            // Verify Deployment
-            List<Deployment> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
-            Deployment dc = capturedDc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(compareTo.getName())));
-            Map<String, String> annotations = new HashMap();
-            annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, loggingCm.getData().get(compareTo.ANCILLARY_CM_KEY_LOG_CONFIG));
-            context.verify(() -> assertThat("Deployments are not equal", dc, is(compareTo.generateDeployment(annotations, true, null, null))));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                assertThat(capturedPdb, hasSize(1));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                assertThat(pdb.getMetadata().getName(), is(compareTo.getName()));
+                assertThat("PodDisruptionBudgets are not equal", pdb, is(compareTo.generatePodDisruptionBudget()));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(compareTo.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(compareTo.generatePodDisruptionBudget())));
+                // Verify scaleDown / scaleUp were not called
+                assertThat(dcScaleDownNameCaptor.getAllValues(), hasSize(1));
+                assertThat(dcScaleUpNameCaptor.getAllValues(), hasSize(1));
 
-            // Verify scaleDown / scaleUp were not called
-            context.verify(() -> assertThat(dcScaleDownNameCaptor.getAllValues().size(), is(1)));
-            context.verify(() -> assertThat(dcScaleUpNameCaptor.getAllValues().size(), is(1)));
-
-            // No metrics config  => no CMs created
-            verify(mockCmOps, never()).createOrUpdate(any());
-            async.flag();
-        });
+                // No metrics config  => no CMs created
+                verify(mockCmOps, never()).createOrUpdate(any());
+                async.flag();
+            })));
     }
 
     @Test
@@ -436,11 +430,8 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                 ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(false)));
-
-            async.flag();
-        });
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.failing(v -> context.verify(() -> async.flag())));
     }
 
     @Test
@@ -497,13 +488,11 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                 ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
-
-            verify(mockDcOps).scaleUp(clusterCmNamespace, mirror.getName(), scaleTo);
-
-            async.flag();
-        });
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                verify(mockDcOps).scaleUp(clusterCmNamespace, mirror.getName(), scaleTo);
+                async.flag();
+            })));
     }
 
     @Test
@@ -560,17 +549,15 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                 ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
-
-            verify(mockDcOps).scaleUp(clusterCmNamespace, mirror.getName(), scaleTo);
-
-            async.flag();
-        });
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                verify(mockDcOps).scaleUp(clusterCmNamespace, mirror.getName(), scaleTo);
+                async.flag();
+            })));
     }
 
     @Test
-    public void testReconcile(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    public void testReconcile(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorOps = supplier.mirrorMakerOperator;
         DeploymentOperator mockDcOps = supplier.deploymentOperations;
@@ -617,7 +604,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
 
-        CountDownLatch async = new CountDownLatch(2);
+        Checkpoint createdOrUpdateAsync = context.checkpoint(2);
 
         KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
                 new PlatformFeaturesAvailability(true, kubernetesVersion),
@@ -628,21 +615,23 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
             @Override
             public Future<Void> createOrUpdate(Reconciliation reconciliation, KafkaMirrorMaker kafkaMirrorMakerAssembly) {
                 createdOrUpdated.add(kafkaMirrorMakerAssembly.getMetadata().getName());
-                async.countDown();
+                createdOrUpdateAsync.flag();
                 return Future.succeededFuture();
             }
         };
 
+        Checkpoint async = context.checkpoint();
         // Now try to reconcile all the Kafka Mirror Maker clusters
-        ops.reconcileAll("test", clusterCmNamespace, ignored -> { });
+        ops.reconcileAll("test", clusterCmNamespace,
+            context.succeeding(v -> context.verify(() -> {
+                assertThat(createdOrUpdated, is(new HashSet(asList("foo", "bar"))));
+                async.flag();
+            })));
 
-        async.await(60, TimeUnit.SECONDS);
-        context.verify(() -> assertThat(createdOrUpdated, is(new HashSet(asList("foo", "bar")))));
-        context.completeNow();
     }
 
     @Test
-    public void testCreateClusterStatusNotReady(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    public void testCreateClusterStatusNotReady(VertxTestContext context) throws InterruptedException {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorOps = supplier.mirrorMakerOperator;
         DeploymentOperator mockDcOps = supplier.deploymentOperations;
@@ -683,23 +672,18 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                 supplier,
                 ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
 
-        CountDownLatch async = new CountDownLatch(1);
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(false)));
+        Checkpoint async = context.checkpoint();
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.failing(e -> context.verify(() -> {
+                // Verify status
+                List<KafkaMirrorMaker> capturedMM = statusCaptor.getAllValues();
+                assertThat(capturedMM, hasSize(1));
+                KafkaMirrorMaker mm = capturedMM.get(0);
+                assertThat(mm.getStatus().getConditions().get(0).getType(), is("NotReady"));
+                assertThat(mm.getStatus().getConditions().get(0).getStatus(), is("True"));
+                assertThat(mm.getStatus().getConditions().get(0).getMessage(), is(failureMsg));
 
-            // Verify status
-            List<KafkaMirrorMaker> capturedMM = statusCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedMM.size(), is(1)));
-            KafkaMirrorMaker mm = capturedMM.get(0);
-            context.verify(() -> assertThat(mm.getStatus().getConditions().get(0).getType(), is("NotReady")));
-            context.verify(() -> assertThat(mm.getStatus().getConditions().get(0).getStatus(), is("True")));
-            context.verify(() -> assertThat(mm.getStatus().getConditions().get(0).getMessage(), is(failureMsg)));
-
-            async.countDown();
-        });
-        if (!async.await(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
-        context.completeNow();
+                async.flag();
+            })));
     }
 }


### PR DESCRIPTION
### Description

For this Pull request I have continued the context
succeeding work, and taken the opportunity to remove
unneeded concurrency based dependencies.
minor test renames, hamcrest additions and variable
renames to improve clarity.

Part 8 : Finishing cluster-operator

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

