### PR TITLE
ST: Strip too long logs from executor

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -217,6 +217,7 @@ All environment variables can be seen in [Environment](systemtest/src/main/java/
 | OLM_APP_BUNDLE_PREFIX     | CSV bundle name                                                                      | strimzi                                             |
 | OLM_OPERATOR_VERSION      | Version of the operator which will be installed                                      | v0.16.2                                             |
 | DEFAULT_TO_DENY_NETWORK_POLICIES | Determines how will be network policies set - to deny-all (true) or allow-all (false)    | true                                            |
+| STRIMZI_EXEC_MAX_LOG_OUTPUT_CHARACTERS | Set maximum count of characters printed from [Executor](test/src/main/java/io/strimzi/test/executor/Exec.java) stdout and stderr | 20000   |
 
 If you want to use your own images with a different tag or from a different repository, you can use `DOCKER_REGISTRY`, `DOCKER_ORG` and `DOCKER_TAG` environment variables.
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/VerifiableClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/VerifiableClient.java
@@ -209,12 +209,12 @@ public class VerifiableClient {
                         LOGGER.info("{} RETURN code: {}", clientType,  ret);
                         if (!executor.out().isEmpty()) {
                             LOGGER.info("======STDOUT START=======");
-                            LOGGER.info("{}", executor.out());
+                            LOGGER.info("{}", Exec.cutExecutorLog(executor.out()));
                             LOGGER.info("======STDOUT END======");
                         }
                         if (!executor.err().isEmpty()) {
                             LOGGER.info("======STDERR START=======");
-                            LOGGER.info("{}", executor.err());
+                            LOGGER.info("{}", Exec.cutExecutorLog(executor.err()));
                             LOGGER.info("======STDERR END======");
                         }
                     }

--- a/test/src/main/java/io/strimzi/test/executor/Exec.java
+++ b/test/src/main/java/io/strimzi/test/executor/Exec.java
@@ -40,7 +40,7 @@ public class Exec {
     private static final Pattern ERROR_PATTERN = Pattern.compile("Error from server \\(([a-zA-Z0-9]+)\\):");
     private static final Pattern INVALID_PATTERN = Pattern.compile("The ([a-zA-Z0-9]+) \"([a-z0-9.-]+)\" is invalid:");
     private static final Pattern PATH_SPLITTER = Pattern.compile(System.getProperty("path.separator"));
-    private static final int MAXIMUM_EXEC_LOG_CHARACTER_SIZE = 20000;
+    private static final int MAXIMUM_EXEC_LOG_CHARACTER_SIZE = Integer.parseInt(System.getenv().getOrDefault("STRIMZI_EXEC_MAX_LOG_OUTPUT_CHARACTERS", "20000"));
     private static final Object LOCK = new Object();
 
     public Process process;

--- a/test/src/main/java/io/strimzi/test/executor/Exec.java
+++ b/test/src/main/java/io/strimzi/test/executor/Exec.java
@@ -40,6 +40,7 @@ public class Exec {
     private static final Pattern ERROR_PATTERN = Pattern.compile("Error from server \\(([a-zA-Z0-9]+)\\):");
     private static final Pattern INVALID_PATTERN = Pattern.compile("The ([a-zA-Z0-9]+) \"([a-z0-9.-]+)\" is invalid:");
     private static final Pattern PATH_SPLITTER = Pattern.compile(System.getProperty("path.separator"));
+    private static final int MAXIMUM_EXEC_LOG_CHARACTER_SIZE = 20000;
     private static final Object LOCK = new Object();
 
     public Process process;
@@ -167,12 +168,12 @@ public class Exec {
                     LOGGER.info("RETURN code: {}", ret);
                     if (!executor.out().isEmpty()) {
                         LOGGER.info("======STDOUT START=======");
-                        LOGGER.info("{}", executor.out());
+                        LOGGER.info("{}", cutExecutorLog(executor.out()));
                         LOGGER.info("======STDOUT END======");
                     }
                     if (!executor.err().isEmpty()) {
                         LOGGER.info("======STDERR START=======");
-                        LOGGER.info("{}", executor.err());
+                        LOGGER.info("{}", cutExecutorLog(executor.err()));
                         LOGGER.info("======STDERR END======");
                     }
                 }
@@ -329,6 +330,19 @@ public class Exec {
             }
         }
         return false;
+    }
+
+    /**
+     * This method check the size of executor output log and cut it if it's too long.
+     * @param log executor log
+     * @return updated log if size is too big
+     */
+    public static String cutExecutorLog(String log) {
+        if (log.length() > MAXIMUM_EXEC_LOG_CHARACTER_SIZE) {
+            LOGGER.warn("Executor log is too long. Going to strip it and print only first {} characters", MAXIMUM_EXEC_LOG_CHARACTER_SIZE);
+            return log.substring(0, MAXIMUM_EXEC_LOG_CHARACTER_SIZE);
+        }
+        return log;
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Enhancement / new feature

### Description

This PR adds a strip to `Executor` log in system tests for output bigger than 25k characters. In some cases, it causes issues in Jenkins, where one test log was simply too long with unnecessary output from kafka clients. 

I can change the size, but when I tested it, it was enough.

### Checklist

- [x] Make sure all tests pass
