### PR TITLE
[jenkins] Fix issues with nodeport on CRC 

### DIFF
--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -22,7 +22,7 @@ def downloadOcOrigin() {
 
 def downloadCRC() {
     downloadOcOrigin()
-    def crcBundleUrl = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/latest/crc-linux-amd64.tar.xz"
+    def crcBundleUrl = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/1.6.0/crc-linux-amd64.tar.xz"
     withCredentials([string(credentialsId: 'crc-secret', variable: 'secret')]) {
         sh(script: "echo \'${secret}\' > ${WORKSPACE}/crcSecret")
     }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR gonna change the version of CRC to latest fully stable version, because on `1.10.0` is problem with NodePort so we cannot run the tests on it.

### Checklist

- [ ] Make sure all tests pass

