### PR TITLE
Fix incorrect warning about loadBalancerSourceRanges field

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -673,7 +673,9 @@ public class KafkaCluster extends AbstractModel {
 
                 if (result.isExposedWithLoadBalancer()) {
                     result.templateExternalBootstrapServiceLoadBalancerSourceRanges = template.getExternalBootstrapService().getLoadBalancerSourceRanges();
-                } else {
+                } else if (template.getExternalBootstrapService().getLoadBalancerSourceRanges() != null
+                        && template.getExternalBootstrapService().getLoadBalancerSourceRanges().size() > 0) {
+                    // LoadBalancerSourceRanges have been set, but LaodBalancers are not used
                     log.warn("The Kafka.spec.kafka.template.externalBootstrapService.loadBalancerSourceRanges option can be used only with load balancer type listeners");
                 }
             }
@@ -688,7 +690,9 @@ public class KafkaCluster extends AbstractModel {
 
                 if (result.isExposedWithLoadBalancer()) {
                     result.templatePerPodServiceLoadBalancerSourceRanges = template.getPerPodService().getLoadBalancerSourceRanges();
-                } else {
+                } else if (template.getPerPodService().getLoadBalancerSourceRanges() != null
+                        && template.getPerPodService().getLoadBalancerSourceRanges().size() > 0) {
+                    // LoadBalancerSourceRanges have been set, but LaodBalancers are not used
                     log.warn("The Kafka.spec.kafka.template.perPodService.loadBalancerSourceRanges option can be used only with load balancer type listeners");
                 }
             }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The external services can have a template field `loadBalancerSourceRanges` which in supported environments (e.g. AWS) configure the firewall (security groups) and allow access only for clients comming from the CIDRs specified in this field. This is applicable only for load balancer type services. We have a check for it in the `KafkaCluster` class. If these fields are set for non-loadbalancer listener (e.g. routes or node ports), following warnings will be printed:

```
2020-05-18 23:34:56 WARN  AbstractModel:679 - The Kafka.spec.kafka.template.externalBootstrapService.loadBalancerSourceRanges option can be used only with load balancer type listeners
2020-05-18 23:34:56 WARN  AbstractModel:696 - The Kafka.spec.kafka.template.perPodService.loadBalancerSourceRanges option can be used only with load balancer type listeners
```

However, the check is implemented badly and prints this warning anytime something else than load balancer is used. Even when these fields are not set at all. THSI PR fixes the check to make sure the warnings are printed only when the fields are actually used.

This seems to exist since 0.16.0 without noticing. So there should be no reason to do 0.18.0-RC3 because of this. But should we do it for any other reason or do a patch release, we should try to include this.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally