### PR TITLE
ST: Check NPE in CO logs only if it's not handled

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -24,7 +24,7 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
     @Override
     public boolean matches(Object actualValue) {
         if (!"".equals(actualValue)) {
-            if (actualValue.toString().contains("NullPointer") || actualValue.toString().contains("Unhandled Exception")) {
+            if (actualValue.toString().contains("Unhandled Exception")) {
                 return false;
             }
             // This pattern is used for split each log ine with stack trace if it's there from some reasons
@@ -33,6 +33,9 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
             for (String line : ((String) actualValue).split(logLineSplitPattern)) {
                 if (line.contains("DEBUG") || line.contains("WARN") || line.contains("INFO")) {
                     continue;
+                }
+                if (line.startsWith("java.lang.NullPointerException")) {
+                    return false;
                 }
                 String lineLowerCase = line.toLowerCase(Locale.ENGLISH);
                 if (lineLowerCase.contains("error") || lineLowerCase.contains("exception")) {
@@ -62,7 +65,7 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
 
     enum LogWhiteList {
         CO_TIMEOUT_EXCEPTION("io.strimzi.operator.common.operator.resource.TimeoutException"),
-        // "NO_ERROR" is necessary because DnsNameResolver prints debug information `QUERY(0), NoError(0), RD RA` after `recived` operation
+        // "NO_ERROR" is necessary because DnsNameResolver prints debug information `QUERY(0), NoError(0), RD RA` after `received` operation
         NO_ERROR("NoError\\(0\\)"),
         // This is necessary for OCP 3.10 or less because of having exception handling during the patching of NetworkPolicy
         CAUGHT_EXCEPTION_FOR_NETWORK_POLICY("Caught exception while patching NetworkPolicy"


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix
- Enhancement / new feature

### Description

It current master, we check CO log after each test and if `NPE` is somewhere in the log, the test simply fails. However, this is not much suitable for situations, when `NPE` is raised by some component used by CO like zookeeper admin client. This PR changes the way how our log check is performed. Now it fails tests only when `java.lang.NullPointerException` starts log like, which means the CO didn't handle something properly.

### Checklist

- [x] Make sure all tests pass

