### PR TITLE
[DOC] Minor review edits to make the namespace install instructions consistent

### DIFF
--- a/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
@@ -8,7 +8,7 @@
 
 In order to create your Kafka cluster, you deploy the Cluster Operator to manage the Kafka cluster, then deploy the Kafka cluster.
 
-When deploying the Kafka cluster using the `Kafka` resource, you can configure the deployment to deploy the Topic Operator and User Operator at the same time.
+When deploying the Kafka cluster using the `Kafka` resource, you can deploy the Topic Operator and User Operator at the same time.
 Alternatively, if you are using a non-{ProductName} Kafka cluster, you can deploy the Topic Operator and User Operator as standalone components.
 
 [discrete]

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-multiple-namespaces.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-multiple-namespaces.adoc
@@ -14,9 +14,9 @@ Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means t
 
 .Procedure
 
-. Edit the {ProductName} installation files to use the namespace the Cluster Operator is going to be installed to.
+. Edit the {ProductName} installation files to use the namespace the Cluster Operator is going to be installed into.
 +
-For example, in this procedure the Cluster Operator is installed to the namespace `_my-cluster-operator-namespace_`.
+For example, in this procedure the Cluster Operator is installed into the namespace `_my-cluster-operator-namespace_`.
 +
 include::snip-cluster-operator-namespace-sed.adoc[]
 
@@ -53,7 +53,7 @@ kubectl apply -f install/cluster-operator/020-RoleBinding-strimzi-cluster-operat
 kubectl apply -f install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml -n _watched-namespace_
 kubectl apply -f install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml -n _watched-namespace_
 
-. Deploy the Cluster Operator
+. Deploy the Cluster Operator:
 +
 [source,shell,subs="+quotes,attributes+"]
 kubectl apply -f install/cluster-operator -n _my-cluster-operator-namespace_

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-namespace.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-namespace.adoc
@@ -14,9 +14,9 @@ Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means t
 
 .Procedure
 
-. Edit the {ProductName} installation files to use the namespace the Cluster Operator is going to be installed to.
+. Edit the {ProductName} installation files to use the namespace the Cluster Operator is going to be installed into.
 +
-For example, in this procedure the Cluster Operator is installed to the namespace `_my-cluster-operator-namespace_`.
+For example, in this procedure the Cluster Operator is installed into the namespace `_my-cluster-operator-namespace_`.
 +
 include::snip-cluster-operator-namespace-sed.adoc[]
 

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-whole-cluster.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-whole-cluster.adoc
@@ -16,9 +16,9 @@ Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means t
 
 .Procedure
 
-. Edit the {ProductName} installation files to use the namespace the Cluster Operator is going to be installed to.
+. Edit the {ProductName} installation files to use the namespace the Cluster Operator is going to be installed into.
 +
-For example, in this procedure the Cluster Operator is installed to the namespace `_my-cluster-operator-namespace_`.
+For example, in this procedure the Cluster Operator is installed into the namespace `_my-cluster-operator-namespace_`.
 +
 include::snip-cluster-operator-namespace-sed.adoc[]
 
@@ -51,7 +51,7 @@ kubectl create clusterrolebinding strimzi-cluster-operator-namespaced --clusterr
 kubectl create clusterrolebinding strimzi-cluster-operator-entity-operator-delegation --clusterrole=strimzi-entity-operator --serviceaccount _my-cluster-operator-namespace_:strimzi-cluster-operator
 kubectl create clusterrolebinding strimzi-cluster-operator-topic-operator-delegation --clusterrole=strimzi-topic-operator --serviceaccount _my-cluster-operator-namespace_:strimzi-cluster-operator
 +
-Replace `_my-cluster-operator-namespace_` with the namespace you want to install the Cluster Operator to.
+Replace `_my-cluster-operator-namespace_` with the namespace you want to install the Cluster Operator into.
 
 . Deploy the Cluster Operator to your Kubernetes cluster.
 +

--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus.adoc
@@ -18,7 +18,7 @@ NOTE: By default, the Prometheus Operator only supports jobs that include an `en
 
 .Procedure
 
-. Modify the Prometheus installation file (`prometheus.yaml`) according to the namespace Prometheus is going to be installed in:
+. Modify the Prometheus installation file (`prometheus.yaml`) according to the namespace Prometheus is going to be installed into:
 +
 On Linux, use:
 +


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

### Type of change
**Documentation**

Small doc change to use _install into_ when referring to namespaces.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

