### PR TITLE
[DOC] Clarify Kafka Connect configuration

### DIFF
--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect-with-plugins.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect-with-plugins.adoc
@@ -29,6 +29,8 @@ The procedures in this section show how to add your own connector classes to con
 
 * xref:using-openshift-s2i-create-image-{context}[Creating a container image using OpenShift builds and Source-to-Image (S2I) (available only on OpenShift)]
 
+IMPORTANT: You create the configuration for connectors directly xref:con-creating-managing-connectors-{context}[using the Kafka Connect REST API or KafkaConnector custom resources].
+
 //Procedure to create a container images from base image
 include::modules/proc-deploy-kafka-connect-new-image-from-base.adoc[leveloffset=+1]
 //Procedure to create a base images from OpenShift builds and S2I

--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
@@ -9,7 +9,7 @@
 link:https://kafka.apache.org/documentation/#connect[Kafka Connect^] is a tool for streaming data between Apache Kafka and external systems.
 
 In Strimzi, Kafka Connect is deployed in distributed mode.
-Kafka Connect can also work in standalone mode, but this is currently not supported by Strimzi.
+Kafka Connect can also work in standalone mode, but this is not supported by Strimzi.
 
 Using the concept of _connectors_, Kafka Connect provides a framework for moving large amounts of data into and out of your Kafka cluster while maintaining scalability and reliability.
 

--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
@@ -8,6 +8,9 @@
 
 link:https://kafka.apache.org/documentation/#connect[Kafka Connect^] is a tool for streaming data between Apache Kafka and external systems.
 
+In Strimzi, Kafka Connect is deployed in distributed mode.
+Kafka Connect can also work in standalone mode, but this is currently not supported by Strimzi.
+
 Using the concept of _connectors_, Kafka Connect provides a framework for moving large amounts of data into and out of your Kafka cluster while maintaining scalability and reliability.
 
 Kafka Connect is typically used to integrate Kafka with external databases and storage and messaging systems.
@@ -19,7 +22,7 @@ The procedures in this section show how to:
 * xref:con-creating-managing-connectors-{context}[Create and manage connectors using a `KafkaConnector` resource or the Kafka Connect REST API]
 * xref:proc-deploying-kafkaconnector-{context}[Deploy a `KafkaConnector` resource to Kafka Connect]
 
-NOTE: The term _connector_ is used interchangably to mean a connector instance running within a Kafka Connect cluster, or a connector class.
+NOTE: The term _connector_ is used interchangeably to mean a connector instance running within a Kafka Connect cluster, or a connector class.
 In this guide, the term _connector_ is used when the meaning is clear from the context.
 
 //Procedure to deploy a Kafka Connect cluster

--- a/documentation/modules/deploying/proc-deploy-kafka-connect-new-image-from-base.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-new-image-from-base.adoc
@@ -26,6 +26,45 @@ USER root:root
 COPY ./_my-plugins_/ /opt/kafka/plugins/
 USER {DockerImageUser}
 ----
++
+.Example plug-in file
+[source,subs="+quotes"]
+----
+$ tree ./_my-plugins_/
+./_my-plugins_/
+├── debezium-connector-mongodb
+│   ├── bson-3.4.2.jar
+│   ├── CHANGELOG.md
+│   ├── CONTRIBUTE.md
+│   ├── COPYRIGHT.txt
+│   ├── debezium-connector-mongodb-0.7.1.jar
+│   ├── debezium-core-0.7.1.jar
+│   ├── LICENSE.txt
+│   ├── mongodb-driver-3.4.2.jar
+│   ├── mongodb-driver-core-3.4.2.jar
+│   └── README.md
+├── debezium-connector-mysql
+│   ├── CHANGELOG.md
+│   ├── CONTRIBUTE.md
+│   ├── COPYRIGHT.txt
+│   ├── debezium-connector-mysql-0.7.1.jar
+│   ├── debezium-core-0.7.1.jar
+│   ├── LICENSE.txt
+│   ├── mysql-binlog-connector-java-0.13.0.jar
+│   ├── mysql-connector-java-5.1.40.jar
+│   ├── README.md
+│   └── wkb-1.0.2.jar
+└── debezium-connector-postgres
+    ├── CHANGELOG.md
+    ├── CONTRIBUTE.md
+    ├── COPYRIGHT.txt
+    ├── debezium-connector-postgres-0.7.1.jar
+    ├── debezium-core-0.7.1.jar
+    ├── LICENSE.txt
+    ├── postgresql-42.0.0.jar
+    ├── protobuf-java-2.6.1.jar
+    └── README.md
+----
 
 . Build the container image.
 
@@ -45,10 +84,15 @@ apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnect
 metadata:
   name: my-connect-cluster
-spec:
+spec: <1>
   #...
-  image: my-new-container-image
+  image: my-new-container-image <2>
+  config: <3>
+    #...
 ----
+<1> xref:type-KafkaConnectSpec-reference[The specification for the Kafka Connect cluster].
+<2> The docker image for the pods.
+<3> Configuration of the Kafka Connect _workers_ (not connectors).
 +
 or
 +

--- a/documentation/modules/security/proc-configuring-internal-clients-to-trust-cluster-ca.adoc
+++ b/documentation/modules/security/proc-configuring-internal-clients-to-trust-cluster-ca.adoc
@@ -31,7 +31,7 @@ For example:
 [source,shell,subs="+quotes,attributes"]
 ----
 kind: Pod
-apiVersion: {API_Version}
+apiVersion: v1
 metadata:
   name: client-pod
 spec:
@@ -76,7 +76,7 @@ For example:
 [source,shell,subs="+quotes,attributes"]
 ----
 kind: Pod
-apiVersion: {API_Version}
+apiVersion: v1
 metadata:
   name: client-pod
 spec:

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -127,7 +127,6 @@
 :KafkaTopicApiVersion: kafka.strimzi.io/v1beta1
 :KafkaUserApiVersion: kafka.strimzi.io/v1beta1
 :KafkaMirrorMakerApiVersion: kafka.strimzi.io/v1beta1
-:ApiVersion: v1beta1
 
 // API Versions previous
 :KafkaApiVersionPrev: kafka.strimzi.io/v1alpha1


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

A few minor changes to the Kafka Connect config sections used in the _Using_ and _Deploying_ guide.

Clarifies that we deploy only Kafka Connect in distributed mode and `spec.config` is not a place for connector options.

Couple of fixes to API versions too.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

