### PR TITLE
Move to Java 11 as runtime

### DIFF
--- a/.azure/pull-request-pipeline.yaml
+++ b/.azure/pull-request-pipeline.yaml
@@ -13,10 +13,10 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'java-8':
+        'java-11':
           image: 'Ubuntu-18.04'
-          jdk_version: '1.8'
-          jdk_path: '/usr/lib/jvm/java-8-openjdk-amd64'
+          jdk_version: '11'
+          jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
     # Base system
     pool:
       vmImage: 'Ubuntu-18.04'
@@ -29,8 +29,8 @@ jobs:
     steps:
       - template: 'templates/setup_java.yaml'
         parameters:
-          JDK_PATH: '/usr/lib/jvm/java-8-openjdk-amd64'
-          JDK_VERSION: '1.8'
+          JDK_PATH: $(jdk_path)
+          JDK_VERSION: $(jdk_version)
 
       - template: "templates/log_variables.yaml"
 

--- a/.azure/scripts/build.sh
+++ b/.azure/scripts/build.sh
@@ -3,9 +3,8 @@ set -e
 
 # The first segment of the version number is '1' for releases < 9; then '9', '10', '11', ...
 JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
-
-if [ ${JAVA_MAJOR_VERSION} -eq 1 ] ; then
-  # sme parts of the workflow should be done only one on the main build which is currently Java 8
+if [ ${JAVA_MAJOR_VERSION} -eq 11 ] ; then
+  # some parts of the workflow should be done only one on the main build which is currently Java 11
   export MAIN_BUILD="TRUE"
 fi
 

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -3,9 +3,8 @@ set -e
 
 # The first segment of the version number is '1' for releases < 9; then '9', '10', '11', ...
 JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
-
-if [ ${JAVA_MAJOR_VERSION} -eq 1 ] ; then
-  # sme parts of the workflow should be done only one on the main build which is currently Java 8
+if [ ${JAVA_MAJOR_VERSION} -eq 11 ] ; then
+  # some parts of the workflow should be done only one on the main build which is currently Java 11
   export MAIN_BUILD="TRUE"
 fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 ## 0.19.0
 
-* Remove deprecated `Kafka.spec.topicOperator` classes and deployment logic 
+* Remove deprecated `Kafka.spec.topicOperator` classes and deployment logic
+* Use Java 11 as the Java runtime
 
 ## 0.18.0
 

--- a/DEV_QUICK_START_MACOS.md
+++ b/DEV_QUICK_START_MACOS.md
@@ -10,8 +10,8 @@ https://brew.sh/
 #### Install git
 `brew install git`
 
-#### Install java 8
-`brew cask install adoptopenjdk/openjdk/adoptopenjdk8`
+#### Install java 11
+`brew cask install adoptopenjdk/openjdk/adoptopenjdk11`
 
 #### Install maven
 `brew install maven`

--- a/HACKING.md
+++ b/HACKING.md
@@ -94,7 +94,7 @@ When building the Docker images you can use an alternative JRE or use an alterna
 
 #### Alternative Docker image JRE
 
-The docker images can be built with an alternative java version by setting the environment variable `JAVA_VERSION`.  For example, to build docker images that have the java 11 JRE installed use `JAVA_VERSION=11 make docker_build`.  If not present, JAVA_VERSION is defaulted to **1.8.0**.
+The docker images can be built with an alternative java version by setting the environment variable `JAVA_VERSION`.  For example, to build docker images that have the java 8 JRE installed use `JAVA_VERSION=1.8.0 make docker_build`.  If not present, JAVA_VERSION is defaulted to Java **11**.
 
 If `JAVA_VERSION` environment variable is set, a profile in the parent pom.xml will set the `maven.compiler.source` and `maven.compiler.target` properties.
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -19,7 +19,7 @@ This document gives a detailed breakdown of the various build processes and opti
 
 To build this project you must first install several command line utilities and a Kubernetes or OpenShift cluster
 
-#### Command line tools
+### Command line tools
 
 - [`make`](https://www.gnu.org/software/make/) - Make build system
 - [`mvn`](https://maven.apache.org/index.html) (version 3.5 and above) - Maven CLI
@@ -33,17 +33,17 @@ To build this project you must first install several command line utilities and 
 
 In order to use `make` these all need to be available in your `$PATH`.
 
-##### Mac OS
+#### Mac OS
 
 The `make` build is using GNU versions of `find` and `sed` utilities and is not compatible with the BSD versions available on Mac OS. When using Mac OS, you have to install the GNU versions of `find` and `sed`. When using `brew`, you can do `brew install gnu-sed findutils grep coreutils`. This command will install the GNU versions as `gcp`, `ggrep`, `gsed` and `gfind` and our `make` build will automatically pick them up and use them.
 
 The build requires `bash` version 4+ which is not shipped Mac OS but can be installed via homebrew. You can run `brew install bash` to install a compatible version of `bash`. If you wish to change the default shell to the updated bash run `sudo bash -c 'echo /usr/local/bin/bash >> /etc/shells'` and `chsh -s /usr/local/bin/bash`
 
-#### Kubernetes or OpenShift Cluster
+### Kubernetes or OpenShift Cluster
 
 In order to run the integration tests and test any changes made to the operators you will need a functioning Kubernetes or OpenShift cluster. This can be a remote cluster or a local development cluster.
 
-##### Minishift 
+#### Minishift 
 
 In order to perform the operations necessary for the integration tests, your user must have the cluster administrator role assigned. For example, if your username is `developer`, you can add the `cluster-admin` role using the commands below:
 
@@ -53,7 +53,7 @@ In order to perform the operations necessary for the integration tests, your use
     
     oc login -u developer -p <password>
 
-##### Minikube
+#### Minikube
 
 The default minishift setup should allow the integration tests to be run without additional configuration changes. 
 
@@ -73,13 +73,18 @@ Commonly used Make targets:
 
 >*Note*: If you are having trouble running any of the Make commands it may help to run `mvn clean` and then `mvn install -DskipTests -DskipITs` before running the commands again.
 
-#### Building Docker images
+### Java versions
+
+To use different Java version for the Maven build, you can specify the environment variable `JAVA_VERSION_BUILD` and set it to the desired Java version.
+For example, for building with Java 8, you can use `export JAVA_VERSION_BUILD=1.8.0` or for Java 11 you can use `export JAVA_VERSION_BUILD=11`. 
+
+### Building Docker images
 
 The `docker_build` target will build the Docker images provided by the Strimzi project. You can build all Strimzi Docker images by calling `make docker_build` from the root of the Strimzi repository. Or you can build an individual Docker image by running `make docker_build` from the subdirectories with their respective Dockerfiles - e.g. `kafka_base`, `kafka` etc.
 
 The `docker_build` target will **always** build the images under the `strimzi` organization. This is necessary in order to be able to reuse the base image you might have just built without modifying all Dockerfiles. The `DOCKER_TAG` environment variable configures the Docker tag to use (default is `latest`).
 
-#### Tagging and pushing Docker images
+### Tagging and pushing Docker images
 
 Target `docker_tag` tags the Docker images built by the `docker_build` target. This target is automatically called as part of the `docker_push` target, but can be called separately if you wish to avoid pushing images to an external registry.
 
@@ -92,17 +97,16 @@ To configure the `docker_tag` and `docker_push` targets you can set following en
 
 When building the Docker images you can use an alternative JRE or use an alternate base image.
 
-#### Alternative Docker image JRE
+### Alternative Docker image JRE
 
-The docker images can be built with an alternative java version by setting the environment variable `JAVA_VERSION`.  For example, to build docker images that have the java 8 JRE installed use `JAVA_VERSION=1.8.0 make docker_build`.  If not present, JAVA_VERSION is defaulted to Java **11**.
+The docker images can be built with an alternative Java version by setting the environment variable `JAVA_VERSION`. 
+For example, to build docker images that have the Java 8 JRE installed use `JAVA_VERSION=1.8.0 make docker_build`.  If not present, the container images will use Java **11** by default.
 
-If `JAVA_VERSION` environment variable is set, a profile in the parent pom.xml will set the `maven.compiler.source` and `maven.compiler.target` properties.
-
-#### Alternative `docker` command
+### Alternative `docker` command
 
 The build assumes the `docker` command is available on your `$PATH`. You can set the `DOCKER_CMD` environment variable to use a different `docker` binary or an alternative implementation such as [`podman`](https://podman.io/).
 
-#### Alternative Docker base image
+### Alternative Docker base image
 
 The docker images can be built with an alternative container OS version by adding the environment variable `ALTERNATE_BASE`.  When this environment variable is set, for each component the build will look for a Dockerfile in the subdirectory named by `ALTERNATE_BASE`.  For example, to build docker images based on alpine, use `ALTERNATE_BASE=alpine make docker_build`.  Alternative docker images are an experimental feature not supported by the core Strimzi team.
 
@@ -122,15 +126,15 @@ Other build options:
  - [Local build with push to Minishift Docker registry](#local-build-with-push-to-minishift-docker-registry)
  - [Local build on Minishift or Minikube](#local-build-on-minishift-or-minikube)
 
-#### Kafka versions
+### Kafka versions
 
 As part of the Docker image build several different versions of Kafka will be built, which can increase build times. Which Kafka versions are to be built are defined in the [kafka-versions.yaml](https://github.com/strimzi/strimzi-kafka-operator/blob/master/kafka-versions.yaml) file. Unwanted versions can be commented out to speed up the build process. 
 
-#### Maven Settings
+### Maven Settings
 
 Running `make` invokes Maven for packaging Java based applications (that is, Cluster Operator, Topic Operator, etc). The `mvn` command can be customized by setting the `MVN_ARGS` environment variable when launching `make all`. For example, `MVN_ARGS=-DskipTests make all` can be used to avoid running the unit tests and adding `-DskipIT` will skip the integration tests.
 
-#### Local build with push to Docker Hub
+### Local build with push to Docker Hub
 
 To build the images on your local machine and push them to the Docker Hub, log into Docker Hub with your account details. This sets the Hub as the `docker push` registry target.
 
@@ -160,7 +164,7 @@ Finally, you can deploy the cluster custom resource running:
 
     oc create -f examples/kafka/kafka-ephemeral.yaml
 
-#### Local build with push to Minishift Docker registry
+### Local build with push to Minishift Docker registry
 
 When developing locally you might want to push the docker images to the docker repository running in your local OpenShift (minishift) cluster. This can be quicker than pushing to Docker Hub and works even without a network connection.
 
@@ -207,7 +211,7 @@ Assuming your OpenShift login is `developer` (a user with the `cluster-admin` ro
 
     oc create -f examples/kafka/kafka-ephemeral.yaml
 
-#### Local build on Minishift or Minikube
+### Local build on Minishift or Minikube
 
 If you do not want to have the docker daemon running on your local development machine, you can build the container images in your minishift or minikube VM by setting your docker host to the address of the VM's daemon:
 
@@ -219,7 +223,7 @@ or
 
 The images will then be built and stored in the cluster VM's local image store and then pushed to your configured Docker registry. 
 
-##### Skipping the registry push
+#### Skipping the registry push
 
 You can avoid the `docker_push` step and `sed` commands above by configuring the Docker Host as above and then running:
 

--- a/Jenkinsfile-pr
+++ b/Jenkinsfile-pr
@@ -40,6 +40,7 @@ pipeline {
         TEST_CLUSTER_ADMIN = "admin"
         OPERATOR_IMAGE_PULL_POLICY = "IfNotPresent"
         COMPONENTS_IMAGE_PULL_POLICY = "IfNotPresent"
+        JAVA_VERSION = "11"
     }
     stages {
         stage('Clean WS') {

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -129,6 +129,7 @@
                         <configuration>
                             <executable>java</executable>
                             <arguments>
+                                <argument>--illegal-access=deny</argument>
                                 <argument>-classpath</argument>
                                 <argument>${pom.basedir}${file.separator}target${file.separator}classes${path.separator}${pom.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
                                 <argument>io.strimzi.crdgenerator.CrdGenerator</argument>
@@ -157,6 +158,7 @@
                         <configuration>
                             <executable>java</executable>
                             <arguments>
+                                <argument>--illegal-access=deny</argument>
                                 <argument>-classpath</argument>
                                 <argument>${pom.basedir}${file.separator}target${file.separator}classes${path.separator}${pom.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
                                 <argument>io.strimzi.crdgenerator.DocGenerator</argument>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -129,7 +129,6 @@
                         <configuration>
                             <executable>java</executable>
                             <arguments>
-                                <argument>--illegal-access=deny</argument>
                                 <argument>-classpath</argument>
                                 <argument>${pom.basedir}${file.separator}target${file.separator}classes${path.separator}${pom.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
                                 <argument>io.strimzi.crdgenerator.CrdGenerator</argument>
@@ -158,7 +157,6 @@
                         <configuration>
                             <executable>java</executable>
                             <arguments>
-                                <argument>--illegal-access=deny</argument>
                                 <argument>-classpath</argument>
                                 <argument>${pom.basedir}${file.separator}target${file.separator}classes${path.separator}${pom.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
                                 <argument>io.strimzi.crdgenerator.DocGenerator</argument>

--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:7
-ARG JAVA_VERSION=1.8.0
+ARG JAVA_VERSION=11
 
 RUN yum -y update \
     && yum -y install java-${JAVA_VERSION}-openjdk-headless openssl \

--- a/docker-images/build.sh
+++ b/docker-images/build.sh
@@ -145,7 +145,7 @@ function build {
     
     local targets=$*
     local tag="${DOCKER_TAG:-latest}"
-    local java_version="${JAVA_VERSION:-1.8.0}"
+    local java_version="${JAVA_VERSION:-11}"
 
     # Base images
     for image in $base_images

--- a/docker-images/operator/scripts/launch_java.sh
+++ b/docker-images/operator/scripts/launch_java.sh
@@ -26,5 +26,11 @@ JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp -Djava.security.egd=file:/dev/
 # Enable GC logging for memory tracking
 JAVA_OPTS="${JAVA_OPTS} $(get_gc_opts)"
 
+# Deny illegal access option is supported only on Java 9 and higher
+JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
+if [ "$JAVA_MAJOR_VERSION" -ge "9" ] ; then
+  JAVA_OPTS="${JAVA_OPTS} --illegal-access=deny"
+fi
+
 # shellcheck disable=SC2086
 exec /usr/bin/tini -w -e 143 -- java $JAVA_OPTS -classpath "$JAVA_CLASSPATH" "$JAVA_MAIN" "$@"

--- a/docker-images/test-client/scripts/launch_java.sh
+++ b/docker-images/test-client/scripts/launch_java.sh
@@ -34,4 +34,10 @@ JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp -Djava.security.egd=file:/dev/
 # Enable GC logging for memory tracking
 JAVA_OPTS="${JAVA_OPTS} $(get_gc_opts)"
 
+# Deny illegal access option is supported only on Java 9 and higher
+JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
+if [ "$JAVA_MAJOR_VERSION" -ge "9" ] ; then
+  JAVA_OPTS="${JAVA_OPTS} --illegal-access=deny"
+fiq
+
 exec java $JAVA_OPTS -jar $JAR $@

--- a/pom.xml
+++ b/pom.xml
@@ -856,7 +856,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>3.1.12</version><dependencies>
+                <version>4.0.0</version><dependencies>
                 <!-- overwrite dependency on spotbugs if you want to specify the version of˓→spotbugs -->
                 <dependency>
                     <groupId>com.github.spotbugs</groupId>
@@ -1070,6 +1070,8 @@
             </activation>
             <properties>
                 <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR implements the issue #2948 (originating from the _[Move to Java 11 proposal](https://github.com/strimzi/strimzi-kafka-operator/blob/master/design/java-11.md)_) and moves our Docker images to Java 11 as the main runtime. In addition it also:

* Makes the Java 11 build the main build
* Updates the Jenkins and Azure system test builds to use Java 11
* Uses the `-illegal-access=deny` option in the container images running our own software (it does not use it for third party software such as Kafka or Cruise Control)
* Updates the Developer Quick Start and Hacking documents
* Updates the Spotbugs Maven plugin (which was complaining about illegal access in the old version)
* Makes sure that we use the Java 11 on Java 11 environments also locally without the `JAVA_VERSION` being set.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

