### PR TITLE
Make it possible to run tests against any Kubernetes cluster

### DIFF
--- a/test/src/main/java/io/strimzi/test/k8s/cluster/KubeCluster.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/KubeCluster.java
@@ -56,6 +56,9 @@ public interface KubeCluster {
                 case "minikube":
                     clusters = new KubeCluster[]{new Minikube()};
                     break;
+                case "kubernetes":
+                    clusters = new KubeCluster[]{new Kubernetes()};
+                    break;
                 case "minishift":
                     clusters = new KubeCluster[]{new Minishift()};
                     break;

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Kubernetes.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Kubernetes.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.k8s.cluster;
+
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.strimzi.test.executor.Exec;
+import io.strimzi.test.k8s.KubeClient;
+import io.strimzi.test.k8s.cmdClient.KubeCmdClient;
+import io.strimzi.test.k8s.cmdClient.Kubectl;
+import io.strimzi.test.k8s.exceptions.KubeClusterException;
+
+/**
+ * A {@link KubeCluster} implementation for {@code minikube} and {@code minishift}.
+ */
+public class Kubernetes implements KubeCluster {
+
+    public static final String CMD = "kubectl";
+    private static final String OLM_NAMESPACE = "operators";
+
+    @Override
+    public boolean isAvailable() {
+        return Exec.isExecutableOnPath(CMD);
+    }
+
+    @Override
+    public boolean isClusterUp() {
+        try {
+            return Exec.exec(CMD, "cluster-info").exitStatus();
+        } catch (KubeClusterException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    @Override
+    public KubeCmdClient defaultCmdClient() {
+        return new Kubectl();
+    }
+
+    @Override
+    public KubeClient defaultClient() {
+        return new KubeClient(new DefaultKubernetesClient(CONFIG), "default");
+    }
+
+    public String toString() {
+        return CMD;
+    }
+
+    @Override
+    public String defaultOlmNamespace() {
+        return OLM_NAMESPACE;
+    }
+}

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Kubernetes.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Kubernetes.java
@@ -12,7 +12,7 @@ import io.strimzi.test.k8s.cmdClient.Kubectl;
 import io.strimzi.test.k8s.exceptions.KubeClusterException;
 
 /**
- * A {@link KubeCluster} implementation for {@code minikube} and {@code minishift}.
+ * A {@link KubeCluster} implementation for any {@code Kubernetes} cluster.
  */
 public class Kubernetes implements KubeCluster {
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, it is not possible to run integration tests against any Kubernetes cluster. You can run it against Minishift or `oc` (which both use `oc` as the command line tool) or against `minikube` (whcih uses `kubectl`). However, Minikube checks the Minikube cluster state using `minikube status` and therefore it does not work with any Kubernetes cluster (e.g. bare metal) but only with Minikube.

This PR adds new cluster type Kubernetes, which uses also `kubectl` but checks cluster status using `kubectl cluster-info` and can be used with any Kubernetes cluster.