### PR TITLE
[DOC] Reformat custom IDs and x-refs in the Cruise Control section, plus improve capacity limits info

### DIFF
--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -33,12 +33,12 @@ NOTE: CPU goals, intra-broker disk goals, "Write your own" goals, and Kafka assi
 [discrete]
 == Goals configuration in Strimzi custom resources
 
-You configure optimization goals in `Kafka` and `KafkaRebalance` custom resources. Cruise Control has configurations for xref:#hard-soft-goals[_hard_] optimization goals that must be satisfied, as well as xref:#master-goals[_master_], xref:#default-goals[_default_], and xref:#user-provided-goals[_user-provided_] optimization goals. 
-Optimization goals are subject to any xref:#capacity-configuration[_capacity limits_] on broker resources.
+You configure optimization goals in `Kafka` and `KafkaRebalance` custom resources. Cruise Control has configurations for xref:hard-soft-goals[hard] optimization goals that must be satisfied, as well as xref:master-goals[master], xref:#default-goals[default], and xref:#user-provided-goals[user-provided] optimization goals. 
+Optimization goals are subject to any xref:capacity-configuration[capacity limits] on broker resources.
 
 The following sections describe each goal configuration in more detail.
 
-[#hard-soft-goals]
+[[hard-soft-goals]]
 [discrete]
 === Hard goals and soft goals
 
@@ -53,7 +53,7 @@ An optimization proposal that does _not_ satisfy all the hard goals is rejected 
 NOTE: For example, you might have a soft goal to distribute a topic's replicas evenly across the cluster (the topic replica distribution goal). 
 Cruise Control will ignore this goal if doing so enables all the configured hard goals to be met.
 
-In Cruise Control, the following xref:#master-goals[master optimization goals] are preset as hard goals:
+In Cruise Control, the following xref:master-goals[master optimization goals] are preset as hard goals:
 
 [source]
 RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal
@@ -95,7 +95,7 @@ Increasing the number of configured hard goals will reduce the likelihood of Cru
 If `skipHardGoalCheck: true` is specified in the `KafkaRebalance` custom resource, Cruise Control does _not_ check that the list of user-provided optimization goals (in `KafkaRebalance.spec.goals`) contains _all_ the configured hard goals (`hard.goals`). 
 Therefore, if some, but not all, of the user-provided optimization goals are in the `hard.goals` list, Cruise Control will still treat them as hard goals even if `skipHardGoalCheck: true` is specified.
 
-[#master-goals]
+[[master-goals]]
 [discrete]
 === Master optimization goals
 
@@ -107,9 +107,9 @@ Unless you change the Cruise Control xref:proc-deploying-cruise-control-{context
 [source]
 RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; ReplicaDistributionGoal; PotentialNwOutGoal; DiskUsageDistributionGoal; NetworkInboundUsageDistributionGoal; NetworkOutboundUsageDistributionGoal; TopicReplicaDistributionGoal; LeaderReplicaDistributionGoal; LeaderBytesInDistributionGoal; PreferredLeaderElectionGoal
 
-Six of these goals are preset as xref:#hard-soft-goals[hard goals].
+Six of these goals are preset as xref:hard-soft-goals[hard goals].
 
-To reduce complexity, we recommend that you use the inherited master optimization goals, unless you need to _completely_ exclude one or more goals from use in `KafkaRebalance` resources. The priority order of the master optimization goals can be modified, if desired, in the configuration for xref:#default-goals[default optimization goals].
+To reduce complexity, we recommend that you use the inherited master optimization goals, unless you need to _completely_ exclude one or more goals from use in `KafkaRebalance` resources. The priority order of the master optimization goals can be modified, if desired, in the configuration for xref:default-goals[default optimization goals].
 
 You configure master optimization goals, if necessary, in the Cruise Control deployment configuration: `Kafka.spec.cruiseControl.config.goals`
 
@@ -119,14 +119,14 @@ You configure master optimization goals, if necessary, in the Cruise Control dep
 
 NOTE: If you change the inherited master optimization goals, you must ensure that the hard goals, if configured in the `hard.goals` property in `Kafka.spec.cruiseControl.config`, are a subset of the master optimization goals that you configured. Otherwise, errors will occur when generating optimization proposals.
 
-[#default-goals]
+[[default-goals]]
 [discrete]
 === Default optimization goals
 
 Cruise Control uses the _default optimization goals_ to generate the _cached optimization proposal_.
 For more information about the cached optimization proposal, see xref:con-optimization-proposals-{context}[]. 
 
-You can override the default optimization goals by setting xref:#user-provided-goals[user-provided optimization goals] in a `KafkaRebalance` custom resource.
+You can override the default optimization goals by setting xref:user-provided-goals[user-provided optimization goals] in a `KafkaRebalance` custom resource.
 
 Unless you specify `default.goals` in the Cruise Control xref:proc-deploying-cruise-control-{context}[deployment configuration], the master optimization goals are used as the default optimization goals. 
 In this case, the cached optimization proposal is generated using the master optimization goals.
@@ -166,7 +166,7 @@ spec:
 
 If no default optimization goals are specified, the cached proposal is generated using the master optimization goals.
 
-[#user-provided-goals]
+[[user-provided-goals]]
 [discrete]
 === User-provided optimization goals
 
@@ -183,7 +183,7 @@ So, you create a `KafkaRebalance` custom resource containing a single user-provi
 
 User-provided optimization goals must:
 
-* Include all configured xref:#hard-soft-goals[hard goals], or an error occurs
+* Include all configured xref:hard-soft-goals[hard goals], or an error occurs
 * Be a subset of the master optimization goals
 
 To ignore the configured hard goals in an optimization proposal, add the `skipHardGoalCheck: true` option to the `KafkaRebalance` custom resource.

--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -7,7 +7,7 @@
 = Optimization proposals overview
 
 An _optimization proposal_ is a summary of proposed changes that would produce a more balanced Kafka cluster, with partition workloads distributed more evenly among the brokers. 
-Each optimization proposal is based on the set of xref:con-optimization-goals-{context}[optimization goals] that was used to generate it, subject to any configured xref:#capacity-configuration[capacity limits on broker resources].
+Each optimization proposal is based on the set of xref:con-optimization-goals-{context}[optimization goals] that was used to generate it, subject to any configured xref:capacity-configuration[capacity limits on broker resources].
 
 An optimization proposal is contained in the `Status.Optimization Result` property of a `KafkaRebalance` custom resource. 
 The information provided is a summary of the full optimization proposal. 
@@ -30,7 +30,7 @@ If you generate an optimization proposal using the default optimization goals, C
 To change the cached optimization proposal refresh interval, edit the `proposal.expiration.ms` setting in the Cruise Control deployment configuration.
 Consider a shorter interval for fast changing clusters, although this increases the load on the Cruise Control server.
 
-[#contents-optimization-proposals]
+[[contents-optimization-proposals]]
 [discrete]
 == Contents of optimization proposals
 

--- a/documentation/modules/cruise-control/proc-approving-optimization-proposal.adoc
+++ b/documentation/modules/cruise-control/proc-approving-optimization-proposal.adoc
@@ -14,7 +14,7 @@ Cruise Control will then apply the optimization proposal to the Kafka cluster, r
 *This is not a dry run.* Before you approve an optimization proposal, you must:
 
 * Refresh the proposal in case it has become out of date.
-* Carefully review the xref:#contents-optimization-proposals[contents of the proposal].
+* Carefully review the xref:contents-optimization-proposals[contents of the proposal].
 ====
 
 .Prerequisites

--- a/documentation/modules/cruise-control/proc-deploying-cruise-control.adoc
+++ b/documentation/modules/cruise-control/proc-deploying-cruise-control.adoc
@@ -70,12 +70,12 @@ spec:
       timeoutSeconds: 5
 # ...
 ----
-<1> Specifies capacity limits for broker resources. For more information, see xref:#capacity-configuration[Capacity configuration].
+<1> Specifies capacity limits for broker resources. For more information, see xref:capacity-configuration[Capacity configuration].
 <2> Defines the Cruise Control configuration, including the default optimization goals (in `default.goals`) and any customizations to the master optimization goals (in `goals`) or the hard goals (in `hard.goals`). 
 You can provide any xref:ref-cruise-control-configuration-{context}[standard Cruise Control configuration option] apart from those managed directly by Strimzi. 
 For more information on configuring optimization goals, see xref:con-optimization-goals-{context}[]. 
 <3> CPU and memory resources reserved for Cruise Control. For more information, see xref:assembly-resource-limits-and-requests-deployment-configuration-kafka[].
-<4> Defined loggers and log levels added directly (inline) or indirectly (external) through a ConfigMap. A custom ConfigMap must be placed under the log4j.properties key. Cruise Control has a single logger named `cruisecontrol.root.logger`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF. For more information, see xref:#logging-configuration[Logging configuration].
+<4> Defined loggers and log levels added directly (inline) or indirectly (external) through a ConfigMap. A custom ConfigMap must be placed under the log4j.properties key. Cruise Control has a single logger named `cruisecontrol.root.logger`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF. For more information, see xref:logging-configuration[Logging configuration].
 <5> xref:assembly-customizing-deployments-str[Customization of deployment templates and pods].
 <6> xref:assembly-healthchecks-deployment-configuration-kafka[Healthcheck readiness probes].
 <7> xref:assembly-healthchecks-deployment-configuration-kafka[Healthcheck liveness probes].

--- a/documentation/modules/cruise-control/proc-generating-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/proc-generating-optimization-proposals.adoc
@@ -13,7 +13,7 @@ Analyze the summary information in the optimization proposal and decide whether 
 
 * You have xref:proc-deploying-cruise-control-{context}[deployed Cruise Control] to your Strimzi cluster.
 
-* You have configured xref:con-optimization-goals-{context}[optimization goals] and, optionally, xref:#capacity-configuration[capacity limits on broker resources].
+* You have configured xref:con-optimization-goals-{context}[optimization goals] and, optionally, xref:capacity-configuration[capacity limits on broker resources].
 
 .Procedure
 
@@ -108,7 +108,7 @@ Status:
 ----
 +
 The properties in the `Optimization Result` section describe the pending cluster rebalance operation. 
-For descriptions of each property, see xref:#contents-optimization-proposals[Contents of optimization proposals]. 
+For descriptions of each property, see xref:contents-optimization-proposals[Contents of optimization proposals]. 
 
 .What to do next
 

--- a/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
+++ b/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
@@ -62,10 +62,11 @@ spec:
 [discrete]
 == Capacity configuration
 
-Cruise Control uses _capacity limits_ to determine if optimization goals for broker resources are being broken.
-An optimization will fail if a hard goal is broken, preventing the optimization from being used to generate an optimization proposal.
+Cruise Control uses _capacity limits_ to determine if certain resource-based optimization goals are being broken. 
+An attempted optimization fails if one or more of these resource-based goals is set as a hard goal and then broken. 
+This prevents the optimization from being used to generate an optimization proposal.
 
-You specify capacity limits for broker resources in the `brokerCapacity` property in `Kafka.spec.cruiseControl` .
+You specify capacity limits for Kafka broker resources in the `brokerCapacity` property in `Kafka.spec.cruiseControl` .
 Capacity limits can be set for the following broker resources in the described units:
 
 * `disk`            - Disk storage in bytes

--- a/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
+++ b/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
@@ -58,7 +58,7 @@ spec:
     # ...
 ----
 
-[#capacity-configuration]
+[[capacity-configuration]]
 [discrete]
 == Capacity configuration
 
@@ -97,7 +97,7 @@ spec:
 .Additional resources
 For more information, refer to the xref:type-BrokerCapacity-reference[].
 
-[#logging-configuration]
+[[logging-configuration]]
 [discrete]
 == Logging configuration
 

--- a/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
+++ b/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
@@ -63,8 +63,6 @@ spec:
 == Capacity configuration
 
 Cruise Control uses _capacity limits_ to determine if certain resource-based optimization goals are being broken. 
-An attempted optimization fails if one or more of these resource-based goals is set as a hard goal and then broken. 
-This prevents the optimization from being used to generate an optimization proposal.
 
 You specify capacity limits for Kafka broker resources in the `brokerCapacity` property in `Kafka.spec.cruiseControl` .
 Capacity limits can be set for the following broker resources in the described units:


### PR DESCRIPTION
### Type of change

- Documentation

### Description

A couple of minor changes to the  "Cruise Control for cluster rebalancing" section of the _Using Strimzi_ guide. 

- Updated the section IDs (i.e. anchors) to use the recommended [Asciidoctor standard](https://asciidoctor-docs.netlify.app/asciidoc/1.5/sections/id/#assign-custom-ids). For example: ``[[cluster-rebalance]]`` without the use of any `#`s in the ID.

- Updated all `xrefs` that point to the above sections.

- Based on input from @tomncooper, improved the explanation of capacity limits. The current doc does not state that a goal must be set as a hard goal for a capacity limit to apply.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

