### PR TITLE
[systemtest][fix] Update testJSONFormatLogging

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -38,6 +38,9 @@ public class StUtils {
 
     private static final Pattern VERSION_IMAGE_PATTERN = Pattern.compile("(?<version>[0-9.]+)=(?<image>[^\\s]*)");
 
+    private static final Pattern JSON_PATTERN = Pattern.compile("(\\{.*})\\{");
+    private static Matcher jsonMatcher;
+
     private StUtils() { }
 
     /**
@@ -202,14 +205,11 @@ public class StUtils {
     public static boolean checkLogForJSONFormat(Map<String, String> pods, String containerName) {
         boolean isJSON = false;
 
-        String regex = "(\\{.*})\\{";
-        Pattern pattern = Pattern.compile(regex);
-
         for (String podName : pods.keySet()) {
             String log = cmdKubeClient().exec(true, false, "logs", podName, "-c", containerName, "--tail=100").out();
             log = log.replaceAll("[\n|\r]", "");
-            Matcher matcher = pattern.matcher(log);
-            if (matcher.find()) {
+            jsonMatcher = JSON_PATTERN.matcher(log);
+            if (jsonMatcher.find()) {
                 LOGGER.info("JSON format logging successfully set for {} - {}", podName, containerName);
                 isJSON = true;
             } else {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -204,7 +204,7 @@ public class StUtils {
     public static boolean checkLogForJSONFormat(Map<String, String> pods, String containerName) {
         boolean isJSON = false;
         //this is only for decrease the number of records - kafka have record/line, operators record/11lines
-        String tail = "--tail=" + (containerName.contains("operator") ? "50" : "5");
+        String tail = "--tail=" + (containerName.contains("operator") ? "50" : "10");
 
         for (String podName : pods.keySet()) {
             String log = cmdKubeClient().execInCurrentNamespace(false, "logs", podName, "-c", containerName, tail).out();

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -38,7 +38,7 @@ public class StUtils {
 
     private static final Pattern VERSION_IMAGE_PATTERN = Pattern.compile("(?<version>[0-9.]+)=(?<image>[^\\s]*)");
 
-    private static final Pattern JSON_PATTERN = Pattern.compile("(\\{.*})\\{");
+    private static final Pattern JSON_PATTERN = Pattern.compile("}[\\n]+\\{");
     private static Matcher jsonMatcher;
 
     private StUtils() { }
@@ -204,15 +204,18 @@ public class StUtils {
 
     public static boolean checkLogForJSONFormat(Map<String, String> pods, String containerName) {
         boolean isJSON = false;
+        //this is only for decrease the number of records - kafka have record/line, operators record/11lines
+        String tail = "--tail=" + (containerName.contains("operator") ? "50" : "20");
 
         for (String podName : pods.keySet()) {
-            String log = cmdKubeClient().exec(true, false, "logs", podName, "-c", containerName, "--tail=100").out();
-            log = log.replaceAll("[\n|\r]", "");
+            String log = cmdKubeClient().exec(true, false, "logs", podName, "-c", containerName, tail).out();
             jsonMatcher = JSON_PATTERN.matcher(log);
-            if (jsonMatcher.find()) {
+            log = "[" + jsonMatcher.replaceAll("}, \\{").replaceAll("\n", " ").replaceFirst("(.*\\s)}, \\{", "{") + "]";
+            try {
+                new JsonArray(log);
                 LOGGER.info("JSON format logging successfully set for {} - {}", podName, containerName);
                 isJSON = true;
-            } else {
+            } catch (Exception e) {
                 LOGGER.info("Failed to set JSON format logging for {} - {}", podName, containerName);
                 isJSON = false;
                 break;

--- a/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
@@ -459,7 +459,7 @@ class LogSettingST extends BaseST {
         eoPods = DeploymentUtils.waitTillDepHasRolled(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), 1, eoPods);
         Map<String, String> operatorSnapshot = DeploymentUtils.depSnapshot("strimzi-cluster-operator");
 
-        assertThat(StUtils.checkLogForJSONFormat(operatorSnapshot, ""), is(true));
+        assertThat(StUtils.checkLogForJSONFormat(operatorSnapshot, "strimzi-cluster-operator"), is(true));
         assertThat(StUtils.checkLogForJSONFormat(kafkaPods, "kafka"), is(true));
         assertThat(StUtils.checkLogForJSONFormat(zkPods, "zookeeper"), is(true));
         assertThat(StUtils.checkLogForJSONFormat(eoPods, "topic-operator"), is(true));

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -241,6 +241,14 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     }
 
     @Override
+    public ExecResult exec(boolean throwError, boolean logToOutput, String... command) {
+        List<String> cmd = new ArrayList<>();
+        cmd.add(cmd());
+        cmd.addAll(asList(command));
+        return Exec.exec(null, cmd, 0, logToOutput, throwError);
+    }
+
+    @Override
     public ExecResult execInCurrentNamespace(String... commands) {
         return Exec.exec(namespacedCommand(commands));
     }

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -253,6 +253,11 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
         return Exec.exec(namespacedCommand(commands));
     }
 
+    @Override
+    public ExecResult execInCurrentNamespace(boolean logToOutput, String... commands) {
+        return Exec.exec(null, namespacedCommand(commands), 0, logToOutput);
+    }
+
     enum ExType {
         BREAK,
         CONTINUE,

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
@@ -76,6 +76,8 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
 
     ExecResult execInCurrentNamespace(String... commands);
 
+    ExecResult execInCurrentNamespace(boolean logToOutput, String... commands);
+
     /**
      * Execute the given {@code command} in the given {@code container} which is deployed in {@code pod}.
      * @param pod The pod

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
@@ -101,6 +101,15 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
     ExecResult exec(boolean throwError, String... command);
 
     /**
+     * Execute the given {@code command}. You can specify if potential failure will thrown the exception or not.
+     * @param throwError parameter which control thrown exception in case of failure
+     * @param command The command
+     * @param logToOutput determines if we want to print whole output of command
+     * @return The process result.
+     */
+    ExecResult exec(boolean throwError, boolean logToOutput, String... command);
+
+    /**
      * Wait for the resource with the given {@code name} to be created.
      * @param resourceType The resource type.
      * @param resourceName The resource name.


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix
- Refactoring

### Description

This PR gonna fix our failing test `testJSONFormatLogging`.

The problem here was in new updated version of JsonObject from vertx, the creation of the object is more sensitive than in the version when I wrote the test. 
Because i was taking the whole log of each component, it was sometimes really messy and it was really big burden for the memory, so I little bit simplify that to only 100 lines per component. But I needed to do some changes - I didn't wanted to log that 100 lines from each component, so I add option to our `cmdKubeClient().exec` method to enable/disable logging of output.

Now I'm not trying to make a JsonObject (because it needs more things that only get the `matcher`) and returning, if it finds the right pattern or not.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

