### PR TITLE
Fix Prometheus operator installation

### DIFF
--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
@@ -45,7 +45,7 @@ NOTE: If it is not required, you can manually remove the `spec.template.spec.sec
 . Deploy the Prometheus Operator:
 +
 [source,shell,subs="+attributes"]
-kubectl apply -f prometheus-operator-deployment.yaml
+kubectl apply -f prometheus-operator-service-account.yaml
 kubectl apply -f prometheus-operator-cluster-role.yaml
 kubectl apply -f prometheus-operator-cluster-role-binding.yaml
-kubectl apply -f prometheus-operator-service-account.yaml
+kubectl apply -f prometheus-operator-deployment.yaml

--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
@@ -29,4 +29,4 @@ NOTE: If it is not required, you can manually remove the `spec.template.spec.sec
 [source,shell,subs="+attributes"]
 kubectl apply -f prometheus-operator-deployment.yaml
 +
-NOTE: the latest Prometheus Operator installation works fine with Kubernetes 1.18+. For checking which version to use with a different Kubernetes, see this https://github.com/coreos/kube-prometheus#kubernetes-compatibility-matrix[compatibility matrix]
+NOTE: The Prometheus Operator installation works with Kubernetes 1.18+. To check which version to use with a different Kubernetes version, refer to the https://github.com/coreos/kube-prometheus#kubernetes-compatibility-matrix[Kubernetes compatibility matrix].

--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
@@ -6,46 +6,27 @@
 
 = Deploying the Prometheus Operator
 
-To deploy the Prometheus Operator to your Kafka cluster, apply the YAML resource files from the https://github.com/coreos/prometheus-operator/tree/master/example/rbac/prometheus-operator[Prometheus CoreOS repository].
+To deploy the Prometheus Operator to your Kafka cluster, apply the YAML bundle resources file from the https://github.com/coreos/prometheus-operator[Prometheus CoreOS repository].
 
 .Procedure
 
-. Download the resource files from the repository and replace the example `namespace` with your own:
+. Download the resource file from the repository and replace the example `namespace` with your own:
 +
 On Linux, use:
 +
 [source,shell,subs=+quotes]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml | sed -e 's/namespace: .\*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
-+
-[source,shell,subs=+quotes]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml > prometheus-operator-cluster-role.yaml
-+
-[source,shell,subs=+quotes]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/rbac/prometheus-operator/prometheus-operator-cluster-role-binding.yaml | sed -e 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-cluster-role-binding.yaml
-+
-[source,shell,subs=+quotes]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/rbac/prometheus-operator/prometheus-operator-service-account.yaml | sed -e 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-service-account.yaml
+curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml | sed -e 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
 +
 On MacOS, use:
 +
 [source,shell,subs=+quotes]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml | sed -e '' 's/namespace: .\*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
-+
-[source,shell,subs=+quotes]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml > prometheus-operator-cluster-role.yaml
-+
-[source,shell,subs=+quotes]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/rbac/prometheus-operator/prometheus-operator-cluster-role-binding.yaml | sed -e '' 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-cluster-role-binding.yaml
-+
-[source,shell,subs=+quotes]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/rbac/prometheus-operator/prometheus-operator-service-account.yaml | sed -e '' 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-service-account.yaml
+curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml | sed -e '' 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
 +
 NOTE: If it is not required, you can manually remove the `spec.template.spec.securityContext` property from the `prometheus-operator-deployment.yaml` file.
 
 . Deploy the Prometheus Operator:
 +
 [source,shell,subs="+attributes"]
-kubectl apply -f prometheus-operator-service-account.yaml
-kubectl apply -f prometheus-operator-cluster-role.yaml
-kubectl apply -f prometheus-operator-cluster-role-binding.yaml
 kubectl apply -f prometheus-operator-deployment.yaml
++
+NOTE: the latest Prometheus Operator installation works fine with Kubernetes 1.18+. For checking which version to use with a different Kubernetes, see this https://github.com/coreos/kube-prometheus#kubernetes-compatibility-matrix[compatibility matrix]


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Documentation

### Description

Trivial PR to fix the installation steps order for the Prometheus installation.
I think it makes more doing service account, cluster role, binding, and finally the deployment (and not applying this one as the first one).

[Updated]

The CoreOS team changed the way to install it, so now the best way is to use the `bundle.yaml` file. The new commit reflects this.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

