### PR TITLE
[DOCS] Installing the operator to watch all namespaces needs to fix the namespaces in RBAC files

### DIFF
--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-whole-cluster.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-whole-cluster.adoc
@@ -16,6 +16,12 @@ Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means t
 
 .Procedure
 
+. Edit the {ProductName} installation files to use the namespace the Cluster Operator is going to be installed to.
++
+For example, in this procedure the Cluster Operator is installed to the namespace `_my-cluster-operator-namespace_`.
++
+include::snip-cluster-operator-namespace-sed.adoc[]
+
 . Edit the `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml` file to set the value of the `STRIMZI_NAMESPACE` environment variable to `*`.
 +
 [source,yaml,subs="attributes"]


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

Our documentation for installing Cluster Operator to watch all namespaces currently does not work properly because it is missing the sed commands for changing the namespace in the ClusterRoleBindings / RoleBinding files. This PR adds it to the procedure to make it work.