### PR TITLE
Fix the docs contributing guide and pushing of it to the website

### DIFF
--- a/.travis/docu-push-to-website.sh
+++ b/.travis/docu-push-to-website.sh
@@ -17,11 +17,9 @@ cp -vrL documentation/html/*                                /tmp/website/docs/op
 
 # Contributing Guide
 rm -rf  /tmp/website/contributing/guide/images
-rm -rf  /tmp/website/contributing/guide/templates
 cp -v   documentation/htmlnoheader/contributing-book.html   /tmp/website/contributing/guide/contributing.html
 cp -v   documentation/html/contributing.html                /tmp/website/contributing/guide/full.html
 cp -vrL documentation/htmlnoheader/images                   /tmp/website/contributing/guide/images
-cp -vrL documentation/contributing/templates                /tmp/website/contributing/guide/templates
 
 pushd /tmp/website
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In #3164 as part of other improvemtns to the Doncumentation contributing guide I removed some files. That broker the pushing of the docs to the website and caused the master build to crash. This fixes the 