### PR TITLE
Fix CC capacity config example typos

### DIFF
--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -80,9 +80,9 @@ spec:
     topicOperator: {}
     userOperator: {}
   cruiseControl:
-    capacity:
-      networkIn: 10000KB/s
-      networkOut: 10000KB/s
+    brokerCapacity:
+      inboundNetwork: 10000KB/s
+      outboundNetwork: 10000KB/s
     config:
       hard.goals: >
         com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,
@@ -153,9 +153,9 @@ spec:
     topicOperator: {}
     userOperator: {}
   cruiseControl:
-    capacity:
-      networkIn: 10000KB/s
-      networkOut: 10000KB/s
+    brokerCapacity:
+      inboundNetwork: 10000KB/s
+      outboundNetwork: 10000KB/s
     config:
       default.goals: >
          com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,

--- a/documentation/modules/cruise-control/proc-deploying-cruise-control.adoc
+++ b/documentation/modules/cruise-control/proc-deploying-cruise-control.adoc
@@ -29,9 +29,9 @@ metadata:
 spec:
   # ...
   cruiseControl:
-    capacity: <1>
-      networkIn: 10000KB/s
-      networkOut: 10000KB/s
+    brokerCapacity: <1>
+      inboundNetwork: 10000KB/s
+      outboundNetwork: 10000KB/s
       # ...
     config: <2>
       default.goals: >


### PR DESCRIPTION
### Type of change

Bugfix

### Description

Fixes a typo in the Cruise Control deployment guides broker capacity config.

### Checklist

- [X] Update documentation


