### PR TITLE
[DOC] Additional mm2 config properties

### DIFF
--- a/documentation/assemblies/assembly-deployment-configuration-kafka-mirror-maker.adoc
+++ b/documentation/assemblies/assembly-deployment-configuration-kafka-mirror-maker.adoc
@@ -17,11 +17,8 @@
 
 This chapter describes how to configure a Kafka MirrorMaker deployment in your {ProductName} cluster to replicate data between Kafka clusters.
 
-You can use {ProductName} with MirrorMaker or MirrorMaker 2.0.
+You can use {ProductName} with MirrorMaker or xref:assembly-mirrormaker-str[MirrorMaker 2.0].
 MirrorMaker 2.0 is the latest version, and offers a more efficient way to mirror data between Kafka clusters.
-
-[discrete]
-== MirrorMaker
 
 If you are using MirrorMaker, you configure the `KafkaMirrorMaker` resource.
 
@@ -38,33 +35,11 @@ The full schema of the `KafkaMirrorMaker` resource is described in the xref:type
 NOTE: Labels applied to a `KafkaMirrorMaker` resource are also applied to the Kubernetes resources comprising Kafka MirrorMaker.
 This provides a convenient mechanism for resources to be labeled as required.
 
-[discrete]
-== MirrorMaker 2.0
-
-If you are using MirrorMaker 2.0, you configure the `KafkaMirrorMaker2` resource.
-
-MirrorMaker 2.0 introduces an entirely new way of replicating data between clusters.
-
-As a result, the resource configuration differs from the previous version of MirrorMaker.
-If you choose to use MirrorMaker 2.0, there is currently no legacy support, so any resources must be manually converted into the new format.
-
-How MirrorMaker 2.0 replicates data is described here:
-
-* xref:con-mirrormaker-{context}[MirrorMaker 2.0 data replication]
-
-The following procedure shows how the resource is configured for MirrorMaker 2.0:
-
-* xref:proc-mirrormaker-replication-{context}[Synchronizing data between Kafka clusters]
-
-The full schema of the `KafkaMirrorMaker2` resource is described in the xref:type-KafkaMirrorMaker2-reference[KafkaMirrorMaker2 schema reference].
-
 include::../modules/proc-configuring-mirror-maker.adoc[leveloffset=+1]
 
 include::../modules/con-configuring-mirror-maker.adoc[leveloffset=+1]
 
 include::../modules/ref-list-of-kafka-mirror-maker-resources.adoc[leveloffset=+1]
-
-include::mirrormaker2/assembly-mirrormaker.adoc[leveloffset=+1]
 
 // Restore the context to what it was before this assembly.
 :context: {parent-context-deployment-configuration-kafka-mirror-maker}

--- a/documentation/assemblies/assembly-deployment-configuration.adoc
+++ b/documentation/assemblies/assembly-deployment-configuration.adoc
@@ -29,6 +29,8 @@ include::assembly-deployment-configuration-kafka-connect-s2i.adoc[leveloffset=+1
 
 include::assembly-deployment-configuration-kafka-mirror-maker.adoc[leveloffset=+1]
 
+include::mirrormaker2/assembly-mirrormaker.adoc[leveloffset=+1]
+
 include::assembly-deployment-configuration-kafka-bridge.adoc[leveloffset=+1]
 
 include::oauth/assembly-oauth-authentication.adoc[leveloffset=+1]

--- a/documentation/assemblies/mirrormaker2/assembly-mirrormaker.adoc
+++ b/documentation/assemblies/mirrormaker2/assembly-mirrormaker.adoc
@@ -3,9 +3,9 @@
 // assembly-deployment-configuration-kafka-mirror-maker.adoc
 
 [id='assembly-mirrormaker-{context}']
-= Using {ProductName} with MirrorMaker 2.0.
+= Kafka MirrorMaker 2.0 configuration
 
-This section describes using {ProductName} with MirrorMaker 2.0.
+This section describes how to configure a Kafka MirrorMaker 2.0 deployment in your {ProductName} cluster.
 
 MirrorMaker 2.0 is used to replicate data between two or more active Kafka clusters, within or across data centers.
 
@@ -16,7 +16,22 @@ Data replication across clusters supports scenarios that require:
 * Restriction of data access to a specific cluster
 * Provision of data at a specific location to improve latency
 
-NOTE: MirrorMaker 2.0 has features not supported by the previous version of MirrorMaker.
+If you are using MirrorMaker 2.0, you configure the `KafkaMirrorMaker2` resource.
+
+MirrorMaker 2.0 introduces an entirely new way of replicating data between clusters.
+
+As a result, the resource configuration differs from the previous version of MirrorMaker.
+If you choose to use MirrorMaker 2.0, there is currently no legacy support, so any resources must be manually converted into the new format.
+
+How MirrorMaker 2.0 replicates data is described here:
+
+* xref:con-mirrormaker-{context}[MirrorMaker 2.0 data replication]
+
+The following procedure shows how the resource is configured for MirrorMaker 2.0:
+
+* xref:proc-mirrormaker-replication-{context}[Synchronizing data between Kafka clusters]
+
+The full schema of the `KafkaMirrorMaker2` resource is described in the xref:type-KafkaMirrorMaker2-reference[KafkaMirrorMaker2 schema reference].
 
 //Describes the underlying archiecture and how it is used in replication
 include::modules/con-mirrormaker-replication.adoc[leveloffset=+1]

--- a/documentation/modules/mirrormaker2/proc-mirrormaker-replication.adoc
+++ b/documentation/modules/mirrormaker2/proc-mirrormaker-replication.adoc
@@ -7,10 +7,6 @@
 
 Use MirrorMaker 2.0 to synchronize data between Kafka clusters through configuration.
 
-The previous version of MirrorMaker continues to be supported.
-If you wish to use the resources configured for the previous version,
-they must be updated to the format supported by MirrorMaker 2.0.
-
 The configuration must specify:
 
 * Each Kafka cluster
@@ -20,6 +16,10 @@ The configuration must specify:
 ** Topic to topic
 
 Use the properties of the `KafkaMirrorMaker2` resource to configure your Kafka MirrorMaker 2.0 deployment.
+
+NOTE: The previous version of MirrorMaker continues to be supported.
+If you wish to use the resources configured for the previous version,
+they must be updated to the format supported by MirrorMaker 2.0.
 
 MirrorMaker 2.0 provides default configuration values for properties such as replication factors.
 A minimal configuration, with defaults left unchanged, would be something like this example:
@@ -116,6 +116,62 @@ spec:
         checkpoints.topic.replication.factor: 1 <25>
     topicsPattern: ".*" <26>
     groupsPattern: "group1|group2|group3" <27>
+  resources: <28>
+    requests:
+      cpu: "1"
+      memory: 2Gi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+  logging: <29>
+    type: inline
+    loggers:
+      connect.root.logger.level: "INFO"
+  readinessProbe: <30>
+    initialDelaySeconds: 15
+    timeoutSeconds: 5
+  livenessProbe:
+    initialDelaySeconds: 15
+    timeoutSeconds: 5
+  jvmOptions: <31>
+    "-Xmx": "1g"
+    "-Xms": "1g"
+  image: my-org/my-image:latest <32>
+  template: <33>
+    pod:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: application
+                    operator: In
+                    values:
+                      - postgresql
+                      - mongodb
+              topologyKey: "kubernetes.io/hostname"
+    connectContainer: 1
+      env:
+        - name: JAEGER_SERVICE_NAME
+          value: my-jaeger-service
+        - name: JAEGER_AGENT_HOST
+          value: jaeger-agent-name
+        - name: JAEGER_AGENT_PORT
+          value: "6831"
+  tracing:
+    type: jaeger <34>
+  externalConfiguration: <35>
+    env:
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: aws-creds
+            key: awsAccessKey
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: aws-creds
+            key: awsSecretAccessKey
 ----
 <1> The Kafka Connect version.
 <2> The number of replica nodes.
@@ -146,6 +202,15 @@ Standard Apache Kafka configuration may be provided, restricted to those propert
 <26> Topic replication from the source cluster defined as regular expression patterns. Here we request all topics.
 <27> Consumer group replication from the source cluster defined as regular expression patterns. Here we request three consumer groups by name.
 You can use comma-separated lists.
+<28> Requests for reservation of supported resources, currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
+<29> Specified loggers and log levels added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. Kafka Connect has a single logger called `connect.root.logger.level`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<30> Healthchecks to know when to restart a container (liveness) and when a container can accept traffic (readiness).
+<31> JVM configuration options to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
+<32> ADVANCED OPTION: Container image configuration, which is xref:con-configuring-container-images-deployment-configuration-kafka-mirror-maker[recommended only in special situations].
+<33> xref:assembly-customizing-deployments-str[Template customization]. Here a pod is scheduled based with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
+Environment variables are also set for distributed tracing using Jaeger.
+<34> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
+<35> Kubernetes Secret mounted to Kafka Connect as an environment variable.
 
 . Create or update the resource:
 +

--- a/documentation/modules/mirrormaker2/proc-mirrormaker-replication.adoc
+++ b/documentation/modules/mirrormaker2/proc-mirrormaker-replication.adoc
@@ -150,7 +150,7 @@ spec:
                       - postgresql
                       - mongodb
               topologyKey: "kubernetes.io/hostname"
-    connectContainer: 1
+    connectContainer: <34>
       env:
         - name: JAEGER_SERVICE_NAME
           value: my-jaeger-service
@@ -159,8 +159,8 @@ spec:
         - name: JAEGER_AGENT_PORT
           value: "6831"
   tracing:
-    type: jaeger <34>
-  externalConfiguration: <35>
+    type: jaeger <35>
+  externalConfiguration: <36>
     env:
       - name: AWS_ACCESS_KEY_ID
         valueFrom:
@@ -208,9 +208,9 @@ You can use comma-separated lists.
 <31> JVM configuration options to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
 <32> ADVANCED OPTION: Container image configuration, which is xref:con-configuring-container-images-deployment-configuration-kafka-mirror-maker[recommended only in special situations].
 <33> xref:assembly-customizing-deployments-str[Template customization]. Here a pod is scheduled based with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-Environment variables are also set for distributed tracing using Jaeger.
-<34> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
-<35> Kubernetes Secret mounted to Kafka Connect as an environment variable.
+<34> Environment variables are also xref:ref-tracing-environment-variables-{context}[set for distributed tracing using Jaeger].
+<35> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
+<36> Kubernetes Secret mounted to Kafka MirroMaker as an environment variable.
 
 . Create or update the resource:
 +

--- a/documentation/modules/mirrormaker2/proc-mirrormaker-replication.adoc
+++ b/documentation/modules/mirrormaker2/proc-mirrormaker-replication.adoc
@@ -208,7 +208,7 @@ You can use comma-separated lists.
 <31> JVM configuration options to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
 <32> ADVANCED OPTION: Container image configuration, which is xref:con-configuring-container-images-deployment-configuration-kafka-mirror-maker[recommended only in special situations].
 <33> xref:assembly-customizing-deployments-str[Template customization]. Here a pod is scheduled based with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<34> Environment variables are also xref:ref-tracing-environment-variables-{context}[set for distributed tracing using Jaeger].
+<34> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
 <35> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
 <36> Kubernetes Secret mounted to Kafka MirroMaker as an environment variable.
 

--- a/documentation/modules/proc-configuring-mirror-maker.adoc
+++ b/documentation/modules/proc-configuring-mirror-maker.adoc
@@ -114,7 +114,15 @@ spec:
                       - postgresql
                       - mongodb
               topologyKey: "kubernetes.io/hostname"
-  tracing: <20>
+    connectContainer: <20>
+      env:
+        - name: JAEGER_SERVICE_NAME
+          value: my-jaeger-service
+        - name: JAEGER_AGENT_HOST
+          value: jaeger-agent-name
+        - name: JAEGER_AGENT_PORT
+          value: "6831
+  tracing: <21>
     type: jaeger
 ----
 <1> The number of replica nodes.
@@ -136,7 +144,8 @@ spec:
 <17> JVM configuration options to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
 <18> ADVANCED OPTION: Container image configuration, which is xref:con-configuring-container-images-{context}[recommended only in special situations].
 <19> xref:assembly-customizing-deployments-str[Template customization]. Here a pod is scheduled based with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<20> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
+<20> Environment variables are also xref:ref-tracing-environment-variables-{context}[set for distributed tracing using Jaeger].
+<21> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
 +
 WARNING: With the `abortOnSendFailure` property set to `false`, the producer attempts to send the next message in a topic. The original message might be lost, as there is no attempt to resend a failed message.
 

--- a/documentation/modules/proc-configuring-mirror-maker.adoc
+++ b/documentation/modules/proc-configuring-mirror-maker.adoc
@@ -144,7 +144,7 @@ spec:
 <17> JVM configuration options to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
 <18> ADVANCED OPTION: Container image configuration, which is xref:con-configuring-container-images-{context}[recommended only in special situations].
 <19> xref:assembly-customizing-deployments-str[Template customization]. Here a pod is scheduled based with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<20> Environment variables are also xref:ref-tracing-environment-variables-{context}[set for distributed tracing using Jaeger].
+<20> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
 <21> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
 +
 WARNING: With the `abortOnSendFailure` property set to `false`, the producer attempts to send the next message in a topic. The original message might be lost, as there is no attempt to resend a failed message.

--- a/documentation/modules/proc-configuring-mirror-maker.adoc
+++ b/documentation/modules/proc-configuring-mirror-maker.adoc
@@ -114,8 +114,9 @@ spec:
                       - postgresql
                       - mongodb
               topologyKey: "kubernetes.io/hostname"
+  tracing: <20>
+    type: jaeger
 ----
-+
 <1> The number of replica nodes.
 <2> Bootstrap servers for consumer and producer.
 <3> Group ID for the consumer.
@@ -135,6 +136,7 @@ spec:
 <17> JVM configuration options to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
 <18> ADVANCED OPTION: Container image configuration, which is xref:con-configuring-container-images-{context}[recommended only in special situations].
 <19> xref:assembly-customizing-deployments-str[Template customization]. Here a pod is scheduled based with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
+<20> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
 +
 WARNING: With the `abortOnSendFailure` property set to `false`, the producer attempts to send the next message in a topic. The original message might be lost, as there is no attempt to resend a failed message.
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Common config properties have been added to the MirrorMaker 2.0 configuration procedure.
Also showing tracing config for MirrorMaker and MirrorMaker 2.0.
The old section has been split to have specific sections for MirrorMaker and MirrorMaker 2.0.

This PR fixes #2987.

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

