### PR TITLE
Refactor KafkaRebalance status condition 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Use Java 11 as the Java runtime
 * Removed the need to manually create Cruise Control metrics topics if topic auto creation is disabled.
 * Migration to Helm 3
+* Refactored the format of the `KafkaRebalance` resource's status. The state of the rebalance is now displayed in the associated `Condition`'s `type` field rather than the `status` field. This was done so that the information would display correctly in the Kubernetes web console.
 
 ### Deprecations and removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * Use Java 11 as the Java runtime
 * Removed the need to manually create Cruise Control metrics topics if topic auto creation is disabled.
 * Migration to Helm 3
-* Refactored the format of the `KafkaRebalance` resource's status. The state of the rebalance is now displayed in the associated `Condition`'s `type` field rather than the `status` field. This was done so that the information would display correctly in the Kubernetes web console.
+* Refactored the format of the `KafkaRebalance` resource's status. The state of the rebalance is now displayed in the associated `Condition`'s `type` field rather than the `status` field. This was done so that the information would display correctly in various Kubernetes tools.
 
 ### Deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaRebalanceStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaRebalanceStatus.java
@@ -29,8 +29,6 @@ import java.util.Map;
 @ToString(callSuper = true)
 public class KafkaRebalanceStatus extends Status {
 
-    public static final String REBALANCE_STATUS_CONDITION_STATUS = "True";
-
     private static final long serialVersionUID = 1L;
 
     private String sessionId;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaRebalanceStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaRebalanceStatus.java
@@ -29,7 +29,7 @@ import java.util.Map;
 @ToString(callSuper = true)
 public class KafkaRebalanceStatus extends Status {
 
-    public static final String REBALANCE_STATUS_CONDITION_TYPE = "State";
+    public static final String REBALANCE_STATUS_CONDITION_STATUS = "True";
 
     private static final long serialVersionUID = 1L;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -939,7 +939,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         assertThat(kafkaRebalance.getStatus().getConditions(), notNullValue());
         Condition stateCondition = kcrao.rebalanceStateCondition(kafkaRebalance.getStatus());
         assertThat(stateCondition, notNullValue());
-        assertThat(stateCondition.getStatus(), is(state.toString()));
+        assertThat(stateCondition.getType(), is(state.toString()));
     }
 
     private void assertState(KafkaRebalance kafkaRebalance, KafkaRebalanceAssemblyOperator.State state,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -92,12 +92,12 @@ public class KafkaRebalanceStateMachineTest {
         List<String> foundStatuses = new ArrayList<>();
 
         for (Condition condition :  received.getConditions()) {
-            String status = condition.getStatus();
-            if (status.equals(expectedState.toString())) {
+            String type = condition.getType();
+            if (type.equals(expectedState.toString())) {
                 log.info("Found condition with expected state: " + expectedState.toString());
                 return true;
             } else {
-                foundStatuses.add(status);
+                foundStatuses.add(type);
             }
         }
         log.error("Expected : " + expectedState.toString() + " but found : " + foundStatuses);
@@ -131,8 +131,8 @@ public class KafkaRebalanceStateMachineTest {
         // there is no actual status and related condition when a KafkaRebalance is just created
         if (currentState != KafkaRebalanceAssemblyOperator.State.New) {
             Condition currentRebalanceCondition = new Condition();
-            currentRebalanceCondition.setStatus(currentState.toString());
-            currentRebalanceCondition.setType(KafkaRebalanceStatus.REBALANCE_STATUS_CONDITION_TYPE);
+            currentRebalanceCondition.setType(currentState.toString());
+            currentRebalanceCondition.setStatus(KafkaRebalanceStatus.REBALANCE_STATUS_CONDITION_STATUS);
 
             KafkaRebalanceStatus currentStatus = new KafkaRebalanceStatus();
             currentStatus.setConditions(Collections.singletonList(currentRebalanceCondition));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -132,7 +132,7 @@ public class KafkaRebalanceStateMachineTest {
         if (currentState != KafkaRebalanceAssemblyOperator.State.New) {
             Condition currentRebalanceCondition = new Condition();
             currentRebalanceCondition.setType(currentState.toString());
-            currentRebalanceCondition.setStatus(KafkaRebalanceStatus.REBALANCE_STATUS_CONDITION_STATUS);
+            currentRebalanceCondition.setStatus("True");
 
             KafkaRebalanceStatus currentStatus = new KafkaRebalanceStatus();
             currentStatus.setConditions(Collections.singletonList(currentRebalanceCondition));

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -62,6 +62,14 @@ public class StatusUtils {
                 .build();
     }
 
+    public static Condition buildRebalanceCondition(String type) {
+        return new ConditionBuilder()
+                .withLastTransitionTime(iso8601Now())
+                .withType(type)
+                .withStatus("True")
+                .build();
+    }
+
     public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, AsyncResult<Void> result) {
         setStatusConditionAndObservedGeneration(resource, status, result.cause());
     }
@@ -78,12 +86,20 @@ public class StatusUtils {
         status.setConditions(Collections.singletonList(readyCondition));
     }
 
+    public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, String type, Throwable error) {
+        setStatusConditionAndObservedGeneration(resource, status, type, "True", error);
+    }
+
     public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, String type, String conditionStatus) {
         if (resource.getMetadata().getGeneration() != null)    {
             status.setObservedGeneration(resource.getMetadata().getGeneration());
         }
         Condition condition = StatusUtils.buildCondition(type, conditionStatus, null);
         status.setConditions(Collections.singletonList(condition));
+    }
+
+    public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, String type) {
+        setStatusConditionAndObservedGeneration(resource, status, type, "True");
     }
 
     public static <R extends CustomResource> boolean isResourceV1alpha1(R resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -28,7 +28,6 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
-import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
@@ -418,19 +417,10 @@ public class ResourceManager {
         LOGGER.info("Wait for {}: {} will have desired state: {}", resource.getKind(), resource.getMetadata().getName(), status);
 
         TestUtils.waitFor(String.format("Wait for %s: %s will have desired state: %s", resource.getKind(), resource.getMetadata().getName(), status),
-            Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, resourceTimeout,
-            () -> {
-                // This is a temporary workaround until KafkaRebalance status will have same status structure as other resources
-                if (resource.getKind().equals(KafkaRebalance.RESOURCE_KIND)) {
-                    return operation.inNamespace(resource.getMetadata().getNamespace())
-                            .withName(resource.getMetadata().getName())
-                            .get().getStatus().getConditions().stream().anyMatch(condition -> condition.getStatus().equals(status));
-                } else {
-                    return operation.inNamespace(resource.getMetadata().getNamespace())
-                            .withName(resource.getMetadata().getName())
-                            .get().getStatus().getConditions().stream().anyMatch(condition -> condition.getType().equals(status));
-                }
-            },
+            Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+            () -> operation.inNamespace(resource.getMetadata().getNamespace())
+                    .withName(resource.getMetadata().getName())
+                    .get().getStatus().getConditions().stream().anyMatch(condition -> condition.getType().equals(status)),
             () -> logCurrentResourceStatus(resource));
 
         LOGGER.info("{}:{} is in desired state: {}", resource.getKind(), resource.getMetadata().getName(), status);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
@@ -4,12 +4,17 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
+import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
@@ -20,6 +25,7 @@ public class KafkaRebalanceUtils {
     private KafkaRebalanceUtils() {}
 
     public enum KafkaRebalanceState {
+        New,
         PendingProposal,
         ProposalReady,
         Rebalancing,
@@ -28,13 +34,31 @@ public class KafkaRebalanceUtils {
         Stopped
     }
 
+    private static Condition rebalanceStateCondition(String resourceName) {
+
+        List<Condition> statusConditions = KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(kubeClient().getNamespace())
+                .withName(resourceName).get().getStatus().getConditions().stream()
+                .filter(condition -> condition.getType() != null)
+                .filter(condition -> Arrays.stream(KafkaRebalanceState.values()).anyMatch(stateValue -> stateValue.toString().equals(condition.getType())))
+                .collect(Collectors.toList());
+
+        if (statusConditions.size() == 1) {
+            return statusConditions.get(0);
+        } else if (statusConditions.size() > 1) {
+            LOGGER.warn("Multiple KafkaRebalance State Conditions were present in the KafkaRebalance status");
+            throw new RuntimeException("Multiple KafkaRebalance State Conditions were present in the KafkaRebalance status");
+        } else {
+            LOGGER.warn("No KafkaRebalance State Conditions were present in the KafkaRebalance status");
+            throw new RuntimeException("No KafkaRebalance State Conditions were present in the KafkaRebalance status");
+        }
+    }
+
     // TODO: after revert of changes related to status we should you --> ResourceManager.waitForResourceStatus()
     public static void waitForKafkaRebalanceCustomResourceState(String resourceName, KafkaRebalanceState state) {
-        LOGGER.info("Waiting for KafkaRebalance will be in the {}", state);
+        LOGGER.info("Waiting for KafkaRebalance to be in the {} state", state);
 
-        TestUtils.waitFor("KafkaRebalance will be in the " + state.name(), Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(kubeClient().getNamespace())
-                    .withName(resourceName).get().getStatus().getConditions().get(0).getStatus().equals(state.name()),
+        TestUtils.waitFor("KafkaRebalance to be in the " + state.name(), Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+            () -> rebalanceStateCondition(resourceName).getType().equals(state.toString()),
             () -> ResourceManager.logCurrentResourceStatus(KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(kubeClient().getNamespace())
                 .withName(resourceName).get())
         );


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR changes the KafkaRebalance resource status condition's "type" field to contain the state of the rebalance. Previously the condition's "status" field held this information and this meant that the state was not shown on certain k8 distribution's dashboards. The condition's status field now reads "True/False" in line with the state.

### Checklist


- [X] Make sure all tests pass
- [x] Update documentation
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md

