### PR TITLE
Bridge should use log4j2

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -508,4 +508,9 @@ public class KafkaBridgeCluster extends AbstractModel {
     public KafkaBridgeHttpConfig getHttp() {
         return this.http;
     }
+
+    @Override
+    public String getAncillaryConfigMapKeyLogConfig() {
+        return "log4j2.properties";
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
@@ -89,7 +89,7 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
                 null);
 
         Map<String, String> annotations = new HashMap<>(1);
-        annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, logAndMetricsConfigMap.getData().get(bridge.ANCILLARY_CM_KEY_LOG_CONFIG));
+        annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, logAndMetricsConfigMap.getData().get(bridge.getAncillaryConfigMapKeyLogConfig()));
 
         log.debug("{}: Updating Kafka Bridge cluster", reconciliation);
         kafkaBridgeServiceAccount(namespace, bridge)

--- a/cluster-operator/src/main/resources/kafkaBridgeDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/kafkaBridgeDefaultLoggingProperties
@@ -1,9 +1,25 @@
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n
-bridge.root.logger=INFO
-log4j.rootLogger=${bridge.root.logger}, CONSOLE
-log4j.logger.http.openapi.operation.healthy=WARN, CONSOLE
-log4j.additivity.http.openapi.operation.healthy=false
-log4j.logger.http.openapi.operation.ready=WARN, CONSOLE
-log4j.additivity.http.openapi.operation.ready=false
+#
+# The logging properties used
+#
+name = BridgeConfig
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ISO8601} %p %m (%c) [%t]%n
+
+rootLogger.level = INFO
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.additivity = false
+
+io.strimzi.kafka.bridge.level = INFO
+io.strimzi.kafka.bridge.appenderRefs = stdout
+io.strimzi.kafka.bridge.appenderRef.console.ref = STDOUT
+io.strimzi.kafka.bridge.appenderRef.additivity = false
+
+# HTTP OpenAPI specific logging levels (default is INFO)
+http.openapi.operation.healthy.level=WARN
+http.openapi.operation.healthyadditivity=false
+http.openapi.operation.ready.level=WARN
+http.openapi.operation.ready.additivity=false


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement

`Log4j` contains CVEs so it is reasonable to upgrade this dependency to `log4j2`. This PR relies on https://github.com/strimzi/strimzi-kafka-bridge/pull/412. With changes in the bridge, the operator needs to be adjusted.

TODO docs?

@Frawless how this PR will not pass, because the installation CR contains bridge version `0.16`. The changes in the bridge will be in master. 

### Description

_Please describe your pull request_

### Checklist

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

