### PR TITLE
Moved Dockerfile copies of Cruise Control in the right position

### DIFF
--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -37,10 +37,6 @@ RUN curl -LO https://github.com/danielqsj/kafka_exporter/releases/download/v${KA
 
 COPY ./exporter-scripts $KAFKA_EXPORTER_HOME
 
-ENV CRUISE_CONTROL_HOME=/opt/cruise-control
-RUN mkdir $CRUISE_CONTROL_HOME
-COPY ./cruise-control-scripts $CRUISE_CONTROL_HOME
-
 #####
 # Add Strimzi agents
 #####
@@ -56,7 +52,10 @@ COPY kafka-thirdparty-libs/${THIRD_PARTY_LIBS}/target/dependency/ ${KAFKA_HOME}/
 #####
 # Add Cruise Control
 #####
+ENV CRUISE_CONTROL_HOME=/opt/cruise-control
+RUN mkdir $CRUISE_CONTROL_HOME
 COPY kafka-thirdparty-libs/cc/target/dependency/ ${CRUISE_CONTROL_HOME}/libs/
+COPY ./cruise-control-scripts $CRUISE_CONTROL_HOME
 
 #####
 # Add Stunnel


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Refactoring

### Description

This PR just moves the copies related to Cruise Control stuff in the corresponding section of the Dockerfile for the image creation.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

