### PR TITLE
Update list of maintainers in pom.xml and Helm Chart

### DIFF
--- a/helm-charts/strimzi-kafka-operator/Chart.yaml
+++ b/helm-charts/strimzi-kafka-operator/Chart.yaml
@@ -16,6 +16,8 @@ home: https://strimzi.io/
 sources:
 - https://github.com/strimzi/strimzi-kafka-operator
 maintainers:
+- name: Frawless
 - name: ppatierno
+- name: samuel-hawker
 - name: scholzj
 - name: tombentley

--- a/pom.xml
+++ b/pom.xml
@@ -35,19 +35,31 @@
             <name>Tom Bentley</name>
             <email>tbentley@redhat.com</email>
             <organization>Red Hat</organization>
-            <organizationUrl>http://www.redhat.com</organizationUrl>
+            <organizationUrl>https://www.redhat.com</organizationUrl>
         </developer>
         <developer>
             <name>Paolo Patierno</name>
             <email>ppatierno@live.com</email>
             <organization>Red Hat</organization>
-            <organizationUrl>http://www.redhat.com</organizationUrl>
+            <organizationUrl>https://www.redhat.com</organizationUrl>
         </developer>
         <developer>
             <name>Jakub Scholz</name>
             <email>github@scholzj.com</email>
             <organization>Red Hat</organization>
-            <organizationUrl>http://www.redhat.com</organizationUrl>
+            <organizationUrl>https://www.redhat.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>Sam Hawker</name>
+            <email>sam.b.hawker@gmail.com</email>
+            <organization>IBM</organization>
+            <organizationUrl>https://www.ibm.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>Jakub Stejskal</name>
+            <email>xstejs24@gmail.com</email>
+            <organization>Red Hat</organization>
+            <organizationUrl>https://www.redhat.com</organizationUrl>
         </developer>
     </developers>
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We should add the new maintainers to the `pom.xml` developers list and to the Helm Chart.