### PR TITLE
Add warning of removal of v1alpha1 for some resources to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@
 * Remove deprecated `Kafka.spec.topicOperator` classes and deployment logic
 * Use Java 11 as the Java runtime
 
+### Deprecations and removals
+
+#### Removal of v1alpha1 versions of several custom resources
+
+In Strimzi 0.12.0, the `v1alpha1` versions of the following resources have been deprecated and replaced by `v1beta1`:
+* `Kafka`
+* `KafkaConnect`
+* `KafkaConnectS2I`
+* `KafkaMirrorMaker`
+* `KafkaTopic`
+* `KafkaUser`
+
+In the next release, the `v1alpha1` versions of these resources will be removed. 
+Please follow the guide for upgrading the resources: https://strimzi.io/docs/operators/latest/full/deploying.html#assembly-upgrade-resources-str.
+
 ## 0.18.0
 
 * Add possibility to set Java System Properties for User Operator and Topic Operator via `Kafka` CR.


### PR DESCRIPTION
Already in Strimzi 0.12.0, we added `v1beta1` versions to several of our custom resources and deprecated v1alpha1:
* `Kafka`
* `KafkaConnect`
* `KafkaConnectS2I`
* `KafkaMirrorMaker`
* `KafkaTopic`
* `KafkaUser`

I think we should move to remove the old v1alpha1 versions from the code. But first, I would suggest to add one more final warning to the release notes / CHANGELOG.md which should be published with 0.19.0 release. (and afterwards we can proceed to remove it in 0.20.0)
