### PR TITLE
Added tini for running components where missing

### DIFF
--- a/docker-images/jmxtrans/docker-entrypoint.sh
+++ b/docker-images/jmxtrans/docker-entrypoint.sh
@@ -17,9 +17,9 @@ MONITOR_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=
               -Djava.rmi.server.hostname=${PROXY_HOST}"
 
 if [ "$1" = 'start-without-jmx' ]; then
-    set /usr/bin/tini -- java -server $JAVA_OPTS $JMXTRANS_OPTS $GC_OPTS $EXEC
+    set /usr/bin/tini -w -e 143 -- java -server $JAVA_OPTS $JMXTRANS_OPTS $GC_OPTS $EXEC
 elif [ "$1" = 'start-with-jmx' ]; then
-    set /usr/bin/tini -- java -server $JAVA_OPTS $JMXTRANS_OPTS $GC_OPTS $MONITOR_OPTS $EXEC
+    set /usr/bin/tini -w -e 143 -- java -server $JAVA_OPTS $JMXTRANS_OPTS $GC_OPTS $MONITOR_OPTS $EXEC
 fi
 
 exec "$@"

--- a/docker-images/kafka/cruise-control-scripts/cruise_control_run.sh
+++ b/docker-images/kafka/cruise-control-scripts/cruise_control_run.sh
@@ -49,4 +49,4 @@ if [ -z "$KAFKA_JVM_PERFORMANCE_OPTS" ]; then
 fi
 
 # starting Cruise Control server with final configuration
-exec java ${KAFKA_HEAP_OPTS} ${KAFKA_JVM_PERFORMANCE_OPTS} ${KAFKA_GC_LOG_OPTS} ${KAFKA_JMX_OPTS} ${KAFKA_LOG4J_OPTS} ${KAFKA_OPTS} -classpath ${CLASSPATH} com.linkedin.kafka.cruisecontrol.KafkaCruiseControlMain /tmp/cruisecontrol.properties
+exec /usr/bin/tini -w -e 143 -- java ${KAFKA_HEAP_OPTS} ${KAFKA_JVM_PERFORMANCE_OPTS} ${KAFKA_GC_LOG_OPTS} ${KAFKA_JMX_OPTS} ${KAFKA_LOG4J_OPTS} ${KAFKA_OPTS} -classpath ${CLASSPATH} com.linkedin.kafka.cruisecontrol.KafkaCruiseControlMain /tmp/cruisecontrol.properties

--- a/docker-images/kafka/exporter-scripts/kafka_exporter_run.sh
+++ b/docker-images/kafka/exporter-scripts/kafka_exporter_run.sh
@@ -47,4 +47,4 @@ EOT
 
 chmod +x /tmp/run.sh
 
-exec /tmp/run.sh
+exec /usr/bin/tini -w -e 143 -- /tmp/run.sh

--- a/docker-images/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka/scripts/kafka_connect_run.sh
@@ -58,4 +58,4 @@ fi
 . ./set_kafka_gc_options.sh
 
 # starting Kafka server with final configuration
-exec /usr/bin/tini -w -e 143 -- sh -c "${KAFKA_HOME}/bin/connect-distributed.sh /tmp/strimzi-connect.properties"
+exec /usr/bin/tini -w -e 143 -- ${KAFKA_HOME}/bin/connect-distributed.sh /tmp/strimzi-connect.properties

--- a/docker-images/kafka/scripts/kafka_mirror_maker_run.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_run.sh
@@ -106,7 +106,7 @@ fi
 . ./set_kafka_gc_options.sh
 
 # starting Kafka Mirror Maker with final configuration
-exec $KAFKA_HOME/bin/kafka-mirror-maker.sh \
+exec /usr/bin/tini -w -e 143 -- $KAFKA_HOME/bin/kafka-mirror-maker.sh \
 --consumer.config /tmp/strimzi-consumer.properties \
 --producer.config /tmp/strimzi-producer.properties \
 $whitelist \

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -82,4 +82,4 @@ fi
 . ./set_kafka_gc_options.sh
 
 # starting Kafka server with final configuration
-exec /usr/bin/tini -w -e 143 -- sh -c "${KAFKA_HOME}/bin/kafka-server-start.sh /tmp/strimzi.properties"
+exec /usr/bin/tini -w -e 143 -- ${KAFKA_HOME}/bin/kafka-server-start.sh /tmp/strimzi.properties

--- a/docker-images/kafka/scripts/zookeeper_run.sh
+++ b/docker-images/kafka/scripts/zookeeper_run.sh
@@ -69,4 +69,4 @@ KAFKA_OPTS="$KAFKA_OPTS -Dzookeeper.skipACL=yes"
 export KAFKA_OPTS
 
 # starting Zookeeper with final configuration
-exec /usr/bin/tini -w -e 143 -- sh -c "${KAFKA_HOME}/bin/zookeeper-server-start.sh /tmp/zookeeper.properties"
+exec /usr/bin/tini -w -e 143 -- ${KAFKA_HOME}/bin/zookeeper-server-start.sh /tmp/zookeeper.properties

--- a/docker-images/kafka/stunnel-scripts/cruise_control_stunnel_run.sh
+++ b/docker-images/kafka/stunnel-scripts/cruise_control_stunnel_run.sh
@@ -7,4 +7,4 @@ ${STUNNEL_HOME}/cruise_control_stunnel_config_generator.sh | tee /tmp/stunnel.co
 echo ""
 
 # starting Stunnel with final configuration
-exec /usr/bin/stunnel /tmp/stunnel.conf
+exec /usr/bin/tini -w -e 143 -- /usr/bin/stunnel /tmp/stunnel.conf

--- a/docker-images/kafka/stunnel-scripts/entity_operator_stunnel_run.sh
+++ b/docker-images/kafka/stunnel-scripts/entity_operator_stunnel_run.sh
@@ -7,4 +7,4 @@ ${STUNNEL_HOME}/entity_operator_stunnel_config_generator.sh | tee /tmp/stunnel.c
 echo ""
 
 # starting Stunnel with final configuration
-exec /usr/bin/stunnel /tmp/stunnel.conf
+exec /usr/bin/tini -w -e 143 -- /usr/bin/stunnel /tmp/stunnel.conf

--- a/docker-images/kafka/stunnel-scripts/kafka_stunnel_run.sh
+++ b/docker-images/kafka/stunnel-scripts/kafka_stunnel_run.sh
@@ -9,4 +9,4 @@ ${STUNNEL_HOME}/kafka_stunnel_config_generator.sh | tee /tmp/stunnel.conf
 echo ""
 
 # starting Stunnel with final configuration
-exec /usr/bin/stunnel /tmp/stunnel.conf
+exec /usr/bin/tini -w -e 143 -- /usr/bin/stunnel /tmp/stunnel.conf


### PR DESCRIPTION
Removing "sh -c" command where it's in place

Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Refactoring

### Description

This PR fixes #3073.
It adds tini for running components where missing and remove `sh -c` command where it's in place

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

