### PR TITLE
Fix rebalance examples

### DIFF
--- a/examples/cruise-control/kafka-rebalance-with-goals.yaml
+++ b/examples/cruise-control/kafka-rebalance-with-goals.yaml
@@ -1,0 +1,14 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaRebalance
+metadata:
+  name: my-rebalance
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  goals:
+    - NetworkInboundCapacityGoal
+    - DiskCapacityGoal
+    - RackAwareGoal
+    - NetworkOutboundCapacityGoal
+    - CpuCapacityGoal
+    - ReplicaCapacityGoal

--- a/examples/cruise-control/kafka-rebalance.yaml
+++ b/examples/cruise-control/kafka-rebalance.yaml
@@ -4,8 +4,5 @@ metadata:
   name: my-rebalance
   labels:
     strimzi.io/cluster: my-cluster
-spec:
-  skipHardGoalCheck: true
-  goals:
-    - DiskCapacityGoal
-    - CpuCapacityGoal
+# no goals specified, using the default goals from the Cruise Control configuration
+spec: {}


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Refactoring

### Description

This PR just changes the rebalance example not defining any `goals` so that the `default.goals` (in the Cruise Control configuration) will be used.

[Updated]
Just added an example with the default hard goals in the `spec.goals` section.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

