### PR TITLE
Add the KafkaRebalance CR to the strimzi category

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
@@ -36,7 +36,8 @@ import static java.util.Collections.unmodifiableList;
                 names = @Crd.Spec.Names(
                         kind = KafkaRebalance.RESOURCE_KIND,
                         plural = KafkaRebalance.RESOURCE_PLURAL,
-                        shortNames = {KafkaRebalance.SHORT_NAME}
+                        shortNames = {KafkaRebalance.SHORT_NAME},
+                        categories = {Constants.STRIMZI_CATEGORY}
                 ),
                 group = KafkaRebalance.RESOURCE_GROUP,
                 scope = KafkaRebalance.SCOPE,

--- a/helm-charts/strimzi-kafka-operator/templates/049-Crd-kafkarebalance.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/049-Crd-kafkarebalance.yaml
@@ -25,6 +25,8 @@ spec:
     plural: kafkarebalances
     shortNames:
     - kr
+    categories:
+    - strimzi
   subresources:
     status: {}
   validation:

--- a/install/cluster-operator/049-Crd-kafkarebalance.yaml
+++ b/install/cluster-operator/049-Crd-kafkarebalance.yaml
@@ -20,6 +20,8 @@ spec:
     plural: kafkarebalances
     shortNames:
     - kr
+    categories:
+    - strimzi
   subresources:
     status: {}
   validation:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The KafkaRebalance is not in the `strimzi` category an therefor it is not possible to list use the category for it. This PR adds it to the category.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally