### PR TITLE
fix: Ensure multiple MM2 spec.clusters can use the same secret

### DIFF
--- a/docker-images/kafka/scripts/kafka_mirror_maker_2_connector_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_2_connector_config_generator.sh
@@ -29,7 +29,7 @@ if [ -n "$KAFKA_MIRRORMAKER_2_SASL_PASSWORD_FILES_CLUSTERS" ]; then
         export clusterAlias="${PASSWORD_FILE_CLUSTER[0]}"
         export passwordFile="${PASSWORD_FILE_CLUSTER[1]}"
 
-        PASSWORD=$(cat /opt/kafka/mm2-password/$passwordFile)
+        PASSWORD=$(cat /opt/kafka/mm2-password/$clusterAlias/$passwordFile)
         SASL_AUTH_CONFIGURATION=$(cat <<EOF
 ${SASL_AUTH_CONFIGURATION}
 ${clusterAlias}.sasl.password=${PASSWORD}

--- a/docker-images/kafka/scripts/kafka_mirror_maker_2_run.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_2_run.sh
@@ -48,7 +48,7 @@ do
         "${TLS_AUTH_KEYS["${clusterAlias}"]}" \
         "/tmp/kafka/clusters/${clusterAlias}.truststore.p12" \
         "/tmp/kafka/clusters/${clusterAlias}.keystore.p12" \
-        "/opt/kafka/mm2-certs" \
+        "/opt/kafka/mm2-certs/${clusterAlias}" \
         "/opt/kafka/mm2-oauth-certs/${clusterAlias}" \
         "/tmp/kafka/clusters/${clusterAlias}-oauth.truststore.p12"
 done


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

 - This PR allows multiple different clusters in the MM2
spec.clusters list to use the same secrets for TLS and security
credentials without failing the deployment due to duplicate volume
mount paths.
 - Using the same secret to hold multiple TLS/auth values can be
useful for those who want keep all their security credentials in one
place.

### Checklist

- [ x ] Write tests
- [ x ] Make sure all tests pass
- [ x ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

