### PR TITLE
Bump Vert.x dependency to 3.9.1

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-junit5</artifactId>
-            <version>${vertx-juni5.version}</version>
+            <version>${vertx-junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -134,7 +134,7 @@ public class ClusterOperator extends AbstractVerticle {
                     });
                     return startHealthServer().map((Void) null);
                 })
-                .setHandler(start);
+                .onComplete(start);
     }
 
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -78,13 +78,13 @@ public class Main {
         
         KubernetesClient client = new DefaultKubernetesClient();
 
-        maybeCreateClusterRoles(vertx, config, client).setHandler(crs -> {
+        maybeCreateClusterRoles(vertx, config, client).onComplete(crs -> {
             if (crs.succeeded())    {
-                PlatformFeaturesAvailability.create(vertx, client).setHandler(pfa -> {
+                PlatformFeaturesAvailability.create(vertx, client).onComplete(pfa -> {
                     if (pfa.succeeded()) {
                         log.info("Environment facts gathered: {}", pfa.result());
 
-                        run(vertx, client, pfa.result(), config).setHandler(ar -> {
+                        run(vertx, client, pfa.result(), config).onComplete(ar -> {
                             if (ar.failed()) {
                                 log.error("Unable to start operator for 1 or more namespace", ar.cause());
                                 System.exit(1);
@@ -200,7 +200,7 @@ public class Main {
             }
 
             Promise<Void> returnPromise = Promise.promise();
-            CompositeFuture.all(futures).setHandler(res -> {
+            CompositeFuture.all(futures).onComplete(res -> {
                 if (res.succeeded())    {
                     returnPromise.complete();
                 } else  {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -320,7 +320,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
         Handler<Long> handler = new Handler<Long>() {
             @Override
             public void handle(Long tid) {
-                supplier.get().setHandler(connectorStatus -> {
+                supplier.get().onComplete(connectorStatus -> {
                     if (connectorStatus.succeeded()) {
                         result.complete(connectorStatus.result());
                     } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -147,7 +147,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                 .compose(i -> deploymentOperations.waitForObserved(namespace, connect.getName(), 1_000, operationTimeoutMs))
                 .compose(i -> connectHasZeroReplicas ? Future.succeededFuture() : deploymentOperations.readiness(namespace, connect.getName(), 1_000, operationTimeoutMs))
                 .compose(i -> reconcileConnectors(reconciliation, kafkaConnect, kafkaConnectStatus, connectHasZeroReplicas))
-                .setHandler(reconciliationResult -> {
+                .onComplete(reconciliationResult -> {
                     StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnect, kafkaConnectStatus, reconciliationResult);
 
                     if (!connectHasZeroReplicas) {
@@ -155,7 +155,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                     }
 
                     this.maybeUpdateStatusCommon(resourceOperator, kafkaConnect, reconciliation, kafkaConnectStatus,
-                        (connect1, status) -> new KafkaConnectBuilder(connect1).withStatus(status).build()).setHandler(statusResult -> {
+                        (connect1, status) -> new KafkaConnectBuilder(connect1).withStatus(status).build()).onComplete(statusResult -> {
                             // If both features succeeded, createOrUpdate succeeded as well
                             // If one or both of them failed, we prefer the reconciliation failure as the main error
                             if (reconciliationResult.succeeded() && statusResult.succeeded()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -103,10 +103,10 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
                 .compose(i -> deploymentOperations.scaleUp(namespace, mirror.getName(), mirror.getReplicas()))
                 .compose(i -> deploymentOperations.waitForObserved(namespace, mirror.getName(), 1_000, operationTimeoutMs))
                 .compose(i -> deploymentOperations.readiness(namespace, mirror.getName(), 1_000, operationTimeoutMs))
-                .setHandler(reconciliationResult -> {
+                .onComplete(reconciliationResult -> {
                         StatusUtils.setStatusConditionAndObservedGeneration(assemblyResource, kafkaMirrorMakerStatus, reconciliationResult);
 
-                        updateStatus(assemblyResource, reconciliation, kafkaMirrorMakerStatus).setHandler(statusResult -> {
+                        updateStatus(assemblyResource, reconciliation, kafkaMirrorMakerStatus).onComplete(statusResult -> {
                             // If both features succeeded, createOrUpdate succeeded as well
                             // If one or both of them failed, we prefer the reconciliation failure as the main error
                             if (reconciliationResult.succeeded() && statusResult.succeeded()) {
@@ -135,7 +135,7 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
     Future<Void> updateStatus(KafkaMirrorMaker kafkaMirrorMakerAssembly, Reconciliation reconciliation, KafkaMirrorMakerStatus desiredStatus) {
         Promise<Void> updateStatusPromise = Promise.promise();
 
-        resourceOperator.getAsync(kafkaMirrorMakerAssembly.getMetadata().getNamespace(), kafkaMirrorMakerAssembly.getMetadata().getName()).setHandler(getRes -> {
+        resourceOperator.getAsync(kafkaMirrorMakerAssembly.getMetadata().getNamespace(), kafkaMirrorMakerAssembly.getMetadata().getName()).onComplete(getRes -> {
             if (getRes.succeeded()) {
                 KafkaMirrorMaker mirrorMaker = getRes.result();
 
@@ -151,7 +151,7 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
                         if (!ksDiff.isEmpty()) {
                             KafkaMirrorMaker resourceWithNewStatus = new KafkaMirrorMakerBuilder(mirrorMaker).withStatus(desiredStatus).build();
 
-                            ((CrdOperator<KubernetesClient, KafkaMirrorMaker, KafkaMirrorMakerList, DoneableKafkaMirrorMaker>) resourceOperator).updateStatusAsync(resourceWithNewStatus).setHandler(updateRes -> {
+                            ((CrdOperator<KubernetesClient, KafkaMirrorMaker, KafkaMirrorMakerList, DoneableKafkaMirrorMaker>) resourceOperator).updateStatusAsync(resourceWithNewStatus).onComplete(updateRes -> {
                                 if (updateRes.succeeded()) {
                                     log.debug("{}: Completed status update", reconciliation);
                                     updateStatusPromise.complete();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -155,7 +155,7 @@ public class KafkaRoller {
             futures.add(schedule(podId, 0, TimeUnit.MILLISECONDS));
         }
         Promise<Void> result = Promise.promise();
-        CompositeFuture.join(futures).setHandler(ar -> {
+        CompositeFuture.join(futures).onComplete(ar -> {
             singleExecutor.shutdown();
             vertx.runOnContext(ignored -> result.handle(ar.map((Void) null)));
         });
@@ -393,7 +393,7 @@ public class KafkaRoller {
                                             Function<Throwable, E> exceptionMapper)
             throws E, InterruptedException {
         CompletableFuture<T> cf = new CompletableFuture<>();
-        future.setHandler(ar -> {
+        future.onComplete(ar -> {
             if (ar.succeeded()) {
                 cf.complete(ar.result());
             } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -119,7 +119,7 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
         String namespace = sts.getMetadata().getNamespace();
         Promise<Void> promise = Promise.promise();
         Future<ReconcileResult<PersistentVolumeClaim>> r = pvcOperations.reconcile(namespace, pvcName, null);
-        r.setHandler(h -> {
+        r.onComplete(h -> {
             if (h.succeeded()) {
                 promise.complete();
             } else {
@@ -253,7 +253,7 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
         crt.compose(res -> readiness(namespace, desired.getMetadata().getName(), 1_000, operationTimeoutMs).map(res))
         // ... then wait for all the pods to be ready
             .compose(res -> podReadiness(namespace, desired, 1_000, operationTimeoutMs).map(res))
-            .setHandler(result);
+            .onComplete(result);
 
         return result.future();
     }
@@ -331,7 +331,7 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
                 return sts == null;
             });
 
-            deletedFut.setHandler(res -> {
+            deletedFut.onComplete(res -> {
                 if (res.succeeded())    {
                     StatefulSet result = operation().inNamespace(namespace).withName(name).create(desired);
                     log.debug("{} {} in namespace {} has been replaced", resourceKind, name, namespace);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
@@ -162,7 +162,7 @@ public class ZookeeperLeaderFinder {
         Handler<Long> handler = new Handler<Long>() {
             @Override
             public void handle(Long tid) {
-                zookeeperLeader(pods, netClientOptions).setHandler(leader -> {
+                zookeeperLeader(pods, netClientOptions).onComplete(leader -> {
                     if (leader.succeeded()) {
                         if (leader.result() != UNKNOWN_LEADER) {
                             result.complete(leader.result());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
@@ -95,7 +95,7 @@ public class ZookeeperScaler implements AutoCloseable {
 
                     getCurrentConfig(zkAdmin)
                             .compose(servers -> scaleTo(zkAdmin, servers, scaleTo))
-                            .setHandler(res -> {
+                            .onComplete(res -> {
                                 closeConnection(zkAdmin);
 
                                 if (res.succeeded())    {
@@ -148,7 +148,7 @@ public class ZookeeperScaler implements AutoCloseable {
                 1_000,
                 operationTimeoutMs,
                 () -> zkAdmin.getState().isAlive() && zkAdmin.getState().isConnected())
-                .setHandler(res -> {
+                .onComplete(res -> {
                     if (res.succeeded())  {
                         connected.complete(zkAdmin);
                     } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
@@ -114,7 +114,7 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
                         return maybeRestartPod(sts, KafkaResources.zookeeperPodName(cluster, leader), podRestart);
                     });
                 }
-            }).setHandler(rollFuture);
+            }).onComplete(rollFuture);
         } else {
             rollFuture = Future.succeededFuture();
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -168,7 +168,7 @@ public class ClusterOperatorTest {
         Checkpoint async = context.checkpoint();
         Main.run(vertx, client, new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_9),
                     ClusterOperatorConfig.fromMap(env, KafkaVersionTestUtils.getKafkaVersionLookup()))
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat("A verticle per namespace", vertx.deploymentIDs(), hasSize(namespaceList.size()));
 
                 for (String deploymentId: vertx.deploymentIDs()) {
@@ -237,7 +237,7 @@ public class ClusterOperatorTest {
         Checkpoint async = context.checkpoint();
         Main.run(vertx, client, new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_9),
                 ClusterOperatorConfig.fromMap(env, KafkaVersionTestUtils.getKafkaVersionLookup()))
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat("A verticle per namespace", vertx.deploymentIDs(), hasSize(1));
                 for (String deploymentId: vertx.deploymentIDs()) {
                     vertx.undeploy(deploymentId, context.succeeding());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/MainIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/MainIT.java
@@ -69,7 +69,7 @@ public class MainIT {
 
         Checkpoint a = context.checkpoint();
         Main.maybeCreateClusterRoles(vertx, config, client)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat(cro.get("strimzi-cluster-operator-namespaced"), is(notNullValue()));
                 assertThat(cro.get("strimzi-cluster-operator-global"), is(notNullValue()));
                 assertThat(cro.get("strimzi-kafka-broker"), is(notNullValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -160,7 +160,7 @@ public class CertificateRenewalTest {
 
         Promise reconcileCasComplete = Promise.promise();
         op.new ReconciliationState(reconciliation, kafka).reconcileCas(dateSupplier)
-            .setHandler(ar -> {
+            .onComplete(ar -> {
                 // If succeeded return the argument captor object instead of the Reconciliation state
                 // This is for the purposes of testing
                 // If failed then return the throwable of the reconcileCas
@@ -263,7 +263,7 @@ public class CertificateRenewalTest {
 
         Checkpoint async = context.checkpoint();
         reconcileCa(context, certificateAuthority, certificateAuthority)
-            .setHandler(context.succeeding(c -> context.verify(() -> {
+            .onComplete(context.succeeding(c -> context.verify(() -> {
                 assertThat(c.getAllValues(), hasSize(4));
 
                 assertThat(c.getAllValues().get(0).getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
@@ -290,7 +290,7 @@ public class CertificateRenewalTest {
 
         Checkpoint async = context.checkpoint();
         reconcileCa(context, certificateAuthority, certificateAuthority)
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(InvalidConfigurationException.class));
                 assertThat(e.getMessage(), is("Cluster CA should not be generated, but the secrets were not found."));
                 async.flag();
@@ -349,7 +349,7 @@ public class CertificateRenewalTest {
         Checkpoint async = context.checkpoint();
 
         reconcileCa(context, certificateAuthority, certificateAuthority)
-            .setHandler(context.succeeding(c -> context.verify(() -> {
+            .onComplete(context.succeeding(c -> context.verify(() -> {
                 assertThat(c.getAllValues().get(0).getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
                 assertThat(c.getAllValues().get(0).getData().get(CA_CRT), is(initialClusterCaCertSecret.getData().get(CA_CRT)));
                 assertDoesNotThrow(() -> {
@@ -403,7 +403,7 @@ public class CertificateRenewalTest {
 
         Checkpoint async = context.checkpoint();
         reconcileCa(context, certificateAuthority, certificateAuthority)
-            .setHandler(context.succeeding(c -> context.verify(() -> {
+            .onComplete(context.succeeding(c -> context.verify(() -> {
                 assertThat(c.getAllValues(), hasSize(4));
 
                 Map<String, String> clusterCaCertData = c.getAllValues().get(0).getData();
@@ -486,7 +486,7 @@ public class CertificateRenewalTest {
 
         Checkpoint async = context.checkpoint();
         reconcileCa(context, certificateAuthority, certificateAuthority)
-            .setHandler(context.succeeding(c -> context.verify(() -> {
+            .onComplete(context.succeeding(c -> context.verify(() -> {
                 assertThat(c.getAllValues(), hasSize(4));
 
                 Map<String, String> clusterCaCertData = c.getAllValues().get(0).getData();
@@ -584,7 +584,7 @@ public class CertificateRenewalTest {
 
         Checkpoint async = context.checkpoint();
         reconcileCa(context, kafka, () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 00, 0).atZone(ZoneId.of("GMT")).toInstant()))
-            .setHandler(context.succeeding(c -> context.verify(() -> {
+            .onComplete(context.succeeding(c -> context.verify(() -> {
                 assertThat(c.getAllValues(), hasSize(4));
 
                 Map<String, String> clusterCaCertData = c.getAllValues().get(0).getData();
@@ -685,7 +685,7 @@ public class CertificateRenewalTest {
 
         Checkpoint async = context.checkpoint();
         reconcileCa(context, kafka, () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 12, 0).atZone(ZoneId.of("GMT")).toInstant()))
-            .setHandler(context.succeeding(c -> context.verify(() -> {
+            .onComplete(context.succeeding(c -> context.verify(() -> {
                 assertThat(c.getAllValues().size(), is(4));
 
                 Map<String, String> clusterCaCertData = c.getAllValues().get(0).getData();
@@ -774,7 +774,7 @@ public class CertificateRenewalTest {
 
         Checkpoint async = context.checkpoint();
         reconcileCa(context, certificateAuthority, certificateAuthority)
-            .setHandler(context.succeeding(c -> context.verify(() -> {
+            .onComplete(context.succeeding(c -> context.verify(() -> {
                 assertThat(c.getAllValues(), hasSize(4));
 
                 Map<String, String> clusterCaCertData = c.getAllValues().get(0).getData();
@@ -889,7 +889,7 @@ public class CertificateRenewalTest {
 
         Checkpoint async = context.checkpoint();
         reconcileCa(context, kafka, () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 0, 0).atZone(ZoneId.of("GMT")).toInstant()))
-            .setHandler(context.succeeding(c -> context.verify(() -> {
+            .onComplete(context.succeeding(c -> context.verify(() -> {
                 assertThat(c.getAllValues(), hasSize(4));
 
                 Map<String, String> clusterCaCertData = c.getAllValues().get(0).getData();
@@ -989,7 +989,7 @@ public class CertificateRenewalTest {
 
         Checkpoint async = context.checkpoint();
         reconcileCa(context, kafka, () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 12, 0).atZone(ZoneId.of("GMT")).toInstant()))
-            .setHandler(context.succeeding(c -> context.verify(() -> {
+            .onComplete(context.succeeding(c -> context.verify(() -> {
 
                 assertThat(c.getAllValues(), hasSize(4));
 
@@ -1132,7 +1132,7 @@ public class CertificateRenewalTest {
 
         Checkpoint async = context.checkpoint();
         reconcileCa(context, certificateAuthority, certificateAuthority)
-            .setHandler(context.succeeding(c -> context.verify(() -> {
+            .onComplete(context.succeeding(c -> context.verify(() -> {
                 assertThat(c.getAllValues(), hasSize(4));
 
                 Map<String, String> clusterCaCertData = c.getAllValues().get(0).getData();
@@ -1196,7 +1196,7 @@ public class CertificateRenewalTest {
 
         Checkpoint async = context.checkpoint();
         reconcileCa(context, certificateAuthority, certificateAuthority)
-            .setHandler(context.succeeding(c -> context.verify(() -> {
+            .onComplete(context.succeeding(c -> context.verify(() -> {
                 assertThat(c.getAllValues(), hasSize(0));
                 async.flag();
             })));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -275,7 +275,7 @@ public class ConnectorMockTest {
         Checkpoint async = testContext.checkpoint();
         // Fail test if watcher closes for any reason
         kafkaConnectOperator.createWatch(NAMESPACE, e -> testContext.failNow(e))
-            .setHandler(testContext.succeeding())
+            .onComplete(testContext.succeeding())
             .compose(watch -> {
                 kafkaConnectS2iOperator = new KafkaConnectS2IAssemblyOperator(vertx,
                     pfa,
@@ -285,9 +285,9 @@ public class ConnectorMockTest {
                 // Fail test if watcher closes for any reason
                 return kafkaConnectS2iOperator.createWatch(NAMESPACE, e -> testContext.failNow(e));
             })
-            .setHandler(testContext.succeeding())
+            .onComplete(testContext.succeeding())
             .compose(watch -> AbstractConnectOperator.createConnectorWatch(kafkaConnectOperator, kafkaConnectS2iOperator, NAMESPACE))
-            .setHandler(testContext.succeeding(v -> async.flag()));
+            .onComplete(testContext.succeeding(v -> async.flag()));
     }
 
     private static <T extends HasMetadata & HasStatus<?>> Predicate<T> statusIsForCurrentGeneration() {
@@ -802,7 +802,7 @@ public class ConnectorMockTest {
         // Force reconciliation to assert connector deletion request occurs for first cluster
         Checkpoint async = context.checkpoint();
         kafkaConnectOperator.reconcile(new Reconciliation("test", "KafkaConnect", NAMESPACE, oldConnectClusterName))
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 verify(api, times(1)).delete(
                         eq(KafkaConnectResources.qualifiedServiceName(oldConnectClusterName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                         eq(connectorName));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
@@ -144,7 +144,7 @@ public class JbodStorageTest {
     public void testJbodStorageCreatesPersistentVolumeClaimsMatchingKafkaVolumes(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
         operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME))
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 List<PersistentVolumeClaim> pvcs = getPvcs(NAMESPACE, NAME);
 
                 for (int i = 0; i < this.kafka.getSpec().getKafka().getReplicas(); i++) {
@@ -197,7 +197,7 @@ public class JbodStorageTest {
 
         // reconcile for kafka cluster creation
         operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME))
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 List<PersistentVolumeClaim> pvcs = getPvcs(NAMESPACE, NAME);
                 Set<String> pvcsNames = pvcs.stream().map(pvc -> pvc.getMetadata().getName()).collect(Collectors.toSet());
                 assertThat(pvcsNames, is(expectedPvcs));
@@ -207,7 +207,7 @@ public class JbodStorageTest {
                 // reconcile kafka cluster with new Jbod storage
                 return operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME));
             })
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 List<PersistentVolumeClaim> pvcs = getPvcs(NAMESPACE, NAME);
                 Set<String> pvcsNames = pvcs.stream().map(pvc -> pvc.getMetadata().getName()).collect(Collectors.toSet());
                 assertThat(pvcsNames, is(expectedPvcsWithNewJbodStorageVolume));
@@ -237,7 +237,7 @@ public class JbodStorageTest {
 
         // reconcile for kafka cluster creation
         operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME))
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 List<PersistentVolumeClaim> pvcs = getPvcs(NAMESPACE, NAME);
                 Set<String> pvcsNames = pvcs.stream().map(pvc -> pvc.getMetadata().getName()).collect(Collectors.toSet());
                 assertThat(pvcsNames, is(expectedPvcs));
@@ -247,7 +247,7 @@ public class JbodStorageTest {
                 // reconcile kafka cluster with a Jbod storage volume removed
                 return operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME));
             })
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 List<PersistentVolumeClaim> pvcs = getPvcs(NAMESPACE, NAME);
                 Set<String> pvcsNames = pvcs.stream().map(pvc -> pvc.getMetadata().getName()).collect(Collectors.toSet());
                 assertThat(pvcsNames, is(expectedPvcsWithRemovedJbodStorageVolume));
@@ -276,7 +276,7 @@ public class JbodStorageTest {
 
         // reconcile for kafka cluster creation
         operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME))
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 List<PersistentVolumeClaim> pvcs = getPvcs(NAMESPACE, NAME);
                 Set<String> pvcsNames = pvcs.stream().map(pvc -> pvc.getMetadata().getName()).collect(Collectors.toSet());
                 assertThat(pvcsNames, is(expectedPvcs));
@@ -286,7 +286,7 @@ public class JbodStorageTest {
                 // reconcile kafka cluster with a Jbod storage volume removed
                 return operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME));
             })
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 List<PersistentVolumeClaim> pvcs = getPvcs(NAMESPACE, NAME);
                 Set<String> pvcsNames = pvcs.stream().map(pvc -> pvc.getMetadata().getName()).collect(Collectors.toSet());
                 assertThat(pvcsNames, is(expectedPvcsWithUpdatedJbodStorageVolume));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
@@ -238,7 +238,7 @@ public class KafkaAssemblyOperatorCustomCertTest {
     public void testPodToRestartFalseWhenCustomCertAnnotationsHaveMatchingThumbprints(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
         operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat(reconcileStsCaptor.getAllValues(), hasSize(1));
 
                 StatefulSet reconcileSts = reconcileStsCaptor.getValue();
@@ -259,7 +259,7 @@ public class KafkaAssemblyOperatorCustomCertTest {
     public void testPodToRestartTrueWhenCustomCertTlsListenerThumbprintAnnotationsNotMatchingThumbprint(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
         operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat(reconcileStsCaptor.getAllValues(), hasSize(1));
 
                 StatefulSet reconcileSts = reconcileStsCaptor.getValue();
@@ -288,7 +288,7 @@ public class KafkaAssemblyOperatorCustomCertTest {
     public void testPodToRestartTrueWhenCustomCertExternalListenerThumbprintAnnotationsNotMatchingThumbprint(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
         operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat(reconcileStsCaptor.getAllValues(), hasSize(1));
 
                 StatefulSet reconcileSts = reconcileStsCaptor.getValue();
@@ -338,7 +338,7 @@ public class KafkaAssemblyOperatorCustomCertTest {
 
         Checkpoint async = context.checkpoint();
         operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat(reconcileStsCaptor.getAllValues(), hasSize(1));
 
                 StatefulSet reconcileSts = reconcileStsCaptor.getValue();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -618,7 +618,7 @@ public class KafkaAssemblyOperatorTest {
         // Now try to create a KafkaCluster based on this CM
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 // No metrics config  => no CMs created
                 Set<String> logsAndMetricsNames = new HashSet<>();
@@ -1170,7 +1170,7 @@ public class KafkaAssemblyOperatorTest {
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, clusterNamespace, clusterName),
                 updatedAssembly)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 // rolling restart
                 Set<String> expectedRollingRestarts = set();
                 if (KafkaSetOperator.needsRollingUpdate(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -146,7 +146,7 @@ public class KafkaBridgeAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 // Verify service
                 List<Service> capturedServices = serviceCaptor.getAllValues();
                 assertThat(capturedServices, hasSize(1));
@@ -241,7 +241,7 @@ public class KafkaBridgeAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 // Verify service
                 List<Service> capturedServices = serviceCaptor.getAllValues();
@@ -349,7 +349,7 @@ public class KafkaBridgeAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 KafkaBridgeCluster compareTo = KafkaBridgeCluster.fromCrd(clusterCm,
                         VERSIONS);
@@ -448,7 +448,7 @@ public class KafkaBridgeAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.failing(e -> async.flag()));
+            .onComplete(context.failing(e -> async.flag()));
     }
 
     @Test
@@ -498,7 +498,7 @@ public class KafkaBridgeAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 verify(mockDcOps).scaleUp(clusterCmNamespace, bridge.getName(), scaleTo);
 
                 async.flag();
@@ -558,7 +558,7 @@ public class KafkaBridgeAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), scaledDownCluster)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 verify(mockDcOps).scaleUp(clusterCmNamespace, bridge.getName(), scaleTo);
                 verify(mockDcOps).scaleDown(clusterCmNamespace, bridge.getName(), scaleTo);
                 async.flag();
@@ -630,7 +630,7 @@ public class KafkaBridgeAssemblyOperatorTest {
         // Now try to reconcile all the Kafka Bridge clusters
         ops.reconcileAll("test", clusterCmNamespace, v -> reconciled.complete());
 
-        reconciled.future().setHandler(context.succeeding(v -> context.verify(() -> {
+        reconciled.future().onComplete(context.succeeding(v -> context.verify(() -> {
             assertThat(createdOrUpdated, is(new HashSet(asList("foo", "bar"))));
             async.flag();
         })));
@@ -676,7 +676,7 @@ public class KafkaBridgeAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 // Verify status
                 List<KafkaBridge> capturedStatuses = bridgeCaptor.getAllValues();
                 assertThat(capturedStatuses.get(0).getStatus().getUrl(), is("http://foo-bridge-service.test.svc:8080"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiMockTest.java
@@ -44,7 +44,7 @@ public class KafkaConnectApiMockTest {
         Checkpoint async = context.checkpoint();
 
         api.statusWithBackOff(backOff, "some-host", 8083, "some-connector")
-            .setHandler(context.succeeding(res -> async.flag()));
+            .onComplete(context.succeeding(res -> async.flag()));
     }
 
     @Test
@@ -58,7 +58,7 @@ public class KafkaConnectApiMockTest {
         Checkpoint async = context.checkpoint();
 
         api.statusWithBackOff(backOff, "some-host", 8083, "some-connector")
-            .setHandler(context.succeeding(res -> async.flag()));
+            .onComplete(context.succeeding(res -> async.flag()));
     }
 
     @Test
@@ -73,7 +73,7 @@ public class KafkaConnectApiMockTest {
         Checkpoint async = context.checkpoint();
 
         api.statusWithBackOff(backOff, "some-host", 8083, "some-connector")
-            .setHandler(context.failing(res -> async.flag()));
+            .onComplete(context.failing(res -> async.flag()));
     }
 
     @Test
@@ -85,7 +85,7 @@ public class KafkaConnectApiMockTest {
         Checkpoint async = context.checkpoint();
 
         api.statusWithBackOff(backOff, "some-host", 8083, "some-connector")
-            .setHandler(context.failing(res -> async.flag()));
+            .onComplete(context.failing(res -> async.flag()));
     }
 
     class MockKafkaConnectApi extends KafkaConnectApiImpl   {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -122,7 +122,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
 
         LOGGER.info("Reconciling initially -> create");
         kco.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME))
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat(mockClient.apps().deployments().inNamespace(NAMESPACE).withName(KafkaConnectResources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue()));
                 assertThat(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaConnectResources.metricsAndLogConfigMapName(CLUSTER_NAME)).get(), is(notNullValue()));
                 assertThat(mockClient.services().inNamespace(NAMESPACE).withName(KafkaConnectResources.serviceName(CLUSTER_NAME)).get(), is(notNullValue()));
@@ -150,12 +150,12 @@ public class KafkaConnectAssemblyOperatorMockTest {
 
         Checkpoint async = context.checkpoint();
         createConnectCluster(context, mock)
-            .setHandler(context.succeeding())
+            .onComplete(context.succeeding())
             .compose(v -> {
                 LOGGER.info("Reconciling again -> update");
                 return kco.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME));
             })
-            .setHandler(context.succeeding(v -> async.flag()));
+            .onComplete(context.succeeding(v -> async.flag()));
 
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -155,7 +155,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCm.getMetadata().getNamespace(), clusterCm.getMetadata().getName()), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 // No metrics config  => no CMs created
                 Set<String> metricsNames = new HashSet<>();
                 if (connect.isMetricsEnabled()) {
@@ -294,7 +294,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 // Verify service
                 List<Service> capturedServices = serviceCaptor.getAllValues();
@@ -411,7 +411,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 KafkaConnectCluster compareTo = KafkaConnectCluster.fromCrd(clusterCm, VERSIONS);
 
                 // Verify service
@@ -504,7 +504,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.failing(v -> async.flag()));
+            .onComplete(context.failing(v -> async.flag()));
     }
 
     @Test
@@ -568,7 +568,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 verify(mockDcOps).scaleUp(clusterCmNamespace, connect.getName(), scaleTo);
                 async.flag();
             })));
@@ -635,7 +635,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 verify(mockDcOps).scaleUp(clusterCmNamespace, connect.getName(), scaleTo);
 
                 async.flag();
@@ -700,7 +700,7 @@ public class KafkaConnectAssemblyOperatorTest {
         // Now try to reconcile all the Kafka Connect clusters
         ops.reconcileAll("test", clusterCmNamespace, ignored -> reconciled.complete());
 
-        reconciled.future().setHandler(context.succeeding(v -> context.verify(() -> {
+        reconciled.future().onComplete(context.succeeding(v -> context.verify(() -> {
             assertThat(createdOrUpdated, is(new HashSet(asList("foo", "bar"))));
             async.flag();
         })));
@@ -744,7 +744,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.failing(v -> context.verify(() -> {
+            .onComplete(context.failing(v -> context.verify(() -> {
                 // Verify status
                 List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
                 assertThat(capturedConnects, hasSize(1));
@@ -815,7 +815,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCm.getMetadata().getNamespace(), clusterCm.getMetadata().getName()), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 // No metrics config  => no CMs created
                 Set<String> metricsNames = new HashSet<>();
@@ -912,7 +912,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.failing(error -> context.verify(() -> {
+            .onComplete(context.failing(error -> context.verify(() -> {
                 // Verify status
                 List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
                 assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -170,7 +170,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCm.getMetadata().getNamespace(), clusterCm.getMetadata().getName()), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 // Verify service
                 List<Service> capturedServices = serviceCaptor.getAllValues();
@@ -345,7 +345,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 // Verify service
                 List<Service> capturedServices = serviceCaptor.getAllValues();
                 assertThat(capturedServices, hasSize(1));
@@ -481,7 +481,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 KafkaConnectS2ICluster compareTo = KafkaConnectS2ICluster.fromCrd(clusterCm, VERSIONS);
 
                 // Verify service
@@ -606,7 +606,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.failing(v -> context.verify(() -> async.flag())));
+            .onComplete(context.failing(v -> context.verify(() -> async.flag())));
     }
 
     @Test
@@ -678,7 +678,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 verify(mockDcOps).scaleUp(clusterCmNamespace, connect.getName(), scaleTo);
                 async.flag();
             })));
@@ -754,7 +754,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 // Verify ScaleDown
                 verify(mockDcOps).scaleDown(clusterCmNamespace, connect.getName(), scaleTo);
                 async.flag();
@@ -862,7 +862,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 // Verify status
                 List<KafkaConnectS2I> capturedConnects = connectCaptor.getAllValues();
                 assertThat(capturedConnects.get(0).getStatus().getUrl(), is("http://foo-connect-api.test.svc:8083"));
@@ -944,7 +944,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCm.getMetadata().getNamespace(), clusterCm.getMetadata().getName()), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 // Verify service
                 List<Service> capturedServices = serviceCaptor.getAllValues();
                 assertThat(capturedServices, hasSize(1));
@@ -1053,7 +1053,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.failing(v -> context.verify(() -> {
+            .onComplete(context.failing(v -> context.verify(() -> {
                 // Verify status
                 List<KafkaConnectS2I> capturedConnects = connectCaptor.getAllValues();
                 assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -177,7 +177,7 @@ public class KafkaConnectorIT {
         operator.reconcileConnectorAndHandleResult(new Reconciliation("test", "KafkaConnect", namespace, "bogus"),
                 "localhost", connectClient, true, connectorName,
                 connector)
-            .setHandler(context.succeeding(v -> assertConnectorIsRunning(context, client, namespace, connectorName)))
+            .onComplete(context.succeeding(v -> assertConnectorIsRunning(context, client, namespace, connectorName)))
             .compose(v -> {
                 config.remove(TestingConnector.START_TIME_MS, 1_000);
                 config.put(TestingConnector.START_TIME_MS, 1_000);
@@ -188,7 +188,7 @@ public class KafkaConnectorIT {
                 return operator.reconcileConnectorAndHandleResult(new Reconciliation("test", "KafkaConnect", namespace, "bogus"),
                         "localhost", connectClient, true, connectorName, connector);
             })
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertConnectorIsRunning(context, client, namespace, connectorName);
                 // Assert metrics from Connector Operator
                 MeterRegistry registry = metrics.meterRegistry();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -121,7 +121,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
         Promise created = Promise.promise();
         Checkpoint async = context.checkpoint();
         kco.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME))
-            .setHandler(context.succeeding(ar -> context.verify(() -> {
+            .onComplete(context.succeeding(ar -> context.verify(() -> {
                 assertThat(mockClient.apps().deployments().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue()));
                 assertThat(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(CLUSTER_NAME)).get(), is(notNullValue()));
                 assertThat(mockClient.services().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.serviceName(CLUSTER_NAME)).get(), is(notNullValue()));
@@ -150,12 +150,12 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
 
         Checkpoint async = context.checkpoint();
         createMirrorMaker2Cluster(context, mock)
-            .setHandler(context.succeeding())
+            .onComplete(context.succeeding())
             .compose(v -> {
                 LOGGER.info("Reconciling again -> update");
                 return kco.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME));
             })
-            .setHandler(context.succeeding(v -> async.flag()));
+            .onComplete(context.succeeding(v -> async.flag()));
     }
 
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
@@ -134,7 +134,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 // No metrics config  => no CMs created
                 Set<String> metricsNames = new HashSet<>();
                 if (mirrorMaker2.isMetricsEnabled()) {
@@ -226,7 +226,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 // Verify service
                 List<Service> capturedServices = serviceCaptor.getAllValues();
@@ -333,7 +333,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 KafkaMirrorMaker2Cluster compareTo = KafkaMirrorMaker2Cluster.fromCrd(clusterCm, VERSIONS);
 
                 // Verify service
@@ -424,7 +424,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.failing(v -> async.flag()));
+            .onComplete(context.failing(v -> async.flag()));
     }
 
     @Test
@@ -477,7 +477,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 verify(mockDcOps).scaleUp(clusterCmNamespace, mirrorMaker2.getName(), scaleTo);
                 async.flag();
             })));
@@ -533,7 +533,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 verify(mockDcOps).scaleUp(clusterCmNamespace, mirrorMaker2.getName(), scaleTo);
                 async.flag();
             })));
@@ -631,7 +631,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.failing(v -> context.verify(() -> {
+            .onComplete(context.failing(v -> context.verify(() -> {
                 // Verify status
                 List<KafkaMirrorMaker2> capturedMirrorMaker2s = mirrorMaker2Captor.getAllValues();
                 assertThat(capturedMirrorMaker2s.get(0).getStatus().getUrl(), is("http://foo-mirrormaker2-api.test.svc:8083"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -146,7 +146,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 // No metrics config  => no CMs created
                 Set<String> metricsNames = new HashSet<>();
                 if (mirror.isMetricsEnabled()) {
@@ -236,7 +236,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 // Verify Deployment Config
                 List<Deployment> capturedDc = dcCaptor.getAllValues();
                 assertThat(capturedDc, hasSize(1));
@@ -340,7 +340,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 KafkaMirrorMakerCluster compareTo = KafkaMirrorMakerCluster.fromCrd(clusterCm,
                         VERSIONS);
 
@@ -431,7 +431,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.failing(v -> context.verify(() -> async.flag())));
+            .onComplete(context.failing(v -> context.verify(() -> async.flag())));
     }
 
     @Test
@@ -489,7 +489,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 verify(mockDcOps).scaleUp(clusterCmNamespace, mirror.getName(), scaleTo);
                 async.flag();
             })));
@@ -550,7 +550,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 verify(mockDcOps).scaleUp(clusterCmNamespace, mirror.getName(), scaleTo);
                 async.flag();
             })));
@@ -674,7 +674,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 // Verify status
                 List<KafkaMirrorMaker> capturedMM = statusCaptor.getAllValues();
                 assertThat(capturedMM, hasSize(1));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -174,7 +174,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         Checkpoint checkpoint = context.checkpoint();
         kcrao.reconcileRebalance(
                 new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
-                kr).setHandler(context.succeeding(v -> {
+                kr).onComplete(context.succeeding(v -> {
                     // the resource moved from New directly to ProposalReady (no pending calls in the Mock server)
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.ProposalReady);
                     checkpoint.flag();
@@ -208,7 +208,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         Checkpoint checkpoint = context.checkpoint();
         kcrao.reconcileRebalance(
                 new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
-                kr).setHandler(context.succeeding(v -> {
+                kr).onComplete(context.succeeding(v -> {
                     // the resource moved from New to PendingProposal (due to the configured Mock server pending calls)
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.PendingProposal);
                 })).compose(v -> {
@@ -218,7 +218,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     return kcrao.reconcileRebalance(
                             new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
                             kr1);
-                }).setHandler(context.succeeding(v -> {
+                }).onComplete(context.succeeding(v -> {
                     // the resource moved from New to ProposalReady
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.ProposalReady);
                     checkpoint.flag();
@@ -264,7 +264,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         Checkpoint checkpoint = context.checkpoint();
         kcrao.reconcileRebalance(
                 new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
-                kr).setHandler(context.succeeding(v -> {
+                kr).onComplete(context.succeeding(v -> {
                     // the resource moved from New to PendingProposal (due to the configured Mock server pending calls)
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.PendingProposal);
                 })).compose(v -> {
@@ -274,7 +274,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     return kcrao.reconcileRebalance(
                             new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
                             kr1);
-                }).setHandler(context.succeeding(v -> {
+                }).onComplete(context.succeeding(v -> {
                     // the resource moved from ProposalPending to Stopped
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.Stopped);
                     checkpoint.flag();
@@ -327,7 +327,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         Checkpoint checkpoint = context.checkpoint();
         kcrao.reconcileRebalance(
                 new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
-                kr).setHandler(context.succeeding(v -> {
+                kr).onComplete(context.succeeding(v -> {
                     // the resource moved from New to PendingProposal (due to the configured Mock server pending calls)
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.PendingProposal);
                 })).compose(v -> {
@@ -337,7 +337,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     return kcrao.reconcileRebalance(
                             new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
                             kr1);
-                }).setHandler(context.succeeding(v -> {
+                }).onComplete(context.succeeding(v -> {
                     // the resource moved from ProposalPending to Stopped
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.Stopped);
                 })).compose(v -> {
@@ -348,7 +348,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     return kcrao.reconcileRebalance(
                             new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
                             refreshedKr);
-                }).setHandler(context.succeeding(v -> {
+                }).onComplete(context.succeeding(v -> {
                     // the resource moved from Stopped to PendingProposal
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.PendingProposal);
                 })).compose(v -> {
@@ -358,7 +358,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     return kcrao.reconcileRebalance(
                             new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
                             kr6);
-                }).setHandler(context.succeeding(v -> {
+                }).onComplete(context.succeeding(v -> {
                     // the resource moved from PendingProposal to ProposalReady
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.ProposalReady);
                     checkpoint.flag();
@@ -398,7 +398,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         Checkpoint checkpoint = context.checkpoint();
         kcrao.reconcileRebalance(
                 new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
-                kr).setHandler(context.succeeding(v -> {
+                kr).onComplete(context.succeeding(v -> {
                     // the resource moved from New to ProposalReady directly (no pending calls in the Mock server)
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.ProposalReady);
                 })).compose(v -> {
@@ -408,7 +408,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     return kcrao.reconcileRebalance(
                             new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
                             approvedKr);
-                }).setHandler(context.succeeding(v -> {
+                }).onComplete(context.succeeding(v -> {
                     // the resource moved from ProposalReady to Rebalancing on approval
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.Rebalancing);
                 })).compose(v -> {
@@ -418,7 +418,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     return kcrao.reconcileRebalance(
                             new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
                             kr4);
-                }).setHandler(context.succeeding(v -> {
+                }).onComplete(context.succeeding(v -> {
                     // the resource moved from Rebalancing to Ready
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.Ready);
                     checkpoint.flag();
@@ -455,7 +455,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         Checkpoint checkpoint = context.checkpoint();
         kcrao.reconcileRebalance(
                 new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
-                kr).setHandler(context.succeeding(v -> context.verify(() -> {
+                kr).onComplete(context.succeeding(v -> context.verify(() -> {
                     // the resource moved from New to NotReady due to the error
                     KafkaRebalance kr1 = Crds.kafkaRebalanceOperation(kubernetesClient).inNamespace(CLUSTER_NAMESPACE).withName(RESOURCE_NAME).get();
                     assertState(kr1, KafkaRebalanceAssemblyOperator.State.NotReady, CruiseControlRestException.class,
@@ -497,7 +497,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         Checkpoint checkpoint = context.checkpoint();
         kcrao.reconcileRebalance(
                 new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
-                kr).setHandler(context.succeeding(v -> {
+                kr).onComplete(context.succeeding(v -> {
                     // the resource moved from New directly to ProposalReady (no pending calls in the Mock server)
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.ProposalReady);
                     checkpoint.flag();
@@ -539,7 +539,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         Checkpoint checkpoint = context.checkpoint();
         kcrao.reconcileRebalance(
                 new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
-                kr).setHandler(context.succeeding(v -> context.verify(() -> {
+                kr).onComplete(context.succeeding(v -> context.verify(() -> {
                     // the resource moved from New to NotReady due to the error
                     KafkaRebalance kr1 = Crds.kafkaRebalanceOperation(kubernetesClient).inNamespace(CLUSTER_NAMESPACE).withName(RESOURCE_NAME).get();
                     assertState(kr1, KafkaRebalanceAssemblyOperator.State.NotReady, CruiseControlRestException.class,
@@ -578,7 +578,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     return kcrao.reconcileRebalance(
                             new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
                             patchedKr);
-                }).setHandler(context.succeeding(v -> {
+                }).onComplete(context.succeeding(v -> {
                     // the resource moved from NotReady to ProposalReady
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.ProposalReady);
                     checkpoint.flag();
@@ -625,7 +625,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         Checkpoint checkpoint = context.checkpoint();
         kcrao.reconcileRebalance(
                 new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
-                kr).setHandler(context.succeeding(v -> {
+                kr).onComplete(context.succeeding(v -> {
                     // the resource moved from New to PendingProposal (due to the configured Mock server pending calls)
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.PendingProposal);
                 })).compose(v -> {
@@ -635,7 +635,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     return kcrao.reconcileRebalance(
                             new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
                             kr1);
-                }).setHandler(context.succeeding(v -> context.verify(() -> {
+                }).onComplete(context.succeeding(v -> context.verify(() -> {
                     // the resource doesn't exist anymore
                     KafkaRebalance kr2 = Crds.kafkaRebalanceOperation(kubernetesClient).inNamespace(CLUSTER_NAMESPACE).withName(RESOURCE_NAME).get();
                     assertThat(kr2, is(nullValue()));
@@ -690,7 +690,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         Checkpoint checkpoint = context.checkpoint();
         kcrao.reconcileRebalance(
                 new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
-                kr).setHandler(context.succeeding(v -> {
+                kr).onComplete(context.succeeding(v -> {
                     // the resource moved from New to ProposalReady directly (no pending calls in the Mock server)
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.ProposalReady);
                 })).compose(v -> {
@@ -700,7 +700,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     return kcrao.reconcileRebalance(
                             new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
                             approvedKr);
-                }).setHandler(context.succeeding(v -> {
+                }).onComplete(context.succeeding(v -> {
                     // the resource moved from ProposalReady to Rebalancing on approval
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.Rebalancing);
                 })).compose(v -> {
@@ -710,7 +710,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     return kcrao.reconcileRebalance(
                             new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
                             kr5);
-                }).setHandler(context.succeeding(v -> {
+                }).onComplete(context.succeeding(v -> {
                     // the resource moved from Rebalancing to Stopped
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME, KafkaRebalanceAssemblyOperator.State.Stopped);
                     checkpoint.flag();
@@ -739,7 +739,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         Checkpoint checkpoint = context.checkpoint();
         kcrao.reconcileRebalance(
                 new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
-                kr).setHandler(context.succeeding(v -> context.verify(() -> {
+                kr).onComplete(context.succeeding(v -> context.verify(() -> {
                     // the resource moved from New to NotReady due to the error
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME,
                             KafkaRebalanceAssemblyOperator.State.NotReady, NoSuchResourceException.class,
@@ -780,7 +780,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         Checkpoint checkpoint = context.checkpoint();
         kcrao.reconcileRebalance(
                 new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
-                kr).setHandler(context.succeeding(v -> context.verify(() -> {
+                kr).onComplete(context.succeeding(v -> context.verify(() -> {
                     // the resource moved from New to NotReady due to the error
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME,
                             KafkaRebalanceAssemblyOperator.State.NotReady, InvalidResourceException.class,
@@ -810,7 +810,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         Checkpoint checkpoint = context.checkpoint();
         kcrao.reconcileRebalance(
                 new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
-                kr).setHandler(context.succeeding(v -> context.verify(() -> {
+                kr).onComplete(context.succeeding(v -> context.verify(() -> {
                     // the resource moved from New to NotReady due to the error
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME,
                             KafkaRebalanceAssemblyOperator.State.NotReady, InvalidResourceException.class,
@@ -844,7 +844,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         Checkpoint checkpoint = context.checkpoint();
         kcrao.reconcileRebalance(
                 new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
-                kr).setHandler(context.succeeding(v -> {
+                kr).onComplete(context.succeeding(v -> {
                     // the resource moved from New to NotReady (mocked Cruise Control didn't reply on time)
                     assertState(context, kubernetesClient, CLUSTER_NAMESPACE, RESOURCE_NAME,
                             KafkaRebalanceAssemblyOperator.State.NotReady, TimeoutException.class,
@@ -877,7 +877,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         Checkpoint checkpoint = context.checkpoint();
         kcrao.reconcileRebalance(
                 new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
-                kr).setHandler(context.succeeding(v -> {
+                kr).onComplete(context.succeeding(v -> {
 
                     try {
                         ccServer = MockCruiseControl.getCCServer(CruiseControl.REST_API_PORT);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -247,7 +247,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.New, KafkaRebalanceAssemblyOperator.State.ProposalReady,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.none, null, null)
-                .setHandler(result -> checkOptimizationResults(result, context, false));
+                .onComplete(result -> checkOptimizationResults(result, context, false));
 
     }
 
@@ -260,7 +260,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.New, KafkaRebalanceAssemblyOperator.State.PendingProposal,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.none, null, null)
-                .setHandler(result -> checkOptimizationResults(result, context, true));
+                .onComplete(result -> checkOptimizationResults(result, context, true));
 
     }
 
@@ -271,7 +271,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.New, KafkaRebalanceAssemblyOperator.State.PendingProposal,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.none, null, null)
-                .setHandler(result -> checkOptimizationResults(result, context, true));
+                .onComplete(result -> checkOptimizationResults(result, context, true));
 
     }
 
@@ -295,7 +295,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.New, KafkaRebalanceAssemblyOperator.State.NotReady,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.none, kcRebalance)
-                .setHandler(result -> {
+                .onComplete(result -> {
                     if (result.failed()) {
                         if (result.cause().getMessage().contains("java.lang.IllegalArgumentException: Missing hard goals")) {
                             context.completeNow();
@@ -328,7 +328,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.New, KafkaRebalanceAssemblyOperator.State.ProposalReady,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.none, kcRebalance)
-                .setHandler(result -> checkOptimizationResults(result, context, false));
+                .onComplete(result -> checkOptimizationResults(result, context, false));
 
     }
 
@@ -339,7 +339,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.PendingProposal, KafkaRebalanceAssemblyOperator.State.ProposalReady,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.none, null, null)
-                .setHandler(result -> checkOptimizationResults(result, context, false));
+                .onComplete(result -> checkOptimizationResults(result, context, false));
 
     }
 
@@ -350,7 +350,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.PendingProposal, KafkaRebalanceAssemblyOperator.State.ProposalReady,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.none, null, null)
-                .setHandler(result -> checkOptimizationResults(result, context, false));
+                .onComplete(result -> checkOptimizationResults(result, context, false));
 
     }
 
@@ -361,7 +361,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.PendingProposal, KafkaRebalanceAssemblyOperator.State.Stopped,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.none, "stop", null)
-                .setHandler(result -> checkOptimizationResults(result, context, true));
+                .onComplete(result -> checkOptimizationResults(result, context, true));
 
     }
 
@@ -372,7 +372,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.ProposalReady, KafkaRebalanceAssemblyOperator.State.ProposalReady,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.none, null, null)
-                .setHandler(result -> defaultStatusHandler(result, context));
+                .onComplete(result -> defaultStatusHandler(result, context));
 
     }
 
@@ -383,7 +383,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.ProposalReady, KafkaRebalanceAssemblyOperator.State.PendingProposal,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.approve, null, null)
-                .setHandler(result -> checkOptimizationResults(result, context, true));
+                .onComplete(result -> checkOptimizationResults(result, context, true));
 
     }
 
@@ -394,7 +394,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.ProposalReady, KafkaRebalanceAssemblyOperator.State.Rebalancing,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.approve, null, null)
-                .setHandler(result -> checkOptimizationResults(result, context, true));
+                .onComplete(result -> checkOptimizationResults(result, context, true));
 
     }
 
@@ -405,7 +405,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.ProposalReady, KafkaRebalanceAssemblyOperator.State.Rebalancing,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.approve, null, null)
-                .setHandler(result -> checkOptimizationResults(result, context, false));
+                .onComplete(result -> checkOptimizationResults(result, context, false));
 
     }
 
@@ -416,7 +416,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.ProposalReady, KafkaRebalanceAssemblyOperator.State.ProposalReady,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.refresh, null, null)
-                .setHandler(result -> checkOptimizationResults(result, context, false));
+                .onComplete(result -> checkOptimizationResults(result, context, false));
 
     }
 
@@ -427,7 +427,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.ProposalReady, KafkaRebalanceAssemblyOperator.State.PendingProposal,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.refresh, null, null)
-                .setHandler(result -> checkOptimizationResults(result, context, true));
+                .onComplete(result -> checkOptimizationResults(result, context, true));
 
     }
 
@@ -438,7 +438,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.ProposalReady, KafkaRebalanceAssemblyOperator.State.PendingProposal,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.refresh, null, null)
-                .setHandler(result -> checkOptimizationResults(result, context, true));
+                .onComplete(result -> checkOptimizationResults(result, context, true));
 
     }
 
@@ -450,7 +450,7 @@ public class KafkaRebalanceStateMachineTest {
                 KafkaRebalanceAssemblyOperator.State.Rebalancing, KafkaRebalanceAssemblyOperator.State.Ready,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.none, null,
                 MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID)
-                .setHandler(result -> checkOptimizationResults(result, context, false));
+                .onComplete(result -> checkOptimizationResults(result, context, false));
 
     }
 
@@ -465,7 +465,7 @@ public class KafkaRebalanceStateMachineTest {
                 KafkaRebalanceAssemblyOperator.State.Rebalancing, KafkaRebalanceAssemblyOperator.State.Rebalancing,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.none, null,
                 MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID)
-                .setHandler(result -> checkOptimizationResults(result, context, false));
+                .onComplete(result -> checkOptimizationResults(result, context, false));
 
     }
 
@@ -478,7 +478,7 @@ public class KafkaRebalanceStateMachineTest {
                 KafkaRebalanceAssemblyOperator.State.Rebalancing, KafkaRebalanceAssemblyOperator.State.Stopped,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.none, "stop",
                 MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID)
-                .setHandler(result -> checkOptimizationResults(result, context, true));
+                .onComplete(result -> checkOptimizationResults(result, context, true));
 
     }
 
@@ -490,7 +490,7 @@ public class KafkaRebalanceStateMachineTest {
                 KafkaRebalanceAssemblyOperator.State.Rebalancing, KafkaRebalanceAssemblyOperator.State.NotReady,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.none, null,
                 MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID)
-                .setHandler(result -> checkOptimizationResults(result, context, true));
+                .onComplete(result -> checkOptimizationResults(result, context, true));
 
     }
 
@@ -501,7 +501,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.Stopped, KafkaRebalanceAssemblyOperator.State.PendingProposal,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.refresh, null, null)
-                .setHandler(result -> checkOptimizationResults(result, context, true));
+                .onComplete(result -> checkOptimizationResults(result, context, true));
 
     }
 
@@ -513,7 +513,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.Stopped, KafkaRebalanceAssemblyOperator.State.ProposalReady,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.refresh, null, null)
-                .setHandler(result -> checkOptimizationResults(result, context, false));
+                .onComplete(result -> checkOptimizationResults(result, context, false));
 
     }
 
@@ -524,7 +524,7 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceAssemblyOperator.State.Stopped, KafkaRebalanceAssemblyOperator.State.PendingProposal,
                 KafkaRebalanceAssemblyOperator.RebalanceAnnotation.refresh, null, null)
-                .setHandler(result -> checkOptimizationResults(result, context, true));
+                .onComplete(result -> checkOptimizationResults(result, context, true));
 
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -139,7 +139,7 @@ public class KafkaStatusTest {
                 config);
 
         Checkpoint async = context.checkpoint();
-        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).onComplete(res -> {
             assertThat(res.succeeded(), is(true));
 
             assertThat(kafkaCaptor.getValue(), is(notNullValue()));
@@ -209,7 +209,7 @@ public class KafkaStatusTest {
                 config);
 
         Checkpoint async = context.checkpoint();
-        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).onComplete(res -> {
             assertThat(res.succeeded(), is(true));
             // The status should not change => we test that updateStatusAsync was not called
             assertThat(kafkaCaptor.getAllValues().size(), is(0));
@@ -249,7 +249,7 @@ public class KafkaStatusTest {
                 config);
 
         Checkpoint async = context.checkpoint();
-        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).onComplete(res -> {
             assertThat(res.succeeded(), is(false));
 
             assertThat(kafkaCaptor.getValue(), is(notNullValue()));
@@ -319,7 +319,7 @@ public class KafkaStatusTest {
                 config);
 
         Checkpoint async = context.checkpoint();
-        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).onComplete(res -> {
             assertThat(res.succeeded(), is(false));
 
             assertThat(kafkaCaptor.getValue(), is(notNullValue()));
@@ -481,7 +481,7 @@ public class KafkaStatusTest {
                 config);
 
         Checkpoint async = context.checkpoint();
-        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).onComplete(res -> {
             assertThat(res.succeeded(), is(true));
 
             assertThat(kafkaCaptor.getValue(), is(notNullValue()));
@@ -595,7 +595,7 @@ public class KafkaStatusTest {
                 config);
 
         Checkpoint async = context.checkpoint();
-        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).onComplete(res -> {
             assertThat(res.succeeded(), is(true));
 
             assertThat(kafkaCaptor.getValue(), is(notNullValue()));
@@ -699,7 +699,7 @@ public class KafkaStatusTest {
                 config);
 
         Checkpoint async = context.checkpoint();
-        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).onComplete(res -> {
             assertThat(res.succeeded(), is(true));
 
             assertThat(kafkaCaptor.getValue(), is(notNullValue()));
@@ -800,7 +800,7 @@ public class KafkaStatusTest {
                 config);
 
         Checkpoint async = context.checkpoint();
-        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).onComplete(res -> {
             assertThat(res.succeeded(), is(true));
 
             assertThat(kafkaCaptor.getValue(), is(notNullValue()));
@@ -880,7 +880,7 @@ public class KafkaStatusTest {
                 config);
 
         Checkpoint async = context.checkpoint();
-        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).onComplete(res -> {
             assertThat(res.succeeded(), is(true));
 
             assertThat(kafkaCaptor.getValue(), is(notNullValue()));
@@ -918,7 +918,7 @@ public class KafkaStatusTest {
                 supplier,
                 config);
 
-        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).onComplete(res -> {
             assertThat(res.succeeded(), is(true));
 
             assertThat(kafkaCaptor.getAllValues().size(), is(2));
@@ -955,7 +955,7 @@ public class KafkaStatusTest {
                 supplier,
                 config);
 
-        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).onComplete(res -> {
             assertThat(res.succeeded(), is(true));
 
             assertThat(kafkaCaptor.getAllValues().size(), is(1));
@@ -1002,7 +1002,7 @@ public class KafkaStatusTest {
 
         Checkpoint async = context.checkpoint();
         kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka)
-                .setHandler(context.succeeding(v -> context.verify(() -> {
+                .onComplete(context.succeeding(v -> context.verify(() -> {
                     assertThat(kafkaCaptor.getValue(), is(notNullValue()));
                     assertThat(kafkaCaptor.getValue().getStatus(), is(notNullValue()));
                     KafkaStatus status = kafkaCaptor.getValue().getStatus();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
@@ -191,7 +191,7 @@ public class KafkaUpdateTest {
                 }
                 .kafkaVersionChange();
         AtomicReference<UpgradeException> ex = new AtomicReference<>();
-        future.setHandler(ar -> {
+        future.onComplete(ar -> {
             if (ar.failed()) {
                 ex.set(new UpgradeException(states, ar.cause()));
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -135,7 +135,7 @@ public class PartialRollingUpdateTest {
 
         LOGGER.info("bootstrap reconciliation");
         CountDownLatch createAsync = new CountDownLatch(1);
-        kco.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).setHandler(ar -> {
+        kco.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).onComplete(ar -> {
             context.verify(() -> assertThat(ar.succeeded(), is(true)));
             createAsync.countDown();
         });
@@ -203,7 +203,7 @@ public class PartialRollingUpdateTest {
 
         LOGGER.info("Recovery reconciliation");
         Checkpoint async = context.checkpoint();
-        kco.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).setHandler(ar -> {
+        kco.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).onComplete(ar -> {
             context.verify(() -> assertThat(ar.succeeded(), is(true)));
             for (int i = 0; i <= 4; i++) {
                 Pod pod = mockClient.pods().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaPodName(CLUSTER_NAME, i)).get();
@@ -227,7 +227,7 @@ public class PartialRollingUpdateTest {
 
         LOGGER.info("Recovery reconciliation");
         Checkpoint async = context.checkpoint();
-        kco.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).setHandler(ar -> {
+        kco.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).onComplete(ar -> {
             if (ar.failed()) ar.cause().printStackTrace();
             context.verify(() -> assertThat(ar.succeeded(), is(true)));
             for (int i = 0; i <= 2; i++) {
@@ -257,7 +257,7 @@ public class PartialRollingUpdateTest {
 
         LOGGER.info("Recovery reconciliation");
         Checkpoint async = context.checkpoint();
-        kco.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).setHandler(ar -> {
+        kco.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).onComplete(ar -> {
             if (ar.failed()) ar.cause().printStackTrace();
             context.verify(() -> assertThat(ar.succeeded(), is(true)));
             for (int i = 0; i <= 2; i++) {
@@ -290,7 +290,7 @@ public class PartialRollingUpdateTest {
 
         LOGGER.info("Recovery reconciliation");
         Checkpoint async = context.checkpoint();
-        kco.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).setHandler(ar -> {
+        kco.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).onComplete(ar -> {
             if (ar.failed()) ar.cause().printStackTrace();
             context.verify(() -> assertThat(ar.succeeded(), is(true)));
             for (int i = 0; i <= 4; i++) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/VolumeResizingTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/VolumeResizingTest.java
@@ -132,7 +132,7 @@ public class VolumeResizingTest {
                 config);
 
         kao.resizeVolumes(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName),
-                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
+                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).onComplete(res -> {
                     assertThat(res.succeeded(), is(true));
                     assertThat(pvcCaptor.getAllValues().size(), is(3));
                     assertThat(pvcCaptor.getAllValues(), is(kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage())));
@@ -180,7 +180,7 @@ public class VolumeResizingTest {
                 config);
 
         kao.resizeVolumes(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName),
-                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
+                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).onComplete(res -> {
                     assertThat(res.succeeded(), is(true));
                     assertThat(pvcCaptor.getAllValues().size(), is(3));
                     assertThat(pvcCaptor.getAllValues(), is(kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage())));
@@ -237,7 +237,7 @@ public class VolumeResizingTest {
                 config);
 
         kao.resizeVolumes(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName),
-                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
+                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).onComplete(res -> {
                     assertThat(res.succeeded(), is(true));
                     assertThat(pvcCaptor.getAllValues().size(), is(3));
                     assertThat(pvcCaptor.getAllValues(), is(kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage())));
@@ -294,7 +294,7 @@ public class VolumeResizingTest {
                 config);
 
         kao.resizeVolumes(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName),
-                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
+                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).onComplete(res -> {
                     assertThat(res.succeeded(), is(true));
                     // Resizing is not supported, we do not reconcile
                     assertThat(pvcCaptor.getAllValues().size(), is(0));
@@ -354,7 +354,7 @@ public class VolumeResizingTest {
                 config);
 
         kao.resizeVolumes(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName),
-                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
+                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).onComplete(res -> {
                     assertThat(res.succeeded(), is(true));
                     // The volumes are resizing => no reconciliation
                     assertThat(pvcCaptor.getAllValues().size(), is(0));
@@ -414,7 +414,7 @@ public class VolumeResizingTest {
                 config);
 
         kao.resizeVolumes(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName),
-                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
+                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).onComplete(res -> {
                     assertThat(res.succeeded(), is(true));
 
                     // The volumes are waiting for pod restart => no reconciliation
@@ -476,7 +476,7 @@ public class VolumeResizingTest {
                 config);
 
         kao.resizeVolumes(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName),
-                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
+                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).onComplete(res -> {
                     assertThat(res.succeeded(), is(true));
 
                     assertThat(pvcCaptor.getAllValues().size(), is(3));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailabilityTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailabilityTest.java
@@ -296,7 +296,7 @@ public class KafkaAvailabilityTest {
 
         Checkpoint a = context.checkpoint(ksb.brokers.size());
         for (Integer brokerId : ksb.brokers.keySet()) {
-            kafkaAvailability.canRoll(brokerId).setHandler(context.succeeding(canRoll -> context.verify(() -> {
+            kafkaAvailability.canRoll(brokerId).onComplete(context.succeeding(canRoll -> context.verify(() -> {
                 if (brokerId == 4) {
                     assertTrue(canRoll,
                             "broker " + brokerId + " should be rollable, having no partitions");
@@ -335,7 +335,7 @@ public class KafkaAvailabilityTest {
 
         Checkpoint a = context.checkpoint(ksb.brokers.size());
         for (Integer brokerId : ksb.brokers.keySet()) {
-            kafkaAvailability.canRoll(brokerId).setHandler(context.succeeding(canRoll -> context.verify(() -> {
+            kafkaAvailability.canRoll(brokerId).onComplete(context.succeeding(canRoll -> context.verify(() -> {
                 if (brokerId == 2) {
                     assertTrue(canRoll,
                             "broker " + brokerId + " should be rollable, having no partitions");
@@ -374,7 +374,7 @@ public class KafkaAvailabilityTest {
 
         Checkpoint a = context.checkpoint(ksb.brokers.size());
         for (Integer brokerId : ksb.brokers.keySet()) {
-            kafkaAvailability.canRoll(brokerId).setHandler(context.succeeding(canRoll -> context.verify(() -> {
+            kafkaAvailability.canRoll(brokerId).onComplete(context.succeeding(canRoll -> context.verify(() -> {
                 assertTrue(canRoll,
                         "broker " + brokerId + " should be rollable, being minisr = 1 and having two brokers in its isr");
                 a.flag();
@@ -400,7 +400,7 @@ public class KafkaAvailabilityTest {
 
         Checkpoint a = context.checkpoint(ksb.brokers.size());
         for (Integer brokerId : ksb.brokers.keySet()) {
-            kafkaAvailability.canRoll(brokerId).setHandler(context.succeeding(canRoll -> context.verify(() -> {
+            kafkaAvailability.canRoll(brokerId).onComplete(context.succeeding(canRoll -> context.verify(() -> {
                 assertTrue(canRoll,
                         "broker " + brokerId + " should be rollable, being minisr = 3, but only 3 replicas");
 
@@ -427,7 +427,7 @@ public class KafkaAvailabilityTest {
 
         Checkpoint a = context.checkpoint(ksb.brokers.size());
         for (Integer brokerId : ksb.brokers.keySet()) {
-            kafkaAvailability.canRoll(brokerId).setHandler(context.succeeding(canRoll -> context.verify(() -> {
+            kafkaAvailability.canRoll(brokerId).onComplete(context.succeeding(canRoll -> context.verify(() -> {
                 assertTrue(canRoll,
                         "broker " + brokerId + " should be rollable, being minisr = 3, but only 3 replicas");
 
@@ -453,7 +453,7 @@ public class KafkaAvailabilityTest {
 
         Checkpoint a = context.checkpoint(ksb.brokers.size());
         for (Integer brokerId : ksb.brokers.keySet()) {
-            kafkaAvailability.canRoll(brokerId).setHandler(context.succeeding(canRoll -> context.verify(() -> {
+            kafkaAvailability.canRoll(brokerId).onComplete(context.succeeding(canRoll -> context.verify(() -> {
                 assertTrue(canRoll,
                         "broker " + brokerId + " should be rollable, being minisr = 2, but only 1 replicas");
 
@@ -488,7 +488,7 @@ public class KafkaAvailabilityTest {
 
         Checkpoint a = context.checkpoint(ksb.brokers.size());
         for (Integer brokerId : ksb.brokers.keySet()) {
-            kafkaSorted.canRoll(brokerId).setHandler(context.succeeding(canRoll -> context.verify(() -> {
+            kafkaSorted.canRoll(brokerId).onComplete(context.succeeding(canRoll -> context.verify(() -> {
                 if (brokerId == 0) {
                     assertFalse(canRoll,
                             "broker " + brokerId + " should not be rollable, because B/0 would be below min isr");
@@ -525,7 +525,7 @@ public class KafkaAvailabilityTest {
 
         Checkpoint a = context.checkpoint(ksb.brokers.size());
         for (Integer brokerId : ksb.brokers.keySet()) {
-            kafkaAvailability.canRoll(brokerId).setHandler(context.succeeding(canRoll -> context.verify(() -> {
+            kafkaAvailability.canRoll(brokerId).onComplete(context.succeeding(canRoll -> context.verify(() -> {
                 assertTrue(canRoll,
                         "broker " + brokerId + " should be rollable, being minisr = 1 and having two brokers in its isr");
                 a.flag();
@@ -561,7 +561,7 @@ public class KafkaAvailabilityTest {
 
         Checkpoint a = context.checkpoint(ksb.brokers.size());
         for (Integer brokerId : ksb.brokers.keySet()) {
-            kafkaAvailability.canRoll(brokerId).setHandler(context.failing(e -> context.verify(() -> {
+            kafkaAvailability.canRoll(brokerId).onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(TimeoutException.class));
                 a.flag();
             })));
@@ -595,7 +595,7 @@ public class KafkaAvailabilityTest {
 
         Checkpoint a = context.checkpoint(ksb.brokers.size());
         for (Integer brokerId : ksb.brokers.keySet()) {
-            kafkaAvailability.canRoll(brokerId).setHandler(context.failing(e -> context.verify(() -> {
+            kafkaAvailability.canRoll(brokerId).onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(UnknownTopicOrPartitionException.class));
                 a.flag();
             })));
@@ -630,12 +630,12 @@ public class KafkaAvailabilityTest {
         Checkpoint a = context.checkpoint(ksb.brokers.size());
         for (Integer brokerId : ksb.brokers.keySet()) {
             if (brokerId <= 2) {
-                kafkaAvailability.canRoll(brokerId).setHandler(context.failing(e -> context.verify(() -> {
+                kafkaAvailability.canRoll(brokerId).onComplete(context.failing(e -> context.verify(() -> {
                     assertThat(e, instanceOf(UnknownTopicOrPartitionException.class));
                     a.flag();
                 })));
             } else {
-                kafkaAvailability.canRoll(brokerId).setHandler(context.succeeding(canRoll -> a.flag()));
+                kafkaAvailability.canRoll(brokerId).onComplete(context.succeeding(canRoll -> a.flag()));
             }
         }
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -359,7 +359,7 @@ public class KafkaRollerTest {
                 return null;
             }
         })
-            .setHandler(testContext.succeeding(v -> {
+            .onComplete(testContext.succeeding(v -> {
                 testContext.verify(() -> assertThat(restarted(), is(expected)));
                 assertNoUnclosedAdminClient(testContext, kafkaRoller);
                 async.flag();
@@ -386,7 +386,7 @@ public class KafkaRollerTest {
                 return null;
             }
         })
-            .setHandler(testContext.failing(e -> testContext.verify(() -> {
+            .onComplete(testContext.failing(e -> testContext.verify(() -> {
                 assertThat(e.getClass() + " is not a subclass of " + exception.getName(), e, instanceOf(exception));
                 assertThat("The exception message was not as expected", e.getMessage(), is(message));
                 assertThat("The restarted pods were not as expected", restarted(), is(expectedRestart));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -181,7 +181,7 @@ public class StatefulSetOperatorTest
 
         Checkpoint a = context.checkpoint();
         op.maybeRestartPod(resource, "my-pod-0", pod -> "roll")
-            .setHandler(context.succeeding(v -> a.flag()));
+            .onComplete(context.succeeding(v -> a.flag()));
     }
 
     @Test
@@ -232,7 +232,7 @@ public class StatefulSetOperatorTest
 
         Checkpoint a = context.checkpoint();
         op.maybeRestartPod(resource, "my-pod-0", pod -> "roll")
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(TimeoutException.class));
                 a.flag();
             })));
@@ -278,7 +278,7 @@ public class StatefulSetOperatorTest
         };
 
         Checkpoint a = context.checkpoint();
-        op.maybeRestartPod(resource, "my-pod-0", pod -> "roll").setHandler(context.failing(e -> context.verify(() -> {
+        op.maybeRestartPod(resource, "my-pod-0", pod -> "roll").onComplete(context.failing(e -> context.verify(() -> {
             assertThat(e, instanceOf(TimeoutException.class));
             a.flag();
         })));
@@ -324,7 +324,7 @@ public class StatefulSetOperatorTest
 
         Checkpoint a = context.checkpoint();
         op.maybeRestartPod(resource, "my-pod-0", pod -> "roll")
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e.getMessage(), is("reconcile failed"));
                 a.flag();
             })));
@@ -426,7 +426,7 @@ public class StatefulSetOperatorTest
 
         Checkpoint async = context.checkpoint();
         op.reconcile(sts1.getMetadata().getNamespace(), sts1.getMetadata().getName(), sts2)
-            .setHandler(context.succeeding(rrState -> {
+            .onComplete(context.succeeding(rrState -> {
                 verify(mockDeletable).delete();
                 async.flag();
             }));
@@ -470,7 +470,7 @@ public class StatefulSetOperatorTest
 
         Checkpoint async = context.checkpoint();
         op.deleteAsync(NAMESPACE, RESOURCE_NAME, true)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat(cascadingCaptor.getValue(), is(true));
                 async.flag();
             })));
@@ -514,7 +514,7 @@ public class StatefulSetOperatorTest
 
         Checkpoint a = context.checkpoint();
         op.deleteAsync(NAMESPACE, RESOURCE_NAME, false)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat(cascadingCaptor.getValue(), is(false));
                 a.flag();
             })));
@@ -554,7 +554,7 @@ public class StatefulSetOperatorTest
 
         Checkpoint a = context.checkpoint();
         op.deleteAsync(NAMESPACE, RESOURCE_NAME, false)
-            .setHandler(context.failing(e -> a.flag()));
+            .onComplete(context.failing(e -> a.flag()));
     }
 
     @Test
@@ -594,7 +594,7 @@ public class StatefulSetOperatorTest
 
         Checkpoint async = context.checkpoint();
         op.deleteAsync(NAMESPACE, RESOURCE_NAME, false)
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(MockitoException.class));
                 assertThat(e.getMessage(), is("Something failed"));
                 async.flag();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
@@ -185,7 +185,7 @@ public class ZookeeperLeaderFinderTest {
             final int id = i;
             FakeZk zk = new FakeZk(id, attempt -> fn.apply(id, attempt));
             zks.add(zk);
-            zk.start().setHandler(context.succeeding(port -> {
+            zk.start().onComplete(context.succeeding(port -> {
                 log.debug("ZK {} listening on port {}", id, port);
                 result[id] = port;
                 async.countDown();
@@ -217,7 +217,7 @@ public class ZookeeperLeaderFinderTest {
         ZookeeperLeaderFinder finder = new ZookeeperLeaderFinder(vertx, null, this::backoff);
         Checkpoint a = context.checkpoint();
         finder.findZookeeperLeader(CLUSTER, NAMESPACE, emptyList(), coKeySecret())
-            .setHandler(context.succeeding(leader -> {
+            .onComplete(context.succeeding(leader -> {
                 context.verify(() -> assertThat(leader, is(Integer.valueOf(ZookeeperLeaderFinder.UNKNOWN_LEADER))));
                 a.flag();
             }));
@@ -229,7 +229,7 @@ public class ZookeeperLeaderFinderTest {
         Checkpoint a = context.checkpoint();
         int firstPodIndex = 0;
         finder.findZookeeperLeader(CLUSTER, NAMESPACE, asList(createPodWithId(firstPodIndex)), coKeySecret())
-            .setHandler(context.succeeding(leader -> {
+            .onComplete(context.succeeding(leader -> {
                 context.verify(() -> assertThat(leader, is(Integer.valueOf(firstPodIndex))));
                 a.flag();
             }));
@@ -262,7 +262,7 @@ public class ZookeeperLeaderFinderTest {
         Checkpoint a = context.checkpoint();
 
         finder.findZookeeperLeader(CLUSTER, NAMESPACE, asList(createPodWithId(0), createPodWithId(1)), secretWithMissingClusterOperatorKey)
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(RuntimeException.class));
                 assertThat(e.getMessage(),
                         is("The Secret testns/testcluster-cluster-operator-certs is missing the key cluster-operator.key"));
@@ -300,7 +300,7 @@ public class ZookeeperLeaderFinderTest {
         Checkpoint a = context.checkpoint();
 
         finder.findZookeeperLeader(CLUSTER, NAMESPACE, asList(createPodWithId(0), createPodWithId(1)), secretWithBadCertificate)
-                .setHandler(context.failing(e -> context.verify(() -> {
+                .onComplete(context.failing(e -> context.verify(() -> {
                     assertThat(e, instanceOf(RuntimeException.class));
                     assertThat(e.getMessage(), is("Bad/corrupt certificate found in data.cluster-operator\\.crt of Secret testcluster-cluster-operator-certs in namespace testns"));
                     a.flag();
@@ -340,7 +340,7 @@ public class ZookeeperLeaderFinderTest {
         Checkpoint a = context.checkpoint();
         finder.findZookeeperLeader(CLUSTER, NAMESPACE,
                 asList(createPodWithId(0), createPodWithId(1)), coKeySecret())
-            .setHandler(context.succeeding(leader -> context.verify(() -> {
+            .onComplete(context.succeeding(leader -> context.verify(() -> {
                 assertThat(leader, is(ZookeeperLeaderFinder.UNKNOWN_LEADER));
                 for (FakeZk zk : zks) {
                     assertThat("Unexpected number of attempts for node " + zk.id, zk.attempts.get(), is(MAX_ATTEMPTS + 1));
@@ -380,7 +380,7 @@ public class ZookeeperLeaderFinderTest {
         Checkpoint a = context.checkpoint();
         finder.findZookeeperLeader(CLUSTER, NAMESPACE,
                 asList(createPodWithId(0), createPodWithId(1)), coKeySecret())
-            .setHandler(context.succeeding(leader -> context.verify(() -> {
+            .onComplete(context.succeeding(leader -> context.verify(() -> {
                 assertThat(leader, is(ZookeeperLeaderFinder.UNKNOWN_LEADER));
                 for (FakeZk zk : zks) {
                     assertThat("Unexpected number of attempts for node " + zk.id, zk.attempts.get(), is(0));
@@ -419,7 +419,7 @@ public class ZookeeperLeaderFinderTest {
 
         Checkpoint a = context.checkpoint();
         finder.findZookeeperLeader(CLUSTER, NAMESPACE, asList(createPodWithId(0), createPodWithId(1)), coKeySecret())
-            .setHandler(context.succeeding(leader -> context.verify(() -> {
+            .onComplete(context.succeeding(leader -> context.verify(() -> {
                 assertThat(leader, is(desiredLeaderId));
                 for (FakeZk zk : zks) {
                     assertThat("Unexpected number of attempts for node " + zk.id, zk.attempts.get(), is(succeedOnAttempt + 1));
@@ -457,7 +457,7 @@ public class ZookeeperLeaderFinderTest {
 
         Checkpoint a = context.checkpoint();
         finder.findZookeeperLeader(CLUSTER, NAMESPACE, asList(createPodWithId(0), createPodWithId(1)), coKeySecret())
-            .setHandler(context.succeeding(l -> context.verify(() -> {
+            .onComplete(context.succeeding(l -> context.verify(() -> {
                 assertThat(l, is(leader));
                 for (FakeZk zk : zks) {
                     assertThat("Unexpected number of attempts for node " + zk.id, zk.attempts.get(), is(1));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalerTest.java
@@ -188,7 +188,7 @@ public class ZookeeperScalerTest {
         ZookeeperScaler scaler = new ZookeeperScaler(vertx, zooKeeperAdminProvider, "zookeeper:2181", null, dummyCaSecret, dummyCoSecret, 1_000);
 
         Checkpoint check = context.checkpoint();
-        scaler.scale(5).setHandler(context.failing(cause -> context.verify(() -> {
+        scaler.scale(5).onComplete(context.failing(cause -> context.verify(() -> {
             assertThat(cause.getMessage(), is("Failed to connect to Zookeeper zookeeper:2181. Connection was not ready in 1000 ms."));
             check.flag();
         })));
@@ -214,7 +214,7 @@ public class ZookeeperScalerTest {
         ZookeeperScaler scaler = new ZookeeperScaler(vertx, zooKeeperAdminProvider, "zookeeper:2181", zkNodeAddress, dummyCaSecret, dummyCoSecret, 1_000);
 
         Checkpoint check = context.checkpoint();
-        scaler.scale(1).setHandler(context.succeeding(res -> context.verify(() -> {
+        scaler.scale(1).onComplete(context.succeeding(res -> context.verify(() -> {
             verify(mockZooAdmin, never()).reconfigure(isNull(), isNull(), anyList(), anyLong(), isNull());
             check.flag();
         })));
@@ -245,7 +245,7 @@ public class ZookeeperScalerTest {
         ZookeeperScaler scaler = new ZookeeperScaler(vertx, zooKeeperAdminProvider, "zookeeper:2181", zkNodeAddress, dummyCaSecret, dummyCoSecret, 1_000);
 
         Checkpoint check = context.checkpoint();
-        scaler.scale(1).setHandler(context.succeeding(res -> context.verify(() -> {
+        scaler.scale(1).onComplete(context.succeeding(res -> context.verify(() -> {
             verify(mockZooAdmin, times(1)).reconfigure(isNull(), isNull(), anyList(), anyLong(), isNull());
             check.flag();
         })));
@@ -273,7 +273,7 @@ public class ZookeeperScalerTest {
         ZookeeperScaler scaler = new ZookeeperScaler(vertx, zooKeeperAdminProvider, "zookeeper:2181", zkNodeAddress, dummyCaSecret, dummyCoSecret, 1_000);
 
         Checkpoint check = context.checkpoint();
-        scaler.scale(1).setHandler(context.failing(cause -> context.verify(() -> {
+        scaler.scale(1).onComplete(context.failing(cause -> context.verify(() -> {
             assertThat(cause.getCause(), instanceOf(KeeperException.class));
             check.flag();
         })));
@@ -284,7 +284,7 @@ public class ZookeeperScalerTest {
         ZookeeperScaler scaler = new ZookeeperScaler(vertx, new DefaultZooKeeperAdminProvider(), "i-do-not-exist.com:2181", null, dummyCaSecret, dummyCoSecret, 2_000);
 
         Checkpoint check = context.checkpoint();
-        scaler.scale(5).setHandler(context.failing(cause -> context.verify(() -> {
+        scaler.scale(5).onComplete(context.failing(cause -> context.verify(() -> {
             assertThat(cause.getMessage(), is("Failed to connect to Zookeeper i-do-not-exist.com:2181. Connection was not ready in 2000 ms."));
             check.flag();
         })));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
@@ -55,7 +55,7 @@ public class CruiseControlClientTest {
         CruiseControlApi client = new CruiseControlApiImpl(vertx);
 
         Checkpoint checkpoint = context.checkpoint();
-        client.getCruiseControlState(HOST, PORT, false).setHandler(context.succeeding(result -> {
+        client.getCruiseControlState(HOST, PORT, false).onComplete(context.succeeding(result -> {
             context.verify(() -> assertThat(
                     result.getJson().getJsonObject("ExecutorState").getString("state"),
                     is("NO_TASK_IN_PROGRESS")));
@@ -73,7 +73,7 @@ public class CruiseControlClientTest {
         CruiseControlApi client = new CruiseControlApiImpl(vertx);
 
         Checkpoint checkpoint = context.checkpoint();
-        client.rebalance(HOST, PORT, rbOptions, null).setHandler(context.succeeding(result -> {
+        client.rebalance(HOST, PORT, rbOptions, null).onComplete(context.succeeding(result -> {
             context.verify(() -> assertThat(result.getUserTaskId(), is(MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID)));
             context.verify(() -> assertThat(result.getJson().containsKey("summary"), is(true)));
             context.verify(() -> assertThat(result.getJson().containsKey("goalSummary"), is(true)));
@@ -92,7 +92,7 @@ public class CruiseControlClientTest {
         CruiseControlApi client = new CruiseControlApiImpl(vertx);
 
         Checkpoint checkpoint = context.checkpoint();
-        client.rebalance(HOST, PORT, rbOptions, null).setHandler(context.succeeding(result -> {
+        client.rebalance(HOST, PORT, rbOptions, null).onComplete(context.succeeding(result -> {
             context.verify(() -> assertThat(result.getUserTaskId(), is(MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID)));
             context.verify(() -> assertThat(result.getJson().containsKey("summary"), is(true)));
             context.verify(() -> assertThat(result.getJson().containsKey("goalSummary"), is(true)));
@@ -114,7 +114,7 @@ public class CruiseControlClientTest {
 
         Checkpoint checkpoint = context.checkpoint();
         client.rebalance(HOST, PORT, rbOptions, MockCruiseControl.REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR)
-                .setHandler(context.succeeding(result -> {
+                .onComplete(context.succeeding(result -> {
                     context.verify(() -> assertTrue(result.thereIsNotEnoughDataForProposal()));
                     checkpoint.flag();
                 }));
@@ -131,7 +131,7 @@ public class CruiseControlClientTest {
 
         Checkpoint checkpoint = context.checkpoint();
         client.rebalance(HOST, PORT, rbOptions, MockCruiseControl.REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR)
-                .setHandler(context.succeeding(result -> {
+                .onComplete(context.succeeding(result -> {
                     context.verify(() -> assertTrue(result.proposalIsStillCalculating()));
                     checkpoint.flag();
                 }));
@@ -146,7 +146,7 @@ public class CruiseControlClientTest {
         String userTaskID = MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID;
 
         Checkpoint checkpoint = context.checkpoint();
-        client.getUserTaskStatus(HOST, PORT, userTaskID).setHandler(context.succeeding(result -> {
+        client.getUserTaskStatus(HOST, PORT, userTaskID).onComplete(context.succeeding(result -> {
             context.verify(() -> assertThat(result.getUserTaskId(), is(MockCruiseControl.USER_TASK_REBALANCE_NO_GOALS_RESPONSE_UTID)));
             context.verify(() -> assertThat(result.getJson().getJsonObject(CC_REST_API_SUMMARY), is(notNullValue())));
             checkpoint.flag();
@@ -162,7 +162,7 @@ public class CruiseControlClientTest {
         String userTaskID = MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID;
 
         Checkpoint checkpoint = context.checkpoint();
-        client.getUserTaskStatus(HOST, PORT, userTaskID).setHandler(context.succeeding(result -> {
+        client.getUserTaskStatus(HOST, PORT, userTaskID).onComplete(context.succeeding(result -> {
             context.verify(() -> assertThat(result.getUserTaskId(), is(MockCruiseControl.USER_TASK_REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID)));
             context.verify(() -> assertThat(result.getJson().getJsonObject(CC_REST_API_SUMMARY), is(notNullValue())));
             checkpoint.flag();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControlTest.java
@@ -161,7 +161,7 @@ public class MockCruiseControlTest {
                     is(CruiseControlUserTaskStatus.COMPLETED.toString()))
             );
             return Future.succeededFuture(response);
-        }).setHandler(context.succeeding(result -> {
+        }).onComplete(context.succeeding(result -> {
             context.completeNow();
         }));
     }

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-junit5</artifactId>
-            <version>${vertx-juni5.version}</version>
+            <version>${vertx-junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/operator-common/src/main/java/io/strimzi/operator/PlatformFeaturesAvailability.java
+++ b/operator-common/src/main/java/io/strimzi/operator/PlatformFeaturesAvailability.java
@@ -57,7 +57,7 @@ public class PlatformFeaturesAvailability {
             pfa.setImages(supported);
             return Future.succeededFuture(pfa);
         })
-        .setHandler(pfaPromise);
+        .onComplete(pfaPromise);
 
         return pfaPromise.future();
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -192,7 +192,7 @@ public abstract class AbstractOperator<
         });
 
         Promise<Void> result = Promise.promise();
-        handler.setHandler(reconcileResult -> {
+        handler.onComplete(reconcileResult -> {
             handleResult(reconciliation, reconcileResult, reconciliationTimerSample);
             result.handle(reconcileResult);
         });
@@ -227,7 +227,7 @@ public abstract class AbstractOperator<
                 log.debug("{}: Lock {} acquired", reconciliation, lockName);
                 Lock lock = res.result();
                 try {
-                    callable.call().setHandler(callableRes -> {
+                    callable.call().onComplete(callableRes -> {
                         if (callableRes.succeeded()) {
                             handler.complete(callableRes.result());
                         } else {

--- a/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
@@ -50,7 +50,7 @@ public interface Operator {
      * @param handler Handler called on completion.
      */
     default void reconcileAll(String trigger, String namespace, Handler<AsyncResult<Void>> handler) {
-        allResourceNames(namespace).setHandler(ar -> {
+        allResourceNames(namespace).onComplete(ar -> {
             if (ar.succeeded()) {
                 reconcileThese(trigger, ar.result(), handler);
                 getPeriodicReconciliationsCounter().increment();
@@ -69,7 +69,7 @@ public interface Operator {
                 Reconciliation reconciliation = new Reconciliation(trigger, kind(), resourceRef.getNamespace(), resourceRef.getName());
                 futures.add(reconcile(reconciliation));
             }
-            CompositeFuture.join(futures).map((Void) null).setHandler(handler);
+            CompositeFuture.join(futures).map((Void) null).onComplete(handler);
         } else {
             getResourceCounter().set(0);
             handler.handle(Future.succeededFuture());

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
@@ -96,16 +96,16 @@ public abstract class AbstractNonNamespacedResourceOperator<C extends Kubernetes
                 if (desired != null) {
                     if (current == null) {
                         log.debug("{} {} does not exist, creating it", resourceKind, name);
-                        internalCreate(name, desired).setHandler(future);
+                        internalCreate(name, desired).onComplete(future);
                     } else {
                         log.debug("{} {} already exists, patching it", resourceKind, name);
-                        internalPatch(name, current, desired).setHandler(future);
+                        internalPatch(name, current, desired).onComplete(future);
                     }
                 } else {
                     if (current != null) {
                         // Deletion is desired
                         log.debug("{} {} exist, deleting it", resourceKind, name);
-                        internalDelete(name).setHandler(future);
+                        internalDelete(name).onComplete(future);
                     } else {
                         log.debug("{} {} does not exist, noop", resourceKind, name);
                         future.complete(ReconcileResult.noop(null));

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -97,16 +97,16 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
                 if (desired != null) {
                     if (current == null) {
                         log.debug("{} {}/{} does not exist, creating it", resourceKind, namespace, name);
-                        internalCreate(namespace, name, desired).setHandler(future);
+                        internalCreate(namespace, name, desired).onComplete(future);
                     } else {
                         log.debug("{} {}/{} already exists, patching it", resourceKind, namespace, name);
-                        internalPatch(namespace, name, current, desired).setHandler(future);
+                        internalPatch(namespace, name, current, desired).onComplete(future);
                     }
                 } else {
                     if (current != null) {
                         // Deletion is desired
                         log.debug("{} {}/{} exist, deleting it", resourceKind, namespace, name);
-                        internalDelete(namespace, name).setHandler(future);
+                        internalDelete(namespace, name).onComplete(future);
                     } else {
                         log.debug("{} {}/{} does not exist, noop", resourceKind, namespace, name);
                         future.complete(ReconcileResult.noop(null));

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperator.java
@@ -28,9 +28,9 @@ public class PodDisruptionBudgetOperator extends AbstractResourceOperator<Kubern
     @Override
     protected Future<ReconcileResult<PodDisruptionBudget>> internalPatch(String namespace, String name, PodDisruptionBudget current, PodDisruptionBudget desired, boolean cascading) {
         Promise<ReconcileResult<PodDisruptionBudget>> promise = Promise.promise();
-        internalDelete(namespace, name).setHandler(delRes -> {
+        internalDelete(namespace, name).onComplete(delRes -> {
             if (delRes.succeeded())    {
-                internalCreate(namespace, name, desired).setHandler(createRes -> {
+                internalCreate(namespace, name, desired).onComplete(createRes -> {
                     if (createRes.succeeded())  {
                         promise.complete(createRes.result());
                     } else {

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodOperator.java
@@ -83,7 +83,7 @@ public class PodOperator extends AbstractReadyResourceOperator<KubernetesClient,
                     return del;
                 });
 
-        podReconcileFuture.setHandler(deleteResult -> {
+        podReconcileFuture.onComplete(deleteResult -> {
             if (deleteResult.succeeded()) {
                 log.debug("{}: Pod {} was deleted", logContext, podName);
             }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
@@ -111,14 +111,14 @@ public class ResourceSupport {
                 this.timerId = vertx.setTimer(timeoutMs, ignored -> {
                     donePromise.tryFail(new TimeoutException());
                 });
-                CompositeFuture.join(watchPromise.future(), donePromise.future()).setHandler(joinResult -> {
+                CompositeFuture.join(watchPromise.future(), donePromise.future()).onComplete(joinResult -> {
                     Future<Void> closeFuture;
                     if (watchPromise.future().succeeded()) {
                         closeFuture = closeOnWorkerThread(watchPromise.future().result());
                     } else {
                         closeFuture = Future.succeededFuture();
                     }
-                    closeFuture.setHandler(closeResult -> {
+                    closeFuture.onComplete(closeResult -> {
                         vertx.runOnContext(ignored2 -> {
                             LOGGER.warn("Completing watch future");
                             if (joinResult.succeeded() && closeResult.succeeded()) {

--- a/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
@@ -75,7 +75,7 @@ public class PlatformFeaturesAvailabilityTest {
 
         Checkpoint a = context.checkpoint();
 
-        PlatformFeaturesAvailability.create(vertx, client).setHandler(context.succeeding(pfa -> context.verify(() -> {
+        PlatformFeaturesAvailability.create(vertx, client).onComplete(context.succeeding(pfa -> context.verify(() -> {
             assertThat("Versions are not equal", pfa.getKubernetesVersion(), is(KubernetesVersion.V1_9));
             stopMockApi(context, mockHttp);
             a.flag();
@@ -102,7 +102,7 @@ public class PlatformFeaturesAvailabilityTest {
 
         Checkpoint async = context.checkpoint();
 
-        PlatformFeaturesAvailability.create(vertx, client).setHandler(context.succeeding(pfa -> context.verify(() -> {
+        PlatformFeaturesAvailability.create(vertx, client).onComplete(context.succeeding(pfa -> context.verify(() -> {
             assertThat("Versions are not equal", pfa.getKubernetesVersion(), is(KubernetesVersion.V1_14));
             stopMockApi(context, mockHttp);
             async.flag();
@@ -121,7 +121,7 @@ public class PlatformFeaturesAvailabilityTest {
 
         Checkpoint async = context.checkpoint();
 
-        PlatformFeaturesAvailability.create(vertx, client).setHandler(context.succeeding(pfa -> context.verify(() -> {
+        PlatformFeaturesAvailability.create(vertx, client).onComplete(context.succeeding(pfa -> context.verify(() -> {
             assertThat(pfa.hasRoutes(), is(true));
             assertThat(pfa.hasBuilds(), is(true));
             assertThat(pfa.hasImages(), is(false));
@@ -145,7 +145,7 @@ public class PlatformFeaturesAvailabilityTest {
 
         Checkpoint async = context.checkpoint();
 
-        PlatformFeaturesAvailability.create(vertx, client).setHandler(context.succeeding(pfa -> context.verify(() -> {
+        PlatformFeaturesAvailability.create(vertx, client).onComplete(context.succeeding(pfa -> context.verify(() -> {
             assertThat(pfa.hasRoutes(), is(true));
             assertThat(pfa.hasBuilds(), is(true));
             assertThat(pfa.hasImages(), is(true));
@@ -163,7 +163,7 @@ public class PlatformFeaturesAvailabilityTest {
 
         Checkpoint async = context.checkpoint();
 
-        PlatformFeaturesAvailability.create(vertx, client).setHandler(context.succeeding(pfa -> context.verify(() -> {
+        PlatformFeaturesAvailability.create(vertx, client).onComplete(context.succeeding(pfa -> context.verify(() -> {
             assertThat(pfa.hasRoutes(), is(false));
             assertThat(pfa.hasBuilds(), is(false));
             assertThat(pfa.hasImages(), is(false));

--- a/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
@@ -74,7 +74,7 @@ public class OperatorMetricsTest {
 
         Checkpoint async = context.checkpoint();
         operator.reconcile(new Reconciliation("test", "TestResource", "my-namespace", "my-resource"))
-                .setHandler(context.succeeding(v -> context.verify(() -> {
+                .onComplete(context.succeeding(v -> context.verify(() -> {
                     MeterRegistry registry = metrics.meterRegistry();
 
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
@@ -113,7 +113,7 @@ public class OperatorMetricsTest {
 
         Checkpoint async = context.checkpoint();
         operator.reconcile(new Reconciliation("test", "TestResource", "my-namespace", "my-resource"))
-                .setHandler(context.failing(v -> context.verify(() -> {
+                .onComplete(context.failing(v -> context.verify(() -> {
                     MeterRegistry registry = metrics.meterRegistry();
 
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
@@ -152,7 +152,7 @@ public class OperatorMetricsTest {
 
         Checkpoint async = context.checkpoint();
         operator.reconcile(new Reconciliation("test", "TestResource", "my-namespace", "my-resource"))
-                .setHandler(context.failing(v -> context.verify(() -> {
+                .onComplete(context.failing(v -> context.verify(() -> {
                     MeterRegistry registry = metrics.meterRegistry();
 
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
@@ -201,7 +201,7 @@ public class OperatorMetricsTest {
 
         Checkpoint async = context.checkpoint();
         operator.reconcile(new Reconciliation("test", "TestResource", "my-namespace", "my-resource"))
-                .setHandler(context.succeeding(v -> context.verify(() -> {
+                .onComplete(context.succeeding(v -> context.verify(() -> {
                     MeterRegistry registry = metrics.meterRegistry();
 
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
@@ -251,7 +251,7 @@ public class OperatorMetricsTest {
         operator.reconcileAll("test", "my-namespace", reconcileAllPromise);
 
         Checkpoint async = context.checkpoint();
-        reconcileAllPromise.future().setHandler(context.succeeding(v -> context.verify(() -> {
+        reconcileAllPromise.future().onComplete(context.succeeding(v -> context.verify(() -> {
             MeterRegistry registry = metrics.meterRegistry();
 
             assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.periodical").tag("kind", "TestResource").counter().count(), is(1.0));

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractCustomResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractCustomResourceOperatorIT.java
@@ -120,7 +120,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
 
         log.info("Getting Kubernetes version");
         PlatformFeaturesAvailability.create(vertx, client)
-                .setHandler(context.succeeding(pfa -> context.verify(() -> {
+                .onComplete(context.succeeding(pfa -> context.verify(() -> {
                     assertThat("Kubernetes version : " + pfa.getKubernetesVersion() + " is too old",
                             pfa.getKubernetesVersion().compareTo(KubernetesVersion.V1_11), CoreMatchers.is(not(lessThan(0))));
                 })))
@@ -129,17 +129,17 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
                     log.info("Creating resource");
                     return op.reconcile(namespace, RESOURCE_NAME, getResource());
                 })
-                .setHandler(context.succeeding())
+                .onComplete(context.succeeding())
                 .compose(rrCreated -> {
                     T newStatus = getResourceWithNewReadyStatus(rrCreated.resource());
 
                     log.info("Updating resource status");
                     return op.updateStatusAsync(newStatus);
                 })
-                .setHandler(context.succeeding())
+                .onComplete(context.succeeding())
 
                 .compose(rrModified -> op.getAsync(namespace, RESOURCE_NAME))
-                .setHandler(context.succeeding(modifiedCustomResource -> context.verify(() -> {
+                .onComplete(context.succeeding(modifiedCustomResource -> context.verify(() -> {
                     assertReady(context, modifiedCustomResource);
                 })))
 
@@ -147,7 +147,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
                     log.info("Deleting resource");
                     return op.reconcile(namespace, RESOURCE_NAME, null);
                 })
-                .setHandler(context.succeeding(rrDeleted ->  async.flag()));
+                .onComplete(context.succeeding(rrDeleted ->  async.flag()));
     }
 
 
@@ -167,7 +167,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
 
         log.info("Getting Kubernetes version");
         PlatformFeaturesAvailability.create(vertx, client)
-                .setHandler(context.succeeding(pfa -> context.verify(() -> {
+                .onComplete(context.succeeding(pfa -> context.verify(() -> {
                     assertThat("Kubernetes version : " + pfa.getKubernetesVersion() + " is too old",
                             pfa.getKubernetesVersion().compareTo(KubernetesVersion.V1_11), CoreMatchers.is(not(lessThan(0))));
                 })))
@@ -175,7 +175,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
                     log.info("Creating resource");
                     return op.reconcile(namespace, RESOURCE_NAME, getResource());
                 })
-                .setHandler(context.succeeding())
+                .onComplete(context.succeeding())
 
                 .compose(rr -> {
                     log.info("Saving resource with status change prior to deletion");
@@ -183,13 +183,13 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
                     log.info("Deleting resource");
                     return op.reconcile(namespace, RESOURCE_NAME, null);
                 })
-                .setHandler(context.succeeding())
+                .onComplete(context.succeeding())
 
                 .compose(rrDeleted -> {
                     log.info("Updating resource with new status - should fail");
                     return op.updateStatusAsync(newStatus.get());
                 })
-                .setHandler(context.failing(e -> context.verify(() -> {
+                .onComplete(context.failing(e -> context.verify(() -> {
                     assertThat(e, instanceOf(KubernetesClientException.class));
                     async.flag();
                 })));
@@ -211,7 +211,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
 
         log.info("Getting Kubernetes version");
         PlatformFeaturesAvailability.create(vertx, client)
-                .setHandler(context.succeeding(pfa -> context.verify(() -> {
+                .onComplete(context.succeeding(pfa -> context.verify(() -> {
                     assertThat("Kubernetes version : " + pfa.getKubernetesVersion() + " is too old",
                             pfa.getKubernetesVersion().compareTo(KubernetesVersion.V1_11), CoreMatchers.is(not(lessThan(0))));
                 })))
@@ -219,7 +219,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
                     log.info("Creating resource");
                     return op.reconcile(namespace, RESOURCE_NAME, getResource());
                 })
-                .setHandler(context.succeeding())
+                .onComplete(context.succeeding())
                 .compose(rrCreated -> {
                     T updated = getResourceWithModifications(rrCreated.resource());
                     T newStatus = getResourceWithNewReadyStatus(rrCreated.resource());
@@ -230,7 +230,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
                     log.info("Updating resource status after underlying resource has changed");
                     return op.updateStatusAsync(newStatus);
                 })
-                .setHandler(context.failing(e -> context.verify(() -> {
+                .onComplete(context.failing(e -> context.verify(() -> {
                     assertThat("Exception was not KubernetesClientException, it was : " + e.toString(),
                             e, instanceOf(KubernetesClientException.class));
                     updateFailed.complete();
@@ -240,7 +240,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
             log.info("Deleting resource");
             return op.reconcile(namespace, RESOURCE_NAME, null);
         })
-        .setHandler(context.succeeding(v -> async.flag()));
+        .onComplete(context.succeeding(v -> async.flag()));
     }
 }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorIT.java
@@ -63,21 +63,21 @@ public abstract class AbstractNonNamespacedResourceOperatorIT<C extends Kubernet
         T modResource = getModified();
 
         op.reconcile(RESOURCE_NAME, newResource)
-            .setHandler(context.succeeding(rrCreate -> context.verify(() -> {
+            .onComplete(context.succeeding(rrCreate -> context.verify(() -> {
                 T created = op.get(RESOURCE_NAME);
 
                 assertThat("Failed to get created Resource", created, is(notNullValue()));
                 assertResources(context, newResource, created);
             })))
             .compose(rr -> op.reconcile(RESOURCE_NAME, modResource))
-            .setHandler(context.succeeding(rrModified -> context.verify(() -> {
+            .onComplete(context.succeeding(rrModified -> context.verify(() -> {
                 T modified = (T) op.get(RESOURCE_NAME);
 
                 assertThat("Failed to get modified Resource", modified, is(notNullValue()));
                 assertResources(context, modResource, modified);
             })))
             .compose(rr -> op.reconcile(RESOURCE_NAME, null))
-            .setHandler(context.succeeding(rrDelete -> context.verify(() -> {
+            .onComplete(context.succeeding(rrDelete -> context.verify(() -> {
                 T deleted = (T) op.get(RESOURCE_NAME);
 
                 assertThat("Failed to get modified Resource", deleted, is(nullValue()));

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
@@ -108,7 +108,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(resource())
-            .setHandler(context.succeeding(ar -> {
+            .onComplete(context.succeeding(ar -> {
                 verify(mockResource).get();
                 verify(mockResource).patch(any());
                 verify(mockResource, never()).create(any());
@@ -139,7 +139,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         AbstractNonNamespacedResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        op.createOrUpdate(resource).setHandler(context.failing(e -> {
+        op.createOrUpdate(resource).onComplete(context.failing(e -> {
             context.verify(() -> assertThat(e, is(ex)));
             async.flag();
         }));
@@ -165,7 +165,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
                 vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        op.createOrUpdate(resource).setHandler(context.succeeding(rr -> {
+        op.createOrUpdate(resource).onComplete(context.succeeding(rr -> {
             verify(mockResource).get();
             verify(mockResource).create(eq(resource));
             async.flag();
@@ -193,7 +193,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         AbstractNonNamespacedResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        op.createOrUpdate(resource).setHandler(context.failing(e -> {
+        op.createOrUpdate(resource).onComplete(context.failing(e -> {
             context.verify(() -> assertThat(e, is(ex)));
             async.flag();
         }));
@@ -216,7 +216,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         AbstractNonNamespacedResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        op.reconcile(resource.getMetadata().getName(), null).setHandler(context.succeeding(rrDeleted -> {
+        op.reconcile(resource.getMetadata().getName(), null).onComplete(context.succeeding(rrDeleted -> {
             verify(mockResource).get();
             verify(mockResource, never()).delete();
             async.flag();
@@ -252,7 +252,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         AbstractNonNamespacedResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        op.reconcile(resource.getMetadata().getName(), null).setHandler(context.succeeding(rrDeleted -> {
+        op.reconcile(resource.getMetadata().getName(), null).onComplete(context.succeeding(rrDeleted -> {
             verify(mockResource).delete();
             context.verify(() -> assertThat("Watch was not closed", watchWasClosed.get(), is(true)));
             async.flag();
@@ -286,7 +286,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         AbstractNonNamespacedResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        op.reconcile(resource.getMetadata().getName(), null).setHandler(context.failing(e -> context.verify(() -> {
+        op.reconcile(resource.getMetadata().getName(), null).onComplete(context.failing(e -> context.verify(() -> {
             assertThat(e, instanceOf(TimeoutException.class));
             verify(mockResource).delete();
             assertThat("Watch was not closed", watchWasClosed.get(), is(true));
@@ -323,7 +323,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         AbstractNonNamespacedResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        op.reconcile(resource.getMetadata().getName(), null).setHandler(context.succeeding(rrDeleted -> {
+        op.reconcile(resource.getMetadata().getName(), null).onComplete(context.succeeding(rrDeleted -> {
             verify(mockResource).delete();
             context.verify(() -> assertThat("Watch was not closed", watchWasClosed.get(), is(true)));
             async.flag();
@@ -360,7 +360,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         AbstractNonNamespacedResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        op.reconcile(resource.getMetadata().getName(), null).setHandler(context.failing(e -> context.verify(() -> {
+        op.reconcile(resource.getMetadata().getName(), null).onComplete(context.failing(e -> context.verify(() -> {
             assertThat(e, is(ex));
             assertThat("Watch was not closed", watchWasClosed.get(), is(true));
             async.flag();
@@ -389,7 +389,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         AbstractNonNamespacedResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        op.reconcile(resource.getMetadata().getName(), null).setHandler(context.failing(e -> {
+        op.reconcile(resource.getMetadata().getName(), null).onComplete(context.failing(e -> {
             context.verify(() -> assertThat(e, is(ex)));
             async.flag();
         }));
@@ -425,7 +425,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         AbstractNonNamespacedResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        op.reconcile(resource.getMetadata().getName(), null).setHandler(context.failing(e -> {
+        op.reconcile(resource.getMetadata().getName(), null).onComplete(context.failing(e -> {
             verify(mockResource).delete();
             context.verify(() -> assertThat("Watch was not closed", watchWasClosed.get(), is(true)));
             async.flag();

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorIT.java
@@ -90,21 +90,21 @@ public abstract class AbstractResourceOperatorIT<C extends KubernetesClient, T e
         T modResource = getModified();
 
         op.reconcile(namespace, RESOURCE_NAME, newResource)
-            .setHandler(context.succeeding(rrCreated -> {
+            .onComplete(context.succeeding(rrCreated -> {
                 T created = op.get(namespace, RESOURCE_NAME);
 
                 context.verify(() -> assertThat(created, is(notNullValue())));
                 assertResources(context, newResource, created);
             }))
             .compose(rr -> op.reconcile(namespace, RESOURCE_NAME, modResource))
-            .setHandler(context.succeeding(rrModified -> {
+            .onComplete(context.succeeding(rrModified -> {
                 T modified = op.get(namespace, RESOURCE_NAME);
 
                 context.verify(() -> assertThat(modified, is(notNullValue())));
                 assertResources(context, modResource, modified);
             }))
             .compose(rr -> op.reconcile(namespace, RESOURCE_NAME, null))
-            .setHandler(context.succeeding(rrDeleted -> {
+            .onComplete(context.succeeding(rrDeleted -> {
                 T deleted = op.get(namespace, RESOURCE_NAME);
 
                 context.verify(() -> assertThat(deleted, is(nullValue())));

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorTest.java
@@ -103,7 +103,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         AbstractResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        op.createOrUpdate(resource()).setHandler(context.succeeding(rr -> context.verify(() -> {
+        op.createOrUpdate(resource()).onComplete(context.succeeding(rr -> context.verify(() -> {
             verify(mockResource).get();
             verify(mockResource).patch(any());
             verify(mockResource, never()).create(any());
@@ -134,7 +134,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         AbstractResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        op.createOrUpdate(resource).setHandler(context.failing(e -> context.verify(() -> {
+        op.createOrUpdate(resource).onComplete(context.failing(e -> context.verify(() -> {
             assertThat(e, is(ex));
             async.flag();
         })));
@@ -159,7 +159,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         AbstractResourceOperator<C, T, L, D, R> op = createResourceOperationsWithMockedReadiness(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        op.createOrUpdate(resource).setHandler(context.succeeding(rr -> context.verify(() -> {
+        op.createOrUpdate(resource).onComplete(context.succeeding(rr -> context.verify(() -> {
             verify(mockResource).get();
             verify(mockResource).create(eq(resource));
             async.flag();
@@ -187,7 +187,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         AbstractResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        op.createOrUpdate(resource).setHandler(context.failing(e -> {
+        op.createOrUpdate(resource).onComplete(context.failing(e -> {
             context.verify(() -> assertThat(e, is(ex)));
             async.flag();
         }));
@@ -211,7 +211,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
 
         Checkpoint async = context.checkpoint();
         op.reconcile(resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
-            .setHandler(context.succeeding(rr -> context.verify(() -> {
+            .onComplete(context.succeeding(rr -> context.verify(() -> {
                 verify(mockResource).get();
                 verify(mockResource, never()).delete();
                 async.flag();
@@ -243,7 +243,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
 
         Checkpoint async = context.checkpoint();
         op.reconcile(resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
-            .setHandler(context.succeeding(rr -> context.verify(() -> {
+            .onComplete(context.succeeding(rr -> context.verify(() -> {
                 verify(mockDeletable).delete();
                 async.flag();
             })));
@@ -274,7 +274,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
 
         Checkpoint async = context.checkpoint();
         op.reconcile(resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
-            .setHandler(context.succeeding(rr -> context.verify(() -> {
+            .onComplete(context.succeeding(rr -> context.verify(() -> {
                 verify(mockDeletable).delete();
                 async.flag();
             })));
@@ -307,7 +307,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
 
         Checkpoint async = context.checkpoint();
         op.reconcile(resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, is(ex));
                 async.flag();
             })));

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbtractReadyResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbtractReadyResourceOperatorTest.java
@@ -53,7 +53,7 @@ public abstract class AbtractReadyResourceOperatorTest<C extends KubernetesClien
         AbstractReadyResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
         Checkpoint async = context.checkpoint();
         op.readiness(NAMESPACE, RESOURCE_NAME, 20, 100)
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(TimeoutException.class));
                 verify(mockResource, atLeastOnce()).get();
                 verify(mockResource, never()).isReady();
@@ -83,7 +83,7 @@ public abstract class AbtractReadyResourceOperatorTest<C extends KubernetesClien
 
         Checkpoint async = context.checkpoint();
         op.readiness(NAMESPACE, RESOURCE_NAME, 20, 100)
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(TimeoutException.class));
                 verify(mockResource, never()).isReady();
                 async.flag();
@@ -135,7 +135,7 @@ public abstract class AbtractReadyResourceOperatorTest<C extends KubernetesClien
 
         Checkpoint async = context.checkpoint();
         op.readiness(NAMESPACE, RESOURCE_NAME, 20, 5_000)
-            .setHandler(context.succeeding(v -> {
+            .onComplete(context.succeeding(v -> {
                 verify(mockResource, times(Readiness.isReadinessApplicable(resource.getClass()) ? unreadyCount + 1 : 1)).get();
 
                 if (Readiness.isReadinessApplicable(resource.getClass())) {
@@ -171,7 +171,7 @@ public abstract class AbtractReadyResourceOperatorTest<C extends KubernetesClien
 
         Checkpoint async = context.checkpoint();
         op.readiness(NAMESPACE, RESOURCE_NAME, 20, 100)
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(TimeoutException.class));
                 verify(mockResource, atLeastOnce()).get();
                 verify(mockResource, atLeastOnce()).isReady();
@@ -207,7 +207,7 @@ public abstract class AbtractReadyResourceOperatorTest<C extends KubernetesClien
 
         Checkpoint async = context.checkpoint();
         op.readiness(NAMESPACE, RESOURCE_NAME, 20, 100)
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(TimeoutException.class));
                 async.flag();
             })));

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
@@ -105,7 +105,7 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
 
         createResourceOperations(vertx, mockClient)
             .updateStatusAsync(resource())
-            .setHandler(context.succeeding(kafka -> async.flag()));
+            .onComplete(context.succeeding(kafka -> async.flag()));
     }
 
     @Test
@@ -125,7 +125,7 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
         Checkpoint async = context.checkpoint();
         createResourceOperations(vertx, mockClient)
             .updateStatusAsync(resource())
-            .setHandler(context.succeeding(kafka -> async.flag()));
+            .onComplete(context.succeeding(kafka -> async.flag()));
 
     }
 
@@ -146,7 +146,7 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
         Checkpoint async = context.checkpoint();
         createResourceOperations(vertx, mockClient)
             .updateStatusAsync(resource())
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(KubernetesClientException.class));
                 async.flag();
             })));
@@ -170,7 +170,7 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
         Checkpoint async = context.checkpoint();
         createResourceOperations(vertx, mockClient)
             .updateStatusAsync(resource())
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(KubernetesClientException.class));
                 async.flag();
             })));
@@ -193,7 +193,7 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
         Checkpoint async = context.checkpoint();
         createResourceOperations(vertx, mockClient)
             .updateStatusAsync(resource())
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(KubernetesClientException.class));
                 async.flag();
             })));

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperatorTest.java
@@ -94,7 +94,7 @@ public class PodDisruptionBudgetOperatorTest extends AbstractResourceOperatorTes
 
         Checkpoint async = context.checkpoint();
         Future<ReconcileResult<PodDisruptionBudget>> fut = op.createOrUpdate(resource());
-        fut.setHandler(ar -> {
+        fut.onComplete(ar -> {
             if (!ar.succeeded()) {
                 ar.cause().printStackTrace();
             }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodOperatorTest.java
@@ -55,7 +55,7 @@ public class PodOperatorTest extends
         context.verify(() -> assertThat(pr.list(NAMESPACE, Labels.EMPTY), is(emptyList())));
 
         Checkpoint async = context.checkpoint(1);
-        pr.createOrUpdate(resource()).setHandler(createResult -> {
+        pr.createOrUpdate(resource()).onComplete(createResult -> {
             context.verify(() -> assertThat(createResult.succeeded(), is(true)));
             context.verify(() -> assertThat(pr.list(NAMESPACE, Labels.EMPTY).stream()
                         .map(p -> p.getMetadata().getName())
@@ -89,7 +89,7 @@ public class PodOperatorTest extends
                 patchAsync.complete();
             });
             patchAsync.await();*/
-            pr.reconcile(NAMESPACE, RESOURCE_NAME, null).setHandler(deleteResult -> {
+            pr.reconcile(NAMESPACE, RESOURCE_NAME, null).onComplete(deleteResult -> {
                 context.verify(() -> assertThat(deleteResult.succeeded(), is(true)));
                 async.flag();
             });

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
@@ -87,7 +87,7 @@ public class ServiceAccountOperatorTest extends AbstractResourceOperatorTest<Kub
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(resource)
-            .setHandler(context.succeeding(rr -> {
+            .onComplete(context.succeeding(rr -> {
                 context.verify(() -> assertThat(rr, instanceOf(ReconcileResult.Noop.class)));
                 verify(mockResource).get();
                 //verify(mockResource).patch(any());

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <okhttp.version>3.12.6</okhttp.version>
         <okio.version>1.15.0</okio.version>
-        <vertx.version>3.8.5</vertx.version>
-        <vertx-juni5.version>3.8.5</vertx-juni5.version>
+        <vertx.version>3.9.1</vertx.version>
+        <vertx-junit5.version>3.9.1</vertx-junit5.version>
         <log4j.version>2.13.0</log4j.version>
         <hamcrest.version>2.2</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>
@@ -110,7 +110,7 @@
         <jupiter.version>5.5.1</jupiter.version>
         <junit.platform.version>1.5.1</junit.platform.version>
         <gson.version>2.8.2</gson.version>
-        <vertx.kafka.client>3.7.1</vertx.kafka.client>
+        <vertx.kafka.client>3.9.1</vertx.kafka.client>
         <netty.version>4.1.45.Final</netty.version>
         <micrometer.version>1.3.1</micrometer.version>
     </properties>
@@ -614,7 +614,7 @@
             <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-junit5</artifactId>
-                <version>${vertx-juni5.version}</version>
+                <version>${vertx-junit5.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -801,7 +801,7 @@
                     <dependency>
                         <groupId>io.vertx</groupId>
                         <artifactId>vertx-junit5</artifactId>
-                        <version>${vertx-juni5.version}</version>
+                        <version>${vertx-junit5.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-junit5</artifactId>
-            <version>${vertx-juni5.version}</version>
+            <version>${vertx-junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
@@ -99,7 +99,7 @@ public class K8sImpl implements K8s {
                         boolean notExists = kafkaTopic == null;
                         LOGGER.debug("KafkaTopic {} deleted {}", resourceName.toString(), notExists);
                         return notExists;
-                    }).setHandler(future);
+                    }).onComplete(future);
                 }
             } catch (Exception e) {
                 future.fail(e);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
@@ -59,7 +59,7 @@ class K8sTopicWatcher implements Watcher<KafkaTopic> {
                 }
             };
             if (!action.equals(Action.ERROR)) {
-                topicOperator.onResourceEvent(logContext, kafkaTopic, action).setHandler(resultHandler);
+                topicOperator.onResourceEvent(logContext, kafkaTopic, action).onComplete(resultHandler);
             } else {
                 LOGGER.error("Watch received action=ERROR for {} {}", kind, name);
             }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -223,7 +223,7 @@ public class Session extends AbstractVerticle {
                         if (!stopped) {
                             timerId = null;
                             boolean isInitialReconcile = oldTimerId == null;
-                            topicOperator.reconcileAllTopics(isInitialReconcile ? "initial " : "periodic ").setHandler(result -> {
+                            topicOperator.reconcileAllTopics(isInitialReconcile ? "initial " : "periodic ").onComplete(result -> {
                                 topicOperator.getPeriodicReconciliationsCounter().increment();
                                 if (isInitialReconcile) {
                                     initReconcilePromise.complete();
@@ -236,7 +236,7 @@ public class Session extends AbstractVerticle {
                     }
                 };
                 periodic.handle(null);
-                promise.future().setHandler(start);
+                promise.future().onComplete(start);
                 LOGGER.info("Started");
             });
     }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicConfigsWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicConfigsWatcher.java
@@ -21,7 +21,7 @@ class TopicConfigsWatcher extends ZkWatcher {
     protected void notifyOperator(String child) {
         LogContext logContext = LogContext.zkWatch(CONFIGS_ZNODE, "=" + child);
         log.info("{}: Topic config change", logContext);
-        topicOperator.onTopicConfigChanged(logContext, new TopicName(child)).setHandler(ar2 -> {
+        topicOperator.onTopicConfigChanged(logContext, new TopicName(child)).onComplete(ar2 -> {
             log.info("{}: Reconciliation result due to topic config change on topic {}: {}", logContext, child, ar2);
         });
     }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicMetadataHandler.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicMetadataHandler.java
@@ -72,10 +72,10 @@ public abstract class TopicMetadataHandler implements Handler<AsyncResult<TopicM
 
         if (delay < 1) {
             // vertx won't tolerate a zero delay
-            vertx.runOnContext(timerId -> kafka.topicMetadata(topicName).setHandler(this));
+            vertx.runOnContext(timerId -> kafka.topicMetadata(topicName).onComplete(this));
         } else {
             vertx.setTimer(TimeUnit.MILLISECONDS.convert(delay, TimeUnit.MILLISECONDS),
-                timerId -> kafka.topicMetadata(topicName).setHandler(this));
+                timerId -> kafka.topicMetadata(topicName).onComplete(this));
         }
     }
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -122,7 +122,7 @@ class TopicOperator {
                     LOGGER.warn("{}", message);
                     break;
             }
-            k8s.createEvent(event).setHandler(handler);
+            k8s.createEvent(event).onComplete(handler);
         }
 
         public String toString() {
@@ -151,7 +151,7 @@ class TopicOperator {
         @Override
         public void handle(Void v) throws OperatorException {
             KafkaTopic kafkaTopic = TopicSerialization.toTopicResource(this.topic, labels);
-            k8s.createResource(kafkaTopic).setHandler(handler);
+            k8s.createResource(kafkaTopic).onComplete(handler);
         }
 
         @Override
@@ -181,7 +181,7 @@ class TopicOperator {
 
         @Override
         public void handle(Void v) {
-            k8s.deleteResource(resourceName).setHandler(handler);
+            k8s.deleteResource(resourceName).onComplete(handler);
             statusUpdateGeneration.remove(resourceName.toString());
         }
 
@@ -213,7 +213,7 @@ class TopicOperator {
         @Override
         public void handle(Void v) {
             KafkaTopic kafkaTopic = TopicSerialization.toTopicResource(this.topic, labels);
-            k8s.updateResource(kafkaTopic).setHandler(handler);
+            k8s.updateResource(kafkaTopic).onComplete(handler);
         }
 
         @Override
@@ -247,7 +247,7 @@ class TopicOperator {
 
         @Override
         public void handle(Void v) throws OperatorException {
-            kafka.createTopic(topic).setHandler(ar -> {
+            kafka.createTopic(topic).onComplete(ar -> {
                 if (ar.succeeded()) {
                     LOGGER.debug("{}: Created topic '{}' for KafkaTopic '{}'",
                             logContext, topic.getTopicName(), topic.getResourceName());
@@ -289,7 +289,7 @@ class TopicOperator {
 
         @Override
         public void handle(Void v) throws OperatorException {
-            kafka.updateTopicConfig(topic).setHandler(ar -> {
+            kafka.updateTopicConfig(topic).onComplete(ar -> {
                 if (ar.failed()) {
                     enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> { }));
                 }
@@ -322,7 +322,7 @@ class TopicOperator {
 
         @Override
         public void handle(Void v) throws OperatorException {
-            kafka.increasePartitions(topic).setHandler(ar -> {
+            kafka.increasePartitions(topic).onComplete(ar -> {
                 if (ar.failed()) {
                     enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> { }));
                 }
@@ -359,7 +359,7 @@ class TopicOperator {
         @Override
         public void handle(Void v) throws OperatorException {
             LOGGER.info("{}: Deleting topic '{}'", logContext, topicName);
-            kafka.deleteTopic(topicName).setHandler(handler);
+            kafka.deleteTopic(topicName).onComplete(handler);
         }
 
         @Override
@@ -468,11 +468,11 @@ class TopicOperator {
             if (lockResult.succeeded()) {
                 LOGGER.debug("{}: Lock acquired", logContext);
                 LOGGER.debug("{}: Executing action {} on topic {}", logContext, action, lockName);
-                action.execute().setHandler(actionResult -> {
+                action.execute().onComplete(actionResult -> {
                     LOGGER.debug("{}: Executing handler for action {} on topic {}", logContext, action, lockName);
                     action.result = actionResult;
                     // Update status with lock held so that event is ignored via statusUpdateGeneration
-                    action.updateStatus(logContext).setHandler(statusResult -> {
+                    action.updateStatus(logContext).onComplete(statusResult -> {
                         if (statusResult.failed()) {
                             LOGGER.error("{}: Error updating KafkaTopic.status for action {}", logContext, action,
                                     statusResult.cause());
@@ -801,7 +801,7 @@ class TopicOperator {
                 Reconciliation self = this;
                 Promise<Void> promise = Promise.promise();
                 // getting topic information from the private store
-                topicStore.read(topicName).setHandler(topicResult -> {
+                topicStore.read(topicName).onComplete(topicResult -> {
 
                     TopicMetadataHandler handler = new TopicMetadataHandler(vertx, kafka, topicName, topicMetadataBackOff()) {
                         @Override
@@ -817,7 +817,7 @@ class TopicOperator {
                                     } else {
                                         LOGGER.info("Topic {} partitions changed to {}", topicName, kafkaTopic.getNumPartitions());
                                         reconcileOnTopicChange(logContext, topicName, kafkaTopic, self)
-                                            .setHandler(promise);
+                                            .onComplete(promise);
                                     }
 
                                 } else {
@@ -836,7 +836,7 @@ class TopicOperator {
                             promise.complete();
                         }
                     };
-                    kafka.topicMetadata(topicName).setHandler(handler);
+                    kafka.topicMetadata(topicName).onComplete(handler);
                 });
                 return promise.future();
             }
@@ -886,7 +886,7 @@ class TopicOperator {
                                 // resource...
                                 Topic kafkaTopic = TopicSerialization.fromTopicMetadata(metadataResult.result());
                                 reconcileOnTopicChange(logContext, topicName, kafkaTopic, self)
-                                        .setHandler(promise);
+                                        .onComplete(promise);
                             }
                         } else {
                             promise.fail(metadataResult.cause());
@@ -898,7 +898,7 @@ class TopicOperator {
                         promise.fail(e);
                     }
                 };
-                kafka.topicMetadata(topicName).setHandler(handler);
+                kafka.topicMetadata(topicName).onComplete(handler);
                 return promise.future();
             }
         };
@@ -955,7 +955,7 @@ class TopicOperator {
                     if (!ksDiff.isEmpty()) {
                         Promise<Void> promise = Promise.promise();
                         statusFuture = promise.future();
-                        k8s.updateResourceStatus(new KafkaTopicBuilder(topic).withStatus(kts).build()).setHandler(ar -> {
+                        k8s.updateResourceStatus(new KafkaTopicBuilder(topic).withStatus(kts).build()).onComplete(ar -> {
                             if (ar.succeeded() && ar.result() != null) {
                                 ObjectMeta metadata = ar.result().getMetadata();
                                 LOGGER.debug("{}: status was set rv={}, generation={}, observedGeneration={}",
@@ -1079,7 +1079,7 @@ class TopicOperator {
 
         @Override
         public void handle(Void v) throws OperatorException {
-            topicStore.update(topic).setHandler(ar -> {
+            topicStore.update(topic).onComplete(ar -> {
                 if (ar.failed()) {
                     enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> { }));
                 }
@@ -1116,7 +1116,7 @@ class TopicOperator {
         @Override
         public void handle(Void v) throws OperatorException {
             LOGGER.debug("Executing {}", this);
-            topicStore.create(topic).setHandler(ar -> {
+            topicStore.create(topic).onComplete(ar -> {
                 LOGGER.debug("Completing {}", this);
                 if (ar.failed()) {
                     LOGGER.debug("{} failed", this);
@@ -1157,7 +1157,7 @@ class TopicOperator {
 
         @Override
         public void handle(Void v) throws OperatorException {
-            topicStore.delete(topicName).setHandler(ar -> {
+            topicStore.delete(topicName).onComplete(ar -> {
                 if (ar.failed()) {
                     enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> { }));
                 }
@@ -1368,7 +1368,7 @@ class TopicOperator {
                     Topic topicFromKafka = TopicSerialization.fromTopicMetadata(kafkaTopicMeta);
                     return reconcile(reconciliation, logContext, kafkaTopicResource, k8sTopic, topicFromKafka, privateTopic);
                 })
-                .setHandler(ar -> {
+                .onComplete(ar -> {
                     if (ar.failed()) {
                         reconciliation.failed();
                         LOGGER.error("Error reconciling KafkaTopic {}", logTopic(kafkaTopicResource), ar.cause());

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicWatcher.java
@@ -22,7 +22,7 @@ public class ZkTopicWatcher extends ZkWatcher {
         LogContext logContext = LogContext.zkWatch(TOPICS_ZNODE, "=" + child);
         log.info("{}: Partitions change", logContext);
         topicOperator.onTopicPartitionsChanged(logContext,
-            new TopicName(child)).setHandler(ar -> {
+            new TopicName(child)).onComplete(ar -> {
                 log.info("{}: Reconciliation result due to topic partitions change on topic {}: {}", logContext, child, ar);
             });
     }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicsWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicsWatcher.java
@@ -82,7 +82,7 @@ class ZkTopicsWatcher {
                     tcw.removeChild(topicName);
                     tw.removeChild(topicName);
                     LogContext logContext = LogContext.zkWatch(TOPICS_ZNODE, "-" + topicName);
-                    topicOperator.onTopicDeleted(logContext, new TopicName(topicName)).setHandler(ar -> {
+                    topicOperator.onTopicDeleted(logContext, new TopicName(topicName)).onComplete(ar -> {
                         if (ar.succeeded()) {
                             LOGGER.debug("{}: Success responding to deletion of topic {}", logContext, topicName);
                         } else {
@@ -98,7 +98,7 @@ class ZkTopicsWatcher {
                     tcw.addChild(topicName);
                     tw.addChild(topicName);
                     LogContext logContext = LogContext.zkWatch(TOPICS_ZNODE, "+" + topicName);
-                    topicOperator.onTopicCreated(logContext, new TopicName(topicName)).setHandler(ar -> {
+                    topicOperator.onTopicCreated(logContext, new TopicName(topicName)).onComplete(ar -> {
                         if (ar.succeeded()) {
                             LOGGER.debug("{}: Success responding to creation of topic {}", logContext, topicName);
                         } else {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
@@ -68,7 +68,7 @@ public class K8sImplTest {
 
         K8sImpl k8s = new K8sImpl(vertx, mockClient, new Labels("foo", "bar"), "default");
 
-        k8s.listResources().setHandler(context.succeeding(kafkaTopics -> context.verify(() -> {
+        k8s.listResources().onComplete(context.succeeding(kafkaTopics -> context.verify(() -> {
             assertThat(kafkaTopics, is(mockKafkaTopicsList));
             async.flag();
         })));

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -237,7 +237,7 @@ public class TopicOperatorMockTest {
         AtomicReference<Topic> ref = new AtomicReference<>();
         Checkpoint async = context.checkpoint();
         Future<TopicMetadata> kafkaMetadata = session.kafka.topicMetadata(new TopicName(topicName));
-        kafkaMetadata.map(metadata -> TopicSerialization.fromTopicMetadata(metadata)).setHandler(fromKafka -> {
+        kafkaMetadata.map(metadata -> TopicSerialization.fromTopicMetadata(metadata)).onComplete(fromKafka -> {
             if (fromKafka.succeeded()) {
                 ref.set(fromKafka.result());
             } else {
@@ -276,7 +276,7 @@ public class TopicOperatorMockTest {
 
     void reconcile(VertxTestContext context) throws InterruptedException {
         Checkpoint async = context.checkpoint();
-        session.topicOperator.reconcileAllTopics("test").setHandler(ar -> {
+        session.topicOperator.reconcileAllTopics("test").onComplete(ar -> {
             if (!ar.succeeded()) {
                 context.failNow(ar.cause());
             }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
@@ -75,11 +75,11 @@ public class ZkTopicStoreTest {
 
         // Create the topic
         store.create(topic)
-            .setHandler(context.succeeding())
+            .onComplete(context.succeeding())
 
             // Read the topic
             .compose(v -> store.read(new TopicName("my_topic")))
-            .setHandler(context.succeeding(readTopic -> context.verify(() -> {
+            .onComplete(context.succeeding(readTopic -> context.verify(() -> {
                 // assert topics equal
                 assertThat(readTopic.getTopicName(), is(topic.getTopicName()));
                 assertThat(readTopic.getNumPartitions(), is(topic.getNumPartitions()));
@@ -89,7 +89,7 @@ public class ZkTopicStoreTest {
 
             // try to create it again: assert an error
             .compose(v -> store.create(topic))
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(TopicStore.EntityExistsException.class));
                 failedCreateCompleted.complete();
             })));
@@ -104,11 +104,11 @@ public class ZkTopicStoreTest {
                 // update my_topic
                 return store.update(updatedTopic);
             })
-            .setHandler(context.succeeding())
+            .onComplete(context.succeeding())
 
             // re-read it and assert equal
             .compose(v -> store.read(new TopicName("my_topic")))
-            .setHandler(context.succeeding(rereadTopic -> context.verify(() -> {
+            .onComplete(context.succeeding(rereadTopic -> context.verify(() -> {
                 // assert topics equal
                 assertThat(rereadTopic.getTopicName(), is(updatedTopic.getTopicName()));
                 assertThat(rereadTopic.getNumPartitions(), is(updatedTopic.getNumPartitions()));
@@ -118,17 +118,17 @@ public class ZkTopicStoreTest {
 
             // delete it
             .compose(v -> store.delete(updatedTopic.getTopicName()))
-            .setHandler(context.succeeding())
+            .onComplete(context.succeeding())
 
             // assert we can't read it again
             .compose(v -> store.read(new TopicName("my_topic")))
-            .setHandler(context.succeeding(deletedTopic -> context.verify(() -> {
+            .onComplete(context.succeeding(deletedTopic -> context.verify(() -> {
                 assertThat(deletedTopic, is(nullValue()));
             })))
 
             // delete it again: assert an error
             .compose(v -> store.delete(updatedTopic.getTopicName()))
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(TopicStore.NoSuchEntityExistsException.class));
                 async.flag();
             })));

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-junit5</artifactId>
-            <version>${vertx-juni5.version}</version>
+            <version>${vertx-junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -69,7 +69,7 @@ public class Main {
         KubernetesClient client = new DefaultKubernetesClient();
         AdminClientProvider adminClientProvider = new DefaultAdminClientProvider();
 
-        run(vertx, client, adminClientProvider, config).setHandler(ar -> {
+        run(vertx, client, adminClientProvider, config).onComplete(ar -> {
             if (ar.failed()) {
                 log.error("Unable to start operator", ar.cause());
                 System.exit(1);

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
@@ -75,7 +75,7 @@ public class UserOperator extends AbstractVerticle {
 
                 return startHealthServer().map((Void) null);
             })
-            .setHandler(start);
+            .onComplete(start);
     }
 
     @Override

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
@@ -95,15 +95,15 @@ public class SimpleAclOperator {
                         future.complete(ReconcileResult.noop(desired));
                     } else {
                         log.debug("User {}: No expected Acl rules, but {} existing Acl rules -> Deleting rules", username, current.size());
-                        internalDelete(username, current).setHandler(future);
+                        internalDelete(username, current).onComplete(future);
                     }
                 } else {
                     if (current.isEmpty())  {
                         log.debug("User {}: {} expected Acl rules, but no existing Acl rules -> Adding rules", username, desired.size());
-                        internalCreate(username, desired).setHandler(future);
+                        internalCreate(username, desired).onComplete(future);
                     } else  {
                         log.debug("User {}: {} expected Acl rules and {} existing Acl rules -> Reconciling rules", username, desired.size(), current.size());
-                        internalUpdate(username, desired, current).setHandler(future);
+                        internalUpdate(username, desired, current).onComplete(future);
                     }
                 }
             },
@@ -147,7 +147,7 @@ public class SimpleAclOperator {
 
         Promise<ReconcileResult<Set<SimpleAclRule>>> promise = Promise.promise();
 
-        CompositeFuture.all(updates).setHandler(res -> {
+        CompositeFuture.all(updates).onComplete(res -> {
             if (res.succeeded())    {
                 promise.complete(ReconcileResult.patched(desired));
             } else  {

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
@@ -103,7 +103,7 @@ public class KafkaUserOperatorTest {
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 List<String> capturedNames = secretNameCaptor.getAllValues();
                 assertThat(capturedNames, hasSize(1));
@@ -184,7 +184,7 @@ public class KafkaUserOperatorTest {
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 List<String> capturedNames = secretNameCaptor.getAllValues();
                 assertThat(capturedNames, hasSize(1));
@@ -259,7 +259,7 @@ public class KafkaUserOperatorTest {
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 List<String> capturedNames = secretNameCaptor.getAllValues();
                 assertThat(capturedNames, hasSize(1));
                 assertThat(capturedNames.get(0), is(ResourceUtils.NAME));
@@ -329,7 +329,7 @@ public class KafkaUserOperatorTest {
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 List<String> capturedNames = secretNameCaptor.getAllValues();
                 assertThat(capturedNames, hasSize(1));
@@ -378,7 +378,7 @@ public class KafkaUserOperatorTest {
 
         Checkpoint async = context.checkpoint();
         op.delete(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME))
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 List<String> capturedNames = secretNameCaptor.getAllValues();
                 assertThat(capturedNames, hasSize(1));
@@ -433,7 +433,7 @@ public class KafkaUserOperatorTest {
 
         Checkpoint async = context.checkpoint();
         op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME))
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 List<String> capturedNames = secretNameCaptor.getAllValues();
                 assertThat(capturedNames, hasSize(1));
@@ -517,7 +517,7 @@ public class KafkaUserOperatorTest {
 
         Checkpoint async = context.checkpoint();
         op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME))
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 List<String> capturedNames = secretNameCaptor.getAllValues();
                 assertThat(capturedNames, hasSize(1));
@@ -596,7 +596,7 @@ public class KafkaUserOperatorTest {
 
         Checkpoint async = context.checkpoint();
         op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME))
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 List<String> capturedNames = secretNameCaptor.getAllValues();
                 assertThat(capturedNames, hasSize(1));
@@ -723,7 +723,7 @@ public class KafkaUserOperatorTest {
 
         Checkpoint async = context.checkpoint();
         op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME))
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 List<String> capturedNames = secretNameCaptor.getAllValues();
                 assertThat(capturedNames, hasSize(1));
@@ -807,7 +807,7 @@ public class KafkaUserOperatorTest {
 
         Checkpoint async = context.checkpoint();
         op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME))
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 List<String> capturedNames = secretNameCaptor.getAllValues();
                 assertThat(capturedNames, hasSize(1));
@@ -887,7 +887,7 @@ public class KafkaUserOperatorTest {
 
         Checkpoint async = context.checkpoint();
         op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME))
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
 
                 List<String> capturedNames = secretNameCaptor.getAllValues();
                 assertThat(capturedNames, hasSize(1));
@@ -939,7 +939,7 @@ public class KafkaUserOperatorTest {
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user)
-            .setHandler(context.failing(e -> context.verify(() -> {
+            .onComplete(context.failing(e -> context.verify(() -> {
                 List<KafkaUser> capturedStatuses = userCaptor.getAllValues();
                 assertThat(capturedStatuses.get(0).getStatus().getUsername(), is("CN=user"));
                 assertThat(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), is("True"));
@@ -977,7 +977,7 @@ public class KafkaUserOperatorTest {
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .onComplete(context.succeeding(v -> context.verify(() -> {
                 List<KafkaUser> capturedStatuses = userCaptor.getAllValues();
                 assertThat(capturedStatuses.get(0).getStatus().getUsername(), is("CN=user"));
                 assertThat(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), is("True"));

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserQuotasIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserQuotasIT.java
@@ -339,7 +339,7 @@ public class KafkaUserQuotasIT {
 
         Checkpoint async = testContext.checkpoint();
         kuq.reconcile(username, quotas)
-            .setHandler(testContext.succeeding(rr -> testContext.verify(() -> {
+            .onComplete(testContext.succeeding(rr -> testContext.verify(() -> {
                 assertThat(kuq.exists(username), is(true));
                 assertThat(kuq.getQuotas(username).getJsonObject("config").getString("consumer_byte_rate"), is("2000000"));
                 assertThat(kuq.getQuotas(username).getJsonObject("config").getString("producer_byte_rate"), is("1000000"));
@@ -375,7 +375,7 @@ public class KafkaUserQuotasIT {
 
         Checkpoint async = testContext.checkpoint();
         kuq.reconcile(username, updatedQuotas)
-            .setHandler(testContext.succeeding(rr -> testContext.verify(() -> {
+            .onComplete(testContext.succeeding(rr -> testContext.verify(() -> {
                 assertThat(kuq.exists(username), is(true));
                 assertThat(kuq.getQuotas(username).getJsonObject("config").getString("consumer_byte_rate"), is("4000000"));
                 assertThat(kuq.getQuotas(username).getJsonObject("config").getString("producer_byte_rate"), is("3000000"));
@@ -410,7 +410,7 @@ public class KafkaUserQuotasIT {
 
         Checkpoint async = testContext.checkpoint();
         kuq.reconcile(username, updatedQuotas)
-            .setHandler(testContext.succeeding(rr -> testContext.verify(() -> {
+            .onComplete(testContext.succeeding(rr -> testContext.verify(() -> {
                 assertThat(kuq.exists(username), is(true));
                 assertThat(kuq.getQuotas(username).getJsonObject("config").getString("consumer_byte_rate"), is("4000000"));
                 assertThat(kuq.getQuotas(username).getJsonObject("config").getString("producer_byte_rate"), is("3000000"));
@@ -442,7 +442,7 @@ public class KafkaUserQuotasIT {
 
         Checkpoint async = testContext.checkpoint();
         kuq.reconcile(username, null)
-            .setHandler(testContext.succeeding(rr -> testContext.verify(() -> {
+            .onComplete(testContext.succeeding(rr -> testContext.verify(() -> {
                 assertThat(kuq.exists(username), is(false));
                 async.flag();
             })));

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorIT.java
@@ -98,7 +98,7 @@ public class SimpleAclOperatorIT {
 
         CountDownLatch async = new CountDownLatch(1);
         simpleAclOperator.reconcile("my-user", Collections.singleton(rule))
-                .setHandler(ignore -> context.verify(() -> {
+                .onComplete(ignore -> context.verify(() -> {
                     Set<SimpleAclRule> acls = simpleAclOperator.getAcls("my-user");
                     assertThat(acls, hasSize(1));
                     assertThat(acls, hasItem(rule));
@@ -119,7 +119,7 @@ public class SimpleAclOperatorIT {
 
         CountDownLatch async1 = new CountDownLatch(1);
         simpleAclOperator.reconcile("my-user", Collections.singleton(rule1))
-                .setHandler(ignore -> context.verify(() -> {
+                .onComplete(ignore -> context.verify(() -> {
                     Set<SimpleAclRule> acls = simpleAclOperator.getAcls("my-user");
                     assertThat(acls, hasSize(1));
                     assertThat(acls, hasItem(rule1));
@@ -136,7 +136,7 @@ public class SimpleAclOperatorIT {
 
         CountDownLatch async2 = new CountDownLatch(1);
         simpleAclOperator.reconcile("my-user", new HashSet<>(asList(rule1, rule2)))
-                .setHandler(ignore -> context.verify(() -> {
+                .onComplete(ignore -> context.verify(() -> {
                     Set<SimpleAclRule> acls = simpleAclOperator.getAcls("my-user");
                     assertThat(acls, hasSize(2));
                     assertThat(acls, hasItems(rule1, rule2));
@@ -157,7 +157,7 @@ public class SimpleAclOperatorIT {
 
         CountDownLatch async1 = new CountDownLatch(1);
         simpleAclOperator.reconcile("my-user", Collections.singleton(rule1))
-                .setHandler(ignore -> context.verify(() -> {
+                .onComplete(ignore -> context.verify(() -> {
                     Set<SimpleAclRule> acls = simpleAclOperator.getAcls("my-user");
                     assertThat(acls, hasSize(1));
                     assertThat(acls, hasItem(rule1));
@@ -168,7 +168,7 @@ public class SimpleAclOperatorIT {
 
         CountDownLatch async2 = new CountDownLatch(1);
         simpleAclOperator.reconcile("my-user", null)
-                .setHandler(ignore -> context.verify(() -> {
+                .onComplete(ignore -> context.verify(() -> {
                     Set<SimpleAclRule> acls = simpleAclOperator.getAcls("my-user");
                     assertThat(acls, IsEmptyCollection.empty());
                     async2.countDown();
@@ -188,7 +188,7 @@ public class SimpleAclOperatorIT {
 
         CountDownLatch async1 = new CountDownLatch(1);
         simpleAclOperator.reconcile("my-user", Collections.singleton(rule1))
-                .setHandler(ignore -> context.verify(() -> {
+                .onComplete(ignore -> context.verify(() -> {
                     Set<SimpleAclRule> acls = simpleAclOperator.getAcls("my-user");
                     assertThat(acls, hasSize(1));
                     assertThat(acls, hasItem(rule1));
@@ -205,7 +205,7 @@ public class SimpleAclOperatorIT {
 
         CountDownLatch async2 = new CountDownLatch(1);
         simpleAclOperator.reconcile("my-user-2", Collections.singleton(rule2))
-                .setHandler(ignore -> context.verify(() -> {
+                .onComplete(ignore -> context.verify(() -> {
                     Set<SimpleAclRule> acls = simpleAclOperator.getAcls("my-user-2");
                     assertThat(acls, hasSize(1));
                     assertThat(acls, hasItem(rule2));

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
@@ -131,7 +131,7 @@ public class SimpleAclOperatorTest {
 
         Checkpoint async = context.checkpoint();
         aclOp.reconcile("CN=foo", new LinkedHashSet<>(asList(resource2ReadRule, resource2WriteRule, resource1DescribeRule)))
-                .setHandler(context.succeeding(rr -> context.verify(() -> {
+                .onComplete(context.succeeding(rr -> context.verify(() -> {
                     Collection<AclBinding> capturedAclBindings = aclBindingsCaptor.getValue();
                     assertThat(capturedAclBindings, hasSize(3));
                     assertThat(capturedAclBindings, hasItems(describeAclBinding, readAclBinding, writeAclBinding));
@@ -170,7 +170,7 @@ public class SimpleAclOperatorTest {
 
         Checkpoint async = context.checkpoint();
         aclOp.reconcile("CN=foo", new LinkedHashSet(asList(rule1)))
-                .setHandler(context.succeeding(rr -> context.verify(() -> {
+                .onComplete(context.succeeding(rr -> context.verify(() -> {
 
                     // Create Write rule for resource 2
                     Collection<AclBinding> capturedAclBindings = aclBindingsCaptor.getValue();
@@ -213,7 +213,7 @@ public class SimpleAclOperatorTest {
 
         Checkpoint async = context.checkpoint();
         aclOp.reconcile("CN=foo", null)
-                .setHandler(context.succeeding(rr -> context.verify(() -> {
+                .onComplete(context.succeeding(rr -> context.verify(() -> {
 
                     Collection<AclBindingFilter> capturedAclBindingFilters = aclBindingFiltersCaptor.getValue();
                     assertThat(capturedAclBindingFilters, hasSize(1));


### PR DESCRIPTION
### Type of change

- Maintenance

### Description

This PR updates the Vert.x version to 3.9.1. The main change is that `setHandler(...)` method of `Future` is depdecated and replaced with `onComplete(...)`. These funstions seem to be replacebale one to one without any further changes to the code.

Apart from updating Vert.x, I also renamed the Maven property `vertx-juni5.version` to `vertx-junit5.version`. I assume that was just a typo in the name.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally