### PR TITLE
[systemtest][fixes] ListenersST, RollingUpdateST

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -137,14 +137,4 @@ public class SecretUtils {
             }
         });
     }
-
-    public static void deleteSecretWithWait(String secretName, String namespace) {
-        kubeClient().getClient().secrets().inNamespace(namespace).withName(secretName).delete();
-
-        LOGGER.info("Waiting for Secret: {} to be deleted", secretName);
-        TestUtils.waitFor(String.format("Deletion of secret: {}", secretName), Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_RESOURCE_DELETION,
-            () -> kubeClient().getSecret(secretName) == null);
-
-        LOGGER.info("Secret: {} successfully deleted", secretName);
-    }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -118,6 +118,7 @@ public class SecretUtils {
         certsPaths.put("ca.key", keyPath);
 
         SecretUtils.createSecretFromFile(certsPaths, name, namespace, secretLabels);
+        waitForSecretReady(name);
     }
 
     public static void waitForCertToChange(String originalCert, String secretName) {
@@ -135,5 +136,15 @@ public class SecretUtils {
                 return false;
             }
         });
+    }
+
+    public static void deleteSecretWithWait(String secretName, String namespace) {
+        kubeClient().getClient().secrets().inNamespace(namespace).withName(secretName).delete();
+
+        LOGGER.info("Waiting for Secret: {} to be deleted", secretName);
+        TestUtils.waitFor(String.format("Deletion of secret: {}", secretName), Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_RESOURCE_DELETION,
+            () -> kubeClient().getSecret(secretName) == null);
+
+        LOGGER.info("Secret: {} successfully deleted", secretName);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -137,4 +137,14 @@ public class SecretUtils {
             }
         });
     }
+
+    public static void deleteSecretWithWait(String secretName, String namespace) {
+        kubeClient().getClient().secrets().inNamespace(namespace).withName(secretName).delete();
+
+        LOGGER.info("Waiting for Secret: {} to be deleted", secretName);
+        TestUtils.waitFor(String.format("Deletion of secret: {}", secretName), Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_RESOURCE_DELETION,
+            () -> kubeClient().getSecret(secretName) == null);
+
+        LOGGER.info("Secret: {} successfully deleted", secretName);
+    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -962,7 +962,7 @@ class RollingUpdateST extends BaseST {
 
     @Test
     void testKafkaTopicRFLowerThanMinInSyncReplicas() {
-        KafkaResource.kafkaPersistent(CLUSTER_NAME, 2).done();
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3).done();
         KafkaTopicResource.topic(CLUSTER_NAME, TOPIC_NAME, 1, 1).done();
 
         String kafkaName = KafkaResources.kafkaStatefulSetName(CLUSTER_NAME);

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
@@ -1151,12 +1151,12 @@ public class ListenersST extends BaseST {
 
     @BeforeEach
     void setupCertificates() {
-        SecretUtils.deleteSecretWithWait(customCertChain1, NAMESPACE);
-        SecretUtils.deleteSecretWithWait(customCertChain2, NAMESPACE);
-        SecretUtils.deleteSecretWithWait(customCertServer1, NAMESPACE);
-        SecretUtils.deleteSecretWithWait(customCertServer2, NAMESPACE);
-        SecretUtils.deleteSecretWithWait(customRootCA1, NAMESPACE);
-        SecretUtils.deleteSecretWithWait(customRootCA2, NAMESPACE);
+        kubeClient().getClient().secrets().inNamespace(NAMESPACE).withName(customCertChain1).delete();
+        kubeClient().getClient().secrets().inNamespace(NAMESPACE).withName(customCertChain2).delete();
+        kubeClient().getClient().secrets().inNamespace(NAMESPACE).withName(customCertServer1).delete();
+        kubeClient().getClient().secrets().inNamespace(NAMESPACE).withName(customCertServer2).delete();
+        kubeClient().getClient().secrets().inNamespace(NAMESPACE).withName(customRootCA1).delete();
+        kubeClient().getClient().secrets().inNamespace(NAMESPACE).withName(customRootCA2).delete();
 
         SecretUtils.createCustomSecret(customCertChain1, CLUSTER_NAME, NAMESPACE,
                 Objects.requireNonNull(getClass().getClassLoader().getResource("custom-certs/ver1/chain/strimzi-bundle.crt")).getFile(),

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
@@ -1151,12 +1151,12 @@ public class ListenersST extends BaseST {
 
     @BeforeEach
     void setupCertificates() {
-        kubeClient().getClient().secrets().inNamespace(NAMESPACE).withName(customCertChain1).delete();
-        kubeClient().getClient().secrets().inNamespace(NAMESPACE).withName(customCertChain2).delete();
-        kubeClient().getClient().secrets().inNamespace(NAMESPACE).withName(customCertServer1).delete();
-        kubeClient().getClient().secrets().inNamespace(NAMESPACE).withName(customCertServer2).delete();
-        kubeClient().getClient().secrets().inNamespace(NAMESPACE).withName(customRootCA1).delete();
-        kubeClient().getClient().secrets().inNamespace(NAMESPACE).withName(customRootCA2).delete();
+        SecretUtils.deleteSecretWithWait(customCertChain1, NAMESPACE);
+        SecretUtils.deleteSecretWithWait(customCertChain2, NAMESPACE);
+        SecretUtils.deleteSecretWithWait(customCertServer1, NAMESPACE);
+        SecretUtils.deleteSecretWithWait(customCertServer2, NAMESPACE);
+        SecretUtils.deleteSecretWithWait(customRootCA1, NAMESPACE);
+        SecretUtils.deleteSecretWithWait(customRootCA2, NAMESPACE);
 
         SecretUtils.createCustomSecret(customCertChain1, CLUSTER_NAME, NAMESPACE,
                 Objects.requireNonNull(getClass().getClassLoader().getResource("custom-certs/ver1/chain/strimzi-bundle.crt")).getFile(),

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -128,6 +128,6 @@ class KafkaRollerST extends BaseST {
 
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT).done();
+        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_MEDIUM).done();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -52,10 +52,11 @@ class KafkaRollerST extends BaseST {
 
         KafkaResource.kafkaPersistent(CLUSTER_NAME, 4)
             .editSpec()
-            .editKafka()
-            .addToConfig("auto.create.topics.enable", "false")
-            .endKafka()
-            .endSpec().done();
+                .editKafka()
+                    .addToConfig("auto.create.topics.enable", "false")
+                .endKafka()
+            .endSpec()
+            .done();
 
         LOGGER.info("Running kafkaScaleUpScaleDown {}", CLUSTER_NAME);
         final int initialReplicas = kubeClient().getStatefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).getStatus().getReplicas();
@@ -86,8 +87,9 @@ class KafkaRollerST extends BaseST {
         // set annotation to trigger Kafka rolling update
         kubeClient().statefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).cascading(false).edit()
             .editMetadata()
-            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
-            .endMetadata().done();
+                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
+            .endMetadata()
+            .done();
 
         StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), kafkaPods);
     }
@@ -109,8 +111,9 @@ class KafkaRollerST extends BaseST {
         // set annotation to trigger Kafka rolling update
         kubeClient().statefulSet(kafkaName).cascading(false).edit()
             .editMetadata()
-            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
-            .endMetadata().done();
+                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
+            .endMetadata()
+            .done();
 
         StatefulSetUtils.waitTillSsHasRolled(kafkaName, 3, kafkaPods);
         assertThat(StatefulSetUtils.ssSnapshot(kafkaName), is(not(kafkaPods)));

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.rollingupdate;
+
+import io.fabric8.kubernetes.api.model.Event;
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.systemtest.BaseST;
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.resources.KubernetesResource;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.test.timemeasuring.Operation;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.k8s.Events.Created;
+import static io.strimzi.systemtest.k8s.Events.Pulled;
+import static io.strimzi.systemtest.k8s.Events.Scheduled;
+import static io.strimzi.systemtest.k8s.Events.Started;
+import static io.strimzi.systemtest.matchers.Matchers.hasAllOfReasons;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag(REGRESSION)
+@Tag(INTERNAL_CLIENTS_USED)
+class KafkaRollerST extends BaseST {
+    private static final Logger LOGGER = LogManager.getLogger(RollingUpdateST.class);
+    static final String NAMESPACE = "kafka-roller-cluster-test";
+
+    @Test
+    void testKafkaRollsWhenTopicIsUnderReplicated() {
+        String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
+        timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_RECOVERY));
+
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 4)
+            .editSpec()
+            .editKafka()
+            .addToConfig("auto.create.topics.enable", "false")
+            .endKafka()
+            .endSpec().done();
+
+        LOGGER.info("Running kafkaScaleUpScaleDown {}", CLUSTER_NAME);
+        final int initialReplicas = kubeClient().getStatefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).getStatus().getReplicas();
+        assertEquals(4, initialReplicas);
+
+        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
+
+        KafkaTopicResource.topic(CLUSTER_NAME, topicName, 4, 4, 4).done();
+
+        //Test that the new pod does not have errors or failures in events
+        String uid = kubeClient().getPodUid(KafkaResources.kafkaPodName(CLUSTER_NAME,  3));
+        List<Event> events = kubeClient().listEvents(uid);
+        assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
+
+        //Test that CO doesn't have any exceptions in log
+        timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
+        assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSeconds(testClass, testName, timeMeasuringSystem.getOperationID()));
+
+        // scale down
+        int scaledDownReplicas = 3;
+        LOGGER.info("Scaling down to {}", scaledDownReplicas);
+        timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.SCALE_DOWN));
+        KafkaResource.replaceKafkaResource(CLUSTER_NAME, k -> k.getSpec().getKafka().setReplicas(scaledDownReplicas));
+        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), scaledDownReplicas);
+
+        PodUtils.verifyThatRunningPodsAreStable(CLUSTER_NAME);
+
+        // set annotation to trigger Kafka rolling update
+        kubeClient().statefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).cascading(false).edit()
+            .editMetadata()
+            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
+            .endMetadata().done();
+
+        StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), kafkaPods);
+    }
+
+    @Test
+    void testKafkaTopicRFLowerThanMinInSyncReplicas() {
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3).done();
+        KafkaTopicResource.topic(CLUSTER_NAME, TOPIC_NAME, 1, 1).done();
+
+        String kafkaName = KafkaResources.kafkaStatefulSetName(CLUSTER_NAME);
+        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaName);
+
+        LOGGER.info("Setting KafkaTopic's min.insync.replicas to be higher than replication factor");
+        KafkaTopicResource.replaceTopicResource(TOPIC_NAME, kafkaTopic -> kafkaTopic.getSpec().getConfig().replace("min.insync.replicas", 2));
+
+        // rolling update for kafka
+        LOGGER.info("Annotate Kafka StatefulSet {} with manual rolling update annotation", kafkaName);
+        timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.ROLLING_UPDATE));
+        // set annotation to trigger Kafka rolling update
+        kubeClient().statefulSet(kafkaName).cascading(false).edit()
+            .editMetadata()
+            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
+            .endMetadata().done();
+
+        StatefulSetUtils.waitTillSsHasRolled(kafkaName, 3, kafkaPods);
+        assertThat(StatefulSetUtils.ssSnapshot(kafkaName), is(not(kafkaPods)));
+    }
+
+    @Override
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+        super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
+    }
+
+    @BeforeAll
+    void setup() {
+        ResourceManager.setClassResources();
+        prepareEnvForOperator(NAMESPACE);
+
+        applyRoleBindings(NAMESPACE);
+        // 050-Deployment
+        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT).done();
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/ManualRollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/ManualRollingUpdateST.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.rollingupdate;
+
+import io.fabric8.kubernetes.api.model.Event;
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.KafkaUser;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.systemtest.BaseST;
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
+import io.strimzi.systemtest.resources.KubernetesResource;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
+import io.strimzi.systemtest.resources.crd.KafkaUserResource;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.test.TestUtils;
+import io.strimzi.test.timemeasuring.Operation;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.k8s.Events.Created;
+import static io.strimzi.systemtest.k8s.Events.Pulled;
+import static io.strimzi.systemtest.k8s.Events.Scheduled;
+import static io.strimzi.systemtest.k8s.Events.Started;
+import static io.strimzi.systemtest.matchers.Matchers.hasAllOfReasons;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag(REGRESSION)
+@Tag(INTERNAL_CLIENTS_USED)
+class ManualRollingUpdateST extends BaseST {
+
+    private static final Logger LOGGER = LogManager.getLogger(RollingUpdateST.class);
+
+    static final String NAMESPACE = "manual-rolling-update-cluster-test";
+
+    /**
+     * This test cover case, when KafkaRoller will not roll Kafka pods, because created topic doesn't meet requirements for roll remaining pods
+     * 1. Deploy kafka cluster with 4 pods
+     * 2. Create topic with 4 replicas
+     * 3. Scale down kafka cluster to 3 replicas
+     * 4. Trigger rolling update for Kafka cluster
+     * 5. Rolling update will not be performed, because topic which we created had some replicas on deleted pods - manual fix is needed in that case
+     */
+    @Test
+    void testKafkaWontRollUpBecauseTopic() {
+        String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
+        timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_RECOVERY));
+
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 4)
+            .editSpec()
+            .editKafka()
+            .addToConfig("auto.create.topics.enable", "false")
+            .endKafka()
+            .endSpec().done();
+
+        LOGGER.info("Running kafkaScaleUpScaleDown {}", CLUSTER_NAME);
+        final int initialReplicas = kubeClient().getStatefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).getStatus().getReplicas();
+        assertEquals(4, initialReplicas);
+
+        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
+
+        KafkaTopicResource.topic(CLUSTER_NAME, topicName, 4, 4, 4).done();
+
+        //Test that the new pod does not have errors or failures in events
+        String uid = kubeClient().getPodUid(KafkaResources.kafkaPodName(CLUSTER_NAME,  3));
+        List<Event> events = kubeClient().listEvents(uid);
+        assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
+
+        //Test that CO doesn't have any exceptions in log
+        timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
+        assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSeconds(testClass, testName, timeMeasuringSystem.getOperationID()));
+
+        // scale down
+        int scaledDownReplicas = 3;
+        LOGGER.info("Scaling down to {}", scaledDownReplicas);
+        timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.SCALE_DOWN));
+        KafkaResource.replaceKafkaResource(CLUSTER_NAME, k -> k.getSpec().getKafka().setReplicas(scaledDownReplicas));
+        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), scaledDownReplicas);
+
+        // set annotation to trigger Kafka rolling update
+        kubeClient().statefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).cascading(false).edit()
+            .editMetadata()
+            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
+            .endMetadata().done();
+
+        PodUtils.verifyThatRunningPodsAreStable(CLUSTER_NAME);
+
+        Map<String, String> kafkaPodsScaleDown = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
+
+        for (Map.Entry<String, String> entry : kafkaPodsScaleDown.entrySet()) {
+            assertThat(kafkaPods, hasEntry(entry.getKey(), entry.getValue()));
+        }
+    }
+
+    @Test
+    void testManualTriggeringRollingUpdate() {
+        String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
+
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3).done();
+
+        String kafkaName = KafkaResources.kafkaStatefulSetName(CLUSTER_NAME);
+        String zkName = KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME);
+        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaName);
+        Map<String, String> zkPods = StatefulSetUtils.ssSnapshot(zkName);
+
+        KafkaTopicResource.topic(CLUSTER_NAME, topicName).done();
+
+        String userName = KafkaUserUtils.generateRandomNameOfKafkaUser();
+        KafkaUser user = KafkaUserResource.tlsUser(CLUSTER_NAME, userName).done();
+
+        KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, user).done();
+
+        final String defaultKafkaClientsPodName =
+            ResourceManager.kubeClient().listPodsByPrefixInName(CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
+
+        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
+            .withUsingPodName(defaultKafkaClientsPodName)
+            .withTopicName(topicName)
+            .withNamespaceName(NAMESPACE)
+            .withClusterName(CLUSTER_NAME)
+            .withMessageCount(MESSAGE_COUNT)
+            .withKafkaUsername(userName)
+            .build();
+
+        int sent = internalKafkaClient.sendMessagesTls();
+        assertThat(sent, is(MESSAGE_COUNT));
+
+        // rolling update for kafka
+        LOGGER.info("Annotate Kafka StatefulSet {} with manual rolling update annotation", kafkaName);
+        timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.ROLLING_UPDATE));
+        // set annotation to trigger Kafka rolling update
+        kubeClient().statefulSet(kafkaName).cascading(false).edit()
+            .editMetadata()
+            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
+            .endMetadata().done();
+
+        // check annotation to trigger rolling update
+        assertThat(Boolean.parseBoolean(kubeClient().getStatefulSet(kafkaName)
+            .getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE)), is(true));
+
+        StatefulSetUtils.waitTillSsHasRolled(kafkaName, 3, kafkaPods);
+
+        // wait when annotation will be removed
+        TestUtils.waitFor("CO removes rolling update annotation", Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+            () -> kubeClient().getStatefulSet(kafkaName).getMetadata().getAnnotations() == null
+                || !kubeClient().getStatefulSet(kafkaName).getMetadata().getAnnotations().containsKey(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE));
+
+        // rolling update for zookeeper
+        LOGGER.info("Annotate Zookeeper StatefulSet {} with manual rolling update annotation", zkName);
+        timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.ROLLING_UPDATE));
+
+        int received = internalKafkaClient.receiveMessagesTls();
+        assertThat(received, is(sent));
+
+        // set annotation to trigger Zookeeper rolling update
+        kubeClient().statefulSet(zkName).cascading(false).edit()
+            .editMetadata()
+            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
+            .endMetadata().done();
+
+        // check annotation to trigger rolling update
+        assertThat(Boolean.parseBoolean(kubeClient().getStatefulSet(zkName)
+            .getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE)), is(true));
+
+        StatefulSetUtils.waitTillSsHasRolled(zkName, 3, zkPods);
+
+        // wait when annotation will be removed
+        TestUtils.waitFor("CO removes rolling update annotation", Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+            () -> kubeClient().getStatefulSet(zkName).getMetadata().getAnnotations() == null
+                || !kubeClient().getStatefulSet(zkName).getMetadata().getAnnotations().containsKey(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE));
+
+
+        internalKafkaClient.setConsumerGroup("group" + new Random().nextInt(Integer.MAX_VALUE));
+
+        received = internalKafkaClient.receiveMessagesTls();
+        assertThat(received, is(sent));
+
+        // Create new topic to ensure, that ZK is working properly
+        String newTopicName = "new-test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
+        KafkaTopicResource.topic(CLUSTER_NAME, newTopicName, 1, 1).done();
+
+        internalKafkaClient.setTopicName(newTopicName);
+        internalKafkaClient.setConsumerGroup("group" + new Random().nextInt(Integer.MAX_VALUE));
+
+        sent = internalKafkaClient.sendMessagesTls();
+        assertThat(sent, is(MESSAGE_COUNT));
+
+        received = internalKafkaClient.receiveMessagesTls();
+        assertThat(received, is(sent));
+    }
+
+    @Test
+    void testKafkaTopicRFLowerThanMinInSyncReplicas() {
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3).done();
+        KafkaTopicResource.topic(CLUSTER_NAME, TOPIC_NAME, 1, 1).done();
+
+        String kafkaName = KafkaResources.kafkaStatefulSetName(CLUSTER_NAME);
+        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaName);
+
+        LOGGER.info("Setting KafkaTopic's min.insync.replicas to be higher than replication factor");
+        KafkaTopicResource.replaceTopicResource(TOPIC_NAME, kafkaTopic -> kafkaTopic.getSpec().getConfig().replace("min.insync.replicas", 2));
+
+        // rolling update for kafka
+        LOGGER.info("Annotate Kafka StatefulSet {} with manual rolling update annotation", kafkaName);
+        timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.ROLLING_UPDATE));
+        // set annotation to trigger Kafka rolling update
+        kubeClient().statefulSet(kafkaName).cascading(false).edit()
+            .editMetadata()
+            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
+            .endMetadata().done();
+
+        StatefulSetUtils.waitTillSsHasRolled(kafkaName, 3, kafkaPods);
+        assertThat(StatefulSetUtils.ssSnapshot(kafkaName), is(not(kafkaPods)));
+    }
+
+    @Override
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+        super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
+    }
+
+    @BeforeAll
+    void setup() {
+        ResourceManager.setClassResources();
+        prepareEnvForOperator(NAMESPACE);
+
+        applyRoleBindings(NAMESPACE);
+        // 050-Deployment
+        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT).done();
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/ManualRollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/ManualRollingUpdateST.java
@@ -44,7 +44,6 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag(REGRESSION)
@@ -55,16 +54,8 @@ class ManualRollingUpdateST extends BaseST {
 
     static final String NAMESPACE = "manual-rolling-update-cluster-test";
 
-    /**
-     * This test cover case, when KafkaRoller will not roll Kafka pods, because created topic doesn't meet requirements for roll remaining pods
-     * 1. Deploy kafka cluster with 4 pods
-     * 2. Create topic with 4 replicas
-     * 3. Scale down kafka cluster to 3 replicas
-     * 4. Trigger rolling update for Kafka cluster
-     * 5. Rolling update will not be performed, because topic which we created had some replicas on deleted pods - manual fix is needed in that case
-     */
     @Test
-    void testKafkaWontRollUpBecauseTopic() {
+    void testKafkaRollsWhenTopicIsUnderReplicated() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_RECOVERY));
 
@@ -99,19 +90,15 @@ class ManualRollingUpdateST extends BaseST {
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, k -> k.getSpec().getKafka().setReplicas(scaledDownReplicas));
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), scaledDownReplicas);
 
+        PodUtils.verifyThatRunningPodsAreStable(CLUSTER_NAME);
+
         // set annotation to trigger Kafka rolling update
         kubeClient().statefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).cascading(false).edit()
             .editMetadata()
             .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
             .endMetadata().done();
 
-        PodUtils.verifyThatRunningPodsAreStable(CLUSTER_NAME);
-
-        Map<String, String> kafkaPodsScaleDown = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
-
-        for (Map.Entry<String, String> entry : kafkaPodsScaleDown.entrySet()) {
-            assertThat(kafkaPods, hasEntry(entry.getKey(), entry.getValue()));
-        }
+        StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), kafkaPods);
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/ManualRollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/ManualRollingUpdateST.java
@@ -84,8 +84,9 @@ class ManualRollingUpdateST extends BaseST {
         // set annotation to trigger Kafka rolling update
         kubeClient().statefulSet(kafkaName).cascading(false).edit()
             .editMetadata()
-            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
-            .endMetadata().done();
+                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
+            .endMetadata()
+            .done();
 
         // check annotation to trigger rolling update
         assertThat(Boolean.parseBoolean(kubeClient().getStatefulSet(kafkaName)
@@ -108,8 +109,9 @@ class ManualRollingUpdateST extends BaseST {
         // set annotation to trigger Zookeeper rolling update
         kubeClient().statefulSet(zkName).cascading(false).edit()
             .editMetadata()
-            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
-            .endMetadata().done();
+                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
+            .endMetadata()
+            .done();
 
         // check annotation to trigger rolling update
         assertThat(Boolean.parseBoolean(kubeClient().getStatefulSet(zkName)

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/ManualRollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/ManualRollingUpdateST.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest.rollingupdate;
 
-import io.fabric8.kubernetes.api.model.Event;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.operator.common.Annotations;
@@ -20,7 +19,6 @@ import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
-import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.timemeasuring.Operation;
 import org.apache.logging.log4j.LogManager;
@@ -35,16 +33,9 @@ import java.util.Random;
 
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
-import static io.strimzi.systemtest.k8s.Events.Created;
-import static io.strimzi.systemtest.k8s.Events.Pulled;
-import static io.strimzi.systemtest.k8s.Events.Scheduled;
-import static io.strimzi.systemtest.k8s.Events.Started;
-import static io.strimzi.systemtest.matchers.Matchers.hasAllOfReasons;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag(REGRESSION)
 @Tag(INTERNAL_CLIENTS_USED)
@@ -53,53 +44,6 @@ class ManualRollingUpdateST extends BaseST {
     private static final Logger LOGGER = LogManager.getLogger(RollingUpdateST.class);
 
     static final String NAMESPACE = "manual-rolling-update-cluster-test";
-
-    @Test
-    void testKafkaRollsWhenTopicIsUnderReplicated() {
-        String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
-        timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_RECOVERY));
-
-        KafkaResource.kafkaPersistent(CLUSTER_NAME, 4)
-            .editSpec()
-            .editKafka()
-            .addToConfig("auto.create.topics.enable", "false")
-            .endKafka()
-            .endSpec().done();
-
-        LOGGER.info("Running kafkaScaleUpScaleDown {}", CLUSTER_NAME);
-        final int initialReplicas = kubeClient().getStatefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).getStatus().getReplicas();
-        assertEquals(4, initialReplicas);
-
-        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
-
-        KafkaTopicResource.topic(CLUSTER_NAME, topicName, 4, 4, 4).done();
-
-        //Test that the new pod does not have errors or failures in events
-        String uid = kubeClient().getPodUid(KafkaResources.kafkaPodName(CLUSTER_NAME,  3));
-        List<Event> events = kubeClient().listEvents(uid);
-        assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
-
-        //Test that CO doesn't have any exceptions in log
-        timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
-        assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSeconds(testClass, testName, timeMeasuringSystem.getOperationID()));
-
-        // scale down
-        int scaledDownReplicas = 3;
-        LOGGER.info("Scaling down to {}", scaledDownReplicas);
-        timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.SCALE_DOWN));
-        KafkaResource.replaceKafkaResource(CLUSTER_NAME, k -> k.getSpec().getKafka().setReplicas(scaledDownReplicas));
-        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), scaledDownReplicas);
-
-        PodUtils.verifyThatRunningPodsAreStable(CLUSTER_NAME);
-
-        // set annotation to trigger Kafka rolling update
-        kubeClient().statefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).cascading(false).edit()
-            .editMetadata()
-            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
-            .endMetadata().done();
-
-        StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), kafkaPods);
-    }
 
     @Test
     void testManualTriggeringRollingUpdate() {
@@ -196,30 +140,6 @@ class ManualRollingUpdateST extends BaseST {
 
         received = internalKafkaClient.receiveMessagesTls();
         assertThat(received, is(sent));
-    }
-
-    @Test
-    void testKafkaTopicRFLowerThanMinInSyncReplicas() {
-        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3).done();
-        KafkaTopicResource.topic(CLUSTER_NAME, TOPIC_NAME, 1, 1).done();
-
-        String kafkaName = KafkaResources.kafkaStatefulSetName(CLUSTER_NAME);
-        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaName);
-
-        LOGGER.info("Setting KafkaTopic's min.insync.replicas to be higher than replication factor");
-        KafkaTopicResource.replaceTopicResource(TOPIC_NAME, kafkaTopic -> kafkaTopic.getSpec().getConfig().replace("min.insync.replicas", 2));
-
-        // rolling update for kafka
-        LOGGER.info("Annotate Kafka StatefulSet {} with manual rolling update annotation", kafkaName);
-        timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.ROLLING_UPDATE));
-        // set annotation to trigger Kafka rolling update
-        kubeClient().statefulSet(kafkaName).cascading(false).edit()
-            .editMetadata()
-            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
-            .endMetadata().done();
-
-        StatefulSetUtils.waitTillSsHasRolled(kafkaName, 3, kafkaPods);
-        assertThat(StatefulSetUtils.ssSnapshot(kafkaName), is(not(kafkaPods)));
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR gonna deal with flaky tests in our two suites: ListenersST, RollingUpdateST.

ListenersST -> I added wait for secrets creation -> the problem here was that we added secret that hasn't even created or it was deleted by some race condition.

RollingUpdateST -> I split our RollingUpdateST to two suites and added a new package `rollingupdate`  -> the problem here was that we used different `operationTimeout` for tests where we trigger rolling update manually -> in these tests we deleted CO and recreated with different `operationTimeout`, on the test end we deleted CO once again and recreated with default `operationTimeout`

### Checklist

- [ ] Make sure all tests pass


