### PR TITLE
[systemtest][small-refactor] Create new log package, new suite, update the test

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
@@ -2,15 +2,10 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.systemtest;
+package io.strimzi.systemtest.log;
 
-import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.EnvVarBuilder;
-import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
-import io.strimzi.api.kafka.model.ExternalLoggingBuilder;
 import io.strimzi.api.kafka.model.JvmOptions;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBridgeResources;
@@ -18,6 +13,7 @@ import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.systemtest.BaseST;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaBridgeResource;
@@ -28,7 +24,6 @@ import io.strimzi.systemtest.resources.crd.KafkaMirrorMakerResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
-import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.test.timemeasuring.Operation;
@@ -307,163 +302,6 @@ class LogSettingST extends BaseST {
         assertThat(strimziCRs, containsString(CONNECT_NAME));
         assertThat(strimziCRs, containsString(userName));
         assertThat(strimziCRs, containsString(topicName));
-    }
-
-    @Test
-    @Order(13)
-    @SuppressWarnings({"checkstyle:MethodLength"})
-    void testJSONFormatLogging() {
-
-        KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(GC_LOGGING_SET_NAME).delete();
-
-        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
-        Map<String, String> zkPods = StatefulSetUtils.ssSnapshot(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME));
-        Map<String, String> eoPods = DeploymentUtils.depSnapshot(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME));
-
-        String loggersConfigKafka = "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
-                "log4j.appender.CONSOLE.layout=net.logstash.log4j.JSONEventLayoutV1\n" +
-                "kafka.root.logger.level=INFO\n" +
-                "log4j.rootLogger=${kafka.root.logger.level}, CONSOLE\n" +
-                "log4j.logger.org.I0Itec.zkclient.ZkClient=INFO\n" +
-                "log4j.logger.org.apache.zookeeper=INFO\n" +
-                "log4j.logger.kafka=INFO\n" +
-                "log4j.logger.org.apache.kafka=INFO\n" +
-                "log4j.logger.kafka.request.logger=WARN, CONSOLE\n" +
-                "log4j.logger.kafka.network.Processor=OFF\n" +
-                "log4j.logger.kafka.server.KafkaApis=OFF\n" +
-                "log4j.logger.kafka.network.RequestChannel$=WARN\n" +
-                "log4j.logger.kafka.controller=TRACE\n" +
-                "log4j.logger.kafka.log.LogCleaner=INFO\n" +
-                "log4j.logger.state.change.logger=TRACE\n" +
-                "log4j.logger.kafka.authorizer.logger=INFO";
-
-        String loggersConfigOperators = "appender.console.type=Console\n" +
-                "appender.console.name=STDOUT\n" +
-                "appender.console.layout.type=JsonLayout\n" +
-                "rootLogger.level=INFO\n" +
-                "rootLogger.appenderRefs=stdout\n" +
-                "rootLogger.appenderRef.console.ref=STDOUT\n" +
-                "rootLogger.additivity=false";
-
-        String loggersConfigZookeeper = "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
-                "log4j.appender.CONSOLE.layout=net.logstash.log4j.JSONEventLayoutV1\n" +
-                "zookeeper.root.logger=INFO\n" +
-                "log4j.rootLogger=${zookeeper.root.logger}, CONSOLE";
-
-        String loggersConfigCO = "name = COConfig\n" +
-                "appender.console.type = Console\n" +
-                "appender.console.name = STDOUT\n" +
-                "appender.console.layout.type = JsonLayout\n" +
-                "rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}\n" +
-                "rootLogger.appenderRefs = stdout\n" +
-                "rootLogger.appenderRef.console.ref = STDOUT\n" +
-                "rootLogger.additivity = false\n" +
-                "logger.kafka.name = org.apache.kafka\n" +
-                "logger.kafka.level = ${env:STRIMZI_AC_LOG_LEVEL:-WARN}\n" +
-                "logger.kafka.additivity = false";
-
-        String configMapOpName = "json-layout-operators";
-        String configMapZookeeperName = "json-layout-zookeeper";
-        String configMapKafkaName = "json-layout-kafka";
-        String configMapCOName = "json-layout-cluster-operator";
-
-        ConfigMap configMapKafka = new ConfigMapBuilder()
-                .withNewMetadata()
-                    .withNewName(configMapKafkaName)
-                    .withNamespace(NAMESPACE)
-                .endMetadata()
-                .addToData("log4j.properties", loggersConfigKafka)
-                .build();
-
-        ConfigMap configMapOperators = new ConfigMapBuilder()
-                .withNewMetadata()
-                    .withNewName(configMapOpName)
-                    .withNamespace(NAMESPACE)
-                .endMetadata()
-                .addToData("log4j2.properties", loggersConfigOperators)
-                .build();
-
-        ConfigMap configMapZookeeper = new ConfigMapBuilder()
-                .withNewMetadata()
-                    .withNewName(configMapZookeeperName)
-                    .withNamespace(NAMESPACE)
-                .endMetadata()
-                .addToData("log4j.properties", loggersConfigZookeeper)
-                .build();
-
-        ConfigMap configMapCO = new ConfigMapBuilder()
-                .withNewMetadata()
-                    .withNewName(configMapCOName)
-                    .withNamespace(NAMESPACE)
-                .endMetadata()
-                .addToData("log4j2.properties", loggersConfigCO)
-                .build();
-
-        kubeClient().deleteDeployment(Constants.STRIMZI_DEPLOYMENT_NAME);
-        ResourceManager.setClassResources();
-        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT).done();
-        ResourceManager.setMethodResources();
-
-        kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMapKafka);
-        kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMapOperators);
-        kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMapZookeeper);
-        kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMapOperators);
-        kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMapCO);
-
-        KubernetesResource.clusterOperator(NAMESPACE)
-                .editOrNewSpec()
-                    .editOrNewTemplate()
-                        .editOrNewSpec()
-                            .addNewVolume()
-                                .withName("logging-config-volume")
-                                .editOrNewConfigMap()
-                                    .withName(configMapCOName)
-                                .endConfigMap()
-                            .endVolume()
-                            .editFirstContainer()
-                                .withVolumeMounts(new VolumeMountBuilder().withName("logging-config-volume").withMountPath("/tmp/log-config-map-file").build())
-                                .addToEnv(new EnvVarBuilder().withName("JAVA_OPTS").withValue("-Dlog4j2.configurationFile=file:/tmp/log-config-map-file/log4j2.properties").build())
-                            .endContainer()
-                        .endSpec()
-                    .endTemplate()
-                .endSpec()
-                .done();
-
-        KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka -> {
-
-            kafka.getSpec().getKafka().getJvmOptions().setGcLoggingEnabled(false);
-            kafka.getSpec().getZookeeper().getJvmOptions().setGcLoggingEnabled(false);
-            kafka.getSpec().getEntityOperator().getUserOperator().getJvmOptions().setGcLoggingEnabled(false);
-            kafka.getSpec().getEntityOperator().getTopicOperator().getJvmOptions().setGcLoggingEnabled(false);
-
-            kafka.getSpec().getKafka()
-                    .setLogging(new ExternalLoggingBuilder()
-                        .withName(configMapKafkaName).build());
-
-            kafka.getSpec().getZookeeper().setLogging(new ExternalLoggingBuilder()
-                    .withName(configMapZookeeperName)
-                    .build());
-
-            kafka.getSpec().getEntityOperator().getTopicOperator().setLogging(new ExternalLoggingBuilder()
-                    .withName(configMapOpName)
-                    .build());
-
-            kafka.getSpec().getEntityOperator().getUserOperator().setLogging(new ExternalLoggingBuilder()
-                    .withName(configMapOpName)
-                    .build());
-
-        });
-
-        zkPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME), 1, zkPods);
-        kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaPods);
-        eoPods = DeploymentUtils.waitTillDepHasRolled(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), 1, eoPods);
-        Map<String, String> operatorSnapshot = DeploymentUtils.depSnapshot("strimzi-cluster-operator");
-
-        assertThat(StUtils.checkLogForJSONFormat(operatorSnapshot, "strimzi-cluster-operator"), is(true));
-        assertThat(StUtils.checkLogForJSONFormat(kafkaPods, "kafka"), is(true));
-        assertThat(StUtils.checkLogForJSONFormat(zkPods, "zookeeper"), is(true));
-        assertThat(StUtils.checkLogForJSONFormat(eoPods, "topic-operator"), is(true));
-        assertThat(StUtils.checkLogForJSONFormat(eoPods, "user-operator"), is(true));
     }
 
     private boolean checkLoggersLevel(Map<String, String> loggers, String configMapName) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.log;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.strimzi.api.kafka.model.ExternalLoggingBuilder;
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.systemtest.BaseST;
+import io.strimzi.systemtest.resources.KubernetesResource;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.utils.StUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Tag(REGRESSION)
+class LoggingChangeST extends BaseST {
+    static final String NAMESPACE = "logging-change-cluster-test";
+    private static final Logger LOGGER = LogManager.getLogger(LoggingChangeST.class);
+
+    @Test
+    @SuppressWarnings({"checkstyle:MethodLength"})
+    void testJSONFormatLogging() {
+        String loggersConfigKafka = "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
+            "log4j.appender.CONSOLE.layout=net.logstash.log4j.JSONEventLayoutV1\n" +
+            "kafka.root.logger.level=INFO\n" +
+            "log4j.rootLogger=${kafka.root.logger.level}, CONSOLE\n" +
+            "log4j.logger.org.I0Itec.zkclient.ZkClient=INFO\n" +
+            "log4j.logger.org.apache.zookeeper=INFO\n" +
+            "log4j.logger.kafka=INFO\n" +
+            "log4j.logger.org.apache.kafka=INFO\n" +
+            "log4j.logger.kafka.request.logger=WARN, CONSOLE\n" +
+            "log4j.logger.kafka.network.Processor=OFF\n" +
+            "log4j.logger.kafka.server.KafkaApis=OFF\n" +
+            "log4j.logger.kafka.network.RequestChannel$=WARN\n" +
+            "log4j.logger.kafka.controller=TRACE\n" +
+            "log4j.logger.kafka.log.LogCleaner=INFO\n" +
+            "log4j.logger.state.change.logger=TRACE\n" +
+            "log4j.logger.kafka.authorizer.logger=INFO";
+
+        String loggersConfigOperators = "appender.console.type=Console\n" +
+            "appender.console.name=STDOUT\n" +
+            "appender.console.layout.type=JsonLayout\n" +
+            "rootLogger.level=INFO\n" +
+            "rootLogger.appenderRefs=stdout\n" +
+            "rootLogger.appenderRef.console.ref=STDOUT\n" +
+            "rootLogger.additivity=false";
+
+        String loggersConfigZookeeper = "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
+            "log4j.appender.CONSOLE.layout=net.logstash.log4j.JSONEventLayoutV1\n" +
+            "zookeeper.root.logger=INFO\n" +
+            "log4j.rootLogger=${zookeeper.root.logger}, CONSOLE";
+
+        String loggersConfigCO = "name = COConfig\n" +
+            "appender.console.type = Console\n" +
+            "appender.console.name = STDOUT\n" +
+            "appender.console.layout.type = JsonLayout\n" +
+            "rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}\n" +
+            "rootLogger.appenderRefs = stdout\n" +
+            "rootLogger.appenderRef.console.ref = STDOUT\n" +
+            "rootLogger.additivity = false\n" +
+            "logger.kafka.name = org.apache.kafka\n" +
+            "logger.kafka.level = ${env:STRIMZI_AC_LOG_LEVEL:-WARN}\n" +
+            "logger.kafka.additivity = false";
+
+        String configMapOpName = "json-layout-operators";
+        String configMapZookeeperName = "json-layout-zookeeper";
+        String configMapKafkaName = "json-layout-kafka";
+        String configMapCOName = "json-layout-cluster-operator";
+
+        ConfigMap configMapKafka = new ConfigMapBuilder()
+            .withNewMetadata()
+                .withNewName(configMapKafkaName)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .addToData("log4j.properties", loggersConfigKafka)
+            .build();
+
+        ConfigMap configMapOperators = new ConfigMapBuilder()
+            .withNewMetadata()
+                .withNewName(configMapOpName)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .addToData("log4j2.properties", loggersConfigOperators)
+            .build();
+
+        ConfigMap configMapZookeeper = new ConfigMapBuilder()
+            .withNewMetadata()
+                .withNewName(configMapZookeeperName)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .addToData("log4j.properties", loggersConfigZookeeper)
+            .build();
+
+        ConfigMap configMapCO = new ConfigMapBuilder()
+            .withNewMetadata()
+                .withNewName(configMapCOName)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .addToData("log4j2.properties", loggersConfigCO)
+            .build();
+
+        kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMapKafka);
+        kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMapOperators);
+        kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMapZookeeper);
+        kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMapOperators);
+        kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMapCO);
+
+        KubernetesResource.clusterOperator(NAMESPACE)
+            .editOrNewSpec()
+                .editOrNewTemplate()
+                    .editOrNewSpec()
+                        .addNewVolume()
+                            .withName("logging-config-volume")
+                            .editOrNewConfigMap()
+                                .withName(configMapCOName)
+                            .endConfigMap()
+                        .endVolume()
+                        .editFirstContainer()
+                            .withVolumeMounts(new VolumeMountBuilder().withName("logging-config-volume").withMountPath("/tmp/log-config-map-file").build())
+                            .addToEnv(new EnvVarBuilder().withName("JAVA_OPTS").withValue("-Dlog4j2.configurationFile=file:/tmp/log-config-map-file/log4j2.properties").build())
+                        .endContainer()
+                    .endSpec()
+                .endTemplate()
+            .endSpec()
+            .done();
+
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3)
+            .editOrNewSpec()
+                .editKafka()
+                    .withLogging(new ExternalLoggingBuilder().withName(configMapKafkaName).build())
+                .endKafka()
+                .editZookeeper()
+                    .withLogging(new ExternalLoggingBuilder().withName(configMapZookeeperName).build())
+                .endZookeeper()
+                .editEntityOperator()
+                    .editTopicOperator()
+                        .withLogging(new ExternalLoggingBuilder().withName(configMapOpName).build())
+                    .endTopicOperator()
+                    .editUserOperator()
+                        .withLogging(new ExternalLoggingBuilder().withName(configMapOpName).build())
+                    .endUserOperator()
+                .endEntityOperator()
+            .endSpec()
+            .done();
+
+        Map<String, String> zkPods = StatefulSetUtils.ssSnapshot(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME));
+        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
+        Map<String, String> eoPods = DeploymentUtils.depSnapshot(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME));
+        Map<String, String> operatorSnapshot = DeploymentUtils.depSnapshot("strimzi-cluster-operator");
+
+        assertThat(StUtils.checkLogForJSONFormat(operatorSnapshot, "strimzi-cluster-operator"), is(true));
+        assertThat(StUtils.checkLogForJSONFormat(kafkaPods, "kafka"), is(true));
+        assertThat(StUtils.checkLogForJSONFormat(zkPods, "zookeeper"), is(true));
+        assertThat(StUtils.checkLogForJSONFormat(eoPods, "topic-operator"), is(true));
+        assertThat(StUtils.checkLogForJSONFormat(eoPods, "user-operator"), is(true));
+    }
+
+    @BeforeAll
+    void setup() {
+        ResourceManager.setClassResources();
+        prepareEnvForOperator(NAMESPACE);
+
+        applyRoleBindings(NAMESPACE);
+
+        // 050-Deployment
+        KubernetesResource.clusterOperator(NAMESPACE).done();
+    }
+
+    @Override
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+        LOGGER.info("Skip env recreation after failed tests!");
+    }
+
+    @Override
+    protected void tearDownEnvironmentAfterAll() {
+        teardownEnvForOperator();
+    }
+
+
+    @Override
+    protected void assertNoCoErrorsLogged(long sinceSeconds) {
+        LOGGER.info("Skipping assertion if CO has some unexpected errors");
+    }
+}


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement / new feature

### Description

In this PR I'm gonna create new package `log` for log STs -> the reason why I done this is that we don't want to setup all resources as we are doing in `LogSettingST`. The problem here was that when we wanted to test for example JSON logging, we had to delete second Kafka, terminate and run again CO with different configuration. Also there is some problems when we wanted to write test about dynamically changing EO logging from @stanlyDoge #2867. Now it will be much easier and more readable.

I also little bit edit the test, cause we didn't need to delete the resources or update it as in previous ST.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass


