### PR TITLE
Add auto-created topics info to CC deployment proc

### DIFF
--- a/documentation/modules/cruise-control/proc-deploying-cruise-control.adoc
+++ b/documentation/modules/cruise-control/proc-deploying-cruise-control.adoc
@@ -104,6 +104,33 @@ kubectl apply -f _kafka.yaml_
 kubectl get deployments -l app.kubernetes.io/name=strimzi
 ----
 
+[discrete]
+== Auto-created topics
+
+The following table shows the three topics that are automatically created when Cruise Control is deployed. These topics are required for Cruise Control to work properly and must not be deleted or changed.
+
+[cols="20,20,60",options="header",stripes="none",separator=¦]
+|===
+
+m¦Auto-created topic
+¦Created by
+¦Function
+
+m¦strimzi.cruisecontrol.metrics
+¦Strimzi Metrics Reporter
+¦Reports broker metrics to Cruise Control.
+
+m¦strimzi.cruisecontrol.partitionmetricsamples
+¦Cruise Control
+.2+¦Obtains metric samples from partitions every two minutes to generate workload snapshots. To change the sampling interval, edit `metric.sampling.interval.ms` in the Cruise Control deployment configuration. 
+
+m¦strimzi.cruisecontrol.modeltrainingsamples
+¦Cruise Control
+
+|===
+
+Log compaction is disabled in the auto-created topics (`auto.create.topics.enable: false`). This prevents the removal of records that are needed by Cruise Control.
+
 .What to do next
 After configuring and deploying Cruise Control, you can xref:proc-generating-optimization-proposals-{context}[generate optimization proposals]. 
 


### PR DESCRIPTION
Signed-off-by: Daniel Laing <dlaing@redhat.com>

### Type of change

- Documentation

### Description

As discussed in #3173 , this pull request moves the information on "Auto-created topics and log compaction" out of the "Configuring Cruise Control" module. 

I moved the information to below the "Deploying Cruise Control" procedure. I used a table to present the topics rather than a bulleted list. Please check my description of the `partitionmetricsamples` and `modeltrainingsamples` topics.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

