### PR TITLE
[DOC] Fix to Cruise Control annotation (and some typos)

### DIFF
--- a/documentation/modules/con-kafka-mirror-maker-configuration.adoc
+++ b/documentation/modules/con-kafka-mirror-maker-configuration.adoc
@@ -39,7 +39,7 @@ Specifically, all configuration options with keys equal to or starting with one 
 * `bootstrap.servers`
 * `group.id`
 
-When a forbidden option is present in the `config` property, it is ignored and a warning message is printed to the Custer Operator log file.
+When a forbidden option is present in the `config` property, it is ignored and a warning message is printed to the Cluster Operator log file.
 All other options are passed to Kafka MirrorMaker.
 
 IMPORTANT: The Cluster Operator does not validate keys or values in the provided `config` object.

--- a/documentation/modules/cruise-control/proc-approving-optimization-proposal.adoc
+++ b/documentation/modules/cruise-control/proc-approving-optimization-proposal.adoc
@@ -30,7 +30,7 @@ Perform these steps for the optimization proposal that you want to approve:
 . Unless the optimization proposal is newly generated, check that it is based on current information about the state of the Kafka cluster.
 To do so, refresh the optimization proposal to make sure it uses the latest cluster metrics:
 
-.. Annotate the `KafkaRebalance` resource in Kubernetes with `approve`:
+.. Annotate the `KafkaRebalance` resource in Kubernetes with `refresh`:
 +
 [source,shell,subs="+quotes"]
 ----

--- a/documentation/modules/ref-kafka-authorization.adoc
+++ b/documentation/modules/ref-kafka-authorization.adoc
@@ -36,7 +36,7 @@ You can optionally designate a list of super users in the `superUsers` field.
 == Super users
 
 Super users can access all resources in your Kafka cluster regardless of any access restrictions defined in ACLs.
-To designate super users for a Kafka cluster, enter a list of user principles in the `superUsers` field.
+To designate super users for a Kafka cluster, enter a list of user principals in the `superUsers` field.
 If a user uses TLS Client Authentication, the username will be the common name from their certificate subject prefixed with `CN=`.
 
 .An example of designating super users

--- a/documentation/modules/ref-kafka-bridge-consumer-configuration.adoc
+++ b/documentation/modules/ref-kafka-bridge-consumer-configuration.adoc
@@ -22,7 +22,7 @@ Specifically, all configuration options with keys equal to or starting with one 
 * `bootstrap.servers`
 * `group.id`
 
-When one of the forbidden options is present in the `config` property, it will be ignored and a warning message will be printed to the Custer Operator log file.
+When one of the forbidden options is present in the `config` property, it will be ignored and a warning message will be printed to the Cluster Operator log file.
 All other options will be passed to Kafka
 
 IMPORTANT: The Cluster Operator does not validate keys or values in the `config` object provided.

--- a/documentation/modules/ref-kafka-connect-configuration.adoc
+++ b/documentation/modules/ref-kafka-connect-configuration.adoc
@@ -24,7 +24,7 @@ Specifically, configuration options with keys equal to or starting with one of t
 * `rest.`
 * `bootstrap.servers`
 
-When a forbidden option is present in the `config` property, it is ignored and a warning message is printed to the Custer Operator log file.
+When a forbidden option is present in the `config` property, it is ignored and a warning message is printed to the Cluster Operator log file.
 All other options are passed to Kafka Connect.
 
 IMPORTANT: The Cluster Operator does not validate keys or values in the `config` object provided.

--- a/documentation/modules/ref-zookeeper-node-configuration.adoc
+++ b/documentation/modules/ref-zookeeper-node-configuration.adoc
@@ -24,7 +24,7 @@ Specifically, all configuration options with keys equal to or starting with one 
 * `quorum.auth`
 * `requireClientAuthScheme`
 
-When one of the forbidden options is present in the `config` property, it is ignored and a warning message is printed to the Custer Operator log file.
+When one of the forbidden options is present in the `config` property, it is ignored and a warning message is printed to the Cluster Operator log file.
 All other options are passed to ZooKeeper.
 
 IMPORTANT: The Cluster Operator does not validate keys or values in the provided `config` object.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Replaced the `approve` annotation with the `refresh` annotation in [Approving an optimization proposal](https://strimzi.io/docs/operators/master/using.html#proc-approving-optimization-proposal-str).

Also fixed typos and the spelling of "user principals".

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

