### PR TITLE
ST: Create a bunch of topics for upgrade for upgrade tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
@@ -53,7 +53,7 @@ public class TestExecutionWatcher implements TestExecutionExceptionHandler, Life
         throw throwable;
     }
 
-    void collectLogs(String testClass, String testMethod) {
+    public static void collectLogs(String testClass, String testMethod) {
         // Stop test execution time counter in case of failures
         TimeMeasuringSystem.getInstance().stopOperation(Operation.TEST_EXECUTION);
         // Get current date to create a unique folder

--- a/systemtest/src/main/resources/StrimziUpgradeST.json
+++ b/systemtest/src/main/resources/StrimziUpgradeST.json
@@ -196,6 +196,7 @@
     "toExamples":"strimzi-0.17.0",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.16.2/strimzi-0.16.2.zip",
     "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.17.0/strimzi-0.17.0.zip",
+    "bunchTopicsUpgrade": false,
     "imagesBeforeKafkaUpdate": {
       "zookeeper": "strimzi/kafka:0.17.0-kafka-2.4.0",
       "kafka": "strimzi/kafka:0.17.0-kafka-2.4.0",

--- a/systemtest/src/main/resources/StrimziUpgradeST.json
+++ b/systemtest/src/main/resources/StrimziUpgradeST.json
@@ -6,6 +6,7 @@
     "toExamples":"strimzi-0.12.1",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.11.4/strimzi-0.11.4.zip",
     "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.12.1/strimzi-0.12.1.zip",
+    "bunchTopicsUpgrade": false,
     "imagesBeforeKafkaUpdate": {
       "zookeeper": "strimzi/kafka:0.12.1-kafka-2.1.0",
       "kafka": "strimzi/kafka:0.12.1-kafka-2.1.0",
@@ -43,6 +44,7 @@
     "toExamples":"strimzi-0.13.0",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.12.1/strimzi-0.12.1.zip",
     "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.13.0/strimzi-0.13.0.zip",
+    "bunchTopicsUpgrade": false,
     "imagesBeforeKafkaUpdate": {
       "zookeeper": "strimzi/kafka:0.13.0-kafka-2.2.1",
       "kafka": "strimzi/kafka:0.13.0-kafka-2.2.1",
@@ -80,6 +82,7 @@
     "toExamples":"strimzi-0.14.0",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.13.0/strimzi-0.13.0.zip",
     "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.14.0/strimzi-0.14.0.zip",
+    "bunchTopicsUpgrade": false,
     "imagesBeforeKafkaUpdate": {
       "zookeeper": "strimzi/kafka:0.14.0-kafka-2.3.0",
       "kafka": "strimzi/kafka:0.14.0-kafka-2.3.0",
@@ -117,6 +120,7 @@
     "toExamples":"strimzi-0.15.0",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.14.0/strimzi-0.14.0.zip",
     "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.15.0/strimzi-0.15.0.zip",
+    "bunchTopicsUpgrade": false,
     "imagesBeforeKafkaUpdate": {
       "zookeeper": "strimzi/kafka:0.15.0-kafka-2.3.1",
       "kafka": "strimzi/kafka:0.15.0-kafka-2.3.0",
@@ -154,6 +158,7 @@
     "toExamples":"strimzi-0.16.2",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.15.0/strimzi-0.15.0.zip",
     "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.16.2/strimzi-0.16.2.zip",
+    "bunchTopicsUpgrade": false,
     "imagesBeforeKafkaUpdate": {
       "zookeeper": "strimzi/kafka:0.16.2-kafka-2.3.1",
       "kafka": "strimzi/kafka:0.16.2-kafka-2.3.1",
@@ -228,6 +233,7 @@
     "toExamples":"strimzi-0.18.0",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.17.0/strimzi-0.17.0.zip",
     "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.18.0/strimzi-0.18.0.zip",
+    "bunchTopicsUpgrade": false,
     "imagesBeforeKafkaUpdate": {
       "zookeeper": "strimzi/kafka:0.18.0-kafka-2.4.0",
       "kafka": "strimzi/kafka:0.18.0-kafka-2.4.0",
@@ -265,6 +271,7 @@
     "toExamples":"HEAD",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.18.0/strimzi-0.18.0.zip",
     "urlTo":"HEAD",
+    "bunchTopicsUpgrade": true,
     "imagesBeforeKafkaUpdate": {
       "zookeeper": "strimzi/kafka:latest-kafka-2.5.0",
       "kafka": "strimzi/kafka:latest-kafka-2.5.0",

--- a/systemtest/src/main/resources/StrimziUpgradeST.json
+++ b/systemtest/src/main/resources/StrimziUpgradeST.json
@@ -6,7 +6,7 @@
     "toExamples":"strimzi-0.12.1",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.11.4/strimzi-0.11.4.zip",
     "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.12.1/strimzi-0.12.1.zip",
-    "bunchTopicsUpgrade": false,
+    "generateTopics": false,
     "imagesBeforeKafkaUpdate": {
       "zookeeper": "strimzi/kafka:0.12.1-kafka-2.1.0",
       "kafka": "strimzi/kafka:0.12.1-kafka-2.1.0",
@@ -44,7 +44,7 @@
     "toExamples":"strimzi-0.13.0",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.12.1/strimzi-0.12.1.zip",
     "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.13.0/strimzi-0.13.0.zip",
-    "bunchTopicsUpgrade": false,
+    "generateTopics": false,
     "imagesBeforeKafkaUpdate": {
       "zookeeper": "strimzi/kafka:0.13.0-kafka-2.2.1",
       "kafka": "strimzi/kafka:0.13.0-kafka-2.2.1",
@@ -82,7 +82,7 @@
     "toExamples":"strimzi-0.14.0",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.13.0/strimzi-0.13.0.zip",
     "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.14.0/strimzi-0.14.0.zip",
-    "bunchTopicsUpgrade": false,
+    "generateTopics": false,
     "imagesBeforeKafkaUpdate": {
       "zookeeper": "strimzi/kafka:0.14.0-kafka-2.3.0",
       "kafka": "strimzi/kafka:0.14.0-kafka-2.3.0",
@@ -120,7 +120,7 @@
     "toExamples":"strimzi-0.15.0",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.14.0/strimzi-0.14.0.zip",
     "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.15.0/strimzi-0.15.0.zip",
-    "bunchTopicsUpgrade": false,
+    "generateTopics": false,
     "imagesBeforeKafkaUpdate": {
       "zookeeper": "strimzi/kafka:0.15.0-kafka-2.3.1",
       "kafka": "strimzi/kafka:0.15.0-kafka-2.3.0",
@@ -158,7 +158,7 @@
     "toExamples":"strimzi-0.16.2",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.15.0/strimzi-0.15.0.zip",
     "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.16.2/strimzi-0.16.2.zip",
-    "bunchTopicsUpgrade": false,
+    "generateTopics": false,
     "imagesBeforeKafkaUpdate": {
       "zookeeper": "strimzi/kafka:0.16.2-kafka-2.3.1",
       "kafka": "strimzi/kafka:0.16.2-kafka-2.3.1",
@@ -196,7 +196,7 @@
     "toExamples":"strimzi-0.17.0",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.16.2/strimzi-0.16.2.zip",
     "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.17.0/strimzi-0.17.0.zip",
-    "bunchTopicsUpgrade": false,
+    "generateTopics": false,
     "imagesBeforeKafkaUpdate": {
       "zookeeper": "strimzi/kafka:0.17.0-kafka-2.4.0",
       "kafka": "strimzi/kafka:0.17.0-kafka-2.4.0",
@@ -234,7 +234,7 @@
     "toExamples":"strimzi-0.18.0",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.17.0/strimzi-0.17.0.zip",
     "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.18.0/strimzi-0.18.0.zip",
-    "bunchTopicsUpgrade": false,
+    "generateTopics": false,
     "imagesBeforeKafkaUpdate": {
       "zookeeper": "strimzi/kafka:0.18.0-kafka-2.4.0",
       "kafka": "strimzi/kafka:0.18.0-kafka-2.4.0",
@@ -272,7 +272,7 @@
     "toExamples":"HEAD",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.18.0/strimzi-0.18.0.zip",
     "urlTo":"HEAD",
-    "bunchTopicsUpgrade": true,
+    "generateTopics": true,
     "imagesBeforeKafkaUpdate": {
       "zookeeper": "strimzi/kafka:latest-kafka-2.5.0",
       "kafka": "strimzi/kafka:latest-kafka-2.5.0",

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -235,15 +235,15 @@ public class StrimziUpgradeST extends BaseST {
             kafkaTopicYaml = new File(dir, testParameters.getString("fromExamples") + "/examples/topic/kafka-topic.yaml");
             LOGGER.info("Going to deploy KafkaTopic from: {}", kafkaTopicYaml.getPath());
             cmdKubeClient().create(kafkaTopicYaml);
-
-            if (testParameters.getBoolean("bunchTopicsUpgrade")) {
-                for (int x = 0; x < upgradeTopicCount; x++) {
-                    KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME, topicName + "-" + x, 1, 1, 1)
-                        .editSpec()
-                            .withTopicName(topicName + "-" + x)
-                        .endSpec()
-                        .build());
-                }
+        }
+        // Create bunch of topics for upgrade if it's specified in configuration
+        if (testParameters.getBoolean("bunchTopicsUpgrade")) {
+            for (int x = 0; x < upgradeTopicCount; x++) {
+                KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME, topicName + "-" + x, 1, 1, 1)
+                    .editSpec()
+                        .withTopicName(topicName + "-" + x)
+                    .endSpec()
+                    .build());
             }
         }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -6,12 +6,12 @@ package io.strimzi.systemtest.upgrade;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.systemtest.BaseST;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
-import io.strimzi.systemtest.logs.LogCollector;
+import io.strimzi.systemtest.logs.TestExecutionWatcher;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -40,9 +40,7 @@ import javax.json.JsonValue;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.text.SimpleDateFormat;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -79,6 +77,9 @@ public class StrimziUpgradeST extends BaseST {
     private final String kafkaClusterName = "my-cluster";
     private final String topicName = "my-topic";
     private final String userName = "my-user";
+    private final int upgradeTopicCount = 40;
+    // ExpectedTopicCount contains additionally consumer-offset topic and my-topic
+    private final int expectedTopicCount = upgradeTopicCount + 2;
 
     private final String latestReleasedOperator = "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.18.0/strimzi-0.18.0.zip";
 
@@ -110,16 +111,7 @@ public class StrimziUpgradeST extends BaseST {
 
             throw e;
         } finally {
-            // Get current date to create a unique folder
-            String currentDate = new SimpleDateFormat("yyyyMMdd_HHmmss").format(Calendar.getInstance().getTime());
-            String logDir = Environment.TEST_LOG_DIR + testClass + currentDate;
-
-            LogCollector logCollector = new LogCollector(kubeClient(), new File(logDir));
-            logCollector.collectEvents();
-            logCollector.collectConfigMaps();
-            logCollector.collectLogsFromPods();
-            logCollector.collectStrimzi();
-
+            TestExecutionWatcher.collectLogs(testClass, testName);
             deleteInstalledYamls(coDir);
         }
     }
@@ -161,15 +153,7 @@ public class StrimziUpgradeST extends BaseST {
 
             throw e;
         } finally {
-            // Get current date to create a unique folder
-            String currentDate = new SimpleDateFormat("yyyyMMdd_HHmmss").format(Calendar.getInstance().getTime());
-            String logDir = Environment.TEST_LOG_DIR + testClass + currentDate;
-
-            LogCollector logCollector = new LogCollector(kubeClient(), new File(logDir));
-            logCollector.collectEvents();
-            logCollector.collectConfigMaps();
-            logCollector.collectLogsFromPods();
-
+            TestExecutionWatcher.collectLogs(testClass, testName);
             deleteInstalledYamls(coDir);
         }
     }
@@ -251,6 +235,14 @@ public class StrimziUpgradeST extends BaseST {
             kafkaTopicYaml = new File(dir, testParameters.getString("fromExamples") + "/examples/topic/kafka-topic.yaml");
             LOGGER.info("Going to deploy KafkaTopic from: {}", kafkaTopicYaml.getPath());
             cmdKubeClient().create(kafkaTopicYaml);
+
+            for (int x = 0; x < upgradeTopicCount; x++) {
+                KafkaTopicResource.topic(CLUSTER_NAME, topicName + "-" + x)
+                    .editSpec()
+                        .withTopicName(topicName + "-" + x)
+                    .endSpec()
+                    .done();
+            }
         }
 
         // Wait until user will be created
@@ -321,6 +313,16 @@ public class StrimziUpgradeST extends BaseST {
 
         received = internalKafkaClient.receiveMessagesTls();
         assertThat(received, is(consumeMessagesCount));
+
+        // Check that topics weren't deleted/duplicated during upgrade procedures
+        assertThat("KafkaTopic list doesn't have expected size", KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).list().getItems().size(), is(expectedTopicCount));
+        List<KafkaTopic> kafkaTopicList = KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).list().getItems();
+        assertThat("KafkaTopic " + topicName + " is not in expected topic list",
+                kafkaTopicList.contains(KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(topicName).get()), is(true));
+        for (int x = 0; x < upgradeTopicCount; x++) {
+            KafkaTopic kafkaTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(topicName + "-" + x).get();
+            assertThat("KafkaTopic " + topicName + "-" + x + " is not in expected topic list", kafkaTopicList.contains(kafkaTopic), is(true));
+        }
 
         // Check errors in CO log
         assertNoCoErrorsLogged(0);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -237,7 +237,7 @@ public class StrimziUpgradeST extends BaseST {
             cmdKubeClient().create(kafkaTopicYaml);
         }
         // Create bunch of topics for upgrade if it's specified in configuration
-        if (testParameters.getBoolean("bunchTopicsUpgrade")) {
+        if (testParameters.getBoolean("generateTopics")) {
             for (int x = 0; x < upgradeTopicCount; x++) {
                 KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME, topicName + "-" + x, 1, 1, 1)
                     .editSpec()
@@ -316,7 +316,7 @@ public class StrimziUpgradeST extends BaseST {
         received = internalKafkaClient.receiveMessagesTls();
         assertThat(received, is(consumeMessagesCount));
 
-        if (testParameters.getBoolean("bunchTopicsUpgrade")) {
+        if (testParameters.getBoolean("generateTopics")) {
             // Check that topics weren't deleted/duplicated during upgrade procedures
             assertThat("KafkaTopic list doesn't have expected size", KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).list().getItems().size(), is(expectedTopicCount));
             List<KafkaTopic> kafkaTopicList = KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).list().getItems();


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This PR covers https://github.com/strimzi/strimzi-kafka-operator/pull/3132. In general, we create several topics with `.spec.topicName` set and leave them alive during the upgrade. When upgrade finish, we check the count and names of the existing topics to heck that any of the topics weren't deleted or updated. 

### Checklist

- [ ] Make sure all tests pass

