### PR TITLE
[DOC] Remove unnecessary documentation attributes

### DIFF
--- a/documentation/assemblies/assembly-access-configuration-kafka-mirror-maker.adoc
+++ b/documentation/assemblies/assembly-access-configuration-kafka-mirror-maker.adoc
@@ -11,7 +11,7 @@ Configure Kafka MirrorMaker encryption and authentication using supported mechan
 * Authentication:
 ** TLS client authentication
 ** SASL SCRAM-SHA-512 and PLAIN authentication
-** xref:assembly-oauth-authentication_str[{oauth} token-based authentication]
+** xref:assembly-oauth-authentication_str[OAuth 2.0 token-based authentication]
 +
 For more information on the TLS and SASL authentication mechanisms, see xref:con-kafka-mirror-maker-authentication-{context}[Authentication].
 

--- a/documentation/assemblies/assembly-configuring-container-images.adoc
+++ b/documentation/assemblies/assembly-configuring-container-images.adoc
@@ -13,11 +13,11 @@
 
 = Container images
 
-{ProductName} allows you to configure container images which will be used for its components.
+Strimzi allows you to configure container images which will be used for its components.
 Overriding container images is recommended only in special situations, where you need to use a different container registry.
-For example, because your network does not allow access to the container repository used by {ProductName}.
-In such a case, you should either copy the {ProductName} images or build them from the source.
-If the configured image is not compatible with {ProductName} images, it might not work properly.
+For example, because your network does not allow access to the container repository used by Strimzi.
+In such a case, you should either copy the Strimzi images or build them from the source.
+If the configured image is not compatible with Strimzi images, it might not work properly.
 
 include::../modules/ref-configuring-container-images.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/assembly-configuring-kafka-listeners.adoc
+++ b/documentation/assemblies/assembly-configuring-kafka-listeners.adoc
@@ -16,9 +16,9 @@ The following types of listeners are supported:
 * TLS listener on port 9093 (with TLS encryption)
 * External listener on port 9094 for access from outside of Kubernetes
 
-.{oauth}
-If you are using {oauth} token-based authentication, you can configure the listeners to connect to your authorization server.
-For more information, see xref:assembly-oauth-authentication_str[Using {oauth} token-based authentication].
+.OAuth 2.0
+If you are using OAuth 2.0 token-based authentication, you can configure the listeners to connect to your authorization server.
+For more information, see xref:assembly-oauth-authentication_str[Using OAuth 2.0 token-based authentication].
 
 .Listener certificates
 You can provide your own server certificates, called _Kafka listener certificates_, for TLS listeners or external listeners which have TLS encryption enabled. 

--- a/documentation/assemblies/assembly-customizing-deployments.adoc
+++ b/documentation/assemblies/assembly-customizing-deployments.adoc
@@ -5,7 +5,7 @@
 [id='assembly-customizing-deployments-{context}']
 = Customizing deployments
 
-{ProductName} creates several Kubernetes resources, such as `Deployments`, `StatefulSets`, `Pods`, and `Services`, which are managed by Kubernetes operators.
+Strimzi creates several Kubernetes resources, such as `Deployments`, `StatefulSets`, `Pods`, and `Services`, which are managed by Kubernetes operators.
 Only the operator that is responsible for managing a particular Kubernetes resource can change that resource.
 If you try to manually change an operator-managed Kubernetes resource, the operator will revert your changes back.
 
@@ -14,7 +14,7 @@ However, changing an operator-managed Kubernetes resource can be useful if you w
 - Adding custom labels or annotations that control how `Pods` are treated by Istio or other services;
 - Managing how `Loadbalancer`-type Services are created by the cluster.
 
-You can make these types of changes using the `template` property in the {ProductName} custom resources.
+You can make these types of changes using the `template` property in the Strimzi custom resources.
 
 include::../modules/con-customizing-template-properties.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/assembly-deploying-the-topic-operator.adoc
+++ b/documentation/assemblies/assembly-deploying-the-topic-operator.adoc
@@ -14,7 +14,7 @@ The Topic Operator manages Kafka topics through custom resources.
 The Topic Operator is deployed:
 
 * link:{BookURLDeploying}#deploying-the-topic-operator-using-the-cluster-operator-{context}[Using the Cluster Operator (recommended)^]
-* link:{BookURLDeploying}#deploying-the-topic-operator-standalone-{context}[Standalone to operate with Kafka clusters not managed by {ProductName}^]
+* link:{BookURLDeploying}#deploying-the-topic-operator-standalone-{context}[Standalone to operate with Kafka clusters not managed by Strimzi^]
 
 :parent-context-deploying: {context}
 :context: deploying

--- a/documentation/assemblies/assembly-deployment-configuration-kafka-mirror-maker.adoc
+++ b/documentation/assemblies/assembly-deployment-configuration-kafka-mirror-maker.adoc
@@ -15,9 +15,9 @@
 
 :context: deployment-configuration-kafka-mirror-maker
 
-This chapter describes how to configure a Kafka MirrorMaker deployment in your {ProductName} cluster to replicate data between Kafka clusters.
+This chapter describes how to configure a Kafka MirrorMaker deployment in your Strimzi cluster to replicate data between Kafka clusters.
 
-You can use {ProductName} with MirrorMaker or xref:assembly-mirrormaker-str[MirrorMaker 2.0].
+You can use Strimzi with MirrorMaker or xref:assembly-mirrormaker-str[MirrorMaker 2.0].
 MirrorMaker 2.0 is the latest version, and offers a more efficient way to mirror data between Kafka clusters.
 
 If you are using MirrorMaker, you configure the `KafkaMirrorMaker` resource.

--- a/documentation/assemblies/assembly-deployment-configuration.adoc
+++ b/documentation/assemblies/assembly-deployment-configuration.adoc
@@ -17,8 +17,8 @@ This chapter describes how to configure different aspects of the supported deplo
 * Kafka Connect clusters with _Source2Image_ support
 * Kafka MirrorMaker
 * Kafka Bridge
-* {oauth} token-based authentication
-* {oauth} token-based authorization
+* OAuth 2.0 token-based authentication
+* OAuth 2.0 token-based authorization
 * Cruise Control
 
 include::assembly-deployment-configuration-kafka.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-distributed-tracing.adoc
+++ b/documentation/assemblies/assembly-distributed-tracing.adoc
@@ -5,15 +5,15 @@
 [id='assembly-distributed-tracing-{context}']
 = Distributed tracing
 
-This chapter outlines the support for distributed tracing in {ProductName}, using Jaeger.
+This chapter outlines the support for distributed tracing in Strimzi, using Jaeger.
 
-How you configure distributed tracing varies by {ProductName} client and component.
+How you configure distributed tracing varies by Strimzi client and component.
 
 * You __instrument__ Kafka Producer, Consumer, and Streams API applications for distributed tracing using an OpenTracing client library. This involves adding instrumentation code to these clients, which monitors the execution of individual transactions in order to generate trace data.
 
-* Distributed tracing support is built in to the Kafka Connect, MirrorMaker, and Kafka Bridge components of {ProductName}. To configure these components for distributed tracing, you configure and update the relevant custom resources.
+* Distributed tracing support is built in to the Kafka Connect, MirrorMaker, and Kafka Bridge components of Strimzi. To configure these components for distributed tracing, you configure and update the relevant custom resources.
 
-Before configuring distributed tracing in {ProductName} clients and components, you must first initialize and configure a Jaeger tracer in the Kafka cluster, as described in xref:proc-configuring-jaeger-tracer-kafka-clients-{context}[Initializing a Jaeger tracer for Kafka clients].
+Before configuring distributed tracing in Strimzi clients and components, you must first initialize and configure a Jaeger tracer in the Kafka cluster, as described in xref:proc-configuring-jaeger-tracer-kafka-clients-{context}[Initializing a Jaeger tracer for Kafka clients].
 
 NOTE: Distributed tracing is not supported for Kafka brokers.
 
@@ -21,7 +21,7 @@ include::../modules/con-overview-distributed-tracing.adoc[leveloffset=+1]
 
 .Outline of procedures
 
-To set up distributed tracing for {ProductName}, follow these procedures:
+To set up distributed tracing for Strimzi, follow these procedures:
 
 * xref:proc-configuring-jaeger-tracer-kafka-clients-{context}[Initialize a Jaeger tracer for Kafka clients]
 
@@ -31,11 +31,11 @@ To set up distributed tracing for {ProductName}, follow these procedures:
 
 * xref:assembly-setting-up-tracing-mirror-maker-connect-bridge-{context}[Set up tracing for MirrorMaker, Kafka Connect, and the Kafka Bridge]
 
-This chapter covers setting up distributed tracing for {ProductName} clients and components only. Setting up distributed tracing for applications and systems beyond {ProductName} is outside the scope of this chapter. To learn more about this subject, see the {OpenTracingDocs} and search for "inject and extract".
+This chapter covers setting up distributed tracing for Strimzi clients and components only. Setting up distributed tracing for applications and systems beyond Strimzi is outside the scope of this chapter. To learn more about this subject, see the {OpenTracingDocs} and search for "inject and extract".
 
 .Before you start
 
-Before you set up distributed tracing for {ProductName}, it is helpful to understand:
+Before you set up distributed tracing for Strimzi, it is helpful to understand:
 
 * The basics of OpenTracing, including key concepts such as traces, spans, and tracers. Refer to the {OpenTracingDocs}.
 * The components of the {JaegerArch}. 

--- a/documentation/assemblies/assembly-getting-started.adoc
+++ b/documentation/assemblies/assembly-getting-started.adoc
@@ -7,18 +7,18 @@
 // See also the complementary step on the last line of this file.
 
 [id='getting-started-{context}']
-= Getting started with {ProductName}
+= Getting started with Strimzi
 
-{ProductName} is designed to work on all types of Kubernetes cluster regardless of distribution,
+Strimzi is designed to work on all types of Kubernetes cluster regardless of distribution,
 from public and private clouds to local deployments intended for development.
 
 ifdef::Downloading[]
-This section describes the procedures to deploy {ProductName} on Kubernetes {KubernetesVersion}.
+This section describes the procedures to deploy Strimzi on Kubernetes {KubernetesVersion}.
 endif::Downloading[]
 
 ifndef::Downloading[]
-{ProductName} is based on Strimzi {StrimziVersion}.
-This section describes the procedures to deploy {ProductName} on OpenShift {OpenShiftVersion}.
+Strimzi is based on Strimzi {StrimziVersion}.
+This section describes the procedures to deploy Strimzi on OpenShift {OpenShiftVersion}.
 endif::Downloading[]
 
 NOTE: To run the commands in this guide, your cluster user must have the rights to manage role-based access control (RBAC) and CRDs.

--- a/documentation/assemblies/assembly-healthchecks.adoc
+++ b/documentation/assemblies/assembly-healthchecks.adoc
@@ -21,7 +21,7 @@ Kubernetes supports two types of Healthcheck probes:
 * Readiness probes
 
 For more details about the probes, see {K8sLivenessReadinessProbes}.
-Both types of probes are used in {ProductName} components.
+Both types of probes are used in Strimzi components.
 
 Users can configure selected options for liveness and readiness probes.
 

--- a/documentation/assemblies/assembly-jmxtrans.adoc
+++ b/documentation/assemblies/assembly-jmxtrans.adoc
@@ -10,7 +10,7 @@
 
 JmxTrans is a way of retrieving JMX metrics data from Java processes and pushing that data in various formats to remote sinks inside or outside of the cluster.
 JmxTrans can communicate with a secure JMX port.
-{ProductName} supports using JmxTrans to read JMX data from Kafka brokers.
+Strimzi supports using JmxTrans to read JMX data from Kafka brokers.
 
 include::../modules/con-jmxtrans.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/assembly-jvm-options.adoc
+++ b/documentation/assemblies/assembly-jvm-options.adoc
@@ -14,16 +14,16 @@
 
 = JVM Options
 
-The following components of {ProductName} run inside a Virtual Machine (VM):
+The following components of Strimzi run inside a Virtual Machine (VM):
 
 * Apache Kafka
 * Apache ZooKeeper
 * Apache Kafka Connect
 * Apache Kafka MirrorMaker
-* {ProductName} Kafka Bridge
+* Strimzi Kafka Bridge
 
 JVM configuration options optimize the performance for different platforms and architectures.
-{ProductName} allows you to configure some of these options.
+Strimzi allows you to configure some of these options.
 
 include::../modules/ref-jvm-options.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/assembly-kafka-authentication-and-authorization.adoc
+++ b/documentation/assemblies/assembly-kafka-authentication-and-authorization.adoc
@@ -10,7 +10,7 @@
 [id='assembly-kafka-authentication-and-authorization-{context}']
 = Authentication and Authorization
 
-{ProductName} supports authentication and authorization.
+Strimzi supports authentication and authorization.
 Authentication can be configured independently for each xref:assembly-configuring-kafka-broker-listeners-{context}[listener].
 Authorization is always configured for the whole Kafka cluster.
 

--- a/documentation/assemblies/assembly-kafka-bridge-bootstrap-servers.adoc
+++ b/documentation/assemblies/assembly-kafka-bridge-bootstrap-servers.adoc
@@ -16,6 +16,6 @@ On Kubernetes, the list must ideally contain the Kafka cluster bootstrap service
 
 The list of bootstrap servers is configured in the `bootstrapServers` property in `KafkaBridge.kafka.spec`. The servers must be defined as a comma-separated list specifying one or more Kafka brokers, or a service pointing to Kafka brokers specified as a `_hostname_:_port_` pairs.
 
-When using Kafka Bridge with a Kafka cluster not managed by {ProductName}, you can specify the bootstrap servers list according to the configuration of the cluster.
+When using Kafka Bridge with a Kafka cluster not managed by Strimzi, you can specify the bootstrap servers list according to the configuration of the cluster.
 
 include::../modules/proc-configuring-kafka-bridge-bootstrap-servers.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-kafka-bridge-concepts.adoc
+++ b/documentation/assemblies/assembly-kafka-bridge-concepts.adoc
@@ -5,7 +5,7 @@
 [id='kafka-bridge-concepts-{context}']
 = Kafka Bridge
 
-This chapter provides an overview of the {ProductName} Kafka Bridge and helps you get started using its REST API to interact with {ProductName}. To try out the Kafka Bridge in your local environment, see the xref:assembly-kafka-bridge-quickstart-{context}[] later in this chapter.
+This chapter provides an overview of the Strimzi Kafka Bridge and helps you get started using its REST API to interact with Strimzi. To try out the Kafka Bridge in your local environment, see the xref:assembly-kafka-bridge-quickstart-{context}[] later in this chapter.
 
 include::assembly-kafka-bridge-overview.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/assembly-kafka-bridge-configuration.adoc
+++ b/documentation/assemblies/assembly-kafka-bridge-configuration.adoc
@@ -10,7 +10,7 @@
 
 = Kafka Bridge configuration
 
-{ProductName} allows you to customize the configuration of Apache Kafka Bridge nodes by editing certain options listed in {ApacheKafkaConsumerConfig} and {ApacheKafkaProducerConfig}.
+Strimzi allows you to customize the configuration of Apache Kafka Bridge nodes by editing certain options listed in {ApacheKafkaConsumerConfig} and {ApacheKafkaProducerConfig}.
 
 Configuration options that can be configured relate to:
 

--- a/documentation/assemblies/assembly-kafka-bridge-quickstart.adoc
+++ b/documentation/assemblies/assembly-kafka-bridge-quickstart.adoc
@@ -13,7 +13,7 @@
 
 :context: kafka-bridge-quickstart
 
-Use this quickstart to try out the {ProductName} Kafka Bridge in your local development environment. You will learn how to:
+Use this quickstart to try out the Strimzi Kafka Bridge in your local development environment. You will learn how to:
 
 * Deploy the Kafka Bridge to your Kubernetes cluster
 * Expose the Kafka Bridge service to your local machine by using port-forwarding
@@ -32,7 +32,7 @@ In this quickstart, you will produce and consume messages in JSON format, not bi
 .Prerequisites for the quickstart
 
 * Cluster administrator access to a local or remote Kubernetes cluster. 
-* {ProductName} is installed.
+* Strimzi is installed.
 * A running Kafka cluster, deployed by the Cluster Operator, in a Kubernetes namespace.
 * The Entity Operator is deployed and running as part of the Kafka cluster.  
 

--- a/documentation/assemblies/assembly-kafka-broker-configuration.adoc
+++ b/documentation/assemblies/assembly-kafka-broker-configuration.adoc
@@ -10,7 +10,7 @@
 
 = Kafka broker configuration
 
-{ProductName} allows you to customize the configuration of the Kafka brokers in your Kafka cluster.
+Strimzi allows you to customize the configuration of the Kafka brokers in your Kafka cluster.
 You can specify and configure most of the options listed in the "Broker Configs" section of the {ApacheKafkaBrokerConfig}. You cannot configure options that are related to the following areas:
 
 * Security (Encryption, Authentication, and Authorization)
@@ -20,7 +20,7 @@ You can specify and configure most of the options listed in the "Broker Configs"
 * Inter-broker communication
 * ZooKeeper connectivity
 
-These options are automatically configured by {ProductName}.
+These options are automatically configured by Strimzi.
 
 include::../modules/ref-kafka-broker-configuration.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/assembly-kafka-broker-external-listeners.adoc
+++ b/documentation/assemblies/assembly-kafka-broker-external-listeners.adoc
@@ -5,7 +5,7 @@
 [id='assembly-kafka-broker-external-listeners-{context}']
 = External listeners
 
-Use an external listener to expose your {ProductName} Kafka cluster to a client outside a Kubernetes environment.
+Use an external listener to expose your Strimzi Kafka cluster to a client outside a Kubernetes environment.
 
 .Additional resources
 

--- a/documentation/assemblies/assembly-kafka-broker-listener-network-policies.adoc
+++ b/documentation/assemblies/assembly-kafka-broker-listener-network-policies.adoc
@@ -5,7 +5,7 @@
 [id='assembly-kafka-broker-listener-network-policies-{context}']
 = Network policies
 
-{ProductName} automatically creates a `NetworkPolicy` resource for every listener that is enabled on a Kafka broker.
+Strimzi automatically creates a `NetworkPolicy` resource for every listener that is enabled on a Kafka broker.
 By default, a `NetworkPolicy` grants access to a listener to all applications and namespaces.
 
 If you want to restrict access to a listener at the network level to only selected applications or namespaces, use the `networkPolicyPeers` field.

--- a/documentation/assemblies/assembly-kafka-connect-authorization.adoc
+++ b/documentation/assemblies/assembly-kafka-connect-authorization.adoc
@@ -10,7 +10,7 @@
 If authorization is enabled for Kafka Connect, the Kafka Connect user must be configured to provide read/write access rights to the Kafka Connect consumer group and
 internal topics.
 
-The properties for the consumer group and internal topics are automatically configured by {ProductName}, or they can be specified explicitly in the `spec` for the `KafkaConnect` or `KafkaConnectS2I` configuration.
+The properties for the consumer group and internal topics are automatically configured by Strimzi, or they can be specified explicitly in the `spec` for the `KafkaConnect` or `KafkaConnectS2I` configuration.
 
 The following example shows the configuration of the properties in the `KafkaConnect` resource, which need to be represented in the Kafka Connect user configuration.
 

--- a/documentation/assemblies/assembly-kafka-connect-bootstrap-servers.adoc
+++ b/documentation/assemblies/assembly-kafka-connect-bootstrap-servers.adoc
@@ -17,6 +17,6 @@ On Kubernetes, the list must ideally contain the Kafka cluster bootstrap service
 
 The list of bootstrap servers is configured in the `bootstrapServers` property in `KafkaConnect.spec` and `KafkaConnectS2I.spec`. The servers must be defined as a comma-separated list specifying one or more Kafka brokers, or a service pointing to Kafka brokers specified as a `_hostname_:_port_` pairs.
 
-When using Kafka Connect with a Kafka cluster not managed by {ProductName}, you can specify the bootstrap servers list according to the configuration of the cluster.
+When using Kafka Connect with a Kafka cluster not managed by Strimzi, you can specify the bootstrap servers list according to the configuration of the cluster.
 
 include::../modules/proc-configuring-kafka-connect-bootstrap-servers.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-kafka-connect-configuration.adoc
+++ b/documentation/assemblies/assembly-kafka-connect-configuration.adoc
@@ -11,7 +11,7 @@
 
 = Kafka Connect configuration
 
-{ProductName} allows you to customize the configuration of Apache Kafka Connect nodes by editing certain options listed in {ApacheKafkaConnectConfig}.
+Strimzi allows you to customize the configuration of Apache Kafka Connect nodes by editing certain options listed in {ApacheKafkaConnectConfig}.
 
 Configuration options that cannot be configured relate to:
 
@@ -20,7 +20,7 @@ Configuration options that cannot be configured relate to:
 * Listener / REST interface configuration
 * Plugin path configuration
 
-These options are automatically configured by {ProductName}.
+These options are automatically configured by Strimzi.
 
 include::../modules/ref-kafka-connect-configuration.adoc[leveloffset=+1]
 include::../modules/con-kafka-connect-multiple-instances.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-kafka-jmx-options.adoc
+++ b/documentation/assemblies/assembly-kafka-jmx-options.adoc
@@ -11,10 +11,10 @@
 
 = JMX Options
 
-{ProductName} supports obtaining JMX metrics from the Kafka brokers by opening a JMX port on 9999.
+Strimzi supports obtaining JMX metrics from the Kafka brokers by opening a JMX port on 9999.
 You can obtain various metrics about each Kafka broker, for example, usage data such as the `BytesPerSecond` value
 or the request rate of the network of the broker.
-{ProductName} supports opening a password and username protected JMX port or a non-protected JMX port.
+Strimzi supports opening a password and username protected JMX port or a non-protected JMX port.
 
 
 include::../modules/proc-configuring-kafka-jmx-options.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-kafka-rack.adoc
+++ b/documentation/assemblies/assembly-kafka-rack.adoc
@@ -10,7 +10,7 @@
 
 = Kafka rack awareness
 
-The rack awareness feature in {ProductName} helps to spread the Kafka broker pods and Kafka topic replicas across different racks.
+The rack awareness feature in Strimzi helps to spread the Kafka broker pods and Kafka topic replicas across different racks.
 Enabling rack awareness helps to improve availability of Kafka brokers and the topics they are hosting.
 
 NOTE: "Rack" might represent an availability zone, data center, or an actual rack in your data center.

--- a/documentation/assemblies/assembly-overview.adoc
+++ b/documentation/assemblies/assembly-overview.adoc
@@ -7,7 +7,7 @@
 // See also the complementary step on the last line of this file.
 
 [id='overview-{context}']
-= Overview of {ProductName}
+= Overview of Strimzi
 
 //standard intro
 include::../shared/snip-intro-text.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-prometheus-metrics.adoc
+++ b/documentation/assemblies/assembly-prometheus-metrics.adoc
@@ -13,7 +13,7 @@
 
 = Prometheus metrics
 
-{ProductName} supports Prometheus metrics using link:https://github.com/prometheus/jmx_exporter[Prometheus JMX exporter^] to convert the JMX metrics supported by Apache Kafka and ZooKeeper to Prometheus metrics.
+Strimzi supports Prometheus metrics using link:https://github.com/prometheus/jmx_exporter[Prometheus JMX exporter^] to convert the JMX metrics supported by Apache Kafka and ZooKeeper to Prometheus metrics.
 When metrics are enabled, they are exposed on port 9404.
 
 For more information about setting up and deploying Prometheus and Grafana, see link:{BookURLDeploying}#assembly-metrics-setup-str[Introducing Metrics to Kafka].

--- a/documentation/assemblies/assembly-resource-limits-and-requests.adoc
+++ b/documentation/assemblies/assembly-resource-limits-and-requests.adoc
@@ -13,14 +13,14 @@
 
 = CPU and memory resources
 
-For every deployed container, {ProductName} allows you to request specific resources and define the maximum consumption of those resources.
+For every deployed container, Strimzi allows you to request specific resources and define the maximum consumption of those resources.
 
-{ProductName} supports two types of resources:
+Strimzi supports two types of resources:
 
 * CPU
 * Memory
 
-{ProductName} uses the Kubernetes syntax for specifying CPU and memory resources.
+Strimzi uses the Kubernetes syntax for specifying CPU and memory resources.
 
 include::../modules/ref-resource-limits-and-requests.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/assembly-setting-up-tracing-mirror-maker-connect-bridge.adoc
+++ b/documentation/assemblies/assembly-setting-up-tracing-mirror-maker-connect-bridge.adoc
@@ -4,7 +4,7 @@
 [id='assembly-setting-up-tracing-mirror-maker-connect-bridge-{context}']
 = Setting up tracing for MirrorMaker, Kafka Connect, and the Kafka Bridge
 
-Distributed tracing is supported for MirrorMaker, Kafka Connect (including Kafka Connect with Source2Image support), and the {ProductName} Kafka Bridge.
+Distributed tracing is supported for MirrorMaker, Kafka Connect (including Kafka Connect with Source2Image support), and the Strimzi Kafka Bridge.
 
 .Tracing in MirrorMaker
 

--- a/documentation/assemblies/assembly-storage.adoc
+++ b/documentation/assemblies/assembly-storage.adoc
@@ -10,7 +10,7 @@
 [id='assembly-storage-{context}']
 = Kafka and ZooKeeper storage types
 
-As stateful applications, Kafka and ZooKeeper need to store data on disk. {ProductName} supports three storage types for this data:
+As stateful applications, Kafka and ZooKeeper need to store data on disk. Strimzi supports three storage types for this data:
 
 * Ephemeral
 * Persistent

--- a/documentation/assemblies/assembly-tls-sidecar.adoc
+++ b/documentation/assemblies/assembly-tls-sidecar.adoc
@@ -11,7 +11,7 @@
 = TLS sidecar
 
 A sidecar is a container that runs in a pod but serves a supporting purpose.
-In {ProductName}, the TLS sidecar uses TLS to encrypt and decrypt all communication between the various components and ZooKeeper.
+In Strimzi, the TLS sidecar uses TLS to encrypt and decrypt all communication between the various components and ZooKeeper.
 ZooKeeper does not have native TLS support.
 
 The TLS sidecar is used in:

--- a/documentation/assemblies/assembly-user-operator.adoc
+++ b/documentation/assemblies/assembly-user-operator.adoc
@@ -10,7 +10,7 @@ The User Operator manages Kafka users through custom resources.
 The User Operator is deployed:
 
 * link:{BookURLDeploying}#deploying-the-user-operator-using-the-cluster-operator-{context}[Using the Cluster Operator (recommended)^]
-* link:{BookURLDeploying}#deploying-the-user-operator-standalone-{context}[Standalone to operate with Kafka clusters not managed by {ProductName}^]
+* link:{BookURLDeploying}#deploying-the-user-operator-standalone-{context}[Standalone to operate with Kafka clusters not managed by Strimzi^]
 
 :parent-context-deploying-uo: {context}
 :context: deploying-uo

--- a/documentation/assemblies/assembly-zookeeper-connection.adoc
+++ b/documentation/assemblies/assembly-zookeeper-connection.adoc
@@ -6,7 +6,7 @@
 
 = ZooKeeper connection
 
-ZooKeeper services are secured with encryption and authentication and are not intended to be used by external applications that are not part of {ProductName}.
+ZooKeeper services are secured with encryption and authentication and are not intended to be used by external applications that are not part of Strimzi.
 
 However, if you want to use Kafka CLI tools that require a connection to ZooKeeper, such as the `kafka-topics` tool, you can use a terminal inside a Kafka container and connect to the local end of the TLS tunnel to ZooKeeper by using `localhost:2181` as the ZooKeeper address.
 

--- a/documentation/assemblies/assembly-zookeeper-node-configuration.adoc
+++ b/documentation/assemblies/assembly-zookeeper-node-configuration.adoc
@@ -10,7 +10,7 @@
 
 = ZooKeeper configuration
 
-{ProductName} allows you to customize the configuration of Apache ZooKeeper nodes.
+Strimzi allows you to customize the configuration of Apache ZooKeeper nodes.
 You can specify and configure most of the options listed in the {ApacheZookeeperConfig}.
 
 Options which cannot be configured are those related to the following areas:
@@ -20,7 +20,7 @@ Options which cannot be configured are those related to the following areas:
 * Configuration of data directories
 * ZooKeeper cluster composition
 
-These options are automatically configured by {ProductName}.
+These options are automatically configured by Strimzi.
 
 include::../modules/ref-zookeeper-node-configuration.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/assembly-zookeeper-replicas.adoc
+++ b/documentation/assemblies/assembly-zookeeper-replicas.adoc
@@ -12,7 +12,7 @@
 
 ZooKeeper clusters or ensembles usually run with an odd number of nodes, typically three, five, or seven.
 
-The majority of nodes must be available in order to maintain an effective quorum. If the ZooKeeper cluster loses its quorum, it will stop responding to clients and the Kafka brokers will stop working. Having a stable and highly available ZooKeeper cluster is crucial for {ProductName}.
+The majority of nodes must be available in order to maintain an effective quorum. If the ZooKeeper cluster loses its quorum, it will stop responding to clients and the Kafka brokers will stop working. Having a stable and highly available ZooKeeper cluster is crucial for Strimzi.
 
 Three-node cluster::
 A three-node ZooKeeper cluster requires at least two nodes to be up and running in order to maintain the quorum.

--- a/documentation/assemblies/cruise-control/assembly-cruise-control-concepts.adoc
+++ b/documentation/assemblies/cruise-control/assembly-cruise-control-concepts.adoc
@@ -5,11 +5,11 @@
 [id='cruise-control-concepts-{context}']
 = Cruise Control for cluster rebalancing
 
-You can deploy {CruiseControlProject} to your {ProductName} cluster and use it to _rebalance_ the Kafka cluster. 
+You can deploy {CruiseControlProject} to your Strimzi cluster and use it to _rebalance_ the Kafka cluster. 
 
 Cruise Control is an open source system for automating Kafka operations, such as monitoring cluster workload, rebalancing a cluster based on predefined constraints, and detecting and fixing anomalies. 
 It consists of four main components--the Load Monitor, the Analyzer, the Anomaly Detector, and the Executor--and a REST API for client interactions.
-{ProductName} utilizes the REST API to support the following Cruise Control features:
+Strimzi utilizes the REST API to support the following Cruise Control features:
 
 * Generating _optimization proposals_ from multiple _optimization goals_. 
 

--- a/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
@@ -9,12 +9,12 @@
 In order to create your Kafka cluster, you deploy the Cluster Operator to manage the Kafka cluster, then deploy the Kafka cluster.
 
 When deploying the Kafka cluster using the `Kafka` resource, you can deploy the Topic Operator and User Operator at the same time.
-Alternatively, if you are using a non-{ProductName} Kafka cluster, you can deploy the Topic Operator and User Operator as standalone components.
+Alternatively, if you are using a non-Strimzi Kafka cluster, you can deploy the Topic Operator and User Operator as standalone components.
 
 [discrete]
 == Deploying a Kafka cluster with the Topic Operator and User Operator
 
-Perform these deployment steps if you want to use the Topic Operator and User Operator with a Kafka cluster managed by {ProductName}.
+Perform these deployment steps if you want to use the Topic Operator and User Operator with a Kafka cluster managed by Strimzi.
 
 . xref:cluster-operator-{context}[Deploy the Cluster Operator]
 . Use the Cluster Operator to deploy the:
@@ -25,7 +25,7 @@ Perform these deployment steps if you want to use the Topic Operator and User Op
 [discrete]
 == Deploying a standalone Topic Operator and User Operator
 
-Perform these deployment steps if you want to use the Topic Operator and User Operator with a Kafka cluster that is *not managed* by {ProductName}.
+Perform these deployment steps if you want to use the Topic Operator and User Operator with a Kafka cluster that is *not managed* by Strimzi.
 
 . xref:deploying-the-topic-operator-standalone-{context}[Deploy the standalone Topic Operator]
 . xref:deploying-the-user-operator-standalone-{context}[Deploy the standalone User Operator]

--- a/documentation/assemblies/deploying/assembly-deploy-intro-custom-resources.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-intro-custom-resources.adoc
@@ -4,7 +4,7 @@
 // deploying/assembly-deploy-intro.adoc
 
 [id='assembly-custom-resources-{context}']
-= {ProductName} custom resources
+= Strimzi custom resources
 
 //Standard intro text to custom resources
 include::modules/snip-intro-custom-resources.adoc[leveloffset=+1]

--- a/documentation/assemblies/deploying/assembly-deploy-intro.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-intro.adoc
@@ -15,7 +15,7 @@ As well as describing the deployment steps, the guide also provides pre- and pos
 Additional deployment options described include the steps to introduce metrics.
 Upgrade instructions are provided for Strimzi and Kafka upgrades.
 
-{ProductName} is designed to work on all types of Kubernetes cluster regardless of distribution,
+Strimzi is designed to work on all types of Kubernetes cluster regardless of distribution,
 from public and private clouds to local deployments intended for development.
 
 //Description of Operator support for managing a deployment

--- a/documentation/assemblies/deploying/assembly-deploy-kafka-cluster.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-cluster.adoc
@@ -18,7 +18,7 @@ The procedures in this section show:
 ** xref:deploying-the-topic-operator-standalone-{context}[Deploy the standalone Topic Operator]
 ** xref:deploying-the-user-operator-standalone-{context}[Deploy the standalone User Operator]
 
-When installing Kafka, {ProductName} also installs a ZooKeeper cluster and adds the necessary configuration to connect Kafka with ZooKeeper.
+When installing Kafka, Strimzi also installs a ZooKeeper cluster and adds the necessary configuration to connect Kafka with ZooKeeper.
 
 //Deploy Kafka cluster with storage option
 include::modules/proc-deploy-kafka-cluster.adoc[leveloffset=+1]

--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect-with-plugins.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect-with-plugins.adoc
@@ -5,7 +5,7 @@
 [id='using-kafka-connect-with-plug-ins-{context}']
 = Extending Kafka Connect with connector plug-ins
 
-The {ProductName} container images for Kafka Connect include two built-in file connectors for moving file-based data into and out of your Kafka cluster.
+The Strimzi container images for Kafka Connect include two built-in file connectors for moving file-based data into and out of your Kafka cluster.
 
 [cols="2*",options="header",stripes="none",separator=¦]
 |===

--- a/documentation/assemblies/deploying/assembly-deploy-options.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-options.adoc
@@ -3,7 +3,7 @@
 // deploying/master.adoc
 
 [id="deploy-options_{context}"]
-= What is deployed with {ProductName}
+= What is deployed with Strimzi
 
 //Standard kafka deployment introduction
 include::../../shared/snip-intro-kafka-deployment.adoc[leveloffset=+1]

--- a/documentation/assemblies/deploying/assembly-deploy-standalone-operators.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-standalone-operators.adoc
@@ -3,12 +3,12 @@
 // deploying/assembly-deploy-create-cluster.adoc
 
 [id="deploy-standalone-operators_{context}"]
-= Alternative standalone deployment options for {ProductName} Operators
+= Alternative standalone deployment options for Strimzi Operators
 
 When deploying a Kafka cluster using the Cluster Operator, you can also deploy the Topic Operator and User Operator.
 Alternatively, you can perform a standalone deployment.
 
-A standalone deployment means the Topic Operator and User Operator can operate with a Kafka cluster that is not managed by {ProductName}.
+A standalone deployment means the Topic Operator and User Operator can operate with a Kafka cluster that is not managed by Strimzi.
 
 //Procedure for standalone deployment of Topic Operator
 include::modules/proc-deploy-topic-operator-standalone.adoc[leveloffset=+1]

--- a/documentation/assemblies/deploying/assembly-deploy-tasks-prep.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-tasks-prep.adoc
@@ -4,13 +4,13 @@
 // assembly-getting-started.adoc
 
 [id="deploy-tasks-prereqs_{context}"]
-= Preparing for your {ProductName} deployment
+= Preparing for your Strimzi deployment
 
-This section shows how you prepare for a {ProductName} deployment, describing:
+This section shows how you prepare for a Strimzi deployment, describing:
 
-* xref:deploy-prereqs-{context}[The prerequisites you need before you can deploy {ProductName}]
-* xref:downloads-{context}[How to download the {ProductName} release artifacts to use in your deployment]
-* xref:container-images-{context}[How to push the {ProductName} container images into you own registry (if required)]
+* xref:deploy-prereqs-{context}[The prerequisites you need before you can deploy Strimzi]
+* xref:downloads-{context}[How to download the Strimzi release artifacts to use in your deployment]
+* xref:container-images-{context}[How to push the Strimzi container images into you own registry (if required)]
 * xref:adding-users-the-strimzi-admin-role-{context}[How to set up _admin_ roles for configuration of custom resources used in deployment]
 ifdef::InstallationAppendix[]
 * xref:deploy-alternatives_{context}[Alternative deployment options to Kubernetes using _Minikube_ or _Minishift_]

--- a/documentation/assemblies/deploying/assembly-deploy-tasks.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-tasks.adoc
@@ -3,9 +3,9 @@
 // deploying/master.adoc
 
 [id="deploy-tasks_{context}"]
-= Deploying {ProductName}
+= Deploying Strimzi
 
-Having xref:deploy-tasks-prereqs_{context}[prepared your environment for a deployment of {ProductName}], this section shows:
+Having xref:deploy-tasks-prereqs_{context}[prepared your environment for a deployment of Strimzi], this section shows:
 
 * xref:deploy-create-cluster_{context}[How to create the Kafka cluster]
 * Optional procedures to deploy other Kafka components according to your requirements:

--- a/documentation/assemblies/deploying/assembly-deploy-verify.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-verify.adoc
@@ -3,11 +3,11 @@
 // deploying/master.adoc
 
 [id="deploy-verify_{context}"]
-= Verifying the {ProductName} deployment
+= Verifying the Strimzi deployment
 
-Having xref:deploy-tasks_{context}[deployed {ProductName}], the procedure in this section shows how to deploy example producer and consumer clients.
+Having xref:deploy-tasks_{context}[deployed Strimzi], the procedure in this section shows how to deploy example producer and consumer clients.
 
-The procedure assumes a {ProductName} is available and running in a Kubernetes cluster.
+The procedure assumes a Strimzi is available and running in a Kubernetes cluster.
 
 //how to create clients that can access and use the deployment
 include::modules/proc-deploy-example-clients.adoc[leveloffset=+1]

--- a/documentation/assemblies/managing/assembly-management-tasks.adoc
+++ b/documentation/assemblies/managing/assembly-management-tasks.adoc
@@ -3,9 +3,9 @@
 // master.adoc
 
 [id="configuration-points_{context}"]
-= Managing {ProductName}
+= Managing Strimzi
 
-This chapter covers tasks to maintain a deployment of {ProductName}.
+This chapter covers tasks to maintain a deployment of Strimzi.
 
 //Discover internal bootstrap service and HTTP Bridge
 include::modules/con-service-discovery.adoc[leveloffset=+1]

--- a/documentation/assemblies/managing/assembly-resource-status-access.adoc
+++ b/documentation/assemblies/managing/assembly-resource-status-access.adoc
@@ -5,7 +5,7 @@
 [id="resource-status-access_{context}"]
 = Checking the status of a custom resource
 
-The `status` property of a {ProductName} custom resource publishes information about the resource to users and tools that need it.
+The `status` property of a Strimzi custom resource publishes information about the resource to users and tools that need it.
 
 //reference table for resource status
 include::modules/con-custom-resources-status.adoc[leveloffset=+1]

--- a/documentation/assemblies/metrics/assembly-metrics.adoc
+++ b/documentation/assemblies/metrics/assembly-metrics.adoc
@@ -5,7 +5,7 @@
 [id='assembly-metrics-{context}']
 = Introducing Metrics to Kafka
 
-This section describes setup options for monitoring your {ProductName} deployment.
+This section describes setup options for monitoring your Strimzi deployment.
 
 Depending on your requirements, you can:
 

--- a/documentation/assemblies/metrics/assembly_metrics-grafana.adoc
+++ b/documentation/assemblies/metrics/assembly_metrics-grafana.adoc
@@ -8,7 +8,7 @@
 
 Grafana provides visualizations of Prometheus metrics.
 
-You can deploy and enable the example Grafana dashboards provided with {ProductName}.
+You can deploy and enable the example Grafana dashboards provided with Strimzi.
 
 include::modules/con_metrics-grafana-options.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/metrics/assembly_metrics-kafka-exporter.adoc
+++ b/documentation/assemblies/metrics/assembly_metrics-kafka-exporter.adoc
@@ -6,7 +6,7 @@
 = Add Kafka Exporter
 
 {kafka-exporter-project} is an open source project to enhance monitoring of Apache Kafka brokers and clients.
-Kafka Exporter is provided with {ProductName} for deployment with a Kafka cluster to extract additional metrics data from Kafka brokers related to offsets, consumer groups, consumer lag, and topics.
+Kafka Exporter is provided with Strimzi for deployment with a Kafka cluster to extract additional metrics data from Kafka brokers related to offsets, consumer groups, consumer lag, and topics.
 
 The metrics data is used, for example, to help identify slow consumers.
 

--- a/documentation/assemblies/metrics/assembly_metrics-kafka.adoc
+++ b/documentation/assemblies/metrics/assembly_metrics-kafka.adoc
@@ -5,7 +5,7 @@
 
 = Exposing Prometheus metrics
 
-{ProductName} uses the link:https://github.com/prometheus/jmx_exporter[Prometheus JMX Exporter^] to expose JMX metrics from Kafka and ZooKeeper using an HTTP endpoint, which is then scraped by the Prometheus server.
+Strimzi uses the link:https://github.com/prometheus/jmx_exporter[Prometheus JMX Exporter^] to expose JMX metrics from Kafka and ZooKeeper using an HTTP endpoint, which is then scraped by the Prometheus server.
 
 include::modules/con_metrics-kafka-options.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/metrics/assembly_metrics-prometheus-setup.adoc
+++ b/documentation/assemblies/metrics/assembly_metrics-prometheus-setup.adoc
@@ -5,7 +5,7 @@
 [id='assembly-metrics-setup-{context}']
 = Add Prometheus and Grafana
 
-This section describes how to monitor {ProductName} Kafka, ZooKeeper, Kafka Connect, and Kafka MirrorMaker and MirrorMaker 2.0 clusters using Prometheus to provide monitoring data for example Grafana dashboards.
+This section describes how to monitor Strimzi Kafka, ZooKeeper, Kafka Connect, and Kafka MirrorMaker and MirrorMaker 2.0 clusters using Prometheus to provide monitoring data for example Grafana dashboards.
 
 Prometheus and Grafana can be also used to monitor the operators.
 The example Grafana dashboard for operators provides:

--- a/documentation/assemblies/mirrormaker2/assembly-mirrormaker.adoc
+++ b/documentation/assemblies/mirrormaker2/assembly-mirrormaker.adoc
@@ -5,7 +5,7 @@
 [id='assembly-mirrormaker-{context}']
 = Kafka MirrorMaker 2.0 configuration
 
-This section describes how to configure a Kafka MirrorMaker 2.0 deployment in your {ProductName} cluster.
+This section describes how to configure a Kafka MirrorMaker 2.0 deployment in your Strimzi cluster.
 
 MirrorMaker 2.0 is used to replicate data between two or more active Kafka clusters, within or across data centers.
 

--- a/documentation/assemblies/oauth/assembly-oauth-authentication.adoc
+++ b/documentation/assemblies/oauth/assembly-oauth-authentication.adoc
@@ -3,36 +3,36 @@
 // assembly-deployment-configuration.adoc
 
 [id='assembly-oauth-authentication_{context}']
-= Using {oauth} token-based authentication
+= Using OAuth 2.0 token-based authentication
 
-{ProductName} supports the use of {oauth} authentication using the _SASL OAUTHBEARER_ mechanism.
+Strimzi supports the use of OAuth 2.0 authentication using the _SASL OAUTHBEARER_ mechanism.
 
-{oauth} enables standardized token-based authentication and authorization between applications, using a central authorization server to issue tokens that grant limited access to resources.
+OAuth 2.0 enables standardized token-based authentication and authorization between applications, using a central authorization server to issue tokens that grant limited access to resources.
 
-You can configure {oauth} authentication, then xref:assembly-oauth-authorization_{context}[{oauth} authorization].
-{oauth} authentication can also be used in conjunction with xref:simple-acl-{context}[ACL-based Kafka authorization].
+You can configure OAuth 2.0 authentication, then xref:assembly-oauth-authorization_{context}[OAuth 2.0 authorization].
+OAuth 2.0 authentication can also be used in conjunction with xref:simple-acl-{context}[ACL-based Kafka authorization].
 
-Using {oauth} token-based authentication, application clients can access resources on application servers (called _resource servers_) without exposing account credentials.
+Using OAuth 2.0 token-based authentication, application clients can access resources on application servers (called _resource servers_) without exposing account credentials.
 
 The application client passes an access token as a means of authenticating, which application servers can also use to determine the level of access to grant.
 The authorization server handles the granting of access and inquiries about access.
 
-In the context of {ProductName}:
+In the context of Strimzi:
 
-* Kafka brokers act as {oauth} resource servers
-* Kafka clients act as {oauth} application clients
+* Kafka brokers act as OAuth 2.0 resource servers
+* Kafka clients act as OAuth 2.0 application clients
 
 Kafka clients authenticate to Kafka brokers.
-The brokers and clients communicate with the {oauth} authorization server, as necessary, to obtain or validate access tokens.
+The brokers and clients communicate with the OAuth 2.0 authorization server, as necessary, to obtain or validate access tokens.
 
-For a deployment of {ProductName}, {oauth} integration provides:
+For a deployment of Strimzi, OAuth 2.0 integration provides:
 
-* Server-side {oauth} support for Kafka brokers
-* Client-side {oauth} support for Kafka MirrorMaker, Kafka Connect and the Kafka Bridge
+* Server-side OAuth 2.0 support for Kafka brokers
+* Client-side OAuth 2.0 support for Kafka MirrorMaker, Kafka Connect and the Kafka Bridge
 
 .Additional resources
 
-* {oauth2-site}
+* link:https://oauth.net/2/[OAuth 2.0 site^]
 
 include::modules/con-oauth-authentication-flow.adoc[leveloffset=+1]
 include::modules/con-oauth-authentication-broker.adoc[leveloffset=+1]

--- a/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
+++ b/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
@@ -3,7 +3,7 @@
 // assembly-deployment-configuration.adoc
 
 [id='assembly-oauth-authorization_{context}']
-= Using {oauth} token-based authorization
+= Using OAuth 2.0 token-based authorization
 
 include::modules/con-oauth-authorization-intro.adoc[leveloffset=+1]
 include::modules/con-oauth-authorization-mechanism.adoc[leveloffset=+1]

--- a/documentation/assemblies/overview/assembly-kafka-components.adoc
+++ b/documentation/assemblies/overview/assembly-kafka-components.adoc
@@ -3,7 +3,7 @@
 // overview/master.adoc
 
 [id="kafka-components_{context}"]
-= {ProductName} deployment of Kafka
+= Strimzi deployment of Kafka
 
 //standard kafka deployment intro
 include::../../shared/snip-intro-kafka-deployment.adoc[leveloffset=+1]

--- a/documentation/assemblies/overview/assembly-key-features.adoc
+++ b/documentation/assemblies/overview/assembly-key-features.adoc
@@ -8,10 +8,10 @@
 //standard introduction
 include::../../shared/snip-intro-text.adoc[leveloffset=+1]
 
-This guide is intended as a starting point for building an understanding of {ProductName}.
-The guide introduces some of the key concepts behind Kafka, which is central to {ProductName}, explaining briefly the purpose of Kafka components.
+This guide is intended as a starting point for building an understanding of Strimzi.
+The guide introduces some of the key concepts behind Kafka, which is central to Strimzi, explaining briefly the purpose of Kafka components.
 Configuration points are outlined, including options to secure and monitor Kafka.
-A distribution of {ProductName} provides the files to deploy and manage a Kafka cluster, as well as example files for configuration and monitoring of your deployment.
+A distribution of Strimzi provides the files to deploy and manage a Kafka cluster, as well as example files for configuration and monitoring of your deployment.
 
 A typical Kafka deployment is described, as well as the tools used to deploy and manage Kafka.
 

--- a/documentation/assemblies/overview/assembly-metrics-overview.adoc
+++ b/documentation/assemblies/overview/assembly-metrics-overview.adoc
@@ -5,19 +5,19 @@
 [id="metrics-overview_{context}"]
 = Monitoring
 
-Monitoring data allows you to monitor the performance and health of {ProductName}.
+Monitoring data allows you to monitor the performance and health of Strimzi.
 You can configure your deployment to capture metrics data for analysis and notifications.
 
 Metrics data is useful when investigating issues with connectivity and data delivery.
 For example, metrics data can identify under-replicated partitions or the rate at which messages are consumed.
 Alerting rules can provide time-critical notifications on such metrics through a specified communications channel.
 Monitoring visualizations present real-time metrics data to help determine when and how to update the configuration of your deployment.
-Example metrics configuration files are provided with {ProductName}.
+Example metrics configuration files are provided with Strimzi.
 
-Distributed tracing complements the gathering of metrics data by providing a facility for end-to-end tracking of messages through {ProductName}.
+Distributed tracing complements the gathering of metrics data by providing a facility for end-to-end tracking of messages through Strimzi.
 
 .Metrics and monitoring tools
-{ProductName} can employ the following tools for metrics and monitoring:
+Strimzi can employ the following tools for metrics and monitoring:
 
 * *Prometheus* pulls metrics from Kafka, ZooKeeper and Kafka Connect clusters. The Prometheus *Alertmanager* plugin handles alerts and routes them to a notification service.
 * *Kafka Exporter* adds additional Prometheus metrics

--- a/documentation/assemblies/overview/assembly-overview-components.adoc
+++ b/documentation/assemblies/overview/assembly-overview-components.adoc
@@ -4,9 +4,9 @@
 // deploying/assembly_deploy-intro.adoc
 
 [id="overview-components_{context}"]
-= {ProductName} Operators
+= Strimzi Operators
 
-{ProductName} supports Kafka using _Operators_ to deploy and manage the components and dependencies of Kafka to Kubernetes.
+Strimzi supports Kafka using _Operators_ to deploy and manage the components and dependencies of Kafka to Kubernetes.
 
 //standard operator intro
 include::../../shared/snip-intro-operators.adoc[leveloffset=+1]

--- a/documentation/assemblies/overview/assembly-security-overview.adoc
+++ b/documentation/assemblies/overview/assembly-security-overview.adoc
@@ -5,7 +5,7 @@
 [id="security-overview_{context}"]
 = Securing Kafka
 
-A secure deployment of {ProductName} can encompass:
+A secure deployment of Strimzi can encompass:
 
 * Encryption for data exchange
 * Authentication to prove identity

--- a/documentation/assemblies/quickstart/assembly-quickstart-overview.adoc
+++ b/documentation/assemblies/quickstart/assembly-quickstart-overview.adoc
@@ -7,7 +7,7 @@
 // See also the complementary step on the last line of this file.
 
 [id='overview-{context}']
-= Overview of {ProductName}
+= Overview of Strimzi
 
 //standard intro
 include::../shared/snip-intro-text.adoc[leveloffset=+1]
@@ -15,8 +15,8 @@ include::../shared/snip-intro-text.adoc[leveloffset=+1]
 This guide provides instructions for evaluating a working environment of Strimzi.
 The steps describe how to get a Strimzi deployment up-and-running as quickly as possible.
 
-Before trying {ProductName}, it is useful to understand its capabilities and how you might wish to use it.
-This chapter introduces some of the key concepts behind Kafka, and also provides a brief overview of the {ProductName} Operators.
+Before trying Strimzi, it is useful to understand its capabilities and how you might wish to use it.
+This chapter introduces some of the key concepts behind Kafka, and also provides a brief overview of the Strimzi Operators.
 
 //standard operator intro
 include::../shared/snip-intro-operators.adoc[leveloffset=+1]

--- a/documentation/assemblies/quickstart/assembly-quickstart.adoc
+++ b/documentation/assemblies/quickstart/assembly-quickstart.adoc
@@ -4,15 +4,15 @@
 
 [id='assembly-evaluation-{context}']
 
-= Evaluate {ProductName}
+= Evaluate Strimzi
 
-The procedures in this chapter provide a quick way to evaluate the functionality of {ProductName}.
+The procedures in this chapter provide a quick way to evaluate the functionality of Strimzi.
 
-Follow the steps in the order provided to install {ProductName}, and start sending and receiving messages from a topic:
+Follow the steps in the order provided to install Strimzi, and start sending and receiving messages from a topic:
 
 * Ensure you have the required prerequisites
 * Install and start Minikube
-* Install {ProductName}
+* Install Strimzi
 * Create a Kafka cluster
 * Access the Kafka cluster to send and receive messages
 

--- a/documentation/assemblies/security/assembly-security.adoc
+++ b/documentation/assemblies/security/assembly-security.adoc
@@ -5,10 +5,10 @@
 [id='security-{context}']
 = Security
 
-{ProductName} supports encrypted communication between the Kafka and {ProductName} components using the TLS protocol.
-Communication between Kafka brokers (interbroker communication), between ZooKeeper nodes (internodal communication), and between these and the {ProductName} operators is always encrypted.
+Strimzi supports encrypted communication between the Kafka and Strimzi components using the TLS protocol.
+Communication between Kafka brokers (interbroker communication), between ZooKeeper nodes (internodal communication), and between these and the Strimzi operators is always encrypted.
 Communication between Kafka clients and Kafka brokers is encrypted according to how the cluster is configured.
-For the Kafka and {ProductName} components, TLS certificates are also used for authentication.
+For the Kafka and Strimzi components, TLS certificates are also used for authentication.
 
 The Cluster Operator automatically sets up and renews TLS certificates to enable encryption and authentication within your cluster.
 It also sets up other TLS certificates if you want to enable encryption or TLS authentication between Kafka brokers and clients.

--- a/documentation/assemblies/upgrading/assembly-upgrade-kafka-cluster-operator.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-kafka-cluster-operator.adoc
@@ -5,10 +5,10 @@
 [id='assembly-upgrade-cluster-operator-{context}']
 = Upgrading the Cluster Operator
 
-The steps to upgrade your Cluster Operator deployment to use {ProductName} {ProductVersion} are outlined in this section.
+The steps to upgrade your Cluster Operator deployment to use Strimzi {ProductVersion} are outlined in this section.
 
 The availability of Kafka clusters managed by the Cluster Operator is not affected by the upgrade operation.
 
-NOTE: Refer to the documentation supporting a specific version of {ProductName} for information on how to upgrade to that version.
+NOTE: Refer to the documentation supporting a specific version of Strimzi for information on how to upgrade to that version.
 
 include::modules/proc-upgrade-cluster-operator.adoc[leveloffset=+1]

--- a/documentation/assemblies/upgrading/assembly-upgrade-kafka.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-kafka.adoc
@@ -3,11 +3,11 @@
 // assembly-upgrade.adoc
 
 [id='assembly-upgrade-kafka-{context}']
-= {ProductName} and Kafka upgrades
+= Strimzi and Kafka upgrades
 
-Upgrading {ProductName} is a two-stage process. To upgrade brokers and clients without downtime, you _must_ complete the upgrade procedures in the following order:
+Upgrading Strimzi is a two-stage process. To upgrade brokers and clients without downtime, you _must_ complete the upgrade procedures in the following order:
 
-. Update your Cluster Operator to the latest {ProductName} version.
+. Update your Cluster Operator to the latest Strimzi version.
 ** xref:assembly-upgrade-cluster-operator-{context}[]
 
 . Upgrade all Kafka brokers and client applications to the latest Kafka version.

--- a/documentation/assemblies/upgrading/assembly-upgrade-resources.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-resources.adoc
@@ -3,7 +3,7 @@
 // // assembly-upgrade.adoc
 
 [id='assembly-upgrade-resources-{context}']
-= {ProductName} resource upgrades
+= Strimzi resource upgrades
 
 The `{KafkaApiVersionPrev}` API version is deprecated.
 Resources that use the API version `{KafkaApiVersionPrev}` must be updated to use `{KafkaApiVersion}`.

--- a/documentation/assemblies/upgrading/assembly-upgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade.adoc
@@ -4,16 +4,16 @@
 // master.adoc
 
 [id='assembly-upgrade-{context}']
-= Upgrading {ProductName}
+= Upgrading Strimzi
 
-{ProductName} can be upgraded with no cluster downtime.
-Each version of {ProductName} supports one or more versions of Apache Kafka.
-You can upgrade to a higher Kafka version as long as it is supported by your version of {ProductName}.
+Strimzi can be upgraded with no cluster downtime.
+Each version of Strimzi supports one or more versions of Apache Kafka.
+You can upgrade to a higher Kafka version as long as it is supported by your version of Strimzi.
 In some cases, you can also downgrade to a lower supported Kafka version.
 
-Newer versions of {ProductName} may support newer versions of Kafka, but you need to upgrade {ProductName} _before_ you can upgrade to a higher supported Kafka version.
+Newer versions of Strimzi may support newer versions of Kafka, but you need to upgrade Strimzi _before_ you can upgrade to a higher supported Kafka version.
 
-IMPORTANT: If applicable, xref:assembly-upgrade-resources-{context}[Resource upgrades] _must_ be performed after upgrading {ProductName} and Kafka.
+IMPORTANT: If applicable, xref:assembly-upgrade-resources-{context}[Resource upgrades] _must_ be performed after upgrading Strimzi and Kafka.
 
 include::assembly-upgrade-kafka.adoc[leveloffset=+1]
 

--- a/documentation/contributing/introduction.adoc
+++ b/documentation/contributing/introduction.adoc
@@ -18,14 +18,14 @@ Strimzi uses git to manage repositories.
 
 https://github.com/strimzi/strimzi-kafka-operator[`strimzi-kafka-operator`^] (GitHub):: The public GitHub repo hosts all of the Strimzi code and documentation.
 https://github.com/strimzi/strimzi-kafka-bridge[`strimzi-kafka-bridge`^] (GitHub):: The public GitHub repo hosts all of the Strimzi Kafka Bridge code.
-https://github.com/strimzi/strimzi-kafka-oauth[`strimzi-kafka-oauth`^] (GitHub):: The public GitHub repo hosts all of the Strimzi {oauth} code.
+https://github.com/strimzi/strimzi-kafka-oauth[`strimzi-kafka-oauth`^] (GitHub):: The public GitHub repo hosts all of the Strimzi OAuth 2.0 code.
 https://github.com/strimzi/strimzi-kafka-operator/tree/master/documentation[`strimzi-kafka-operator/documentation`^] (GitHub):: The _documentation_ folder is split into _category_ folders to manage the content.
 
 Documentation category folders contain files related to Strimzi guides (Deploying, Quickstart, Overview, Using), and the files that provide the content for one or more of these guides – _assemblies_ and _modules_.
 Assemblies, which usually encapsulate a feature or process, bring the related content contained in modules together.
 
 An assembly is like a sub-section or chapter in a book.
-For example, the _Deploying Strimzi_ guide has a chapter called _Verifying the {ProductName} deployment_, which is contained in its own assembly.
+For example, the _Deploying Strimzi_ guide has a chapter called _Verifying the Strimzi deployment_, which is contained in its own assembly.
 
 [source,options="nowrap",subs="+quotes"]
 ----

--- a/documentation/deploying/master-docinfo.xml
+++ b/documentation/deploying/master-docinfo.xml
@@ -1,8 +1,8 @@
-<productname>{ProductLongName}</productname>
+<productname>Strimzi</productname>
 <productnumber>{ProductVersion}</productnumber>
-<subtitle>For Use with {ProductName}</subtitle>
+<subtitle>For Use with Strimzi</subtitle>
 <abstract>
-    <para>Instructions for deploying and upgrading {ProductName}</para>
+    <para>Instructions for deploying and upgrading Strimzi</para>
 </abstract>
 <authorgroup>
 </authorgroup>

--- a/documentation/deploying/master.adoc
+++ b/documentation/deploying/master.adoc
@@ -4,7 +4,7 @@ include::shared/attributes.adoc[]
 :context: str
 
 [id="deploying-book_{context}"]
-= Deploying and Upgrading {ProductName}
+= Deploying and Upgrading Strimzi
 
 //Introduction to the install process
 include::assemblies/deploying/assembly-deploy-intro.adoc[leveloffset=+1]

--- a/documentation/modules/appendix_faq.adoc
+++ b/documentation/modules/appendix_faq.adoc
@@ -8,11 +8,11 @@
 == Questions related to the Cluster Operator
 
 [id='co-faq-admin-privileges_{context}']
-=== Why do I need cluster administrator privileges to install {ProductName}?
+=== Why do I need cluster administrator privileges to install Strimzi?
 
-To install {ProductName}, you need to be able to create the following cluster-scoped resources:
+To install Strimzi, you need to be able to create the following cluster-scoped resources:
 
-* Custom Resource Definitions (CRDs) to instruct Kubernetes about resources that are specific to {ProductName}, such as `Kafka` and `KafkaConnect`
+* Custom Resource Definitions (CRDs) to instruct Kubernetes about resources that are specific to Strimzi, such as `Kafka` and `KafkaConnect`
 * `ClusterRoles` and `ClusterRoleBindings`
 
 Cluster-scoped resources, which are not scoped to a particular Kubernetes namespace, typically require _cluster administrator_ privileges to install.
@@ -38,7 +38,7 @@ The Cluster Operator needs to be able to grant access so that:
 
 * The Topic Operator can manage  `KafkaTopics`, by creating `Roles` and `RoleBindings` in the namespace that the operator runs in
 * The User Operator can manage `KafkaUsers`, by creating `Roles` and `RoleBindings` in the namespace that the operator runs in
-* The failure domain of a `Node` is discovered by {ProductName}, by creating a `ClusterRoleBinding`
+* The failure domain of a `Node` is discovered by Strimzi, by creating a `ClusterRoleBinding`
 
 When using rack-aware partition assignment, the broker pod needs to be able to get information about the `Node` it is running on,
 for example, the Availability Zone in Amazon AWS.

--- a/documentation/modules/con-accessing-kafka-bridge-from-outside.adoc
+++ b/documentation/modules/con-accessing-kafka-bridge-from-outside.adoc
@@ -6,7 +6,7 @@
 
 = Accessing the Kafka Bridge outside of Kubernetes
 
-After deployment, the {ProductName} Kafka Bridge can only be accessed by applications running in the same Kubernetes cluster. These applications use the `_kafka-bridge-name_-bridge-service` Service to access the API.
+After deployment, the Strimzi Kafka Bridge can only be accessed by applications running in the same Kubernetes cluster. These applications use the `_kafka-bridge-name_-bridge-service` Service to access the API.
 
 If you want to make the Kafka Bridge accessible to applications running outside of the Kubernetes cluster, you can expose it manually by using one of the following features:
 

--- a/documentation/modules/con-certificates.adoc
+++ b/documentation/modules/con-certificates.adoc
@@ -5,14 +5,14 @@
 [id='certificates-{context}']
 = Certificates
 
-Each {ProductName} component needs its own private keys and public key certificates in order to support encryption.
+Each Strimzi component needs its own private keys and public key certificates in order to support encryption.
 All component certificates are signed by a Certification Authority (CA) called _cluster CA_, while the _clients CA_, is used to sign the certificates for the Kafka clients.
 The CAs themselves use self-signed certificates.
 
 All of the generated certificates are saved as `Secrets` in the Kubernetes cluster, named as follows:
 
 `_cluster-name_-cluster-ca`::
-Contains the private and public keys of the cluster CA which is used for signing server certificates for the Kafka and {ProductName} components (Kafka brokers, ZooKeeper nodes, and so on).
+Contains the private and public keys of the cluster CA which is used for signing server certificates for the Kafka and Strimzi components (Kafka brokers, ZooKeeper nodes, and so on).
 `_cluster-name_-cluster-ca-cert`::
 Contains only the public key of the cluster CA which is used by Kafka clients to verify the identity of the Kafka brokers they are connecting to (TLS server authentication).
 `_cluster-name_-clients-ca`::

--- a/documentation/modules/con-configuring-container-images.adoc
+++ b/documentation/modules/con-configuring-container-images.adoc
@@ -14,8 +14,8 @@ Use the `image` property to configure the container image used by the component.
 
 Overriding container images is recommended only in special situations where you need to use a different container registry or a customized image.
 
-For example, if your network does not allow access to the container repository used by {ProductName}, you can copy the {ProductName} images or build them from the source.
-However, if the configured image is not compatible with {ProductName} images, it might not work properly.
+For example, if your network does not allow access to the container repository used by Strimzi, you can copy the Strimzi images or build them from the source.
+However, if the configured image is not compatible with Strimzi images, it might not work properly.
 
 A copy of the container image might also be customized and used for debugging.
 

--- a/documentation/modules/con-considerations-for-data-storage.adoc
+++ b/documentation/modules/con-considerations-for-data-storage.adoc
@@ -6,7 +6,7 @@
 
 = Data storage considerations
 
-An efficient data storage infrastructure is essential to the optimal performance of {ProductName}.
+An efficient data storage infrastructure is essential to the optimal performance of Strimzi.
 
 Block storage is required.
 File storage, such as NFS, does not work with Kafka.
@@ -23,7 +23,7 @@ NOTE: Strimzi does not require Kubernetes raw block volumes.
 == File systems
 
 It is recommended that you configure your storage system to use the _XFS_ file system.
-{ProductName} is also compatible with the _ext4_ file system, but this might require additional configuration for best results.
+Strimzi is also compatible with the _ext4_ file system, but this might require additional configuration for best results.
 
 == Apache Kafka and ZooKeeper storage
 Use separate disks for Apache Kafka and ZooKeeper.

--- a/documentation/modules/con-customizing-containers.adoc
+++ b/documentation/modules/con-customizing-containers.adoc
@@ -6,11 +6,11 @@
 = Customizing containers with environment variables
 
 You can set custom environment variables for a container by using the relevant `template` container property. 
-The following table lists the {ProductName} containers and the relevant template configuration property (defined under `spec`) for each custom resource.
+The following table lists the Strimzi containers and the relevant template configuration property (defined under `spec`) for each custom resource.
 
 .Table Container environment variable properties
 |===
-|{ProductName} Element |Container |Configuration property
+|Strimzi Element |Container |Configuration property
 
 |Kafka 
 |Kafka Broker 
@@ -76,8 +76,8 @@ spec:
 # ...
 ----
 
-Environment variables prefixed with `KAFKA_` are internal to {ProductName} and should be avoided.
-If you set a custom environment variable that is already in use by {ProductName}, it is ignored and a warning is recorded in the log.
+Environment variables prefixed with `KAFKA_` are internal to Strimzi and should be avoided.
+If you set a custom environment variable that is already in use by Strimzi, it is ignored and a warning is recorded in the log.
 
 .Additional resources
 

--- a/documentation/modules/con-customizing-image-pull-policy.adoc
+++ b/documentation/modules/con-customizing-image-pull-policy.adoc
@@ -5,7 +5,7 @@
 [id='con-customizing-image-pull-policy-{context}']
 = Customizing the image pull policy
 
-{ProductName} allows you to customize the image pull policy for containers in all pods deployed by the Cluster Operator.
+Strimzi allows you to customize the image pull policy for containers in all pods deployed by the Cluster Operator.
 The image pull policy is configured using the environment variable `STRIMZI_IMAGE_PULL_POLICY` in the Cluster Operator deployment.
 The `STRIMZI_IMAGE_PULL_POLICY` environment variable can be set to three different values:
 

--- a/documentation/modules/con-customizing-labels-and-annotations.adoc
+++ b/documentation/modules/con-customizing-labels-and-annotations.adoc
@@ -26,7 +26,7 @@ template:
 ----
 
 The `labels` and `annotations` fields can contain any labels or annotations that do not contain the reserved string `strimzi.io`.
-Labels and annotations containing `strimzi.io` are used internally by {ProductName} and cannot be configured.
+Labels and annotations containing `strimzi.io` are used internally by Strimzi and cannot be configured.
 
 For Kafka Connect, annotations on the `KafkaConnect` resource are used to enable the creation and management of connectors using `KafkaConnector` resources. For more information, see xref:proc-enabling-kafkaconnectors-deployment-configuration-kafka-connect[].
 

--- a/documentation/modules/con-customizing-pod-disruption-budgets.adoc
+++ b/documentation/modules/con-customizing-pod-disruption-budgets.adoc
@@ -5,7 +5,7 @@
 [id='con-customizing-pod-disruption-budgets-{context}']
 = Customizing Pod Disruption Budgets
 
-{ProductName} creates a pod disruption budget for every new `StatefulSet` or `Deployment`.
+Strimzi creates a pod disruption budget for every new `StatefulSet` or `Deployment`.
 By default, these pod disruption budgets only allow a single pod to be unavailable at a given time by setting the `maxUnavailable` value in the `PodDisruptionBudget.spec` resource to 1.
 You can change the amount of unavailable pods allowed by changing the default value of `maxUnavailable` in the pod disruption budget template.
 This template applies to each type of cluster (Kafka and ZooKeeper; Kafka Connect and Kafka Connect with S2I support; and Kafka MirrorMaker).

--- a/documentation/modules/con-healthchecks.adoc
+++ b/documentation/modules/con-healthchecks.adoc
@@ -6,7 +6,7 @@
 
 = Healthchecks
 
-Use the `livenessProbe` and `readinessProbe` properties to configure healthcheck probes supported in {ProductName}.
+Use the `livenessProbe` and `readinessProbe` properties to configure healthcheck probes supported in Strimzi.
 
 Healthchecks are periodical tests which verify the health of an application.
 When a Healthcheck probe fails, Kubernetes assumes that the application is not healthy and attempts to fix it.

--- a/documentation/modules/con-kafka-bridge-authentication.adoc
+++ b/documentation/modules/con-kafka-bridge-authentication.adoc
@@ -12,7 +12,7 @@ The currently supported authentication types are:
 * TLS client authentication
 * SASL-based authentication using the SCRAM-SHA-512 mechanism
 * SASL-based authentication using the PLAIN mechanism
-* xref:assembly-oauth-authentication_str[{oauth} token based authentication]
+* xref:assembly-oauth-authentication_str[OAuth 2.0 token based authentication]
 
 == TLS Client Authentication
 

--- a/documentation/modules/con-kafka-broker-external-listeners-addresses.adoc
+++ b/documentation/modules/con-kafka-broker-external-listeners-addresses.adoc
@@ -6,10 +6,10 @@
 
 = Customizing advertised addresses on external listeners
 
-By default, {ProductName} tries to automatically determine the hostnames and ports that your Kafka cluster advertises to its clients.
-This is not sufficient in all situations, because the infrastructure on which {ProductName} is running might not provide the right hostname or port through which Kafka can be accessed.
+By default, Strimzi tries to automatically determine the hostnames and ports that your Kafka cluster advertises to its clients.
+This is not sufficient in all situations, because the infrastructure on which Strimzi is running might not provide the right hostname or port through which Kafka can be accessed.
 You can customize the advertised hostname and port in the `overrides` property of the external listener.
-{ProductName} will then automatically configure the advertised address in the Kafka brokers and add it to the broker certificates so it can be used for TLS hostname verification.
+Strimzi will then automatically configure the advertised address in the Kafka brokers and add it to the broker certificates so it can be used for TLS hostname verification.
 Overriding the advertised host and ports is available for all types of external listeners.
 
 .Example of an external listener configured with overrides for advertised addresses

--- a/documentation/modules/con-kafka-broker-external-listeners-ingress.adoc
+++ b/documentation/modules/con-kafka-broker-external-listeners-ingress.adoc
@@ -13,7 +13,7 @@ Kafka clients can use these `Ingress` resources to connect to Kafka on port 443.
 NOTE: External listeners using `Ingress` have been currently tested only with the {NginxIngressController}.
 
 Kafka uses a binary protocol over TCP, but the {NginxIngressController} is designed to work with the HTTP protocol.
-To be able to pass the Kafka connections through the Ingress, {ProductName} uses the TLS passthrough feature of the {NginxIngressController}.
+To be able to pass the Kafka connections through the Ingress, Strimzi uses the TLS passthrough feature of the {NginxIngressController}.
 Make sure TLS passthrough is enabled in your {NginxIngressController} deployment.
 For more information about enabling TLS passthrough see {NginxIngressControllerTLSPassthrough}.
 Because it is using the TLS passthrough functionality, TLS encryption cannot be disabled when exposing Kafka using `Ingress`.
@@ -21,7 +21,7 @@ Because it is using the TLS passthrough functionality, TLS encryption cannot be 
 The Ingress controller does not assign any hostnames automatically.
 You have to specify the hostnames which should be used by the bootstrap and per-broker services in the `spec.kafka.listeners.external.configuration` section.
 You also have to make sure that the hostnames resolve to the Ingress endpoints.
-{ProductName} will not perform any validation that the requested hosts are available and properly routed to the Ingress endpoints.
+Strimzi will not perform any validation that the requested hosts are available and properly routed to the Ingress endpoints.
 
 .Example of an external listener of type `ingress`
 [source,yaml,subs="attributes+"]

--- a/documentation/modules/con-kafka-broker-external-listeners-nodeports.adoc
+++ b/documentation/modules/con-kafka-broker-external-listeners-nodeports.adoc
@@ -12,7 +12,7 @@ Each Kafka broker pod is then accessible on a separate port.
 
 An additional `NodePort` type of service is created to serve as a Kafka bootstrap address.
 
-When configuring the advertised addresses for the Kafka broker pods, {ProductName} uses the address of the node on which the given pod is running.
+When configuring the advertised addresses for the Kafka broker pods, Strimzi uses the address of the node on which the given pod is running.
 Nodes often have multiple addresses.
 The address type used is based on the first type found in the following order of priority:
 
@@ -25,7 +25,7 @@ The address type used is based on the first type found in the following order of
 You can use the `preferredAddressType` property in your listener configuration to specify the first address type checked as the node address.
 This property is useful, for example, if your deployment does not have DNS support, or you only want to expose a broker internally through an internal DNS or IP address.
 If an address of this type is found, it is used.
-If the preferred address type is not found, {ProductName} proceeds through the types in the standard order of priority.
+If the preferred address type is not found, Strimzi proceeds through the types in the standard order of priority.
 
 .Example of an external listener configured with a preferred address type
 [source,yaml,subs=attributes+]
@@ -55,7 +55,7 @@ NOTE: TLS hostname verification is not currently supported when exposing Kafka c
 
 By default, the port numbers used for the bootstrap and broker services are automatically assigned by Kubernetes.
 However, you can override the assigned node ports by specifying the requested port numbers in the `overrides` property.
-{ProductName} does not perform any validation on the requested ports; you must ensure that they are free and available for use.
+Strimzi does not perform any validation on the requested ports; you must ensure that they are free and available for use.
 
 .Example of an external listener configured with overrides for node ports
 [source,yaml,subs="attributes+"]

--- a/documentation/modules/con-kafka-broker-external-listeners-routes.adoc
+++ b/documentation/modules/con-kafka-broker-external-listeners-routes.adoc
@@ -14,7 +14,7 @@ TLS encryption is always used with `Routes`.
 
 By default, the route hosts are automatically assigned by OpenShift.
 However, you can override the assigned route hosts by specifying the requested hosts in the `overrides` property.
-{ProductName} will not perform any validation that the requested hosts are available; you must ensure that they are free and can be used.
+Strimzi will not perform any validation that the requested hosts are available; you must ensure that they are free and can be used.
 
 .Example of an external listener of type `routes` configured with overrides for OpenShift route hosts
 [source,yaml,subs="attributes+"]

--- a/documentation/modules/con-kafka-connect-authentication.adoc
+++ b/documentation/modules/con-kafka-connect-authentication.adoc
@@ -12,7 +12,7 @@ The supported authentication types are:
 * TLS client authentication
 * SASL-based authentication using the SCRAM-SHA-512 mechanism
 * SASL-based authentication using the PLAIN mechanism
-* xref:assembly-oauth-authentication_str[{oauth} token based authentication]
+* xref:assembly-oauth-authentication_str[OAuth 2.0 token based authentication]
 
 == TLS Client Authentication
 

--- a/documentation/modules/con-kafka-mirror-maker-bootstrap-servers.adoc
+++ b/documentation/modules/con-kafka-mirror-maker-bootstrap-servers.adoc
@@ -17,9 +17,9 @@ The source and the target Kafka clusters are specified in the form of two lists 
 Each comma-separated list contains one or more Kafka brokers or a `Service` pointing to Kafka brokers specified as a `<hostname>:<port>` pairs.
 
 The bootstrap server lists can refer to Kafka clusters that do not need to be deployed in the same Kubernetes cluster.
-They can even refer to a Kafka cluster not deployed by {ProductName}, or deployed by {ProductName} but on a different Kubernetes cluster accessible outside.
+They can even refer to a Kafka cluster not deployed by Strimzi, or deployed by Strimzi but on a different Kubernetes cluster accessible outside.
 
 If on the same Kubernetes cluster, each list must ideally contain the Kafka cluster bootstrap service which is named `_<cluster-name>_-kafka-bootstrap` and a port of 9092 for plain traffic or 9093 for encrypted traffic.
-If deployed by {ProductName} but on different Kubernetes clusters, the list content depends on the approach used for exposing the clusters (routes, nodeports or loadbalancers).
+If deployed by Strimzi but on different Kubernetes clusters, the list content depends on the approach used for exposing the clusters (routes, nodeports or loadbalancers).
 
-When using Kafka MirrorMaker with a Kafka cluster not managed by {ProductName}, you can specify the bootstrap servers list according to the configuration of the given cluster.
+When using Kafka MirrorMaker with a Kafka cluster not managed by Strimzi, you can specify the bootstrap servers list according to the configuration of the given cluster.

--- a/documentation/modules/con-kafka-mirror-maker-configuration.adoc
+++ b/documentation/modules/con-kafka-mirror-maker-configuration.adoc
@@ -25,7 +25,7 @@ You can specify and configure standard Kafka consumer and producer options:
 * {ApacheKafkaProducerConfig}
 * {ApacheKafkaConsumerConfig}
 
-However, there are exceptions for options automatically configured and managed directly by {ProductName} related to:
+However, there are exceptions for options automatically configured and managed directly by Strimzi related to:
 
 * Kafka cluster bootstrap address
 * Security (encryption, authentication, and authorization)

--- a/documentation/modules/con-maintenance-time-window-definition.adoc
+++ b/documentation/modules/con-maintenance-time-window-definition.adoc
@@ -20,7 +20,7 @@ maintenanceTimeWindows:
 
 In practice, maintenance windows should be set in conjunction with the `Kafka.spec.clusterCa.renewalDays` and `Kafka.spec.clientsCa.renewalDays` properties of the `Kafka` resource, to ensure that the necessary CA certificate renewal can be completed in the configured maintenance time windows.
 
-NOTE: {ProductName} does not schedule maintenance operations exactly according to the given windows. Instead, for each reconciliation, it checks whether a maintenance window is currently "open".
+NOTE: Strimzi does not schedule maintenance operations exactly according to the given windows. Instead, for each reconciliation, it checks whether a maintenance window is currently "open".
 This means that the start of maintenance operations within a given time window can be delayed by up to the Cluster Operator reconciliation interval.
 Maintenance time windows must therefore be at least this long.
 

--- a/documentation/modules/con-mutual-tls-authentication.adoc
+++ b/documentation/modules/con-mutual-tls-authentication.adoc
@@ -7,7 +7,7 @@
 
 Mutual TLS authentication is always used for the communication between Kafka brokers and ZooKeeper pods.
 
-Mutual authentication or two-way authentication is when both the server and the client present certificates. {ProductName} can configure Kafka to use TLS (Transport Layer Security) to provide encrypted communication between Kafka brokers and clients either with or without mutual authentication. When you configure mutual authentication, the broker authenticates the client and the client authenticates the broker.
+Mutual authentication or two-way authentication is when both the server and the client present certificates. Strimzi can configure Kafka to use TLS (Transport Layer Security) to provide encrypted communication between Kafka brokers and clients either with or without mutual authentication. When you configure mutual authentication, the broker authenticates the client and the client authenticates the broker.
 
 NOTE: TLS authentication is more commonly one-way, with one party authenticating the identity of another. For example, when HTTPS is used between a web browser and a web server, the server obtains proof of the identity of the browser.
 

--- a/documentation/modules/con-operators-prometheus-metrics.adoc
+++ b/documentation/modules/con-operators-prometheus-metrics.adoc
@@ -6,7 +6,7 @@
 
 = Prometheus metrics
 
-{ProductName} operators expose Prometheus metrics.
+Strimzi operators expose Prometheus metrics.
 The metrics are automatically enabled and contain information about:
 
 * Number of reconciliations

--- a/documentation/modules/con-overview-distributed-tracing.adoc
+++ b/documentation/modules/con-overview-distributed-tracing.adoc
@@ -3,23 +3,23 @@
 // assembly-distributed-tracing.adoc
 
 [id='con-overview-distributed-tracing-{context}']
-= Overview of distributed tracing in {ProductName}
+= Overview of distributed tracing in Strimzi
 
 Distributed tracing allows developers and system administrators to track the progress of transactions between applications (and services in a microservice architecture) in a distributed system. This information is useful for monitoring application performance and investigating issues with target systems and end-user applications.
 
-In {ProductName} and data streaming platforms in general, distributed tracing facilitates the end-to-end tracking of messages: from source systems to the Kafka cluster and then to target systems and applications.
+In Strimzi and data streaming platforms in general, distributed tracing facilitates the end-to-end tracking of messages: from source systems to the Kafka cluster and then to target systems and applications.
 
 As an aspect of system observability, distributed tracing complements the metrics that are available to view in link:{BookURLDeploying}#assembly-metrics-setup-{context}[Grafana dashboards] and the available loggers for each component. 
 
 .OpenTracing overview
 
-Distributed tracing in {ProductName} is implemented using the open source {OpenTracingHome} and {JaegerHome} projects.
+Distributed tracing in Strimzi is implemented using the open source {OpenTracingHome} and {JaegerHome} projects.
 
 The OpenTracing specification defines APIs that developers can use to instrument applications for distributed tracing. It is independent from the tracing system.
 
 When instrumented, applications generate __traces__ for individual transactions. Traces are composed of __spans__, which define specific units of work.
 
-To simplify the instrumentation of the Kafka Bridge and Kafka Producer, Consumer, and Streams API applications, {ProductName} includes the https://github.com/opentracing-contrib/java-kafka-client/blob/master/README.md[OpenTracing Apache Kafka Client Instrumentation^] library.
+To simplify the instrumentation of the Kafka Bridge and Kafka Producer, Consumer, and Streams API applications, Strimzi includes the https://github.com/opentracing-contrib/java-kafka-client/blob/master/README.md[OpenTracing Apache Kafka Client Instrumentation^] library.
 
 NOTE: The OpenTracing project is merging with the OpenCensus project. The new, combined project is named {OpenTelemetryHome}. OpenTelemetry will provide compatibility for applications that are instrumented using the OpenTracing APIs.
 
@@ -31,13 +31,13 @@ Jaeger, a tracing system, is an implementation of the OpenTracing APIs used for 
 
 image:image_con-overview-distributed-tracing.png[Simple Jaeger query]
 
-== Distributed tracing support in {ProductName}
+== Distributed tracing support in Strimzi
 
-In {ProductName}, distributed tracing is supported in:
+In Strimzi, distributed tracing is supported in:
 
 * Kafka Connect (including Kafka Connect with Source2Image support)
 * MirrorMaker
-* The {ProductName} Kafka Bridge
+* The Strimzi Kafka Bridge
 
 You enable and configure distributed tracing for these components by setting template configuration properties in the relevant custom resource (for example, `KafkaConnect` and `KafkaBridge`).
 

--- a/documentation/modules/con-partition-reassignment.adoc
+++ b/documentation/modules/con-partition-reassignment.adoc
@@ -56,7 +56,7 @@ Where _<PartitionObjects>_ is a comma-separated list of objects like:
 }
 ----
 
-NOTE: Although Kafka also supports a `"log_dirs"` property this should not be used in {ProductLongName}.
+NOTE: Although Kafka also supports a `"log_dirs"` property this should not be used in Strimzi.
 
 The following is an example reassignment JSON file that assigns topic `topic-a`, partition `4` to brokers `2`, `4` and `7`, and topic `topic-b` partition `2` to brokers `1`, `5` and `7`:
 

--- a/documentation/modules/con-product-downloads.adoc
+++ b/documentation/modules/con-product-downloads.adoc
@@ -3,17 +3,17 @@
 // getting-started.adoc
 
 [id='downloads-{context}']
-= Installing {ProductName} and deploying components
+= Installing Strimzi and deploying components
 
 ifdef::Downloading[]
-To install {ProductName}, download the release artefacts from {ReleaseDownload}.
+To install Strimzi, download the release artefacts from {ReleaseDownload}.
 endif::Downloading[]
 
 ifndef::Downloading[]
-To install {ProductName}, download and extract the `amq-streams-x.y.z-ocp-install-examples.zip` file from the {ZipDownload}.
+To install Strimzi, download and extract the `amq-streams-x.y.z-ocp-install-examples.zip` file from the {ZipDownload}.
 endif::Downloading[]
 
-The folder contains several YAML files to help you deploy the components of {ProductName} to Kubernetes, perform common operations, and configure your Kafka cluster. The YAML files are referenced throughout this documentation.
+The folder contains several YAML files to help you deploy the components of Strimzi to Kubernetes, perform common operations, and configure your Kafka cluster. The YAML files are referenced throughout this documentation.
 
 ifdef::Downloading[]
 Additionally, a Helm Chart is provided for deploying the Cluster Operator using link:https://helm.sh/[Helm^]. The container images are available through the {DockerRepository}.
@@ -21,4 +21,4 @@ endif::Downloading[]
 
 The remainder of this chapter provides an overview of each component and instructions for deploying the components to Kubernetes using the YAML files provided.
 
-NOTE: Although container images for {ProductName} are available in the {DockerRepository}, we recommend that you use the YAML files provided instead.
+NOTE: Although container images for Strimzi are available in the {DockerRepository}, we recommend that you use the YAML files provided instead.

--- a/documentation/modules/con-prometheus-metrics.adoc
+++ b/documentation/modules/con-prometheus-metrics.adoc
@@ -13,7 +13,7 @@
 Use the `metrics` property to enable and configure Prometheus metrics.
 
 The `metrics` property can also contain additional configuration for the link:https://github.com/prometheus/jmx_exporter[Prometheus JMX exporter^].
-{ProductName} supports Prometheus metrics using Prometheus JMX exporter to convert the JMX metrics supported by Apache Kafka and ZooKeeper to Prometheus metrics.
+Strimzi supports Prometheus metrics using Prometheus JMX exporter to convert the JMX metrics supported by Apache Kafka and ZooKeeper to Prometheus metrics.
 
 To enable Prometheus metrics export without any further configuration, you can set it to an empty object (`{}`).
 

--- a/documentation/modules/con-resource-limits-and-requests.adoc
+++ b/documentation/modules/con-resource-limits-and-requests.adoc
@@ -12,14 +12,14 @@
 
 Use the `reources.requests` and `resources.limits` properties to configure resource requests and limits.
 
-For every deployed container, {ProductName} allows you to request specific resources and define the maximum consumption of those resources.
+For every deployed container, Strimzi allows you to request specific resources and define the maximum consumption of those resources.
 
-{ProductName} supports requests and limits for the following types of resources:
+Strimzi supports requests and limits for the following types of resources:
 
 * `cpu`
 * `memory`
 
-{ProductName} uses the Kubernetes syntax for specifying these resources.
+Strimzi uses the Kubernetes syntax for specifying these resources.
 
 For more information about managing computing resources on Kubernetes, see {K8sManagingComputingResources}.
 

--- a/documentation/modules/con-scaling-kafka-clusters.adoc
+++ b/documentation/modules/con-scaling-kafka-clusters.adoc
@@ -20,7 +20,7 @@ Once the partitions have been redistributed between all the brokers, the resourc
 
 == Removing brokers from a cluster
 
-Because {ProductName} uses `StatefulSets` to manage broker pods, you cannot remove _any_ pod from the cluster. 
+Because Strimzi uses `StatefulSets` to manage broker pods, you cannot remove _any_ pod from the cluster. 
 You can only remove one or more of the highest numbered pods from the cluster. 
 For example, in a cluster of 12 brokers the pods are named `_cluster-name_-kafka-0` up to `_cluster-name_-kafka-11`.
 If you decide to scale down by one broker, the `_cluster-name_-kafka-11` will be removed.

--- a/documentation/modules/con-scheduling-to-specific-nodes.adoc
+++ b/documentation/modules/con-scheduling-to-specific-nodes.adoc
@@ -8,7 +8,7 @@
 The Kubernetes cluster usually consists of many different types of worker nodes.
 Some are optimized for CPU heavy workloads, some for memory, while other might be optimized for storage (fast local SSDs) or network.
 Using different nodes helps to optimize both costs and performance.
-To achieve the best possible performance, it is important to allow scheduling of {ProductName} components to use the right nodes.
+To achieve the best possible performance, it is important to allow scheduling of Strimzi components to use the right nodes.
 
 Kubernetes uses node affinity to schedule workloads onto specific nodes.
 Node affinity allows you to create a scheduling constraint for the node on which the pod will be scheduled.

--- a/documentation/modules/con-scram-sha-authentication.adoc
+++ b/documentation/modules/con-scram-sha-authentication.adoc
@@ -5,7 +5,7 @@
 [id='con-scram-sha-authentication-{context}']
 = SCRAM-SHA authentication
 
-SCRAM (Salted Challenge Response Authentication Mechanism) is an authentication protocol that can establish mutual authentication using passwords. {ProductName} can configure Kafka to use SASL (Simple Authentication and Security Layer) SCRAM-SHA-512 to provide authentication on both unencrypted and TLS-encrypted client connections. TLS authentication is always used internally between Kafka brokers and ZooKeeper nodes. When used with a TLS client connection, the TLS protocol provides encryption, but is not used for authentication.
+SCRAM (Salted Challenge Response Authentication Mechanism) is an authentication protocol that can establish mutual authentication using passwords. Strimzi can configure Kafka to use SASL (Simple Authentication and Security Layer) SCRAM-SHA-512 to provide authentication on both unencrypted and TLS-encrypted client connections. TLS authentication is always used internally between Kafka brokers and ZooKeeper nodes. When used with a TLS client connection, the TLS protocol provides encryption, but is not used for authentication.
 
 The following properties of SCRAM make it safe to use SCRAM-SHA even on unencrypted connections:
 
@@ -17,7 +17,7 @@ This means that the exchange is resilient against replay attacks.
 
 == Supported SCRAM credentials
 
-{ProductName} supports SCRAM-SHA-512 only.
+Strimzi supports SCRAM-SHA-512 only.
 When a `KafkaUser.spec.authentication.type` is configured with `scram-sha-512` the User Operator will generate a random 12 character password consisting of upper and lowercase ASCII letters and numbers.
 
 == When to use SCRAM-SHA authentication for clients

--- a/documentation/modules/con-securing-kafka-bridge.adoc
+++ b/documentation/modules/con-securing-kafka-bridge.adoc
@@ -6,7 +6,7 @@
 
 = Securing the Kafka Bridge
 
-{ProductName} does not currently provide any encryption, authentication, or authorization for the Kafka Bridge. This means that requests sent from external clients to the Kafka Bridge are:
+Strimzi does not currently provide any encryption, authentication, or authorization for the Kafka Bridge. This means that requests sent from external clients to the Kafka Bridge are:
 
 * Not encrypted, and must use HTTP rather than HTTPS
 

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -8,7 +8,7 @@
 To rebalance a Kafka cluster, Cruise Control uses optimization goals to generate xref:con-optimization-proposals-{context}[optimization proposals], which you can approve or reject.  
 
 Optimization goals are constraints on workload redistribution and resource utilization across a Kafka cluster.
-With a few exceptions, {ProductName} supports all the optimization goals developed in the Cruise Control project. 
+With a few exceptions, Strimzi supports all the optimization goals developed in the Cruise Control project. 
 The supported goals, in the default descending order of priority, are as follows:
 
 . Rack-awareness
@@ -31,7 +31,7 @@ For more information on each optimization goal, see link:https://github.com/link
 NOTE: CPU goals, intra-broker disk goals, "Write your own" goals, and Kafka assigner goals are not yet supported.
 
 [discrete]
-== Goals configuration in {ProductName} custom resources
+== Goals configuration in Strimzi custom resources
 
 You configure optimization goals in `Kafka` and `KafkaRebalance` custom resources. Cruise Control has configurations for xref:#hard-soft-goals[_hard_] optimization goals that must be satisfied, as well as xref:#master-goals[_master_], xref:#default-goals[_default_], and xref:#user-provided-goals[_user-provided_] optimization goals. 
 Optimization goals are subject to any xref:#capacity-configuration[_capacity limits_] on broker resources.
@@ -102,7 +102,7 @@ Therefore, if some, but not all, of the user-provided optimization goals are in 
 The _master optimization goals_ are available to all users.
 Goals that are not listed in the master optimization goals are not available for use in Cruise Control operations.
 
-Unless you change the Cruise Control xref:proc-deploying-cruise-control-{context}[deployment configuration], {ProductName} will inherit the following master optimization goals from Cruise Control, in descending priority order:
+Unless you change the Cruise Control xref:proc-deploying-cruise-control-{context}[deployment configuration], Strimzi will inherit the following master optimization goals from Cruise Control, in descending priority order:
 
 [source]
 RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; ReplicaDistributionGoal; PotentialNwOutGoal; DiskUsageDistributionGoal; NetworkInboundUsageDistributionGoal; NetworkOutboundUsageDistributionGoal; TopicReplicaDistributionGoal; LeaderReplicaDistributionGoal; LeaderBytesInDistributionGoal; PreferredLeaderElectionGoal

--- a/documentation/modules/cruise-control/proc-deploying-cruise-control.adoc
+++ b/documentation/modules/cruise-control/proc-deploying-cruise-control.adoc
@@ -5,7 +5,7 @@
 [id='proc-deploying-cruise-control-{context}']
 = Deploying Cruise Control
 
-To deploy Cruise Control to your {ProductName} cluster, define the configuration using the `cruiseControl` property in the `Kafka` resource, and then create or update the resource.
+To deploy Cruise Control to your Strimzi cluster, define the configuration using the `cruiseControl` property in the `Kafka` resource, and then create or update the resource.
 
 Deploy one instance of Cruise Control per Kafka cluster.
 
@@ -82,7 +82,7 @@ spec:
 ----
 <1> Specifies capacity limits for broker resources. For more information, see xref:#capacity-configuration[Capacity configuration].
 <2> Defines the Cruise Control configuration, including the default optimization goals (in `default.goals`) and any customizations to the master optimization goals (in `goals`) or the hard goals (in `hard.goals`). 
-You can provide any xref:ref-cruise-control-configuration-{context}[standard Cruise Control configuration option] apart from those managed directly by {ProductName}. 
+You can provide any xref:ref-cruise-control-configuration-{context}[standard Cruise Control configuration option] apart from those managed directly by Strimzi. 
 For more information on configuring optimization goals, see xref:con-optimization-goals-{context}[]. 
 <3> CPU and memory resources reserved for Cruise Control. For more information, see xref:assembly-resource-limits-and-requests-deployment-configuration-kafka[].
 <4> Defined loggers and log levels added directly (inline) or indirectly (external) through a ConfigMap. A custom ConfigMap must be placed under the log4j.properties key. Cruise Control has a single logger named `cruisecontrol.root.logger`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF. For more information, see xref:#logging-configuration[Logging configuration].

--- a/documentation/modules/cruise-control/proc-generating-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/proc-generating-optimization-proposals.adoc
@@ -11,7 +11,7 @@ Analyze the summary information in the optimization proposal and decide whether 
 
 .Prerequisites
 
-* You have xref:proc-deploying-cruise-control-{context}[deployed Cruise Control] to your {ProductName} cluster.
+* You have xref:proc-deploying-cruise-control-{context}[deployed Cruise Control] to your Strimzi cluster.
 
 * You have configured xref:con-optimization-goals-{context}[optimization goals] and, optionally, xref:#capacity-configuration[capacity limits on broker resources].
 

--- a/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
+++ b/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
@@ -13,7 +13,7 @@ The `config` property in `Kafka.spec.cruiseControl` contains configuration optio
 
 NOTE: Strings that look like JSON or YAML will need to be explicitly quoted.
 
-You can specify and configure all the options listed in the "Configurations" section of the {CruiseControlConfigDocs}, apart from those managed directly by {ProductName}.
+You can specify and configure all the options listed in the "Configurations" section of the {CruiseControlConfigDocs}, apart from those managed directly by Strimzi.
 Specifically, you *cannot* modify configuration options with keys equal to or starting with one of the following strings:
 
 * `bootstrap.servers`
@@ -73,7 +73,7 @@ Capacity limits can be set for the following broker resources in the described u
 * `inboundNetwork`  - Inbound network throughput in bytes per second
 * `outboundNetwork` - Outbound network throughput in bytes per second
 
-Because {ProductName} Kafka brokers are homogeneous, Cruise Control applies the same capacity limits to every broker it is monitoring.
+Because Strimzi Kafka brokers are homogeneous, Cruise Control applies the same capacity limits to every broker it is monitoring.
 
 .An example Cruise Control brokerCapacity configuration
 [source,yaml,subs="attributes+"]
@@ -107,7 +107,7 @@ Cruise Control requires the following three topics in order to work:
 * `strimzi.cruisecontrol.modeltrainingsamples`
 * `strimzi.cruisecontrol.metrics`
 
-These three topics are usually auto-created by {ProductName} and Cruise Control. First, the metric reporters create the `strimzi.cruisecontrol.metrics` topic. 
+These three topics are usually auto-created by Strimzi and Cruise Control. First, the metric reporters create the `strimzi.cruisecontrol.metrics` topic. 
 Then, Cruise Control creates the `strimzi.cruisecontrol.partitionmetricsamples` and `strimzi.cruisecontrol.modeltrainingsamples` topics.
 
 However, if automatic topic creation is _disabled_ in Kafka (`auto.create.topics.enable: false` is configured in `spec.kafka.config` when starting a new Kafka cluster) the Cruise Control metric reporters are unable to create the `strimzi.cruisecontrol.metrics` topic.

--- a/documentation/modules/deploying/con-deploy-cluster-operator-watch-options.adoc
+++ b/documentation/modules/deploying/con-deploy-cluster-operator-watch-options.adoc
@@ -14,7 +14,7 @@ You can choose to deploy the Cluster Operator to watch Kafka resources from:
 * Multiple namespaces
 * All namespaces
 
-NOTE: {ProductName} provides example YAML files to make the deployment process easier.
+NOTE: Strimzi provides example YAML files to make the deployment process easier.
 
 The Cluster Operator watches for changes to the following resources:
 

--- a/documentation/modules/deploying/con-deploy-container-images.adoc
+++ b/documentation/modules/deploying/con-deploy-container-images.adoc
@@ -6,8 +6,8 @@
 
 = Pushing container images to your own registry
 
-Container images for {ProductName} are available in the {DockerRepository}.
-The installation YAML files provided by {ProductName} will pull the images directly from the {DockerRepository}.
+Container images for Strimzi are available in the {DockerRepository}.
+The installation YAML files provided by Strimzi will pull the images directly from the {DockerRepository}.
 
 If you do not have access to the {DockerRepository} or want to use your own container repository:
 

--- a/documentation/modules/deploying/con-deploy-custom-resources-example.adoc
+++ b/documentation/modules/deploying/con-deploy-custom-resources-example.adoc
@@ -3,15 +3,15 @@
 // assembly_deploy-intro-custom-resources.adoc
 
 [id='con-custom-resources-example-{context}']
-= {ProductName} custom resource example
+= Strimzi custom resource example
 
-CRDs require a one-time installation in a cluster to define the schemas used to instantiate and manage {ProductName}-specific resources.
+CRDs require a one-time installation in a cluster to define the schemas used to instantiate and manage Strimzi-specific resources.
 
 After a new custom resource type is added to your cluster by installing a CRD, you can create instances of the resource based on its specification.
 
 Depending on the cluster setup, installation typically requires cluster admin privileges.
 
-NOTE: Access to manage custom resources is limited to xref:adding-users-the-strimzi-admin-role-{context}[{ProductName} administrators].
+NOTE: Access to manage custom resources is limited to xref:adding-users-the-strimzi-admin-role-{context}[Strimzi administrators].
 
 A CRD defines a new `kind` of resource, such as `kind:Kafka`, within a Kubernetes cluster.
 
@@ -19,8 +19,8 @@ The Kubernetes API server allows custom resources to be created based on the `ki
 
 WARNING: When CRDs are deleted, custom resources of that type are also deleted. Additionally, the resources created by the custom resource, such as pods and statefulsets are also deleted.
 
-Each {ProductName}-specific custom resource conforms to the schema defined by the CRD for the resource's `kind`.
-The custom resources for {ProductName} components have common configuration properties, which are defined under `spec`.
+Each Strimzi-specific custom resource conforms to the schema defined by the CRD for the resource's `kind`.
+The custom resources for Strimzi components have common configuration properties, which are defined under `spec`.
 
 To understand the relationship between a CRD and a custom resource, let's look at a sample of the CRD for a Kafka topic.
 
@@ -70,7 +70,7 @@ spec: <2>
 <5> The current status of the CRD as described in the link:{BookURLUsing}#type-Kafka-reference[schema reference^] for the resource.
 <6> openAPIV3Schema validation provides validation for the creation of topic custom resources. For example, a topic requires at least one partition and one replica.
 
-NOTE: You can identify the CRD YAML files supplied with the {ProductName} installation files, because the file names contain an index number followed by ‘Crd’.
+NOTE: You can identify the CRD YAML files supplied with the Strimzi installation files, because the file names contain an index number followed by ‘Crd’.
 
 Here is a corresponding example of a `KafkaTopic` custom resource.
 
@@ -107,4 +107,4 @@ status:
 Custom resources can be applied to a cluster through the platform CLI.
 When the custom resource is created, it uses the same validation as the built-in resources of the Kubernetes API.
 
-After a `KafkaTopic` custom resource is created, the Topic Operator is notified and corresponding Kafka topics are created in {Productname}.
+After a `KafkaTopic` custom resource is created, the Topic Operator is notified and corresponding Kafka topics are created in Strimzi.

--- a/documentation/modules/deploying/con-deploy-kafka-connect-managing-connectors.adoc
+++ b/documentation/modules/deploying/con-deploy-kafka-connect-managing-connectors.adoc
@@ -17,7 +17,7 @@ You can create _source_ and _sink_ types of connector.
 Source connector:: A source connector is a runtime entity that fetches data from an external system and feeds it to Kafka as messages.
 Sink connector:: A sink connector is a runtime entity that fetches messages from Kafka topics and feeds them to an external system.
 
-{ProductName} provides two APIs for creating and managing connectors:
+Strimzi provides two APIs for creating and managing connectors:
 
 * `KafkaConnector` resources (referred to as `KafkaConnectors`)
 * Kafka Connect REST API
@@ -39,11 +39,11 @@ Like other Kafka resources, you declare a connector’s desired state in a `Kafk
 
 You manage a running connector instance by updating its corresponding `KafkaConnector`, and then applying the updates. You remove a connector by deleting its corresponding `KafkaConnector`.
 
-To ensure compatibility with earlier versions of {ProductName}, `KafkaConnectors` are disabled by default. To enable them for a Kafka Connect cluster, you must use annotations on the `KafkaConnect` resource. For instructions, see link:{BookURLUsing}#proc-enabling-kafkaconnectors-deployment-configuration-kafka-connect[Enabling `KafkaConnector` resources].
+To ensure compatibility with earlier versions of Strimzi, `KafkaConnectors` are disabled by default. To enable them for a Kafka Connect cluster, you must use annotations on the `KafkaConnect` resource. For instructions, see link:{BookURLUsing}#proc-enabling-kafkaconnectors-deployment-configuration-kafka-connect[Enabling `KafkaConnector` resources].
 
 When `KafkaConnectors` are enabled, the Cluster Operator begins to watch for them. It updates the configurations of running connector instances to match the configurations defined in their `KafkaConnectors`.
 
-{ProductName} includes an example `KafkaConnector`, named `examples/connector/source-connector.yaml`. You can use this example to create and manage a `FileStreamSourceConnector`.
+Strimzi includes an example `KafkaConnector`, named `examples/connector/source-connector.yaml`. You can use this example to create and manage a `FileStreamSourceConnector`.
 
 == Availability of the Kafka Connect REST API
 

--- a/documentation/modules/deploying/con-deploy-options-scope.adoc
+++ b/documentation/modules/deploying/con-deploy-options-scope.adoc
@@ -5,27 +5,27 @@
 [id='deploy-options-scope-{context}']
 = Additional deployment configuration options
 
-The deployment procedures in this guide describe a deployment using the example installation YAML files provided with {ProductName}.
+The deployment procedures in this guide describe a deployment using the example installation YAML files provided with Strimzi.
 The procedures highlight any important configuration considerations, but they do not describe all the configuration options available.
 
 You can use custom resources to refine your deployment.
 
-You may wish to review the configuration options available for Kafka components before you deploy {ProductName}.
+You may wish to review the configuration options available for Kafka components before you deploy Strimzi.
 For more information on the configuration through custom resources, see link:{BookURLUsing}#assembly-deployment-configuration-str[Deployment configuration^].
 
 == Securing Kafka
 
 On deployment, the Cluster Operator automatically sets up TLS certificates for data encryption and authentication within your cluster.
 
-{ProductName} provides additional configuration options for _encryption_, _authentication_ and _authorization_:
+Strimzi provides additional configuration options for _encryption_, _authentication_ and _authorization_:
 
 * Secure data exchange between the Kafka cluster and clients by link:{BookURLUsing}#assembly-deployment-configuration-str[configuration of Kafka resources^].
-* Configure your deployment to use an authorization server to provide link:{BookURLUsing}#assembly-oauth-authentication_str[{oauth} authentication^] and link:{BookURLUsing}#assembly-oauth-authorization_str[{oauth} authorization^].
+* Configure your deployment to use an authorization server to provide link:{BookURLUsing}#assembly-oauth-authentication_str[OAuth 2.0 authentication^] and link:{BookURLUsing}#assembly-oauth-authorization_str[OAuth 2.0 authorization^].
 * link:{BookURLUsing}#security-str[Secure Kafka using your own certificates^].
 
 == Monitoring your deployment
 
-{ProductName} supports additional deployment options to monitor your deployment.
+Strimzi supports additional deployment options to monitor your deployment.
 
 * Extract metrics and monitor Kafka components by xref:assembly-metrics-setup-str[deploying Prometheus and Grafana with your Kafka cluster].
 * Extract additional metrics, particularly related to monitoring consumer lag, by xref:assembly-kafka-exporter-{context}[deploying Kafka Exporter with your Kafka cluster].

--- a/documentation/modules/deploying/con-deploy-prereqs.adoc
+++ b/documentation/modules/deploying/con-deploy-prereqs.adoc
@@ -5,7 +5,7 @@
 [id='deploy-prereqs-{context}']
 = Deployment prerequisites
 
-To deploy {ProductName}, make sure:
+To deploy Strimzi, make sure:
 
 ifdef::Downloading[]
 * A Kubernetes {KubernetesVersion} cluster is available
@@ -13,18 +13,18 @@ endif::Downloading[]
 ifndef::Downloading[]
 * An OpenShift {OpenShiftVersion} cluster is available
 +
-{ProductName} is based on Strimzi {StrimziVersion}.
+Strimzi is based on Strimzi {StrimziVersion}.
 endif::Downloading[]
 * The `kubectl` command-line tool is installed and configured to connect to the running cluster.
 
-NOTE: {ProductName} supports some features that are specific to OpenShift,
+NOTE: Strimzi supports some features that are specific to OpenShift,
 where such integration benefits OpenShift users and there is no equivalent implementation using standard Kubernetes.
 
 ifdef::InstallationAppendix[]
 [discrete]
 == Alternatives if a Kubernetes cluster is not available
 
-If you do not have access to a Kubernetes cluster, as an alternative you can try installing {ProductName} with:
+If you do not have access to a Kubernetes cluster, as an alternative you can try installing Strimzi with:
 
 * xref:deploy-kubernetes-{context}[_Minikube_]
 * xref:deploy-openshift-{context}[_Minishift_]

--- a/documentation/modules/deploying/con-deploy-product-downloads.adoc
+++ b/documentation/modules/deploying/con-deploy-product-downloads.adoc
@@ -3,20 +3,20 @@
 // deploying/assembly_deploy-tasks-prep.adoc
 
 [id='downloads-{context}']
-= Downloading {ProductName} release artifacts
+= Downloading Strimzi release artifacts
 
 ifdef::Downloading[]
-To install {ProductName}, download the release artifacts from {ReleaseDownload}.
+To install Strimzi, download the release artifacts from {ReleaseDownload}.
 endif::Downloading[]
 
 ifndef::Downloading[]
-To install {ProductName}, download and extract the release artifacts from the `amq-streams-__<version>__-ocp-install-examples.zip` file from the {ZipDownload}.
+To install Strimzi, download and extract the release artifacts from the `amq-streams-__<version>__-ocp-install-examples.zip` file from the {ZipDownload}.
 endif::Downloading[]
 
-{ProductName} release artifacts include sample YAML files to help you deploy the components of {ProductName} to Kubernetes, perform common operations,
+Strimzi release artifacts include sample YAML files to help you deploy the components of Strimzi to Kubernetes, perform common operations,
 and configure your Kafka cluster.
 
-You deploy {ProductName} to a Kubernetes cluster using the `kubectl` command-line tool.
+You deploy Strimzi to a Kubernetes cluster using the `kubectl` command-line tool.
 
-NOTE: Additionally, {ProductName} container images are available through the {DockerRepository}.
-However, we recommend that you use the YAML files provided to deploy {ProductName}.
+NOTE: Additionally, Strimzi container images are available through the {DockerRepository}.
+However, we recommend that you use the YAML files provided to deploy Strimzi.

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-helm-chart.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-helm-chart.adoc
@@ -6,7 +6,7 @@
 = Deploying the Cluster Operator using a Helm Chart
 
 As an alternative to using the YAML deployment files,
-this procedure shows how to deploy the the Cluster Operator using a Helm chart provided with {ProductName}.
+this procedure shows how to deploy the the Cluster Operator using a Helm chart provided with Strimzi.
 
 .Prerequisites
 

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-multiple-namespaces.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-multiple-namespaces.adoc
@@ -5,7 +5,7 @@
 [id='deploying-cluster-operator-to-watch-multiple-namespaces-{context}']
 = Deploying the Cluster Operator to watch multiple namespaces
 
-This procedure shows how to deploy the Cluster Operator to watch {ProductName} resources across multiple namespaces in your Kubernetes cluster.
+This procedure shows how to deploy the Cluster Operator to watch Strimzi resources across multiple namespaces in your Kubernetes cluster.
 
 .Prerequisites
 
@@ -14,7 +14,7 @@ Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means t
 
 .Procedure
 
-. Edit the {ProductName} installation files to use the namespace the Cluster Operator is going to be installed into.
+. Edit the Strimzi installation files to use the namespace the Cluster Operator is going to be installed into.
 +
 For example, in this procedure the Cluster Operator is installed into the namespace `_my-cluster-operator-namespace_`.
 +

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-namespace.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-namespace.adoc
@@ -5,7 +5,7 @@
 [id='deploying-cluster-operator-{context}']
 = Deploying the Cluster Operator to watch a single namespace
 
-This procedure shows how to deploy the Cluster Operator to watch {ProductName} resources in a single namespace in your Kubernetes cluster.
+This procedure shows how to deploy the Cluster Operator to watch Strimzi resources in a single namespace in your Kubernetes cluster.
 
 .Prerequisites
 
@@ -14,7 +14,7 @@ Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means t
 
 .Procedure
 
-. Edit the {ProductName} installation files to use the namespace the Cluster Operator is going to be installed into.
+. Edit the Strimzi installation files to use the namespace the Cluster Operator is going to be installed into.
 +
 For example, in this procedure the Cluster Operator is installed into the namespace `_my-cluster-operator-namespace_`.
 +

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-whole-cluster.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-whole-cluster.adoc
@@ -5,7 +5,7 @@
 [id='deploying-cluster-operator-to-watch-whole-cluster-{context}']
 = Deploying the Cluster Operator to watch all namespaces
 
-This procedure shows how to deploy the Cluster Operator to watch {ProductName} resources across all namespaces in your Kubernetes cluster.
+This procedure shows how to deploy the Cluster Operator to watch Strimzi resources across all namespaces in your Kubernetes cluster.
 
 When running in this mode, the Cluster Operator automatically manages clusters in any new namespaces that are created.
 
@@ -16,7 +16,7 @@ Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means t
 
 .Procedure
 
-. Edit the {ProductName} installation files to use the namespace the Cluster Operator is going to be installed into.
+. Edit the Strimzi installation files to use the namespace the Cluster Operator is going to be installed into.
 +
 For example, in this procedure the Cluster Operator is installed into the namespace `_my-cluster-operator-namespace_`.
 +

--- a/documentation/modules/deploying/proc-deploy-designating-strimzi-administrators.adoc
+++ b/documentation/modules/deploying/proc-deploy-designating-strimzi-administrators.adoc
@@ -3,26 +3,26 @@
 // deploying/assembly_deploy-tasks-prep.adoc
 
 [id='adding-users-the-strimzi-admin-role-{context}']
-= Designating {ProductName} administrators
+= Designating Strimzi administrators
 
-{ProductName} provides custom resources for configuration of your deployment.
+Strimzi provides custom resources for configuration of your deployment.
 By default, permission to view, create, edit, and delete these resources is limited to Kubernetes cluster administrators.
-{ProductName} provides two cluster roles that you can use to assign these rights to other users:
+Strimzi provides two cluster roles that you can use to assign these rights to other users:
 
-* `strimzi-view` allows users to view and list {ProductName} resources.
-* `strimzi-admin` allows users to also create, edit or delete {ProductName} resources.
+* `strimzi-view` allows users to view and list Strimzi resources.
+* `strimzi-admin` allows users to also create, edit or delete Strimzi resources.
 
 When you install these roles, they will automatically aggregate (add) these rights to the default Kubernetes cluster roles.
 `strimzi-view` aggregates to the `view` role, and `strimzi-admin` aggregates to the `edit` and `admin` roles.
 Because of the aggregation, you might not need to assign these roles to users who already have similar rights.
 
-The following procedure shows how to assign a `strimzi-admin` role that allows non-cluster administrators to manage {ProductName} resources.
+The following procedure shows how to assign a `strimzi-admin` role that allows non-cluster administrators to manage Strimzi resources.
 
-A system administrator can designate {ProductName} administrators after the Cluster Operator is deployed.
+A system administrator can designate Strimzi administrators after the Cluster Operator is deployed.
 
 .Prerequisites
 
-* The {ProductName} Custom Resource Definitions (CRDs) and role-based access control (RBAC) resources to manage the CRDs have been xref:cluster-operator-{context}[deployed with the Cluster Operator].
+* The Strimzi Custom Resource Definitions (CRDs) and role-based access control (RBAC) resources to manage the CRDs have been xref:cluster-operator-{context}[deployed with the Cluster Operator].
 
 .Procedure
 

--- a/documentation/modules/deploying/proc-deploy-kafka-bridge.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-bridge.adoc
@@ -9,7 +9,7 @@ This procedure shows how to deploy a Kafka Bridge cluster to your Kubernetes clu
 
 The deployment uses a YAML file to provide the specification to create a `KafkaBridge` resource.
 
-In this procedure, we use the example file provided with {ProductName}:
+In this procedure, we use the example file provided with Strimzi:
 
 * `examples/kafka-bridge/kafka-bridge.yaml`
 

--- a/documentation/modules/deploying/proc-deploy-kafka-cluster.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-cluster.adoc
@@ -9,7 +9,7 @@ This procedure shows how to deploy a Kafka cluster to your Kubernetes using the 
 
 The deployment uses a YAML file to provide the specification to create a `Kafka` resource.
 
-{ProductName} provides example YAMLs files for deployment in `examples/kafka/`:
+Strimzi provides example YAMLs files for deployment in `examples/kafka/`:
 
 `kafka-persistent.yaml`:: Deploys a persistent cluster with three ZooKeeper and three Kafka nodes.
 `kafka-jbod.yaml`:: Deploys a persistent cluster with three ZooKeeper and three Kafka nodes (each using multiple persistent volumes).

--- a/documentation/modules/deploying/proc-deploy-kafka-connect-new-image-from-base.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-new-image-from-base.adoc
@@ -9,7 +9,7 @@ This procedure shows how to create a custom image and add it to the `/opt/kafka/
 
 You can use the Kafka container image on {DockerRepository} as a base image for creating your own custom image with additional connector plug-ins.
 
-At startup, the {ProductName} version of Kafka Connect loads any third-party connector plug-ins contained in the `/opt/kafka/plugins` directory.
+At startup, the Strimzi version of Kafka Connect loads any third-party connector plug-ins contained in the `/opt/kafka/plugins` directory.
 
 .Prerequisites
 

--- a/documentation/modules/deploying/proc-deploy-kafka-connect.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect.adoc
@@ -11,7 +11,7 @@ A Kafka Connect cluster is implemented as a `Deployment` with a configurable num
 
 The deployment uses a YAML file to provide the specification to create a `KafkaConnect` resource.
 
-In this procedure, we use the example file provided with {ProductName}:
+In this procedure, we use the example file provided with Strimzi:
 
 * `examples/kafka-connect/kafka-connect.yaml`
 

--- a/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
@@ -9,7 +9,7 @@ This procedure shows how to deploy a Kafka MirrorMaker cluster to your Kubernete
 
 The deployment uses a YAML file to provide the specification to create a `KafkaMirrorMaker` or `KafkaMirrorMaker2` resource depending on the version of MirrorMaker deployed.
 
-In this procedure, we use the example files provided with {ProductName}:
+In this procedure, we use the example files provided with Strimzi:
 
 * `examples/kafka-connect/kafka-mirror-maker.yaml`
 * `examples/kafka-connect/kafka-mirror-maker2.yaml`

--- a/documentation/modules/deploying/proc-deploy-topic-operator-with-cluster-operator.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-with-cluster-operator.adoc
@@ -9,7 +9,7 @@ This procedure describes how to deploy the Topic Operator using the Cluster Oper
 
 You configure the `entityOperator` property of the `Kafka` resource to include the `topicOperator`.
 
-If you want to use the Topic Operator with a Kafka cluster that is not managed by {ProductName},
+If you want to use the Topic Operator with a Kafka cluster that is not managed by Strimzi,
 you must xref:deploying-the-topic-operator-standalone-{context}[deploy the Topic Operator as a standalone component].
 
 For more information about configuring the `entityOperator` and `topicOperator` properties,

--- a/documentation/modules/deploying/proc-deploy-user-operator-with-cluster-operator.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-with-cluster-operator.adoc
@@ -9,7 +9,7 @@ This procedure describes how to deploy the User Operator using the Cluster Opera
 
 You configure the `entityOperator` property of the `Kafka` resource to include the `userOperator`.
 
-If you want to use the User Operator with a Kafka cluster that is not managed by {ProductName},
+If you want to use the User Operator with a Kafka cluster that is not managed by Strimzi,
 you must xref:deploying-the-user-operator-standalone-{context}[deploy the User Operator as a standalone component].
 
 For more information about configuring the `entityOperator` and `userOperator` properties, see link:{BookURLUsing}#assembly-kafka-entity-operator-deployment-configuration-kafka[Entity Operator^].

--- a/documentation/modules/managing/con-custom-resources-status.adoc
+++ b/documentation/modules/managing/con-custom-resources-status.adoc
@@ -4,14 +4,14 @@
 
 [id='con-custom-resources-status-{context}']
 
-= {ProductName} custom resource status information
+= Strimzi custom resource status information
 
 Several resources have a `status` property, as described in the following table.
 
 [cols="3*",options="header",stripes="none",separator=¦]
 |===
 
-m¦{ProductName} resource
+m¦Strimzi resource
 ¦Schema reference
 ¦Publishes status information on...
 
@@ -45,7 +45,7 @@ m¦KafkaUser
 
 m¦KafkaBridge
 ¦xref:type-KafkaBridgeStatus-reference[]
-¦The {ProductName} Kafka Bridge, if deployed.
+¦The Strimzi Kafka Bridge, if deployed.
 
 |===
 
@@ -67,7 +67,7 @@ A resource's _current state_ is useful for tracking progress related to the reso
 
 The _last observed generation_ is the generation of the resource that was last reconciled by the Cluster Operator. If the value of `observedGeneration` is different from the value of `metadata.generation`, the operator has not yet processed the latest update to the resource. If these values are the same, the status information reflects the most recent changes to the resource.
 
-{ProductName} creates and maintains the status of custom resources, periodically evaluating the current state of the custom resource and updating its status accordingly.
+Strimzi creates and maintains the status of custom resources, periodically evaluating the current state of the custom resource and updating its status accordingly.
 When performing an update on a custom resource using `kubectl edit`, for example, its `status` is not editable. Moreover, changing the `status` would not affect the configuration of the Kafka cluster.
 
 Here we see the `status` property specified for a Kafka custom resource.

--- a/documentation/modules/managing/con-service-discovery.adoc
+++ b/documentation/modules/managing/con-service-discovery.adoc
@@ -5,7 +5,7 @@
 [id='proc-add-service-discovery-{context}']
 = Discovering services using labels and annotations
 
-Service discovery makes it easier for client applications running in the same Kubernetes cluster as {ProductName} to interact with a Kafka cluster.
+Service discovery makes it easier for client applications running in the same Kubernetes cluster as Strimzi to interact with a Kafka cluster.
 
 A _service discovery_ label and annotation is generated for services used to access the Kafka cluster:
 

--- a/documentation/modules/managing/proc-uninstalling.adoc
+++ b/documentation/modules/managing/proc-uninstalling.adoc
@@ -3,13 +3,13 @@
 // assembly-management-tasks.adoc
 
 [id='uninstalling-{context}']
-= Uninstalling {ProductName}
+= Uninstalling Strimzi
 
-This procedure describes how to uninstall {ProductName} and remove resources related to the deployment.
+This procedure describes how to uninstall Strimzi and remove resources related to the deployment.
 
 .Prerequisites
 
-In order to perform this procedure, identify resources created specifically for a deployment and referenced from the {ProductName} resource.
+In order to perform this procedure, identify resources created specifically for a deployment and referenced from the Strimzi resource.
 
 Such resources include:
 

--- a/documentation/modules/metrics/con_metrics-alertmanager-options.adoc
+++ b/documentation/modules/metrics/con_metrics-alertmanager-options.adoc
@@ -6,7 +6,7 @@
 
 = Alertmanager configuration
 
-{ProductName} provides xref:ref-metrics-config-files-{context}[example configuration files for Prometheus Alertmanager].
+Strimzi provides xref:ref-metrics-config-files-{context}[example configuration files for Prometheus Alertmanager].
 
 A configuration file defines the resources for deploying Alertmanager:
 

--- a/documentation/modules/metrics/con_metrics-grafana-options.adoc
+++ b/documentation/modules/metrics/con_metrics-grafana-options.adoc
@@ -6,7 +6,7 @@
 
 = Grafana configuration
 
-{ProductName} provides xref:ref-metrics-config-files-{context}[example dashboard configuration files for Grafana].
+Strimzi provides xref:ref-metrics-config-files-{context}[example dashboard configuration files for Grafana].
 
 A Grafana docker image is provided for deployment:
 

--- a/documentation/modules/metrics/con_metrics-kafka-options.adoc
+++ b/documentation/modules/metrics/con_metrics-kafka-options.adoc
@@ -6,7 +6,7 @@
 
 = Prometheus metrics configuration
 
-{ProductName} provides xref:ref-metrics-config-files-{context}[example configuration files for Grafana].
+Strimzi provides xref:ref-metrics-config-files-{context}[example configuration files for Grafana].
 
 Grafana dashboards are dependent on Prometheus JMX Exporter relabeling rules, which are defined for:
 

--- a/documentation/modules/metrics/con_metrics-prometheus-options.adoc
+++ b/documentation/modules/metrics/con_metrics-prometheus-options.adoc
@@ -6,7 +6,7 @@
 
 = Prometheus configuration
 
-{ProductName} provides xref:ref-metrics-config-files-{context}[example configuration files for the Prometheus server].
+Strimzi provides xref:ref-metrics-config-files-{context}[example configuration files for the Prometheus server].
 
 A Prometheus image is provided for deployment:
 

--- a/documentation/modules/metrics/kafka-exporter/con_kafka-exporter-lag.adoc
+++ b/documentation/modules/metrics/kafka-exporter/con_kafka-exporter-lag.adoc
@@ -36,6 +36,6 @@ Typical actions to reduce lag include:
 * Increasing the retention time for a message to remain in a topic
 * Adding more disk capacity to increase the message buffer
 
-Actions to reduce consumer lag depend on the underlying infrastructure and the use cases {ProductName} is supporting.
+Actions to reduce consumer lag depend on the underlying infrastructure and the use cases Strimzi is supporting.
 For instance, a lagging consumer is less likely to benefit from the broker being able to service a fetch request from its disk cache.
 And in certain cases, it might be acceptable to automatically drop messages until a consumer has caught up.

--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus-alertmanager.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus-alertmanager.adoc
@@ -8,7 +8,7 @@
 
 To deploy Alertmanager, apply the xref:ref-metrics-config-files-{context}[example configuration files].
 
-The sample configuration provided with {ProductName} configures the Alertmanager to send notifications to a Slack channel.
+The sample configuration provided with Strimzi configures the Alertmanager to send notifications to a Slack channel.
 
 The following resources are defined on deployment:
 

--- a/documentation/modules/metrics/proc_metrics-grafana-dashboard.adoc
+++ b/documentation/modules/metrics/proc_metrics-grafana-dashboard.adoc
@@ -47,7 +47,7 @@ image::grafana_import_dashboard.png[Add Grafana dashboard]
 
 After importing the dashboards, the Grafana dashboard homepage presents Kafka and ZooKeeper dashboards.
 
-When the Prometheus server has been collecting metrics for a {ProductName} cluster for some time, the dashboards are populated.
+When the Prometheus server has been collecting metrics for a Strimzi cluster for some time, the dashboards are populated.
 
 .Kafka dashboard
 [caption="Kafka dashboard"]

--- a/documentation/modules/metrics/ref_metrics-alertmanager-examples.adoc
+++ b/documentation/modules/metrics/ref_metrics-alertmanager-examples.adoc
@@ -6,7 +6,7 @@
 
 = Alerting rule examples
 
-Example alerting rules for Kafka and ZooKeeper metrics are provided with {ProductName} for use in a xref:proc-metrics-deploying-prometheus-{context}[Prometheus deployment].
+Example alerting rules for Kafka and ZooKeeper metrics are provided with Strimzi for use in a xref:proc-metrics-deploying-prometheus-{context}[Prometheus deployment].
 
 General points about the alerting rule definitions:
 

--- a/documentation/modules/mirrormaker2/con-mirrormaker-acls.adoc
+++ b/documentation/modules/mirrormaker2/con-mirrormaker-acls.adoc
@@ -10,4 +10,4 @@ ACL access to remote topics is possible if you are *not* using the User Operator
 If `SimpleAclAuthorizer` is being used, without the User Operator, ACL rules that manage access to brokers also apply to remote topics.
 Users that can read a source topic can read its remote equivalent.
 
-NOTE: {oauth} authorization does not support access to remote topics in this way.
+NOTE: OAuth 2.0 authorization does not support access to remote topics in this way.

--- a/documentation/modules/mirrormaker2/proc-mirrormaker-replication.adoc
+++ b/documentation/modules/mirrormaker2/proc-mirrormaker-replication.adoc
@@ -49,7 +49,7 @@ This procedure shows a configuration that uses TLS encryption and authentication
 
 .Prerequisites
 
-* xref:cluster-operator-str[{ProductName} and Kafka is deployed]
+* xref:cluster-operator-str[Strimzi and Kafka is deployed]
 * Source and target Kafka clusters are available
 
 .Procedure
@@ -185,7 +185,7 @@ spec:
 <10> Authentication for the target Kafka cluster is configured in the same way as for the source Kafka cluster.
 <11> Bootstrap server for connection to the target Kafka cluster.
 <12> xref:assembly-kafka-connect-configuration-deployment-configuration-kafka-connect[Kafka Connect configuration].
-Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by {ProductName}.
+Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi.
 <13> xref:type-KafkaMirrorMaker2ClusterSpec-reference[SSL properties for external listeners to run with a specific _cipher suite_ for a TLS version].
 <14> TLS encryption for the target Kafka cluster is configured in the same way as for the source Kafka cluster.
 <15> MirrorMaker 2.0 connectors.

--- a/documentation/modules/oauth/con-oauth-authentication-broker.adoc
+++ b/documentation/modules/oauth/con-oauth-authentication-broker.adoc
@@ -3,19 +3,19 @@
 // assembly-oauth.adoc
 
 [id='con-oauth-authentication-broker-{context}']
-= {oauth} Kafka broker configuration
+= OAuth 2.0 Kafka broker configuration
 
-Kafka broker configuration for {oauth} involves:
+Kafka broker configuration for OAuth 2.0 involves:
 
-* Creating the {oauth} client in the authorization server
-* Configuring {oauth} authentication in the Kafka custom resource
+* Creating the OAuth 2.0 client in the authorization server
+* Configuring OAuth 2.0 authentication in the Kafka custom resource
 
-NOTE: In relation to the authorization server, Kafka brokers and Kafka clients are both regarded as {oauth} clients.
+NOTE: In relation to the authorization server, Kafka brokers and Kafka clients are both regarded as OAuth 2.0 clients.
 
-== {oauth} client configuration on an authorization server
+== OAuth 2.0 client configuration on an authorization server
 
 To configure a Kafka broker to validate the token received during session initiation,
-the recommended approach is to create an {oauth} _client_ definition in an authorization server, configured as _confidential_, with the following client credentials enabled:
+the recommended approach is to create an OAuth 2.0 _client_ definition in an authorization server, configured as _confidential_, with the following client credentials enabled:
 
 * Client ID of `kafka` (for example)
 * Client ID and Secret as the authentication mechanism
@@ -23,11 +23,11 @@ the recommended approach is to create an {oauth} _client_ definition in an autho
 NOTE: You only need to use a client ID and secret when using a non-public introspection endpoint of the authorization server.
 The credentials are not typically required when using public authorization server endpoints, as with fast local JWT token validation.
 
-== {oauth} authentication configuration in the Kafka cluster
+== OAuth 2.0 authentication configuration in the Kafka cluster
 
-To use {oauth} authentication in the Kafka cluster, you specify for example a TLS listener configuration for your Kafka cluster custom resource with the authentication method `oauth`:
+To use OAuth 2.0 authentication in the Kafka cluster, you specify for example a TLS listener configuration for your Kafka cluster custom resource with the authentication method `oauth`:
 
-.Assigining the authentication method type for {oauth}
+.Assigining the authentication method type for OAuth 2.0
 [source,yaml,subs="+quotes, attributes"]
 ----
 apiVersion: {KafkaApiVersion}
@@ -42,11 +42,11 @@ spec:
 ----
 
 You can configure `plain`, `tls` and `external` listeners, as described in xref:assembly-configuring-kafka-broker-listeners-deployment-configuration-kafka[Kafka broker listeners],
-but it is recommended not to use `plain` listeners or `external` listeners with disabled TLS encryption with {oauth} as this creates a vulnerability to network eavesdropping and unauthorized access through token theft.
+but it is recommended not to use `plain` listeners or `external` listeners with disabled TLS encryption with OAuth 2.0 as this creates a vulnerability to network eavesdropping and unauthorized access through token theft.
 
 You configure an `external` listener with `type: oauth` for a secure transport layer to communicate with the client.
 
-.Using {oauth} with an external listener
+.Using OAuth 2.0 with an external listener
 [source,yaml,subs="+quotes"]
 ----
 # ...
@@ -64,9 +64,9 @@ listeners:
 
 The `tls` property is _true_ by default, so it can be left out.
 
-When you've defined the type of authentication as {oauth}, you add configuration based on the type of validation, either as xref:con-oauth-authentication-broker-fast-local[fast local JWT validation] or xref:con-oauth-authentication-broker-intro-local[token validation using an introspection endpoint].
+When you've defined the type of authentication as OAuth 2.0, you add configuration based on the type of validation, either as xref:con-oauth-authentication-broker-fast-local[fast local JWT validation] or xref:con-oauth-authentication-broker-intro-local[token validation using an introspection endpoint].
 
-The procedure to configure {oauth} for listeners, with descriptions and examples, is described in xref:proc-oauth-authentication-broker-config-{context}[Configuring {oauth} support for Kafka brokers].
+The procedure to configure OAuth 2.0 for listeners, with descriptions and examples, is described in xref:proc-oauth-authentication-broker-config-{context}[Configuring OAuth 2.0 support for Kafka brokers].
 
 [[con-oauth-authentication-broker-fast-local]]
 == Fast local JWT token validation configuration
@@ -82,12 +82,12 @@ The local check ensures that a token:
 You specify a `validIssuerUrI` attribute when you configure the listener, so that any tokens not issued by the authorization server are rejected.
 
 The authorization server does not need to be contacted during fast local JWT token validation.
-You activate fast local JWT token validation by specifying a `jwksEndpointUri` attribute, the endpoint exposed by the {oauth} authorization server.
+You activate fast local JWT token validation by specifying a `jwksEndpointUri` attribute, the endpoint exposed by the OAuth 2.0 authorization server.
 The endpoint contains the public keys used to validate signed JWT tokens, which are sent as credentials by Kafka clients.
 
 NOTE: All communication with the authorization server should be performed using TLS encryption.
 
-You can configure a certificate truststore as a Kubernetes Secret in your {ProductName} project namespace, and use a `tlsTrustedCertificates` attribute to point to the Kubernetes Secret containing the truststore file.
+You can configure a certificate truststore as a Kubernetes Secret in your Strimzi project namespace, and use a `tlsTrustedCertificates` attribute to point to the Kubernetes Secret containing the truststore file.
 
 You might want to configure a `userNameClaim` to properly extract a username from the JWT token.
 If you want to use Kafka ACL authorization, you need to identify the user by their username during authentication.
@@ -113,13 +113,13 @@ spec:
 ----
 
 [[con-oauth-authentication-broker-intro-local]]
-== {oauth} introspection endpoint configuration
+== OAuth 2.0 introspection endpoint configuration
 
-Token validation using an {oauth} introspection endpoint treats a received access token as opaque.
+Token validation using an OAuth 2.0 introspection endpoint treats a received access token as opaque.
 The Kafka broker sends an access token to the introspection endpoint, which responds with the token information necessary for validation.
 Importantly, it returns up-to-date information if the specific access token is valid, and also information about when the token expires.
 
-To configure {oauth} introspection-based validation, you specify an `introspectionEndpointUri` attribute rather than the `jwksEndpointUri` attribute specified for fast local JWT token validation.
+To configure OAuth 2.0 introspection-based validation, you specify an `introspectionEndpointUri` attribute rather than the `jwksEndpointUri` attribute specified for fast local JWT token validation.
 Depending on the authorization server, you typically have to specify a `clientId` and `clientSecret`, because the introspection endpoint is usually protected.
 
 .Example configuration for an introspection endpoint

--- a/documentation/modules/oauth/con-oauth-authentication-client-options.adoc
+++ b/documentation/modules/oauth/con-oauth-authentication-client-options.adoc
@@ -3,7 +3,7 @@
 // assembly-oauth.adoc
 
 [id='con-oauth-authentication-client-options-{context}']
-= {oauth} client authentication flow
+= OAuth 2.0 client authentication flow
 
 In this section, we explain and visualize the communication flow between Kafka client, Kafka broker, and authorization server during Kafka session initiation.
 The flow depends on the client and server configuration.
@@ -13,11 +13,11 @@ When a Kafka client sends an access token as credentials to a Kafka broker, the 
 Depending on the authorization server used, and the configuration options available, you may prefer to use:
 
 * Fast local token validation based on JWT signature checking and local token introspection, without contacting the authorization server
-* An {oauth} introspection endpoint provided by the authorization server
+* An OAuth 2.0 introspection endpoint provided by the authorization server
 
 Using fast local token validation requires the authorization server to provide a JWKS endpoint with public certificates that are used to validate signatures on the tokens.
 
-Another option is to use an {oauth} introspection endpoint on the authorization server.
+Another option is to use an OAuth 2.0 introspection endpoint on the authorization server.
 Each time a new Kafka broker connection is established, the broker passes the access token received from the client to the authorization server, and checks the response to confirm whether or not the token is valid.
 
 Kafka client credentials can also be configured for:

--- a/documentation/modules/oauth/con-oauth-authentication-client.adoc
+++ b/documentation/modules/oauth/con-oauth-authentication-client.adoc
@@ -3,7 +3,7 @@
 // assembly-oauth.adoc
 
 [id='con-oauth-authentication-client-{context}']
-= {oauth} Kafka client configuration
+= OAuth 2.0 Kafka client configuration
 A Kafka client is configured with either:
 
 * The credentials required to obtain a valid access token from an authorization server (client ID and Secret)

--- a/documentation/modules/oauth/con-oauth-authentication-flow.adoc
+++ b/documentation/modules/oauth/con-oauth-authentication-flow.adoc
@@ -3,10 +3,10 @@
 // assembly-oauth.adoc
 
 [id='con-oauth-authentication-flow-{context}']
-= {oauth} authentication mechanism
+= OAuth 2.0 authentication mechanism
 
 The Kafka _SASL OAUTHBEARER_ mechanism is used to establish authenticated sessions with a Kafka broker.
 
 A Kafka client initiates a session with the Kafka broker using the _SASL OAUTHBEARER_ mechanism for credentials exchange, where credentials take the form of an access token.
 
-Kafka brokers and clients need to be configured to use {oauth}.
+Kafka brokers and clients need to be configured to use OAuth 2.0.

--- a/documentation/modules/oauth/con-oauth-authorization-intro.adoc
+++ b/documentation/modules/oauth/con-oauth-authorization-intro.adoc
@@ -3,25 +3,25 @@
 // assembly-oauth-authorization.adoc
 
 [id='con-oauth-authorization-intro_{context}']
-If you are using {oauth} with {keycloak-server} for token-based authentication,
-you can also use {keycloak-server} to configure authorization rules to constrain client access to Kafka brokers.
+If you are using OAuth 2.0 with Keycloak for token-based authentication,
+you can also use Keycloak to configure authorization rules to constrain client access to Kafka brokers.
 Authentication establishes the identity of a user.
 Authorization decides the level of access for that user.
 
-{ProductName} supports the use of {oauth} token-based authorization through {keycloak-server} {keycloak-authorization-services},
+Strimzi supports the use of OAuth 2.0 token-based authorization through Keycloak {keycloak-authorization-services},
 which allows you to manage security policies and permissions centrally.
 
-Security policies and permissions defined in {keycloak-server} are used to grant access to resources on Kafka brokers.
+Security policies and permissions defined in Keycloak are used to grant access to resources on Kafka brokers.
 Users and clients are matched against policies that permit access to perform specific actions on Kafka brokers.
 
 Kafka allows all users full access to brokers by default,
 and also provides the `SimpleACLAuthorizer` plugin to configure authorization based on Access Control Lists (ACLs).
 ZooKeeper stores ACL rules that grant or deny access to resources based on _username_.
-However, {oauth} token-based authorization with  {keycloak-server} offers far greater flexibility on how you wish to implement access control to Kafka brokers.
-In addition, you can configure your Kafka brokers to use {oauth} authorization and ACLs.
+However, OAuth 2.0 token-based authorization with  Keycloak offers far greater flexibility on how you wish to implement access control to Kafka brokers.
+In addition, you can configure your Kafka brokers to use OAuth 2.0 authorization and ACLs.
 
 .Additional resources
 
-* xref:assembly-oauth-authentication_str[Using {oauth} token based authentication]
+* xref:assembly-oauth-authentication_str[Using OAuth 2.0 token based authentication]
 * xref:simple-acl-{context}[ACL authorization]
 * {keycloak-server-doc}

--- a/documentation/modules/oauth/con-oauth-authorization-mechanism.adoc
+++ b/documentation/modules/oauth/con-oauth-authorization-mechanism.adoc
@@ -3,17 +3,17 @@
 // assembly-oauth-authorization.adoc
 
 [id='con-oauth-authorization-mechanism_{context}']
-= {oauth} authorization mechanism
+= OAuth 2.0 authorization mechanism
 
-{oauth} authorization in {ProductName} uses {keycloak-server} server Authorization Services REST endpoints to extend token-based authentication with {keycloak-server} by applying defined security policies on a particular user,
+OAuth 2.0 authorization in Strimzi uses Keycloak server Authorization Services REST endpoints to extend token-based authentication with Keycloak by applying defined security policies on a particular user,
 and providing a list of permissions granted on different resources for that user.
 Policies use roles and groups to match permissions to users.
-{oauth} authorization enforces permissions locally based on the received list of grants for the user from {keycloak-server} Authorization Services.
+OAuth 2.0 authorization enforces permissions locally based on the received list of grants for the user from Keycloak Authorization Services.
 
 == Kafka broker custom authorizer
 
-A {keycloak-server} _authorizer_ (`KeycloakRBACAuthorizer`) is provided with {ProductName}.
-To be able to use the {keycloak-server} REST endpoints for Authorization Services provided by {keycloak-server},
+A Keycloak _authorizer_ (`KeycloakRBACAuthorizer`) is provided with Strimzi.
+To be able to use the Keycloak REST endpoints for Authorization Services provided by Keycloak,
 you configure a custom authorizer on the Kafka broker.
 
 The authorizer fetches a list of granted permissions from the authorization server as needed,

--- a/documentation/modules/oauth/con-oauth-config.adoc
+++ b/documentation/modules/oauth/con-oauth-config.adoc
@@ -3,16 +3,16 @@
 // assembly-oauth.adoc
 
 [id='con-oauth-strimzi-config-{context}']
-= Configuring {oauth} authentication
+= Configuring OAuth 2.0 authentication
 
-{oauth} is used for interaction between Kafka clients and {ProductName} components.
+OAuth 2.0 is used for interaction between Kafka clients and Strimzi components.
 
-In order to use {oauth} for {ProductName}, you must:
+In order to use OAuth 2.0 for Strimzi, you must:
 
-. xref:proc-oauth-server-config-{context}[Configure an {oauth} authorization server for the {ProductName} cluster and Kafka clients]
-. xref:proc-oauth-authentication-broker-config-{context}[Deploy or update the Kafka cluster with Kafka broker listeners configured to use {oauth}]
-. xref:proc-oauth-client-config-{context}[Update your Java-based Kafka clients to use {oauth}]
-. xref:proc-oauth-kafka-config-{context}[Update Kafka component clients to use {oauth}]
+. xref:proc-oauth-server-config-{context}[Configure an OAuth 2.0 authorization server for the Strimzi cluster and Kafka clients]
+. xref:proc-oauth-authentication-broker-config-{context}[Deploy or update the Kafka cluster with Kafka broker listeners configured to use OAuth 2.0]
+. xref:proc-oauth-client-config-{context}[Update your Java-based Kafka clients to use OAuth 2.0]
+. xref:proc-oauth-kafka-config-{context}[Update Kafka component clients to use OAuth 2.0]
 
 include::proc-oauth-server-config.adoc[leveloffset=+1]
 include::proc-oauth-authentication-broker-config.adoc[leveloffset=+1]

--- a/documentation/modules/oauth/con-oauth-server-examples.adoc
+++ b/documentation/modules/oauth/con-oauth-server-examples.adoc
@@ -7,7 +7,7 @@
 
 When choosing an authorization server, consider the features that best support configuration of your chosen authentication flow.
 
-For the purposes of testing {oauth} with {ProductName}, Keycloak and ORY Hydra were implemented as the {oauth} authorization server.
+For the purposes of testing OAuth 2.0 with Strimzi, Keycloak and ORY Hydra were implemented as the OAuth 2.0 authorization server.
 
 For more information, see:
 

--- a/documentation/modules/oauth/proc-oauth-authentication-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authentication-broker-config.adoc
@@ -3,14 +3,14 @@
 // con-oauth-config.adoc
 
 [id='proc-oauth-authentication-broker-config-{context}']
-= Configuring {oauth} support for Kafka brokers
+= Configuring OAuth 2.0 support for Kafka brokers
 
-This procedure describes how to configure Kafka brokers so that the broker listeners are enabled to use {oauth} authentication using an authorization server.
+This procedure describes how to configure Kafka brokers so that the broker listeners are enabled to use OAuth 2.0 authentication using an authorization server.
 
-We advise use of {oauth} over an encrypted interface through configuration of TLS listeners.
+We advise use of OAuth 2.0 over an encrypted interface through configuration of TLS listeners.
 Plain listeners are not recommended.
 
-If the authorization server is using certificates signed by the trusted CA and matching the {oauth} server hostname, TLS connection works using the default settings.
+If the authorization server is using certificates signed by the trusted CA and matching the OAuth 2.0 server hostname, TLS connection works using the default settings.
 Otherwise, you have two connection options for your listener configuration when delegating token validation to the authorization server:
 
 * xref:example-1[Configuring fast local JWT token validation]
@@ -18,7 +18,7 @@ Otherwise, you have two connection options for your listener configuration when 
 
 .Before you start
 
-For more information on the configuration of {oauth} authentication for Kafka broker listeners, see:
+For more information on the configuration of OAuth 2.0 authentication for Kafka broker listeners, see:
 
 * xref:appendix_crds#type-KafkaListenerAuthenticationOAuth-reference[KafkaListenerAuthenticationOAuth schema reference]
 * xref:assembly-configuring-kafka-broker-listeners-deployment-configuration-kafka[Kafka broker listeners]
@@ -26,8 +26,8 @@ For more information on the configuration of {oauth} authentication for Kafka br
 
 .Prerequisites
 
-* {ProductName} and Kafka are running
-* An {oauth} authorization server is deployed
+* Strimzi and Kafka are running
+* An OAuth 2.0 authorization server is deployed
 
 .Procedure
 
@@ -96,7 +96,7 @@ external:
 <3> Client Secret and client ID is used for authentication.
 <4> The token claim (or key) that contains the actual user name in the token. The user name is the _principal_ used to identify the user. The `userNameClaim` value will depend on the authorization server used.
 +
-Depending on how you apply {oauth} authentication, and the type of authorization server, there are additional (optional) configuration settings you can use:
+Depending on how you apply OAuth 2.0 authentication, and the type of authorization server, there are additional (optional) configuration settings you can use:
 +
 [source,yaml,subs="+quotes,attributes"]
 ----
@@ -126,8 +126,8 @@ kubectl logs -f ${POD_NAME} -c ${CONTAINER_NAME}
 kubectl get po -w
 ----
 +
-The rolling update configures the brokers to use {oauth} authentication.
+The rolling update configures the brokers to use OAuth 2.0 authentication.
 
 .What to do next
 
-* xref:proc-oauth-client-config-{context}[Configure your Kafka clients to use {oauth}]
+* xref:proc-oauth-client-config-{context}[Configure your Kafka clients to use OAuth 2.0]

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -3,34 +3,34 @@
 // con-oauth-config.adoc
 
 [id='proc-oauth-authorization-broker-config-{context}']
-= Configuring {oauth} authorization support
+= Configuring OAuth 2.0 authorization support
 
-This procedure describes how to configure Kafka brokers to use {oauth} authorization using {keycloak-server} Authorization Services.
+This procedure describes how to configure Kafka brokers to use OAuth 2.0 authorization using Keycloak Authorization Services.
 
 .Before you begin
 Consider the access you require or want to limit for certain users.
-You can use a combination of {keycloak-server} _groups_, _roles_, _clients_, and _users_ to configure access in {keycloak-server}.
+You can use a combination of Keycloak _groups_, _roles_, _clients_, and _users_ to configure access in Keycloak.
 
 Typically, groups are used to match users based on organizational departments or geographical locations.
 And roles are used to match users based on their function.
 
-With {keycloak-server}, you can store users and groups in LDAP, whereas clients and roles cannot be stored this way.
+With Keycloak, you can store users and groups in LDAP, whereas clients and roles cannot be stored this way.
 Storage and access to user data may be a factor in how you choose to configure authorization policies.
 
 NOTE: xref:ref-kafka-authorization-super-user-deployment-configuration-kafka[Super users] always have unconstrained access to a Kafka broker regardless of the authorization implemented on the Kafka broker.
 
 .Prerequisites
 
-* {ProductName} must be configured to use {oauth} with {keycloak-server} for xref:assembly-oauth-authentication_str[token-based authentication].
-You use the same {keycloak-server} server endpoint when you set up authorization.
-* You need to understand how to manage policies and permissions for {keycloak-server} Authorization Services, as described in the {keycloak-server-doc}.
+* Strimzi must be configured to use OAuth 2.0 with Keycloak for xref:assembly-oauth-authentication_str[token-based authentication].
+You use the same Keycloak server endpoint when you set up authorization.
+* You need to understand how to manage policies and permissions for Keycloak Authorization Services, as described in the {keycloak-server-doc}.
 
 .Procedure
 
-. Access the {keycloak-server} Admin Console or use the {keycloak-server} Admin CLI to enable Authorization Services for the Kafka broker client you created when setting up {oauth} authentication.
+. Access the Keycloak Admin Console or use the Keycloak Admin CLI to enable Authorization Services for the Kafka broker client you created when setting up OAuth 2.0 authentication.
 . Use Authorization Services to define resources, authorization scopes, policies, and permissions for the client.
 . Bind the permissions to users and clients by assigning them roles and groups.
-. Configure the Kafka brokers to use {keycloak-server} authorization by updating the Kafka broker configuration (`Kafka.spec.kafka`) of your `Kafka` resource in an editor.
+. Configure the Kafka brokers to use Keycloak authorization by updating the Kafka broker configuration (`Kafka.spec.kafka`) of your `Kafka` resource in an editor.
 +
 [source,shell]
 ----
@@ -65,10 +65,10 @@ spec:
       certificate: ca.crt
   #...
 ----
-<1> Type `keycloak` enables {keycloak-server} authorization.
-<2> URI of the {keycloak-server} token endpoint. For production, always use HTTPs.
-<3> The client ID of the {oauth} client definition in {keycloak-server} that has Authorization Services enabled. Typically, `kafka` is used as the ID.
-<4> (Optional) Delegate authorization to Kafka `SimpleACLAuthorizer` if access is denied by {keycloak-server} Authorization Services policies.
+<1> Type `keycloak` enables Keycloak authorization.
+<2> URI of the Keycloak token endpoint. For production, always use HTTPs.
+<3> The client ID of the OAuth 2.0 client definition in Keycloak that has Authorization Services enabled. Typically, `kafka` is used as the ID.
+<4> (Optional) Delegate authorization to Kafka `SimpleACLAuthorizer` if access is denied by Keycloak Authorization Services policies.
 The default is `false`.
 <5> (Optional) Disable TLS hostname verification. Default is `false`.
 <6> (Optional) Designated xref:ref-kafka-authorization-super-user-deployment-configuration-kafka[super users].
@@ -84,6 +84,6 @@ kubectl logs -f ${POD_NAME} -c kafka
 kubectl get po -w
 ----
 +
-The rolling update configures the brokers to use {oauth} authorization.
+The rolling update configures the brokers to use OAuth 2.0 authorization.
 
 . Verify the configured permissions by accessing Kafka brokers as clients or  users with specific roles, making sure they have the necessary access, or do not have the access they are not supposed to have.

--- a/documentation/modules/oauth/proc-oauth-client-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-client-config.adoc
@@ -3,21 +3,21 @@
 // con-oauth-config.adoc
 
 [id='proc-oauth-client-config-{context}']
-= Configuring Kafka Java clients to use {oauth}
+= Configuring Kafka Java clients to use OAuth 2.0
 
-This procedure describes how to configure Kafka producer and consumer APIs to use {oauth} for interaction with Kafka brokers.
+This procedure describes how to configure Kafka producer and consumer APIs to use OAuth 2.0 for interaction with Kafka brokers.
 
 Add a client callback plugin to your _pom.xml_ file, and configure the system properties.
 
 .Prerequisites
 
-* {ProductName} and Kafka are running
-* An {oauth} authorization server is deployed and configured for OAuth access to Kafka brokers
-* Kafka brokers are configured for {oauth}
+* Strimzi and Kafka are running
+* An OAuth 2.0 authorization server is deployed and configured for OAuth access to Kafka brokers
+* Kafka brokers are configured for OAuth 2.0
 
 .Procedure
 
-. Add the client library with {oauth} support to the `pom.xml` file for the Kafka client:
+. Add the client library with OAuth 2.0 support to the `pom.xml` file for the Kafka client:
 +
 [source,xml,subs="+attributes"]
 ----
@@ -59,4 +59,4 @@ props.put("sasl.login.callback.handler.class", "io.strimzi.kafka.oauth.client.Ja
 
 .What to do next
 
-* xref:proc-oauth-kafka-config-{context}[Configure Kafka components to use {oauth}]
+* xref:proc-oauth-kafka-config-{context}[Configure Kafka components to use OAuth 2.0]

--- a/documentation/modules/oauth/proc-oauth-kafka-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-kafka-config.adoc
@@ -3,9 +3,9 @@
 // con-oauth-config.adoc
 
 [id='proc-oauth-kafka-config-{context}']
-= Configuring {oauth} for Kafka components
+= Configuring OAuth 2.0 for Kafka components
 
-This procedure describes how to configure Kafka components to use {oauth} authentication using an authorization server.
+This procedure describes how to configure Kafka components to use OAuth 2.0 authentication using an authorization server.
 
 You can configure authentication for:
 
@@ -17,15 +17,15 @@ In this scenario, the Kafka component and the authorization server are running i
 
 .Before you start
 
-For more information on the configuration of {oauth} authentication for Kafka components, see:
+For more information on the configuration of OAuth 2.0 authentication for Kafka components, see:
 
 * xref:appendix_crds#type-KafkaClientAuthenticationOAuth-reference[KafkaClientAuthenticationOAuth schema reference]
 
 .Prerequisites
 
-* {ProductName} and Kafka are running
-* An {oauth} authorization server is deployed and configured for OAuth access to Kafka brokers
-* Kafka brokers are configured for {oauth}
+* Strimzi and Kafka are running
+* An OAuth 2.0 authorization server is deployed and configured for OAuth access to Kafka brokers
+* Kafka brokers are configured for OAuth 2.0
 
 .Procedure
 
@@ -45,9 +45,9 @@ data:
 ----
 <1> The `clientSecret` key must be in base64 format.
 
-. Create or edit the resource for the Kafka component so that {oauth} authentication is configured for the authentication property.
+. Create or edit the resource for the Kafka component so that OAuth 2.0 authentication is configured for the authentication property.
 +
-For {oauth} authentication, you can use:
+For OAuth 2.0 authentication, you can use:
 +
 --
 * Client ID and secret
@@ -58,7 +58,7 @@ For {oauth} authentication, you can use:
 +
 xref:appendix_crds#type-KafkaClientAuthenticationOAuth-reference[KafkaClientAuthenticationOAuth schema reference provides examples of each].
 +
-For example, here {oauth} is assigned to the Kafka Bridge client using a client ID and secret, and TLS:
+For example, here OAuth 2.0 is assigned to the Kafka Bridge client using a client ID and secret, and TLS:
 +
 [source,yaml,subs="+quotes,attributes"]
 ----
@@ -83,7 +83,7 @@ spec:
 <2> URI of the token endpoint for authentication.
 <3> Trusted certificates for TLS connection to the authorization server.
 +
-Depending on how you apply {oauth} authentication, and the type of authorization server, there are additional configuration options you can use:
+Depending on how you apply OAuth 2.0 authentication, and the type of authorization server, there are additional configuration options you can use:
 +
 [source,yaml,subs="+quotes,attributes"]
 ----
@@ -117,4 +117,4 @@ kubectl logs -f ${POD_NAME} -c ${CONTAINER_NAME}
 kubectl get pod -w
 ----
 +
-The rolling updates configure the component for interaction with Kafka brokers using {oauth} authentication.
+The rolling updates configure the component for interaction with Kafka brokers using OAuth 2.0 authentication.

--- a/documentation/modules/oauth/proc-oauth-server-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-server-config.adoc
@@ -3,26 +3,26 @@
 // con-oauth-config.adoc
 
 [id='proc-oauth-server-config-{context}']
-= Configuring an {oauth} authorization server
+= Configuring an OAuth 2.0 authorization server
 
-This procedure describes in general what you need to do to configure an authorization server for integration with {ProductName}.
+This procedure describes in general what you need to do to configure an authorization server for integration with Strimzi.
 
 These instructions are not product specific.
 
 The steps are dependent on the chosen authorization server.
-Consult the product documentation for the authorization server for information on how to set up {oauth} access.
+Consult the product documentation for the authorization server for information on how to set up OAuth 2.0 access.
 
 NOTE: If you already have an authorization server deployed, you can skip the deployment step and use your current deployment.
 
 .Procedure
 
 . Deploy the authorization server to your cluster.
-. Access the CLI or admin console for the authorization server to configure {oauth} for {ProductName}.
+. Access the CLI or admin console for the authorization server to configure OAuth 2.0 for Strimzi.
 +
-Now prepare the authorization server to work with {ProductName}.
+Now prepare the authorization server to work with Strimzi.
 
 . Configure a `kafka-broker` client.
 . Configure clients for each Kafka client component of your application.
 
 .What to do next
-After deploying and configuring the authorization server, xref:proc-oauth-authentication-broker-config-{context}[configure the Kafka brokers to use {oauth}].
+After deploying and configuring the authorization server, xref:proc-oauth-authentication-broker-config-{context}[configure the Kafka brokers to use OAuth 2.0].

--- a/documentation/modules/overview/con-configuration-points-broker.adoc
+++ b/documentation/modules/overview/con-configuration-points-broker.adoc
@@ -12,7 +12,7 @@ You can configure a Kafka cluster to run with multiple broker nodes across _rack
 Storage::
 Kafka and ZooKeeper store data on disks.
 +
-{ProductName} requires block storage provisioned through `StorageClass`.
+Strimzi requires block storage provisioned through `StorageClass`.
 The file system format for storage must be _XFS_ or _EXT4_.
 Three types of data storage are supported:
 +
@@ -43,7 +43,7 @@ External listeners expose Kafka by specifying a `type`:
 * `ingress` to use Kubernetes _Ingress_ and the {NginxIngressController}.
 --
 
-If you are using xref:security-configuration-authentication_{context}[{oauth} for token-based authentication], you can configure listeners to use the authorization server.  
+If you are using xref:security-configuration-authentication_{context}[OAuth 2.0 for token-based authentication], you can configure listeners to use the authorization server.  
 
 Rack awareness:: Rack awareness is a configuration feature that distributes Kafka broker pods and topic replicas across _racks_, which represent data centers or racks in data centers, or availability zones.
 

--- a/documentation/modules/overview/con-configuration-points-mirrormaker.adoc
+++ b/documentation/modules/overview/con-configuration-points-mirrormaker.adoc
@@ -7,7 +7,7 @@
 
 To set up MirrorMaker, a source and target (destination) Kafka cluster must be running.
 
-You can use {ProductName} with MirrorMaker 2.0, although the earlier version of MirrorMaker continues to be supported.
+You can use Strimzi with MirrorMaker 2.0, although the earlier version of MirrorMaker continues to be supported.
 
 [discrete]
 == MirrorMaker 2.0

--- a/documentation/modules/overview/con-configuration-points-resources.adoc
+++ b/documentation/modules/overview/con-configuration-points-resources.adoc
@@ -7,7 +7,7 @@
 
 After a new custom resource type is added to your cluster by installing a CRD, you can create instances of the resource based on its specification.
 
-The custom resources for {ProductName} components have common configuration properties, which are defined under `spec`.
+The custom resources for Strimzi components have common configuration properties, which are defined under `spec`.
 
 In this fragment from a Kafka topic custom resource, the `apiVersion` and `kind` properties identify the associated CRD.
 The `spec` property shows configuration that defines the number of partitions and replicas for the topic.

--- a/documentation/modules/overview/con-kafka-concepts-key.adoc
+++ b/documentation/modules/overview/con-kafka-concepts-key.adoc
@@ -5,7 +5,7 @@
 [id="kafka-concepts-key_{context}"]
 = Kafka concepts
 
-Knowledge of the key concepts of Kafka is important in understanding how {ProductName} works.
+Knowledge of the key concepts of Kafka is important in understanding how Strimzi works.
 
 A Kafka cluster comprises multiple brokers
 Topics are used to receive and store data in a Kafka cluster.

--- a/documentation/modules/overview/con-key-features-product.adoc
+++ b/documentation/modules/overview/con-key-features-product.adoc
@@ -4,11 +4,11 @@
 // deploying/assembly_deploy-intro.adoc
 
 [id="key-features-product_{context}"]
-= How {ProductName} supports Kafka
+= How Strimzi supports Kafka
 
-{ProductName} provides container images and Operators for running Kafka on Kubernetes.
-{ProductName} Operators are fundamental to the running of {ProductName}.
-The Operators provided with {ProductName} are purpose-built with specialist operational knowledge to effectively manage Kafka.
+Strimzi provides container images and Operators for running Kafka on Kubernetes.
+Strimzi Operators are fundamental to the running of Strimzi.
+The Operators provided with Strimzi are purpose-built with specialist operational knowledge to effectively manage Kafka.
 
 Operators simplify the process of:
 

--- a/documentation/modules/overview/con-metrics-overview-exporter.adoc
+++ b/documentation/modules/overview/con-metrics-overview-exporter.adoc
@@ -9,4 +9,4 @@ Kafka Exporter is an open source project to enhance monitoring of Apache Kafka b
 Kafka Exporter is deployed with a Kafka cluster to extract additional Prometheus metrics data from Kafka brokers related to offsets, consumer groups, consumer lag, and topics.
 You can use the Grafana dashboard provided to visualize the data collected by Prometheus from Kafka Exporter.
 
-A sample configuration file, alerting rules and Grafana dashboard for Kafka Exporter are provided with {ProductName}.
+A sample configuration file, alerting rules and Grafana dashboard for Kafka Exporter are provided with Strimzi.

--- a/documentation/modules/overview/con-metrics-overview-grafana.adoc
+++ b/documentation/modules/overview/con-metrics-overview-grafana.adoc
@@ -8,4 +8,4 @@
 Grafana uses the metrics data exposed by Prometheus to present dashboard visualizations for monitoring.
 
 A deployment of Grafana is required, with Prometheus added as a data source.
-Example dashboards, supplied with {ProductName} as JSON files, are imported through the Grafana interface to present monitoring data.
+Example dashboards, supplied with Strimzi as JSON files, are imported through the Grafana interface to present monitoring data.

--- a/documentation/modules/overview/con-metrics-overview-prometheus.adoc
+++ b/documentation/modules/overview/con-metrics-overview-prometheus.adoc
@@ -13,5 +13,5 @@ Kafka resources must also be deployed or redeployed with Prometheus configuratio
 Prometheus scrapes the exposed metrics data for monitoring.
 Alertmanager issues notifications on conditions that indicate potential issues based on pre-defined alerting rules.
 
-Sample metrics and alerting rules configuration files are provided with {ProductName}.
-The sample alerting mechanism provided with {ProductName} is configured to send notifications to a Slack channel.
+Sample metrics and alerting rules configuration files are provided with Strimzi.
+The sample alerting mechanism provided with Strimzi is configured to send notifications to a Slack channel.

--- a/documentation/modules/overview/con-overview-components-cluster-operator.adoc
+++ b/documentation/modules/overview/con-overview-components-cluster-operator.adoc
@@ -7,7 +7,7 @@
 [id='overview-components-cluster-operator-{context}']
 = Cluster Operator
 
-{ProductName} uses the Cluster Operator to deploy and manage clusters for:
+Strimzi uses the Cluster Operator to deploy and manage clusters for:
 
 * Kafka (including ZooKeeper, Entity Operator, Kafka Exporter, and Cruise Control)
 * Kafka Connect

--- a/documentation/modules/overview/con-overview-components-kafka-bridge.adoc
+++ b/documentation/modules/overview/con-overview-components-kafka-bridge.adoc
@@ -5,8 +5,8 @@
 [id="overview-components-kafka-bridge_{context}"]
 = Kafka Bridge interface
 
-{ProductName} Kafka Bridge provides a RESTful interface that allows HTTP-based clients to interact with a Kafka cluster. 
-Kafka Bridge offers the advantages of a web API connection to {ProductName}, without the need for client applications to interpret the Kafka protocol.
+Strimzi Kafka Bridge provides a RESTful interface that allows HTTP-based clients to interact with a Kafka cluster. 
+Kafka Bridge offers the advantages of a web API connection to Strimzi, without the need for client applications to interpret the Kafka protocol.
 
 The API has two main resources — `consumers` and `topics` — that are exposed and made accessible through endpoints to interact with consumers and producers in your Kafka cluster. The resources relate only to the Kafka Bridge, not the consumers and producers connected directly to Kafka.
 

--- a/documentation/modules/overview/con-overview-components-operators.adoc
+++ b/documentation/modules/overview/con-overview-components-operators.adoc
@@ -4,7 +4,7 @@
 
 [id="key-features-operators_{context}"]
 = Operators
-{ProductName} provides Operators for managing a Kafka cluster running within a Kubernetes cluster.
+Strimzi provides Operators for managing a Kafka cluster running within a Kubernetes cluster.
 
 Cluster Operator:: Deploys and manages Apache Kafka clusters, Kafka Connect, Kafka MirrorMaker, Kafka Bridge, Kafka Exporter, and the Entity Operator
 Entity Operator:: Comprises the Topic Operator and User Operator
@@ -13,6 +13,6 @@ User Operator:: Manages Kafka users
 
 The Cluster Operator can deploy the Topic Operator and User Operator as part of an *Entity Operator* configuration at the same time as a Kafka cluster.
 
-.Operators within the {ProductName} architecture
+.Operators within the Strimzi architecture
 
 image:operators.png[Operators]

--- a/documentation/modules/overview/con-security-configuration-authentication.adoc
+++ b/documentation/modules/overview/con-security-configuration-authentication.adoc
@@ -10,10 +10,10 @@ Supported authentication mechanisms:
 
 * TLS client authentication
 * SASL SCRAM-SHA-512
-* {oauth} token based authentication
+* OAuth 2.0 token based authentication
 
-The User Operator manages user credentials for TLS and SCRAM authentication, but not {oauth}.
+The User Operator manages user credentials for TLS and SCRAM authentication, but not OAuth 2.0.
 For example, through the User Operator you can create a user representing a client that requires access to the Kafka cluster, and specify TLS as the authentication type.
 
-Using {oauth} token based authentication, application clients can access Kafka brokers without exposing account credentials.
+Using OAuth 2.0 token based authentication, application clients can access Kafka brokers without exposing account credentials.
 An authorization server handles the granting of access and inquiries about access.

--- a/documentation/modules/overview/con-security-configuration-encryption.adoc
+++ b/documentation/modules/overview/con-security-configuration-encryption.adoc
@@ -5,7 +5,7 @@
 [id="security-configuration-encryption_{context}"]
 = Encryption
 
-{ProductName} supports Transport Layer Security (TLS), a protocol for encrypted communication.
+Strimzi supports Transport Layer Security (TLS), a protocol for encrypted communication.
 
 Communication is always encrypted for communication between:
 
@@ -18,17 +18,17 @@ Communication is always encrypted for communication between:
 You can also configure TLS between Kafka brokers and clients by applying TLS encryption to the listeners of the Kafka broker.
 TLS is specified for external clients when configuring an external listener.
 
-{ProductName} components and Kafka clients use digital certificates for encryption.
+Strimzi components and Kafka clients use digital certificates for encryption.
 The Cluster Operator sets up certificates to enable encryption within the Kafka cluster.
 You can provide your own server certificates, referred to as _Kafka listener certificates_,
 for communication between Kafka clients and Kafka brokers, and inter-cluster communication.
 
-{ProductName} uses _Secrets_ to store the certificates and private keys required for TLS in PEM and PKCS #12 format.
+Strimzi uses _Secrets_ to store the certificates and private keys required for TLS in PEM and PKCS #12 format.
 
 A TLS Certificate Authority (CA) issues certificates to authenticate the identity of a component.
-{ProductName} verifies the certificates for the components against the CA certificate.
+Strimzi verifies the certificates for the components against the CA certificate.
 
-* {ProductName} components are verified against the _cluster CA_ Certificate Authority (CA)
+* Strimzi components are verified against the _cluster CA_ Certificate Authority (CA)
 * Kafka clients are verified against the _clients CA_ Certificate Authority (CA)
 
 As ZooKeeper does not have native support for TLS, a _TLS sidecar_ deployment with ZooKeeper allows the Cluster Operator to provide data encryption and authentication between ZooKeeper nodes in a cluster.

--- a/documentation/modules/proc-accessing-kafka-using-ingress.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-ingress.adoc
@@ -5,7 +5,7 @@
 [id='proc-accessing-kafka-using-ingress-{context}']
 = Accessing Kafka using ingress
 
-This procedure shows how to access {ProductName} Kafka clusters from outside of Kubernetes using Ingress.
+This procedure shows how to access Strimzi Kafka clusters from outside of Kubernetes using Ingress.
 
 .Prerequisites
 

--- a/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
@@ -5,7 +5,7 @@
 [id='proc-accessing-kafka-using-nodeports-{context}']
 = Accessing Kafka using node ports
 
-This procedure describes how to access a {ProductName} Kafka cluster from an external client using node ports.
+This procedure describes how to access a Strimzi Kafka cluster from an external client using node ports.
 
 To connect to a broker, you need the hostname (advertised address) and port number for the Kafka _bootstrap_ address,
 as well as the certificate used for authentication.
@@ -45,7 +45,7 @@ spec:
     # ...
 ----
 <1> Optional configuration for a xref:kafka-listener-certificates-str[Kafka listener certificate] managed by an external Certificate Authority. The `brokerCertChainAndKey` property specifies a `Secret` that holds a server certificate and a private key. Kafka listener certificates can also be configured for TLS listeners.
-<2> Optional configuration to xref:con-kafka-broker-external-listeners-nodeports-{context}[specify a preference for the first address type used by {ProductName} as the node address].
+<2> Optional configuration to xref:con-kafka-broker-external-listeners-nodeports-{context}[specify a preference for the first address type used by Strimzi as the node address].
 
 . Create or update the resource.
 +

--- a/documentation/modules/proc-bridge-seeking-offsets-for-partition.adoc
+++ b/documentation/modules/proc-bridge-seeking-offsets-for-partition.adoc
@@ -60,7 +60,7 @@ NOTE: You can also use the link:https://strimzi.io/docs/bridge/latest/#_seektobe
 
 .What to do next
 
-In this quickstart, you have used the {ProductName} Kafka Bridge to perform several common operations on a Kafka cluster. You can now xref:proc-bridge-deleting-consumer-{context}[delete the Kafka Bridge consumer] that you created earlier. 
+In this quickstart, you have used the Strimzi Kafka Bridge to perform several common operations on a Kafka cluster. You can now xref:proc-bridge-deleting-consumer-{context}[delete the Kafka Bridge consumer] that you created earlier. 
 
 .Additional resources
 

--- a/documentation/modules/proc-configuring-init-container-image.adoc
+++ b/documentation/modules/proc-configuring-init-container-image.adoc
@@ -13,8 +13,8 @@ When the `brokerRackInitImage` field is missing, the following images will be us
 . `{DockerKafkaInit}` container image.
 
 WARNING: Overriding container images is recommended only in situations where you need to use a different container registry.
-For example, if your network does not allow access to the container repository used by {ProductName}, you should either copy the {ProductName} images or build them from source.
-In situations where the configured image is not compatible with {ProductName} images, this might not work properly.
+For example, if your network does not allow access to the container repository used by Strimzi, you should either copy the Strimzi images or build them from source.
+In situations where the configured image is not compatible with Strimzi images, this might not work properly.
 
 .Prerequisites
 

--- a/documentation/modules/proc-configuring-kafka-mirror-maker-tls.adoc
+++ b/documentation/modules/proc-configuring-kafka-mirror-maker-tls.adoc
@@ -7,7 +7,7 @@
 
 .Prerequisites
 
-* xref:cluster-operator-str[{ProductName} and Kafka is deployed]
+* xref:cluster-operator-str[Strimzi and Kafka is deployed]
 * Source and target Kafka clusters are available
 * If they exist, the name of the `Secret` for the certificate used for TLS Server Authentication and the key under which the certificate is stored in the `Secret`
 

--- a/documentation/modules/proc-configuring-mirror-maker.adoc
+++ b/documentation/modules/proc-configuring-mirror-maker.adoc
@@ -12,7 +12,7 @@ This procedure shows a configuration that uses TLS encryption and authentication
 
 .Prerequisites
 
-* xref:cluster-operator-str[{ProductName} and Kafka is deployed]
+* xref:cluster-operator-str[Strimzi and Kafka is deployed]
 * Source and target Kafka clusters are available
 
 .Procedure

--- a/documentation/modules/proc-deploying-kafka-bridge-quickstart.adoc
+++ b/documentation/modules/proc-deploying-kafka-bridge-quickstart.adoc
@@ -5,7 +5,7 @@
 [id='proc-deploying-kafka-bridge-quickstart-{context}']
 = Deploying the Kafka Bridge to your Kubernetes cluster
 
-{ProductName} includes a YAML example that specifies the configuration of the {ProductName} Kafka Bridge. Make some minimal changes to this file and then deploy an instance of the Kafka Bridge to your Kubernetes cluster.
+Strimzi includes a YAML example that specifies the configuration of the Strimzi Kafka Bridge. Make some minimal changes to this file and then deploy an instance of the Kafka Bridge to your Kubernetes cluster.
 
 .Procedure
 

--- a/documentation/modules/proc-enabling-tracing-in-connect-mirror-maker-bridge-resources.adoc
+++ b/documentation/modules/proc-enabling-tracing-in-connect-mirror-maker-bridge-resources.adoc
@@ -7,7 +7,7 @@
 
 Update the configuration of `KafkaMirrorMaker`, `KafkaConnect`, `KafkaConnectS2I`, and `KafkaBridge` custom resources to specify and configure a Jaeger tracer service for each resource. Updating a tracing-enabled resource in your Kubernetes cluster triggers two events:
 
-* Interceptor classes are updated in the integrated consumers and producers in MirrorMaker, Kafka Connect, or the {ProductName} Kafka Bridge.
+* Interceptor classes are updated in the integrated consumers and producers in MirrorMaker, Kafka Connect, or the Strimzi Kafka Bridge.
 
 * For MirrorMaker and Kafka Connect, the tracing agent initializes a Jaeger tracer based on the tracing configuration defined in the resource.
 

--- a/documentation/modules/proc-exposing-kafka-bridge-service-local-machine.adoc
+++ b/documentation/modules/proc-exposing-kafka-bridge-service-local-machine.adoc
@@ -5,7 +5,7 @@
 [id='proc-exposing-kafka-bridge-service-local-machine-{context}']
 = Exposing the Kafka Bridge service to your local machine
 
-Next, use port forwarding to expose the {ProductName} Kafka Bridge service to your local machine on http://localhost:8080.
+Next, use port forwarding to expose the Strimzi Kafka Bridge service to your local machine on http://localhost:8080.
 
 NOTE: Port forwarding is only suitable for development and testing purposes.
 

--- a/documentation/modules/proc-resizing-persistent-volumes.adoc
+++ b/documentation/modules/proc-resizing-persistent-volumes.adoc
@@ -5,7 +5,7 @@
 [id='proc-resizing-persistent-volumes-{context}']
 = Resizing persistent volumes
 
-You can provision increased storage capacity by increasing the size of the persistent volumes used by an existing {ProductName} cluster.
+You can provision increased storage capacity by increasing the size of the persistent volumes used by an existing Strimzi cluster.
 Resizing persistent volumes is supported in clusters that use either a single persistent volume or multiple persistent volumes in a JBOD storage configuration.
 
 NOTE: You can increase but not decrease the size of persistent volumes.

--- a/documentation/modules/proc-scheduling-deployment-to-node-using-node-affinity.adoc
+++ b/documentation/modules/proc-scheduling-deployment-to-node-using-node-affinity.adoc
@@ -12,7 +12,7 @@
 
 .Procedure
 
-. Label the nodes where {ProductName} components should be scheduled.
+. Label the nodes where Strimzi components should be scheduled.
 +
 This can be done using `kubectl label`:
 [source,shell,subs="+quotes,attributes+"]

--- a/documentation/modules/quickstart/proc-creating-kafka-cluster.adoc
+++ b/documentation/modules/quickstart/proc-creating-kafka-cluster.adoc
@@ -5,9 +5,9 @@
 [id='proc-kafka-cluster-{context}']
 = Creating a cluster
 
-With {ProductName} installed, you create a Kafka cluster, then a topic within the cluster.
+With Strimzi installed, you create a Kafka cluster, then a topic within the cluster.
 
-When you create a cluster, the Cluster Operator you deployed when installing {ProductName} watches for new Kafka resources.
+When you create a cluster, the Cluster Operator you deployed when installing Strimzi watches for new Kafka resources.
 
 .Prerequisites
 

--- a/documentation/modules/quickstart/proc-downloading-product.adoc
+++ b/documentation/modules/quickstart/proc-downloading-product.adoc
@@ -3,9 +3,9 @@
 // assembly-evaluation.adoc
 
 [id='proc-product-downloads-{context}']
-= Downloading {ProductName}
+= Downloading Strimzi
 
-The resources and artifacts required to install {ProductName}, along with examples for configuration, are provided in a ZIP file.
+The resources and artifacts required to install Strimzi, along with examples for configuration, are provided in a ZIP file.
 
 .Procedure
 

--- a/documentation/modules/quickstart/proc-installing-product.adoc
+++ b/documentation/modules/quickstart/proc-installing-product.adoc
@@ -3,9 +3,9 @@
 // assembly-evaluation.adoc
 
 [id='proc-install-product-{context}']
-= Installing {ProductName}
+= Installing Strimzi
 
-Using the xref:proc-product-downloads-{context}[download files], install {ProductName} with the Custom Resource Definitions (CRDs) and RBAC configuration required for deployment.
+Using the xref:proc-product-downloads-{context}[download files], install Strimzi with the Custom Resource Definitions (CRDs) and RBAC configuration required for deployment.
 
 In this task you create namespaces in the cluster for your deployment.
 Use namespaces to separate functions.
@@ -18,14 +18,14 @@ Use namespaces to separate functions.
 
 . Log in to the Kubernetes cluster using an account that has cluster admin privileges.
 
-. Create a new `kafka` namespace for the {ProductName} Kafka Cluster Operator.
+. Create a new `kafka` namespace for the Strimzi Kafka Cluster Operator.
 +
 [source, shell, subs=+quotes ]
 ----
 kubectl create ns kafka
 ----
 
-. Modify the installation files to reference the `kafka` namespace where you will install the {ProductName} Kafka Cluster Operator.
+. Modify the installation files to reference the `kafka` namespace where you will install the Strimzi Kafka Cluster Operator.
 +
 NOTE: By default, the files work in the `myproject` namespace.
 +

--- a/documentation/modules/quickstart/proc-sending-messages.adoc
+++ b/documentation/modules/quickstart/proc-sending-messages.adoc
@@ -6,13 +6,13 @@
 
 = Sending and receiving messages from a topic
 
-You can test your {ProductName} installation by sending and receiving messages to `my-topic` from outside the cluster.
+You can test your Strimzi installation by sending and receiving messages to `my-topic` from outside the cluster.
 
 Use a terminal to run a Kafka producer and consumer on a local machine.
 
 .Prerequisites
 
-* Ensure {ProductName} is installed on the Kubernetes cluster.
+* Ensure Strimzi is installed on the Kubernetes cluster.
 * ZooKeeper and Kafka must be running to be able to send and receive messages.
 
 .Procedure

--- a/documentation/modules/quickstart/ref-install-prerequisites.adoc
+++ b/documentation/modules/quickstart/ref-install-prerequisites.adoc
@@ -6,4 +6,4 @@
 = Prerequisites
 
 * {Minikube}.
-* You need to be able to access {ProductName} {ReleaseDownload}.
+* You need to be able to access Strimzi {ReleaseDownload}.

--- a/documentation/modules/ref-configuring-container-images.adoc
+++ b/documentation/modules/ref-configuring-container-images.adoc
@@ -85,9 +85,9 @@ If the `image` name is not defined in the Cluster Operator configuration, then t
 . `{DockerKafkaInit}` container image.
 
 WARNING: Overriding container images is recommended only in special situations, where you need to use a different container registry.
-For example, because your network does not allow access to the container repository used by {ProductName}.
-In such case, you should either copy the {ProductName} images or build them from source.
-In case the configured image is not compatible with {ProductName} images, it might not work properly.
+For example, because your network does not allow access to the container repository used by Strimzi.
+In such case, you should either copy the Strimzi images or build them from source.
+In case the configured image is not compatible with Strimzi images, it might not work properly.
 
 .Example of container image configuration
 [source,yaml,subs=attributes+]

--- a/documentation/modules/ref-kafka-authentication.adoc
+++ b/documentation/modules/ref-kafka-authentication.adoc
@@ -15,7 +15,7 @@ Supported authentication mechanisms:
 
 * TLS client authentication
 * SASL SCRAM-SHA-512
-* xref:assembly-oauth-authentication_str[{oauth} token based authentication]
+* xref:assembly-oauth-authentication_str[OAuth 2.0 token based authentication]
 
 == TLS client authentication
 

--- a/documentation/modules/ref-kafka-authorization.adoc
+++ b/documentation/modules/ref-kafka-authorization.adoc
@@ -13,11 +13,11 @@ The authorization method is defined in the `type` field.
 You can configure:
 
 * Simple authorization
-* xref:assembly-oauth-authorization_str[{oauth} authorization] (if you are using {oauth} token based authentication)
+* xref:assembly-oauth-authorization_str[OAuth 2.0 authorization] (if you are using OAuth 2.0 token based authentication)
 
 == Simple authorization
 
-Simple authorization in {ProductName} uses the `SimpleAclAuthorizer` plugin, the default Access Control Lists (ACLs) authorization plugin provided with Apache Kafka. ACLs allow you to define which users have access to which resources at a granular level.
+Simple authorization in Strimzi uses the `SimpleAclAuthorizer` plugin, the default Access Control Lists (ACLs) authorization plugin provided with Apache Kafka. ACLs allow you to define which users have access to which resources at a granular level.
 To enable simple authorization, set the `type` field to `simple`.
 
 .An example of Simple authorization

--- a/documentation/modules/ref-kafka-bridge-consumer-configuration.adoc
+++ b/documentation/modules/ref-kafka-bridge-consumer-configuration.adoc
@@ -13,7 +13,7 @@ The values can be one of the following JSON types:
 * Number
 * Boolean
 
-Users can specify and configure the options listed in the {ApacheKafkaConsumerConfig} with the exception of those options which are managed directly by {ProductName}.
+Users can specify and configure the options listed in the {ApacheKafkaConsumerConfig} with the exception of those options which are managed directly by Strimzi.
 Specifically, all configuration options with keys equal to or starting with one of the following strings are forbidden:
 
 * `ssl.`

--- a/documentation/modules/ref-kafka-bridge-producer-configuration.adoc
+++ b/documentation/modules/ref-kafka-bridge-producer-configuration.adoc
@@ -13,7 +13,7 @@ The values can be one of the following JSON types:
 * Number
 * Boolean
 
-Users can specify and configure the options listed in the {ApacheKafkaProducerConfig} with the exception of those options which are managed directly by {ProductName}.
+Users can specify and configure the options listed in the {ApacheKafkaProducerConfig} with the exception of those options which are managed directly by Strimzi.
 Specifically, all configuration options with keys equal to or starting with one of the following strings are forbidden:
 
 * `ssl.`

--- a/documentation/modules/ref-kafka-broker-configuration.adoc
+++ b/documentation/modules/ref-kafka-broker-configuration.adoc
@@ -11,7 +11,7 @@ The `config` property in `Kafka.spec.kafka` contains Kafka broker configuration 
 * Number
 * Boolean
 
-You can specify and configure all of the options in the "Broker Configs" section of the {ApacheKafkaBrokerConfig} apart from those managed directly by {ProductName}.
+You can specify and configure all of the options in the "Broker Configs" section of the {ApacheKafkaBrokerConfig} apart from those managed directly by Strimzi.
 Specifically, you are prevented from modifying all configuration options with keys equal to or starting with one of the following strings:
 
 * `listeners`

--- a/documentation/modules/ref-kafka-connect-configuration.adoc
+++ b/documentation/modules/ref-kafka-connect-configuration.adoc
@@ -13,7 +13,7 @@ The values can be one of the following JSON types:
 * Number
 * Boolean
 
-You can specify and configure the options listed in the {ApacheKafkaConnectConfig} with the exception of those options that are managed directly by {ProductName}.
+You can specify and configure the options listed in the {ApacheKafkaConnectConfig} with the exception of those options that are managed directly by Strimzi.
 Specifically, configuration options with keys equal to or starting with one of the following strings are forbidden:
 
 * `ssl.`

--- a/documentation/modules/ref-kafka-listener-network-policy-example.adoc
+++ b/documentation/modules/ref-kafka-listener-network-policy-example.adoc
@@ -43,4 +43,4 @@ The application pods must be running in the same namespace as the Kafka broker.
 The syntax of the `networkPolicyPeers` field is the same as the `from` field in `NetworkPolicy` resources.
 For more information about the schema, see {K8sNetworkPolicyPeerAPI} and the xref:type-KafkaListeners-reference[`KafkaListeners` schema reference].
 
-NOTE: Your configuration of Kubernetes must support ingress NetworkPolicies in order to use network policies in {ProductName}.
+NOTE: Your configuration of Kubernetes must support ingress NetworkPolicies in order to use network policies in Strimzi.

--- a/documentation/modules/ref-kafka-rack.adoc
+++ b/documentation/modules/ref-kafka-rack.adoc
@@ -42,9 +42,9 @@ When the `brokerRackInitImage` field is missing, the following images will be us
 . `{DockerKafkaInit}` container image.
 
 WARNING: Overriding container images is recommended only in situations where you need to use a different container registry.
-For example, because your network does not allow access to the container repository used by {ProductName}.
-In such case, you should either copy the {ProductName} images or build them from source.
-In case the configured image is not compatible with {ProductName} images, it might not work properly.
+For example, because your network does not allow access to the container repository used by Strimzi.
+In such case, you should either copy the Strimzi images or build them from source.
+In case the configured image is not compatible with Strimzi images, it might not work properly.
 
 .Example of `brokerRackInitImage` configuration
 [source,yaml,subs=attributes+]

--- a/documentation/modules/ref-kafka-user.adoc
+++ b/documentation/modules/ref-kafka-user.adoc
@@ -127,7 +127,7 @@ If no authorization is specified, the User Operator does not provision any acces
 To use simple authorization, you set the `type` property to `simple` in `KafkaUser.spec`.
 Simple authorization uses the default Kafka authorization plugin, `SimpleAclAuthorizer`.
 
-Alternatively, if you are using {oauth} token based authentication, you can also xref:assembly-oauth-authorization_str[configure {oauth} authorization].
+Alternatively, if you are using OAuth 2.0 token based authentication, you can also xref:assembly-oauth-authorization_str[configure OAuth 2.0 authorization].
 
 [discrete]
 === ACL rules

--- a/documentation/modules/ref-operators-cluster-operator-configuration.adoc
+++ b/documentation/modules/ref-operators-cluster-operator-configuration.adoc
@@ -28,7 +28,7 @@ The level for printing logging messages. The value can be set to: `ERROR`, `WARN
 
 `STRIMZI_OPERATION_TIMEOUT_MS`:: Optional, default 300000 ms.
 The timeout for internal operations, in milliseconds. This value should be
-increased when using {ProductName} on clusters where regular Kubernetes operations take longer than usual (because of slow downloading of Docker images, for example).
+increased when using Strimzi on clusters where regular Kubernetes operations take longer than usual (because of slow downloading of Docker images, for example).
 
 `STRIMZI_KAFKA_IMAGES`:: Required.
 This provides a mapping from Kafka version to the corresponding Docker image containing a Kafka broker of that version.
@@ -74,7 +74,7 @@ The image name to use as the default when deploying the sidecar container which 
 no image is specified as the `Kafka.spec.entityOperator.tlsSidecar.image` in the xref:assembly-configuring-container-images-deployment-configuration-kafka[].
 
 `STRIMZI_IMAGE_PULL_POLICY`:: Optional.
-The `ImagePullPolicy` which will be applied to containers in all pods managed by {ProductName} Cluster Operator.
+The `ImagePullPolicy` which will be applied to containers in all pods managed by Strimzi Cluster Operator.
 The valid values are `Always`, `IfNotPresent`, and `Never`.
 If not specified, the Kubernetes defaults will be used.
 Changing the policy will result in a rolling update of all your Kafka, Kafka Connect, and Kafka MirrorMaker clusters.

--- a/documentation/modules/ref-resource-limits-and-requests.adoc
+++ b/documentation/modules/ref-resource-limits-and-requests.adoc
@@ -29,7 +29,7 @@ Reserving the resources ensures that they are always available.
 IMPORTANT: If the resource request is for more than the available free resources in the Kubernetes cluster, the pod is not scheduled.
 
 Resources requests are specified in the `requests` property.
-Resources requests currently supported by {ProductName}:
+Resources requests currently supported by Strimzi:
 
 * `cpu`
 * `memory`
@@ -55,7 +55,7 @@ A container can use the resources up to the limit only when they are available.
 Resource limits should be always higher than the resource requests.
 
 Resource limits are specified in the `limits` property.
-Resource limits currently supported by {ProductName}:
+Resource limits currently supported by Strimzi:
 
 * `cpu`
 * `memory`

--- a/documentation/modules/ref-sample-kafka-resource-config.adoc
+++ b/documentation/modules/ref-sample-kafka-resource-config.adoc
@@ -127,14 +127,14 @@ spec:
 <8> External listener configuration specifies xref:assembly-kafka-broker-external-listeners-{context}[how the Kafka cluster is exposed outside Kubernetes, such as through a `route`, `loadbalancer` or `nodeport`].
 <9> Optional configuration for a xref:kafka-listener-certificates-str[Kafka listener certificate] managed by an external Certificate Authority. The `brokerCertChainAndKey` property specifies a `Secret` that holds a server certificate and a private key. Kafka listener certificates can also be configured for TLS listeners.
 <10> Authorization xref:ref-kafka-authorization-{context}[enables `simple` authorization on the Kafka broker using the `SimpleAclAuthorizer` Kafka plugin].
-<11> Config specifies the broker configuration. xref:ref-kafka-broker-configuration-{context}[Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by {ProductName}].
+<11> Config specifies the broker configuration. xref:ref-kafka-broker-configuration-{context}[Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi].
 <12> xref:ref-kafka-broker-configuration-{context}[SSL properties for external listeners to run with a specific _cipher suite_ for a TLS version].
 <13> Storage is xref:assembly-storage-{context}[configured as `ephemeral`, `persistent-claim` or `jbod`].
 <14> Storage size for xref:proc-resizing-persistent-volumes-{context}[persistent volumes may be increased] and additional xref:proc-adding-volumes-to-jbod-storage-{context}[volumes may be added to JBOD storage].
 <15> Persistent storage has xref:ref-persistent-storage-{context}[additional configuration options], such as a storage `id` and `class` for dynamic volume provisioning.
 <16> Rack awareness is configured to xref:assembly-kafka-rack-{context}[spread replicas across different racks]. A `topology` key must match the label of a cluster node.
 <17> Kafka link:{BookURLDeploying}#assembly-metrics-setup-str[metrics configuration for use with Prometheus].
-<18> Kafka rules for exporting metrics to a Grafana dashboard through the JMX Exporter. A set of rules provided with {productName} may be copied to your Kafka resource configuration.
+<18> Kafka rules for exporting metrics to a Grafana dashboard through the JMX Exporter. A set of rules provided with Strimzi may be copied to your Kafka resource configuration.
 <19> xref:assembly-zookeeper-node-configuration-{context}[ZooKeeper-specific configuration], which contains properties similar to the Kafka configuration.
 <20> Entity Operator configuration, which xref:assembly-kafka-entity-operator-{context}[specifies the configuration for the Topic Operator and User Operator].
 <21> Kafka Exporter configuration, which is used xref:assembly-kafka-exporter-configuration-{context}[to expose data as Prometheus metrics].

--- a/documentation/modules/ref-storage-jbod.adoc
+++ b/documentation/modules/ref-storage-jbod.adoc
@@ -5,13 +5,13 @@
 [id='ref-jbod-storage-{context}']
 = JBOD storage overview
 
-You can configure {ProductName} to use JBOD, a data storage configuration of multiple disks or volumes. JBOD is one approach to providing increased data storage for Kafka brokers. It can also improve performance.
+You can configure Strimzi to use JBOD, a data storage configuration of multiple disks or volumes. JBOD is one approach to providing increased data storage for Kafka brokers. It can also improve performance.
 
 A JBOD configuration is described by one or more volumes, each of which can be either xref:ref-ephemeral-storage-{context}[ephemeral] or xref:ref-persistent-storage-{context}[persistent]. The rules and constraints for JBOD volume declarations are the same as those for ephemeral and persistent storage. For example, you cannot change the size of a persistent storage volume after it has been provisioned.
 
 == JBOD configuration
 
-To use JBOD with {ProductName}, the storage `type` must be set to `jbod`. The `volumes` property allows you to describe the disks that make up your JBOD storage array or configuration. The following fragment shows an example JBOD configuration:
+To use JBOD with Strimzi, the storage `type` must be set to `jbod`. The `volumes` property allows you to describe the disks that make up your JBOD storage array or configuration. The following fragment shows an example JBOD configuration:
 
 [source,yaml]
 ----

--- a/documentation/modules/ref-storage-persistent.adoc
+++ b/documentation/modules/ref-storage-persistent.adoc
@@ -30,7 +30,7 @@ It contains key:value pairs representing labels for selecting such a volume.
 Boolean value which specifies if the Persistent Volume Claim has to be deleted when the cluster is undeployed.
 Default is `false`.
 
-WARNING: Increasing the size of persistent volumes in an existing {ProductName} cluster is only supported in Kubernetes versions that support persistent volume resizing. The persistent volume to be resized must use a storage class that supports volume expansion.
+WARNING: Increasing the size of persistent volumes in an existing Strimzi cluster is only supported in Kubernetes versions that support persistent volume resizing. The persistent volume to be resized must use a storage class that supports volume expansion.
 For other versions of Kubernetes and storage classes which do not support volume expansion, you must decide the necessary storage size before deploying the cluster.
 Decreasing the size of existing persistent volumes is not possible.
 
@@ -80,7 +80,7 @@ You can use the `overrides` field for this purpose.
 
 In this example, the default storage class is named `my-storage-class`:
 
-.Example {ProductName} cluster using storage class overrides
+.Example Strimzi cluster using storage class overrides
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: kafka.strimzi.io/v1beta1

--- a/documentation/modules/ref-zookeeper-node-configuration.adoc
+++ b/documentation/modules/ref-zookeeper-node-configuration.adoc
@@ -13,7 +13,7 @@ The values can be described using one of the following JSON types:
 * Number
 * Boolean
 
-Users can specify and configure the options listed in {ApacheZookeeperConfig} with the exception of those options which are managed directly by {ProductName}.
+Users can specify and configure the options listed in {ApacheZookeeperConfig} with the exception of those options which are managed directly by Strimzi.
 Specifically, all configuration options with keys equal to or starting with one of the following strings are forbidden:
 
 * `server.`

--- a/documentation/modules/security/con-certificate-authorities.adoc
+++ b/documentation/modules/security/con-certificate-authorities.adoc
@@ -5,10 +5,10 @@
 [id='certificate-authorities-{context}']
 = Certificate Authorities
 
-To support encryption, each {ProductName} component needs its own private keys and public key certificates.
+To support encryption, each Strimzi component needs its own private keys and public key certificates.
 All component certificates are signed by an internal Certificate Authority (CA) called the _cluster CA_.
 
-Similarly, each Kafka client application connecting to {ProductName} using TLS client authentication needs to provide private keys and certificates.
+Similarly, each Kafka client application connecting to Strimzi using TLS client authentication needs to provide private keys and certificates.
 A second internal CA, named the _clients CA_, is used to sign certificates for the Kafka clients.
 
 == CA certificates
@@ -20,7 +20,7 @@ Components that clients do not need to connect to, such as ZooKeeper, only trust
 Unless TLS encryption for external listeners is disabled, client applications must trust certificates signed by the cluster CA.
 This is also true for client applications that perform xref:con-mutual-tls-authentication-deployment-configuration-kafka[mutual TLS authentication]. 
 
-By default, {ProductName} automatically generates and renews CA certificates issued by the cluster CA or clients CA.
+By default, Strimzi automatically generates and renews CA certificates issued by the cluster CA or clients CA.
 You can configure the management of these CA certificates in the `Kafka.spec.clusterCa` and `Kafka.spec.clientsCa` objects.
 Certificates provided by users are not renewed.
 

--- a/documentation/modules/security/ref-certificates-and-secrets.adoc
+++ b/documentation/modules/security/ref-certificates-and-secrets.adoc
@@ -89,7 +89,7 @@ The CA certificates in `_<cluster>_-cluster-ca-cert` must be trusted by Kafka cl
 
 NOTE: Only `_<cluster>_-cluster-ca-cert` needs to be used by clients.
 All other `Secrets` in the table above only need to be accessed by the
- {ProductName} components.
+ Strimzi components.
  You can enforce this using Kubernetes role-based access controls if necessary.
 
 == Client CA Secrets
@@ -116,7 +116,7 @@ All other `Secrets` in the table above only need to be accessed by the
 The certificates in `_<cluster>_-clients-ca-cert` are those which the Kafka brokers trust.
 
 NOTE: `_<cluster>_-clients-ca` is used to sign certificates of client applications.
-It needs to be accessible to the {ProductName} components and for administrative access if you are intending to issue application certificates without using the User Operator.
+It needs to be accessible to the Strimzi components and for administrative access if you are intending to issue application certificates without using the User Operator.
 You can enforce this using Kubernetes role-based access controls if necessary.
 
 == User Secrets

--- a/documentation/modules/snip-images.adoc
+++ b/documentation/modules/snip-images.adoc
@@ -11,7 +11,7 @@ a|
 * {DockerOrg}/kafka:{DockerTag}-kafka-2.5.0
 
 a|
-{ProductName} image for running Kafka, including:
+Strimzi image for running Kafka, including:
 
 * Kafka Broker
 * Kafka Connect / S2I
@@ -24,7 +24,7 @@ a|
 * {DockerOrg}/operator:{DockerTag}
 
 a|
-{ProductName} image for running the operators:
+Strimzi image for running the operators:
 
 * Cluster Operator
 * Topic Operator
@@ -36,13 +36,13 @@ a|
 * {DockerOrg}/kafka-bridge:{BridgeDockerTag}
 
 a|
-{ProductName} image for running the {ProductName} kafka Bridge
+Strimzi image for running the Strimzi kafka Bridge
 
 |JmxTrans
 a|
 * {DockerOrg}/jmxtrans:{DockerTag}
 
 a|
-{ProductName} image for running the {ProductName} JmxTrans
+Strimzi image for running the Strimzi JmxTrans
 
 |===

--- a/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
@@ -6,7 +6,7 @@
 
 = Downgrading Kafka brokers and client applications
 
-This procedure describes how you can downgrade a {ProductName} Kafka cluster to a lower (previous) version of Kafka, such as downgrading from {KafkaVersionHigher} to {KafkaVersionLower}.
+This procedure describes how you can downgrade a Strimzi Kafka cluster to a lower (previous) version of Kafka, such as downgrading from {KafkaVersionHigher} to {KafkaVersionLower}.
 
 [IMPORTANT]
 ====

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -6,7 +6,7 @@
 
 = Upgrading Kafka brokers and client applications
 
-This procedure describes how to upgrade a {ProductName} Kafka cluster to a higher version of Kafka.
+This procedure describes how to upgrade a Strimzi Kafka cluster to a higher version of Kafka.
 
 .Prerequisites
 
@@ -147,4 +147,4 @@ The Kafka cluster and clients are now using the new Kafka version.
 
 .Additional resources
 
-* See xref:proc-downgrading-brokers-older-kafka-str[] for the procedure to downgrade a {ProductName} Kafka cluster from one version to a lower version.
+* See xref:proc-downgrading-brokers-older-kafka-str[] for the procedure to downgrade a Strimzi Kafka cluster from one version to a lower version.

--- a/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
@@ -42,11 +42,11 @@ Wait for the rolling updates to complete.
 kubectl get po my-cluster-kafka-0 -o jsonpath='{.spec.containers[0].image}'
 ----
 +
-The image tag shows the new {ProductName} version followed by the Kafka version. For example, `_<New {ProductName} version>_-kafka-_<Current Kafka version>_`.
+The image tag shows the new Strimzi version followed by the Kafka version. For example, `_<New Strimzi version>_-kafka-_<Current Kafka version>_`.
 
 . Update existing resources to handle deprecated custom resource properties.
 +
-* xref:assembly-upgrade-resources-{context}[{ProductName} resource upgrades]
+* xref:assembly-upgrade-resources-{context}[Strimzi resource upgrades]
 
 You now have an updated Cluster Operator, but the version of Kafka running in the cluster it manages is unchanged.
 

--- a/documentation/overview/master-docinfo.xml
+++ b/documentation/overview/master-docinfo.xml
@@ -1,8 +1,8 @@
-<productname>{ProductLongName}</productname>
+<productname>Strimzi</productname>
 <productnumber>{ProductVersion}</productnumber>
-<subtitle>For Use with {ProductName} {ProductVersion}</subtitle>
+<subtitle>For Use with Strimzi {ProductVersion}</subtitle>
 <abstract>
-    <para>This Overview provides a brief introduction to the features, components, and functions of {ProductName} {ProductVersion}</para>
+    <para>This Overview provides a brief introduction to the features, components, and functions of Strimzi {ProductVersion}</para>
 </abstract>
 <authorgroup>
 </authorgroup>

--- a/documentation/overview/master.adoc
+++ b/documentation/overview/master.adoc
@@ -4,7 +4,7 @@ include::shared/attributes.adoc[]
 :context: str
 
 [id="overview-book_{context}"]
-= {ProductName} Overview
+= Strimzi Overview
 
 // Add include directives to include modules and assemblies here
 

--- a/documentation/quickstart/master-docinfo.xml
+++ b/documentation/quickstart/master-docinfo.xml
@@ -1,12 +1,12 @@
-<title>Using {ProductLongName}</title>
+<title>Using Strimzi</title>
 
-<productname>{ProductLongName}</productname>
+<productname>Strimzi</productname>
 <productnumber>{ProductVersion}</productnumber>
 
         <!-- The subtitle can be changed manually, as it is only required by CCUTIL and only visible on the portal  -->
-<subtitle>For Use with {ProductName}</subtitle>
+<subtitle>For Use with Strimzi</subtitle>
 <release>{ProductVersion}</release>
 <abstract>
-<para>This guide describes how to install and manage {ProductName} to evaluate its potential use in a production environment.</para>
+<para>This guide describes how to install and manage Strimzi to evaluate its potential use in a production environment.</para>
 </abstract>
 <xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/documentation/quickstart/master.adoc
+++ b/documentation/quickstart/master.adoc
@@ -2,7 +2,7 @@ include::shared/attributes.adoc[]
 
 :context: str
 
-= {ProductName} Quick Start
+= Strimzi Quick Start
 
 // common intro
 include::assemblies/assembly-quickstart-overview.adoc[leveloffset=+1]

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -12,10 +12,7 @@
 :linkattrs:
 :toclevels: 3
 
-// Name and version placeholders
-:ProductLongName: Strimzi
-:ProductName: Strimzi
-:ContextProduct: strimzi
+// Kubernetes and OpenShift versions
 :OpenShiftVersion: 3.11 and later
 :KubernetesVersion: 1.11 and later
 
@@ -39,15 +36,13 @@
 :kafka-exporter-project: link:https://github.com/danielqsj/kafka_exporter[Kafka Exporter^]
 
 //OAuth attributes and links
-:oauth: OAuth 2.0
-:oauth2-site: link:https://oauth.net/2/[{oauth} site^]
-:oauth-artifact-version: 0.2.0
-:keycloak-server: Keycloak
+:oauth2-site: link:https://oauth.net/2/[OAuth 2.0 site^]
+:oauth-artifact-version: 0.5.0
 :keycloak-server-doc: link:https://www.keycloak.org/documentation.html[Keycloak documentation^]
 :keycloak-authorization-services: link:https://www.keycloak.org/docs/latest/authorization_services/index.html[Authorization Services^]
-:oauth-blog: link:https://strimzi.io/2019/10/25/kafka-authentication-using-oauth-2.0.html[Kafka authentication using {oauth}^]
-:oauth-demo-keycloak: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/master/examples[Using Keycloak as the {oauth} authorization server^]
-:oauth-demo-hydra: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/master/examples/docker[Using Hydra as the {oauth} authorization server^]
+:oauth-blog: link:https://strimzi.io/2019/10/25/kafka-authentication-using-oauth-2.0.html[Kafka authentication using OAuth 2.0^]
+:oauth-demo-keycloak: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/master/examples[Using Keycloak as the OAuth 2.0 authorization server^]
+:oauth-demo-hydra: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/master/examples/docker[Using Hydra as the OAuth 2.0 authorization server^]
 
 // External links
 :aws-ebs: link:https://aws.amazon.com/ebs/[Amazon Elastic Block Store (EBS)^]

--- a/documentation/shared/snip-intro-custom-resources.adoc
+++ b/documentation/shared/snip-intro-custom-resources.adoc
@@ -1,10 +1,10 @@
 //standard custom resources intro text
-A deployment of Kafka components to a Kubernetes cluster using {ProductName} is highly configurable through the application of custom resources.
+A deployment of Kafka components to a Kubernetes cluster using Strimzi is highly configurable through the application of custom resources.
 Custom resources are created as instances of APIs added by Custom resource definitions (CRDs) to extend Kubernetes resources.
 
 CRDs act as configuration instructions to describe the custom resources in a Kubernetes cluster,
-and are provided with {ProductName} for each Kafka component used in a deployment, as well as users and topics.
+and are provided with Strimzi for each Kafka component used in a deployment, as well as users and topics.
 CRDs and custom resources are defined as YAML files.
-Example YAML files are provided with the {ProductName} distribution.
+Example YAML files are provided with the Strimzi distribution.
 
-CRDs also allow {ProductName} resources to benefit from native Kubernetes features like CLI accessibility and configuration validation.
+CRDs also allow Strimzi resources to benefit from native Kubernetes features like CLI accessibility and configuration validation.

--- a/documentation/shared/snip-intro-kafka-deployment.adoc
+++ b/documentation/shared/snip-intro-kafka-deployment.adoc
@@ -1,5 +1,5 @@
 //standard kafka deployment text
-Apache Kafka components are provided for deployment to Kubernetes with the {ProductName} distribution.
+Apache Kafka components are provided for deployment to Kubernetes with the Strimzi distribution.
 The Kafka components are generally run as clusters for availability.
 
 A typical deployment incorporating Kafka components might include:

--- a/documentation/shared/snip-intro-operators.adoc
+++ b/documentation/shared/snip-intro-operators.adoc
@@ -1,4 +1,4 @@
 //standard operator intro text
 Operators are a method of packaging, deploying, and managing a Kubernetes application.
-{ProductName} Operators extend Kubernetes functionality, automating common and complex tasks related to a Kafka deployment.
+Strimzi Operators extend Kubernetes functionality, automating common and complex tasks related to a Kafka deployment.
 By implementing knowledge of Kafka operations in code, Kafka administration tasks are simplified and require less manual intervention.

--- a/documentation/shared/snip-intro-text.adoc
+++ b/documentation/shared/snip-intro-text.adoc
@@ -1,2 +1,2 @@
 //standard product intro text
-{ProductName} simplifies the process of running Apache Kafka in a Kubernetes cluster.
+Strimzi simplifies the process of running Apache Kafka in a Kubernetes cluster.

--- a/documentation/snip-images.sh
+++ b/documentation/snip-images.sh
@@ -28,7 +28,7 @@ done
 cat <<EOF
 
 a|
-{ProductName} image for running Kafka, including:
+Strimzi image for running Kafka, including:
 
 * Kafka Broker
 * Kafka Connect / S2I
@@ -41,7 +41,7 @@ a|
 * {DockerOrg}/operator:{DockerTag}
 
 a|
-{ProductName} image for running the operators:
+Strimzi image for running the operators:
 
 * Cluster Operator
 * Topic Operator
@@ -53,14 +53,14 @@ a|
 * {DockerOrg}/kafka-bridge:{BridgeDockerTag}
 
 a|
-{ProductName} image for running the {ProductName} kafka Bridge
+Strimzi image for running the Strimzi kafka Bridge
 
 |JmxTrans
 a|
 * {DockerOrg}/jmxtrans:{DockerTag}
 
 a|
-{ProductName} image for running the {ProductName} JmxTrans
+Strimzi image for running the Strimzi JmxTrans
 
 |===
 EOF

--- a/documentation/using/master-docinfo.xml
+++ b/documentation/using/master-docinfo.xml
@@ -1,14 +1,14 @@
 <!-- No need to manually update the following attribute for each title change, although it should be technically possible to do so -->
 <!-- As far as I know, the topmost Level 0 title in the `master.adoc` file resolves to this attribute -->
-<title>Using {ProductLongName}</title>
+<title>Using Strimzi</title>
 
-<productname>{ProductLongName}</productname>
+<productname>Strimzi</productname>
 <productnumber>{ProductVersion}</productnumber>
 
         <!-- The subtitle can be changed manually, as it is only required by CCUTIL and only visible on the portal  -->
-<subtitle>For Use with {ProductName}</subtitle>
+<subtitle>For Use with Strimzi</subtitle>
 <release>{ProductVersion}</release>
 <abstract>
-<para>This guide provides a getting started experience for {ProductName}.</para>
+<para>This guide provides a getting started experience for Strimzi.</para>
 </abstract>
 <xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/documentation/using/master.adoc
+++ b/documentation/using/master.adoc
@@ -3,7 +3,7 @@ include::shared/attributes.adoc[]
 
 :context: str
 
-= Using {ProductLongName}
+= Using Strimzi
 
 include::assemblies/assembly-overview.adoc[leveloffset=+1]
 


### PR DESCRIPTION
### Type of change

- Refactoring
- Documentation

### Description

Following the accepted proposal #3084, this PR removes some of the attributes which do not seem to have any additional value and just make it harder to write and review the docs. This in particular includes:
* `{ProductLongName}`
* `{ProductName}`
* `{ContextProduct}` (didn't seemed to be used anywhere)
* `{keycloak-server}`
* `{oauth}`

It also changes the version of the OAuth library which seemed to be set incorrectly.

The diff between the master docs and this branch shows only changed dates, which suggest the replacemenets went well:

```diff
diff documentation/html/contributing.html ../strimzi/documentation/html/contributing.html
2703c2703
< <p><em>Revised on 2020-06-01 15:51:47 +0200</em></p>
---
> <p><em>Revised on 2020-06-01 15:30:45 +0200</em></p>
2711c2711
< Last updated 2020-05-04 00:22:19 +0200
---
> Last updated 2019-11-27 23:47:31 +0100
diff documentation/html/deploying.html ../strimzi/documentation/html/deploying.html
6426c6426
< Last updated 2020-06-01 15:32:36 +0200
---
> Last updated 2020-05-11 16:11:52 +0200
Common subdirectories: documentation/html/images and ../strimzi/documentation/html/images
diff documentation/html/overview.html ../strimzi/documentation/html/overview.html
1989c1989
< Last updated 2020-06-01 15:32:36 +0200
---
> Last updated 2019-12-13 21:43:14 +0100
diff documentation/html/quickstart.html ../strimzi/documentation/html/quickstart.html
1032c1032
< Last updated 2020-06-01 15:32:36 +0200
---
> Last updated 2020-01-08 00:43:03 +0100
diff documentation/html/using.html ../strimzi/documentation/html/using.html
22380c22380
<  &lt;version&gt;0.5.0&lt;/version&gt;
---
>  &lt;version&gt;0.2.0&lt;/version&gt;
38632c38632
< Last updated 2020-06-01 15:32:36 +0200
---
> Last updated 2020-05-11 16:11:52 +0200
```