### PR TITLE
Allow disabling hostname verification in Zookeeper

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
@@ -47,7 +47,7 @@ public class ZookeeperClusterSpec implements UnknownPropertyPreserving, Serializ
             "quorum.auth, requireClientAuthScheme, snapshot.trust.empty, standaloneEnabled, " +
             "reconfigEnabled, 4lw.commands.whitelist, secureClientPort, ssl., serverCnxnFactory, sslQuorum";
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.protocol, ssl.quorum.protocol, ssl.enabledProtocols, " +
-            "ssl.quorum.enabledProtocols, ssl.ciphersuites, ssl.quorum.ciphersuites";
+            "ssl.quorum.enabledProtocols, ssl.ciphersuites, ssl.quorum.ciphersuites, ssl.hostnameVerification, ssl.quorum.hostnameVerification";
 
     public static final int DEFAULT_REPLICAS = 3;
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1131,7 +1131,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |string
 |storage         1.2+<.<|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim].
 |xref:type-EphemeralStorage-{context}[`EphemeralStorage`], xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`]
-|config          1.2+<.<|The ZooKeeper broker config. Properties with the following prefixes cannot be set: server., dataDir, dataLogDir, clientPort, authProvider, quorum.auth, requireClientAuthScheme, snapshot.trust.empty, standaloneEnabled, reconfigEnabled, 4lw.commands.whitelist, secureClientPort, ssl., serverCnxnFactory, sslQuorum (with the exception of: ssl.protocol, ssl.quorum.protocol, ssl.enabledProtocols, ssl.quorum.enabledProtocols, ssl.ciphersuites, ssl.quorum.ciphersuites).
+|config          1.2+<.<|The ZooKeeper broker config. Properties with the following prefixes cannot be set: server., dataDir, dataLogDir, clientPort, authProvider, quorum.auth, requireClientAuthScheme, snapshot.trust.empty, standaloneEnabled, reconfigEnabled, 4lw.commands.whitelist, secureClientPort, ssl., serverCnxnFactory, sslQuorum (with the exception of: ssl.protocol, ssl.quorum.protocol, ssl.enabledProtocols, ssl.quorum.enabledProtocols, ssl.ciphersuites, ssl.quorum.ciphersuites, ssl.hostnameVerification, ssl.quorum.hostnameVerification).
 |map
 |affinity        1.2+<.<|*The property `affinity` has been deprecated. This feature should now be configured at path `spec.zookeeper.template.pod.affinity`.* The pod's affinity rules. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[core/v1 affinity].
 

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -2356,7 +2356,8 @@ spec:
                     standaloneEnabled, reconfigEnabled, 4lw.commands.whitelist, secureClientPort,
                     ssl., serverCnxnFactory, sslQuorum (with the exception of: ssl.protocol,
                     ssl.quorum.protocol, ssl.enabledProtocols, ssl.quorum.enabledProtocols,
-                    ssl.ciphersuites, ssl.quorum.ciphersuites).'
+                    ssl.ciphersuites, ssl.quorum.ciphersuites, ssl.hostnameVerification,
+                    ssl.quorum.hostnameVerification).'
                 affinity:
                   type: object
                   properties:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -2351,7 +2351,8 @@ spec:
                     standaloneEnabled, reconfigEnabled, 4lw.commands.whitelist, secureClientPort,
                     ssl., serverCnxnFactory, sslQuorum (with the exception of: ssl.protocol,
                     ssl.quorum.protocol, ssl.enabledProtocols, ssl.quorum.enabledProtocols,
-                    ssl.ciphersuites, ssl.quorum.ciphersuites).'
+                    ssl.ciphersuites, ssl.quorum.ciphersuites, ssl.hostnameVerification,
+                    ssl.quorum.hostnameVerification).'
                 affinity:
                   type: object
                   properties:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Zookeeper has slightl strange implementation of hostname verification which among other things seems to be using reverse lookup based on the pod IP address etc. This looks like something what can cause weird issues such as the one discussed in #3111. This PR adds the two options for disabling hostname verification (`ssl.hostnameVerification` and `ssl.quorum.hostnameVerification`) to user configurable TLS options to make it easier to disable it. However, it is of course still enabled by default.