### PR TITLE
[MO] - [system test] -> cruise control auto-create

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -49,7 +49,9 @@ public interface Constants {
 
     long API_CRUISE_CONTROL_POLL = Duration.ofSeconds(5).toMillis();
     long API_CRUISE_CONTROL_TIMEOUT = Duration.ofMinutes(10).toMillis();
-    long GLOBAL_CRUISE_CONTROL_TIMEOUT = Duration.ofSeconds(20).toMillis();
+    long GLOBAL_CRUISE_CONTROL_TIMEOUT = Duration.ofMinutes(1).toMillis();
+    long GLOBAL_CRUISE_CONTROL_EXCEPT_FAIL_TIMEOUT = Duration.ofSeconds(10).toMillis();
+
 
     long GLOBAL_CLIENTS_POLL = Duration.ofSeconds(15).toMillis();
     long GLOBAL_CLIENTS_TIMEOUT = Duration.ofMinutes(2).toMillis();

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -197,6 +197,26 @@ public class KafkaResource {
         return kafka;
     }
 
+    public static Kafka kafkaWithCruiseControlWithoutWait(String name, int kafkaReplicas, int zookeeperReplicas) {
+        Kafka kafka = getKafkaFromYaml(PATH_TO_KAFKA_CRUISE_CONTROL_CONFIG);
+        kafka = defaultKafka(kafka, name, kafkaReplicas, zookeeperReplicas).build();
+
+        return kafkaClient().inNamespace(ResourceManager.kubeClient().getNamespace()).createOrReplace(kafka);
+    }
+
+    public static Kafka kafkaWithCruiseControlWithoutWaitAutoCreateTopicsDisable(String name, int kafkaReplicas, int zookeeperReplicas) {
+        Kafka kafka = getKafkaFromYaml(PATH_TO_KAFKA_CRUISE_CONTROL_CONFIG);
+        kafka = defaultKafka(kafka, name, kafkaReplicas, zookeeperReplicas)
+                    .editSpec()
+                        .editKafka()
+                            .addToConfig("auto.create.topics.enable", "false")
+                        .endKafka()
+                    .endSpec()
+                .build();
+
+        return kafkaClient().inNamespace(ResourceManager.kubeClient().getNamespace()).createOrReplace(kafka);
+    }
+
     /**
      * This method is used for delete specific Kafka cluster without wait for all resources deletion.
      * It can be use for example for delete Kafka cluster CR with unsupported Kafka version.

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
@@ -79,36 +79,38 @@ public class CruiseControlUtils {
             kafkaProperties.getProperty("cruise.control.metrics.reporter.ssl.truststore.password").equals("${CERTS_STORE_PASSWORD}"));
     }
 
-    public static void verifyThatCruiseControlSamplesTopicsArePresent() {
+    public static void verifyThatCruiseControlSamplesTopicsArePresent(long timeout) {
         final int numberOfPartitionsSamplesTopic = 32;
         final int numberOfReplicasSamplesTopic = 2;
 
-        KafkaTopic modelTrainingSamples = KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(CRUISE_CONTROL_MODEL_TRAINING_SAMPLES_TOPIC).get();
-        KafkaTopic partitionsMetricsSamples = KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC).get();
-
         TestUtils.waitFor("Verify that kafka contains cruise control topics with related configuration.",
-            Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_CRUISE_CONTROL_TIMEOUT, () -> {
+            Constants.GLOBAL_POLL_INTERVAL, timeout, () -> {
+                KafkaTopic modelTrainingSamples = KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(CRUISE_CONTROL_MODEL_TRAINING_SAMPLES_TOPIC).get();
+                KafkaTopic partitionsMetricsSamples = KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC).get();
 
-                boolean hasTopicCorrectPartitionsCount =
-                        modelTrainingSamples.getSpec().getPartitions() == numberOfPartitionsSamplesTopic &&
-                        partitionsMetricsSamples.getSpec().getPartitions() == numberOfPartitionsSamplesTopic;
+                if (modelTrainingSamples != null && partitionsMetricsSamples != null) {
+                    boolean hasTopicCorrectPartitionsCount =
+                            modelTrainingSamples.getSpec().getPartitions() == numberOfPartitionsSamplesTopic &&
+                            partitionsMetricsSamples.getSpec().getPartitions() == numberOfPartitionsSamplesTopic;
 
-                boolean hasTopicCorrectReplicasCount =
-                        modelTrainingSamples.getSpec().getReplicas() == numberOfReplicasSamplesTopic &&
-                        partitionsMetricsSamples.getSpec().getReplicas() == numberOfReplicasSamplesTopic;
+                    boolean hasTopicCorrectReplicasCount =
+                            modelTrainingSamples.getSpec().getReplicas() == numberOfReplicasSamplesTopic &&
+                            partitionsMetricsSamples.getSpec().getReplicas() == numberOfReplicasSamplesTopic;
 
-                return hasTopicCorrectPartitionsCount && hasTopicCorrectReplicasCount;
+                    return hasTopicCorrectPartitionsCount && hasTopicCorrectReplicasCount;
+                }
+                LOGGER.debug("One of the samples {}, {} topics are not present", CRUISE_CONTROL_MODEL_TRAINING_SAMPLES_TOPIC, CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC);
+                return false;
             });
     }
 
-    public static void verifyThatKafkaCruiseControlMetricReporterTopicIsPresent() {
+    public static void verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(long timeout) {
         final int numberOfPartitionsMetricTopic = 1;
         final int numberOfReplicasMetricTopic = 1;
 
-        KafkaTopic metrics = KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(CRUISE_CONTROL_METRICS_TOPIC).get();
-
         TestUtils.waitFor("Verify that kafka contains cruise control topics with related configuration.",
-            Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_CRUISE_CONTROL_TIMEOUT, () -> {
+            Constants.GLOBAL_POLL_INTERVAL, timeout, () -> {
+                KafkaTopic metrics = KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(CRUISE_CONTROL_METRICS_TOPIC).get();
 
                 boolean hasTopicCorrectPartitionsCount =
                     metrics.getSpec().getPartitions() == numberOfPartitionsMetricTopic;
@@ -121,8 +123,8 @@ public class CruiseControlUtils {
     }
 
     public static void verifyThatCruiseControlTopicsArePresent() {
-        verifyThatCruiseControlSamplesTopicsArePresent();
-        verifyThatKafkaCruiseControlMetricReporterTopicIsPresent();
+        verifyThatCruiseControlSamplesTopicsArePresent(Constants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
+        verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(Constants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
     }
 
     public static Properties getKafkaCruiseControlMetricsReporterConfiguration(String clusterName) throws IOException {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
@@ -123,8 +123,8 @@ public class CruiseControlUtils {
     }
 
     public static void verifyThatCruiseControlTopicsArePresent() {
-        verifyThatCruiseControlSamplesTopicsArePresent(Constants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
         verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(Constants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
+        verifyThatCruiseControlSamplesTopicsArePresent(Constants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
     }
 
     public static Properties getKafkaCruiseControlMetricsReporterConfiguration(String clusterName) throws IOException {

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -46,6 +46,10 @@ public class CruiseControlIsolatedST extends BaseST {
         PodUtils.verifyThatRunningPodsAreStable(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
         PodUtils.verifyThatRunningPodsAreStable(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME));
 
+        LOGGER.info("Verifying that metrics reporter topic is not present because of selected config 'auto.create.topics.enable=false'");
+
+        assertThrows(WaitException.class, () -> CruiseControlUtils.verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(Constants.GLOBAL_CRUISE_CONTROL_EXCEPT_FAIL_TIMEOUT));
+
         PodUtils.waitUntilPodIsPresent(CruiseControlResources.deploymentName(CLUSTER_NAME));
         PodUtils.waitUntilPodIsInCrashLoopBackOff(kubeClient().listPodsByPrefixInName(CruiseControlResources.deploymentName(CLUSTER_NAME)).get(0).getMetadata().getName());
 
@@ -53,10 +57,6 @@ public class CruiseControlIsolatedST extends BaseST {
             "'Cruise Control cannot find partitions for the metrics reporter that topic matches strimzi.cruisecontrol.metrics in the target cluster'");
 
         assertThrows(WaitException.class, () -> CruiseControlUtils.verifyThatCruiseControlSamplesTopicsArePresent(Constants.GLOBAL_CRUISE_CONTROL_EXCEPT_FAIL_TIMEOUT));
-
-        LOGGER.info("Verifying that metrics reporter topic is not present because of selected config 'auto.create.topics.enable=false'");
-
-        assertThrows(WaitException.class, () -> CruiseControlUtils.verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(Constants.GLOBAL_CRUISE_CONTROL_EXCEPT_FAIL_TIMEOUT));
 
         // Since log compaction may remove records needed by Cruise Control, all topics created by Cruise Control must
         // be configured with cleanup.policy=delete to disable log compaction.

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -77,10 +77,6 @@ public class CruiseControlIsolatedST extends BaseST {
 
         assertThrows(WaitException.class, CruiseControlUtils::verifyThatKafkaCruiseControlMetricReporterTopicIsPresent);
 
-        LOGGER.info("Verifying that Cruise control pod is running and ready");
-
-        PodUtils.waitForPod(PodUtils.getFirstPodNameContaining("cruise-control"));
-
         // Since log compaction may remove records needed by Cruise Control, all topics created by Cruise Control must
         // be configured with cleanup.policy=delete to disable log compaction.
         // More in docs 8.5.2. Topic creation and configuration
@@ -91,6 +87,11 @@ public class CruiseControlIsolatedST extends BaseST {
             .done();
 
         CruiseControlUtils.verifyThatKafkaCruiseControlMetricReporterTopicIsPresent();
+
+        LOGGER.info("Verifying that Cruise control pod is running and ready");
+
+        PodUtils.waitForPod(PodUtils.getFirstPodNameContaining("cruise-control"));
+
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -4,8 +4,10 @@
  */
 package io.strimzi.systemtest.cruisecontrol;
 
+import io.strimzi.api.kafka.model.CruiseControlResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.BaseST;
+import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -21,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag(REGRESSION)
@@ -41,41 +44,19 @@ public class CruiseControlIsolatedST extends BaseST {
 
         PodUtils.verifyThatRunningPodsAreStable(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME));
         PodUtils.verifyThatRunningPodsAreStable(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
+        PodUtils.verifyThatRunningPodsAreStable(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME));
 
-        PodUtils.waitUntilPodIsInCrashLoopBackOff(PodUtils.getFirstPodNameContaining("cruise-control"));
+        PodUtils.waitUntilPodIsPresent(CruiseControlResources.deploymentName(CLUSTER_NAME));
+        PodUtils.waitUntilPodIsInCrashLoopBackOff(kubeClient().listPodsByPrefixInName(CruiseControlResources.deploymentName(CLUSTER_NAME)).get(0).getMetadata().getName());
 
         LOGGER.info("Verifying that samples topics are not present because of " +
             "'Cruise Control cannot find partitions for the metrics reporter that topic matches strimzi.cruisecontrol.metrics in the target cluster'");
 
-        assertThrows(WaitException.class, CruiseControlUtils::verifyThatCruiseControlSamplesTopicsArePresent);
+        assertThrows(WaitException.class, () -> CruiseControlUtils.verifyThatCruiseControlSamplesTopicsArePresent(Constants.GLOBAL_CRUISE_CONTROL_EXCEPT_FAIL_TIMEOUT));
 
         LOGGER.info("Verifying that metrics reporter topic is not present because of selected config 'auto.create.topics.enable=false'");
 
-        assertThrows(WaitException.class, CruiseControlUtils::verifyThatKafkaCruiseControlMetricReporterTopicIsPresent);
-
-        LOGGER.info("Creating samples topics {},{}", CRUISE_CONTROL_MODEL_TRAINING_SAMPLES_TOPIC, CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC);
-
-        KafkaTopicResource.topic(CLUSTER_NAME, CRUISE_CONTROL_MODEL_TRAINING_SAMPLES_TOPIC)
-            .editSpec()
-                .withPartitions(32)
-                .withReplicas(2)
-                .addToConfig("cleanup.policy", "delete")
-            .endSpec()
-            .done();
-
-        KafkaTopicResource.topic(CLUSTER_NAME, CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC)
-            .editSpec()
-                .withPartitions(32)
-                .withReplicas(2)
-                .addToConfig("cleanup.policy", "delete")
-            .endSpec()
-            .done();
-
-        CruiseControlUtils.verifyThatCruiseControlSamplesTopicsArePresent();
-
-        LOGGER.info("Verifying that metrics reporter topic is not present because of selected config 'auto.create.topics.enable=false'");
-
-        assertThrows(WaitException.class, CruiseControlUtils::verifyThatKafkaCruiseControlMetricReporterTopicIsPresent);
+        assertThrows(WaitException.class, () -> CruiseControlUtils.verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(Constants.GLOBAL_CRUISE_CONTROL_EXCEPT_FAIL_TIMEOUT));
 
         // Since log compaction may remove records needed by Cruise Control, all topics created by Cruise Control must
         // be configured with cleanup.policy=delete to disable log compaction.
@@ -86,12 +67,16 @@ public class CruiseControlIsolatedST extends BaseST {
             .endSpec()
             .done();
 
-        CruiseControlUtils.verifyThatKafkaCruiseControlMetricReporterTopicIsPresent();
+        CruiseControlUtils.verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(Constants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
 
-        LOGGER.info("Verifying that Cruise control pod is running and ready");
+        LOGGER.info("Implicitly creating samples topics {},{} because of explicitly created {} topic",
+            CRUISE_CONTROL_MODEL_TRAINING_SAMPLES_TOPIC, CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC, CRUISE_CONTROL_METRICS_TOPIC);
 
-        PodUtils.waitForPod(PodUtils.getFirstPodNameContaining("cruise-control"));
+        CruiseControlUtils.verifyThatCruiseControlSamplesTopicsArePresent(Constants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
 
+        LOGGER.info("Verifying that Cruise control pod is running and ready (stable)");
+
+        PodUtils.verifyThatRunningPodsAreStable(CruiseControlResources.deploymentName(CLUSTER_NAME));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -43,7 +43,14 @@ public class CruiseControlIsolatedST extends BaseST {
 
         assertThrows(WaitException.class, CruiseControlUtils::verifyThatKafkaCruiseControlMetricReporterTopicIsPresent);
 
-        KafkaTopicResource.topic(CLUSTER_NAME, CRUISE_CONTROL_METRICS_TOPIC).done();
+        // Since log compaction may remove records needed by Cruise Control, all topics created by Cruise Control must
+        // be configured with cleanup.policy=delete to disable log compaction.
+        // More in docs 8.5.2. Topic creation and configuration
+        KafkaTopicResource.topic(CLUSTER_NAME, CRUISE_CONTROL_METRICS_TOPIC)
+            .editSpec()
+                .addToConfig("cleanup.policy", "delete")
+            .endSpec()
+            .done();
 
         CruiseControlUtils.verifyThatKafkaCruiseControlMetricReporterTopicIsPresent();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.cruisecontrol;
+
+import io.strimzi.systemtest.BaseST;
+import io.strimzi.systemtest.resources.KubernetesResource;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
+import io.strimzi.systemtest.utils.specific.CruiseControlUtils;
+import io.strimzi.test.WaitException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CruiseControlIsolatedST extends BaseST {
+
+    private static final Logger LOGGER = LogManager.getLogger(CruiseControlConfigurationST.class);
+    private static final String NAMESPACE = "cruise-control-isolated-test";
+
+    private static final String CRUISE_CONTROL_METRICS_TOPIC = "strimzi.cruisecontrol.metrics"; // partitions 1 , rf - 1
+
+    @Test
+    void testManuallyCreateMetricsReporterTopic() {
+        KafkaResource.kafkaWithCruiseControl(CLUSTER_NAME, 3, 3)
+            .editSpec()
+                .editKafka()
+                    .addToConfig("auto.create.topics.enable", "false")
+                .endKafka()
+            .endSpec()
+            .done();
+
+        LOGGER.info("Verifying that samples topics are present");
+
+        CruiseControlUtils.verifyThatCruiseControlSamplesTopicsArePresent();
+
+        LOGGER.info("Verifying that metrics reporter topic is not present because of selected config 'auto.create.topics.enable=false'");
+
+        assertThrows(WaitException.class, CruiseControlUtils::verifyThatKafkaCruiseControlMetricReporterTopicIsPresent);
+
+        KafkaTopicResource.topic(CLUSTER_NAME, CRUISE_CONTROL_METRICS_TOPIC).done();
+
+        CruiseControlUtils.verifyThatKafkaCruiseControlMetricReporterTopicIsPresent();
+    }
+
+    @BeforeAll
+    void setup() {
+        ResourceManager.setClassResources();
+        prepareEnvForOperator(NAMESPACE);
+
+        applyRoleBindings(NAMESPACE);
+        // 050-Deployment
+        KubernetesResource.clusterOperator(NAMESPACE).done();
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -16,10 +16,15 @@ import io.strimzi.test.WaitException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
+import static io.strimzi.systemtest.Constants.REGRESSION;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@Tag(REGRESSION)
+@Tag(CRUISE_CONTROL)
 public class CruiseControlIsolatedST extends BaseST {
 
     private static final Logger LOGGER = LogManager.getLogger(CruiseControlIsolatedST.class);
@@ -71,6 +76,10 @@ public class CruiseControlIsolatedST extends BaseST {
         LOGGER.info("Verifying that metrics reporter topic is not present because of selected config 'auto.create.topics.enable=false'");
 
         assertThrows(WaitException.class, CruiseControlUtils::verifyThatKafkaCruiseControlMetricReporterTopicIsPresent);
+
+        LOGGER.info("Verifying that Cruise control pod is running and ready");
+
+        PodUtils.waitForPod(PodUtils.getFirstPodNameContaining("cruise-control"));
 
         // Since log compaction may remove records needed by Cruise Control, all topics created by Cruise Control must
         // be configured with cleanup.policy=delete to disable log compaction.


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature

### Description

This PR adding the test case when `auto.create.topics.enable` is set to false then metrics topic is not created. More can be found here https://github.com/strimzi/strimzi-kafka-operator/pull/2921 
### Checklist

- [x] Write tests
- [x] Make sure all tests pass


