### PR TITLE
Add more SANs to better handle Zookeeper hostname verification

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -126,6 +126,10 @@ public class ClusterCa extends Ca {
             sbjAltNames.put("DNS.4", ModelUtils.serviceDnsName(namespace, ZookeeperCluster.serviceName(cluster)));
             sbjAltNames.put("DNS.5", ZookeeperCluster.podDnsName(namespace, cluster, i));
             sbjAltNames.put("DNS.6", ZookeeperCluster.podDnsNameWithoutSuffix(namespace, cluster, i));
+            sbjAltNames.put("DNS.7", ModelUtils.wildcardServiceDnsNameWithoutClusterDomain(namespace, ZookeeperCluster.serviceName(cluster)));
+            sbjAltNames.put("DNS.8", ModelUtils.wildcardServiceDnsName(namespace, ZookeeperCluster.serviceName(cluster)));
+            sbjAltNames.put("DNS.9", ModelUtils.wildcardServiceDnsNameWithoutClusterDomain(namespace, ZookeeperCluster.headlessServiceName(cluster)));
+            sbjAltNames.put("DNS.10", ModelUtils.wildcardServiceDnsName(namespace, ZookeeperCluster.headlessServiceName(cluster)));
 
             Subject subject = new Subject();
             subject.setOrganizationName("io.strimzi");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -120,6 +120,39 @@ public class ModelUtils {
     }
 
     /**
+     * Generates the wildcard DNS name of the service without the cluster domain suffix
+     * (i.e. usually without the cluster.local - but can be different on different clusters)
+     * Example: *.my-service.my-ns.svc
+     *
+     * @param namespace     Namespace of the pod
+     * @param serviceName   Name of the service
+     *
+     * @return              Wildcard DNS name of the service without the cluster domain suffix
+     */
+    public static String wildcardServiceDnsNameWithoutClusterDomain(String namespace, String serviceName) {
+        return String.format("*.%s.%s.svc",
+                serviceName,
+                namespace);
+    }
+
+    /**
+     * Generates the wildcard DNS name of the service including the cluster suffix
+     * (i.e. usually with the cluster.local - but can be different on different clusters)
+     * Example: *.my-service.my-ns.svc.cluster.local
+     *
+     * @param namespace     Namespace of the pod
+     * @param serviceName   Name of the cluster
+     *
+     * @return              Wildcard DNS name of the service
+     */
+    public static String wildcardServiceDnsName(String namespace, String serviceName) {
+        return String.format("*.%s.%s.svc.%s",
+                serviceName,
+                namespace,
+                ModelUtils.KUBERNETES_SERVICE_DNS_DOMAIN);
+    }
+
+    /**
      * Generates the DNS name of the service without the cluster domain suffix
      * (i.e. usually without the cluster.local - but can be different on different clusters)
      * Example: my-service.my-ns.svc

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -327,4 +327,16 @@ public class ModelUtilsTest {
         assertThat(ModelUtils.serviceDnsNameWithoutClusterDomain("my-ns", "my-service"),
                 is("my-service.my-ns.svc"));
     }
+
+    @Test
+    public void testWildcardServiceDnsName()  {
+        assertThat(ModelUtils.wildcardServiceDnsName("my-ns", "my-service"),
+                is("*.my-service.my-ns.svc.cluster.local"));
+    }
+
+    @Test
+    public void testWildcardServiceDnsNameWithoutClusterDomain()  {
+        assertThat(ModelUtils.wildcardServiceDnsNameWithoutClusterDomain("my-ns", "my-service"),
+                is("*.my-service.my-ns.svc"));
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -343,7 +343,11 @@ public class ZookeeperClusterTest {
                 asList(2, "foo-zookeeper-client"),
                 asList(2, "foo-zookeeper-client.test"),
                 asList(2, "foo-zookeeper-client.test.svc"),
-                asList(2, "foo-zookeeper-client.test.svc.cluster.local"))));
+                asList(2, "foo-zookeeper-client.test.svc.cluster.local"),
+                asList(2, "*.foo-zookeeper-client.test.svc"),
+                asList(2, "*.foo-zookeeper-client.test.svc.cluster.local"),
+                asList(2, "*.foo-zookeeper-nodes.test.svc"),
+                asList(2, "*.foo-zookeeper-nodes.test.svc.cluster.local"))));
 
     }
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Zookeeper TLS hostname verification is using reverse DNS lookup and that seems to return different addresses on different cluster. An example of that is the issue #3099 ... this PR adds some additional SANs to make this work on different configs - in particular the wildcard certificates for the Zookeeper services since the returned DNS name seems to be often i the format `<ip-address>.service...`.

The SANs for Kafka brokers are unchanged.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging