### PR TITLE
Move to use Promise instead of Future were still missing

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -2018,7 +2018,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
                 future -> {
                     String routeName = KafkaCluster.serviceName(name);
-                    //Future future = Future.future();
                     Future<Void> address = routeOperations.hasAddress(namespace, routeName, 1_000, operationTimeoutMs);
 
                     address.onComplete(res -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -179,7 +179,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     public Future<Map<String, Object>> createOrUpdatePutRequest(
             String host, int port,
             String connectorName, JsonObject configJson) {
-        Future<Map<String, Object>> result = Future.future();
+        Promise<Map<String, Object>> result = Promise.promise();
         HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
         Buffer data = configJson.toBuffer();
         String path = "/connectors/" + connectorName + "/config";
@@ -216,7 +216,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                 .putHeader("Content-Length", String.valueOf(data.length()))
                 .write(data)
                 .end();
-        return result;
+        return result.future();
     }
 
     @Override
@@ -230,7 +230,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
 
     @SuppressWarnings("unchecked")
     private <T> Future<T> doGet(String host, int port, String path, Set<Integer> okStatusCodes, TypeReference<T> type) {
-        Future<T> result = Future.future();
+        Promise<T> result = Promise.promise();
         HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
         log.debug("Making GET request to {}", path);
         vertx.createHttpClient(options)
@@ -262,7 +262,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                 .setFollowRedirects(true)
                 .putHeader("Accept", "application/json")
                 .end();
-        return result;
+        return result.future();
     }
 
     @Override
@@ -282,7 +282,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
 
     @Override
     public Future<Void> delete(String host, int port, String connectorName) {
-        Future<Void> result = Future.future();
+        Promise<Void> result = Promise.promise();
         HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
         String path = "/connectors/" + connectorName;
         vertx.createHttpClient(options)
@@ -302,7 +302,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                 .putHeader("Accept", "application/json")
                 .putHeader("Content-Type", "application/json")
                 .end();
-        return result;
+        return result.future();
     }
 
     @Override
@@ -382,7 +382,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     private Future<Void> pauseResume(String host, int port, String path) {
-        Future<Void> result = Future.future();
+        Promise<Void> result = Promise.promise();
         HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
         vertx.createHttpClient(options)
                 .put(port, host, path, response -> {
@@ -400,13 +400,13 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                 .setFollowRedirects(true)
                 .putHeader("Accept", "application/json")
                 .end();
-        return result;
+        return result.future();
     }
 
     @Override
     public Future<List<String>> list(String host, int port) {
         String path = "/connectors";
-        Future<List<String>> result = Future.future();
+        Promise<List<String>> result = Promise.promise();
         HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
 
         vertx.createHttpClient(options)
@@ -435,12 +435,12 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                 .setFollowRedirects(true)
                 .putHeader("Accept", "application/json")
                 .end();
-        return result;
+        return result.future();
     }
 
     @Override
     public Future<List<ConnectorPlugin>> listConnectorPlugins(String host, int port) {
-        Future<List<ConnectorPlugin>> result = Future.future();
+        Promise<List<ConnectorPlugin>> result = Promise.promise();
         HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
         String path = "/connector-plugins";
         vertx.createHttpClient(options)
@@ -467,6 +467,6 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                 .setFollowRedirects(true)
                 .putHeader("Accept", "application/json")
                 .end();
-        return result;
+        return result.future();
     }
 }


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Refactoring

### Description

This PR moves to use `Promise`(s) in some places were `Future`(s) were still used.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

