### PR TITLE
Attempt to deflake ST

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -25,7 +25,7 @@ jobs:
           jdk_version: '11'
           jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
     # Set timeout for jobs
-    timeoutInMinutes: 60
+    timeoutInMinutes: 600
     # Base system
     pool:
       vmImage: $(image)
@@ -66,12 +66,47 @@ jobs:
           TEST_HELM2_VERSION: 'v2.16.3'
           TEST_HELM3_VERSION: 'v3.2.0'
 
-      - bash: ".azure/scripts/build.sh"
+      - bash: |
+          make docker_build
+          make docker_tag
         env:
-          DOCKER_USER: $(DOCKER_USER)
-          DOCKER_PASS: $(DOCKER_PASS_SECRET)
-          MVN_ARGS: '-B'
-        displayName: "Build images"
+          MVN_ARGS: '-B -DskipTests'
+        displayName: "Build Strimzi images locally"
+
+      - task: Maven@3
+        inputs:
+          mavenPomFile: 'systemtest/pom.xml'
+          mavenOptions: '-Xmx3072m'
+          javaHomeOption: 'JDKVersion'
+          jdkVersionOption: 'default'
+          jdkArchitectureOption: 'x64'
+          publishJUnitResults: true
+          testResultsFiles: '**/failsafe-reports/TEST-*.xml'
+          goals: 'verify'
+          options: '-Dgroups=acceptance -DexcludedGroups=flaky,loadbalancer -Dmaven.javadoc.skip=true -B -V'
+        env:
+          OPERATOR_IMAGE_PULL_POLICY: "IfNotPresent"
+        displayName: 'Run system tests'
+
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: JUnit
+          testResultsFiles: '**/TEST-*.xml'
+          searchFolder: "systemtest"
+          testRunTitle: "System tests"
+        condition: always()
+
+      - bash: |
+          rm -rf systemtest/target/logs/timeMeasuring
+        displayName: 'Remove timeMeasuring dir from logs'
+        condition: failed()
+
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: 'systemtest/target/logs/'
+          artifactName: systemtest-logs
+          displayName: 'Publish logs from failed tests'
+        condition: failed()
 
       - task: PublishTestResults@2
         inputs:
@@ -79,6 +114,3 @@ jobs:
           testResultsFiles: '**/TEST-*.xml'
           testRunTitle: "Unit & Integration tests"
         condition: always()
-
-
-

--- a/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
@@ -30,7 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+//import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECTOR_OPERATOR;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
@@ -68,7 +68,7 @@ class AllNamespaceST extends AbstractNamespaceST {
      * Test the case when Kafka will be deployed in different namespace than CO
      */
     @Test
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     void testKafkaInDifferentNsThanClusterOperator() {
         LOGGER.info("Deploying Kafka cluster in different namespace than CO when CO watches all namespaces");
         checkKafkaInDiffNamespaceThanCO(SECOND_CLUSTER_NAME, SECOND_NAMESPACE);

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -68,7 +68,7 @@ import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.CONNECTOR_OPERATOR;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.CONNECT_S2I;
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+//import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -381,7 +381,7 @@ class ConnectS2IST extends BaseST {
 
     @Test
     @Tag(CONNECTOR_OPERATOR)
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     void testKafkaConnectorWithConnectS2IAndConnectWithSameName() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
         String connectClusterName = "connect-cluster";

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -53,7 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+//import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECTOR_OPERATOR;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
@@ -249,7 +249,7 @@ class ConnectST extends BaseST {
     }
 
     @Test
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     @Tag(CONNECTOR_OPERATOR)
     @Tag(INTERNAL_CLIENTS_USED)
     void testKafkaConnectAndConnectorFileSinkPlugin() {
@@ -694,7 +694,7 @@ class ConnectST extends BaseST {
     @Test
     @Tag(CONNECTOR_OPERATOR)
     @Tag(INTERNAL_CLIENTS_USED)
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     void testMultiNodeKafkaConnectWithConnectorCreation() {
         String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
         String connectClusterName = "connect-cluster";

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -84,7 +84,7 @@ import java.util.stream.Collectors;
 
 import static io.strimzi.api.kafka.model.KafkaResources.kafkaStatefulSetName;
 import static io.strimzi.api.kafka.model.KafkaResources.zookeeperStatefulSetName;
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+//import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.LOADBALANCER_SUPPORTED;
@@ -577,7 +577,7 @@ class KafkaST extends BaseST {
      * Test sending messages over plain transport using scram sha auth
      */
     @Test
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     @Tag(INTERNAL_CLIENTS_USED)
     void testSendMessagesPlainScramSha() {
         String kafkaUsername = KafkaUserUtils.generateRandomNameOfKafkaUser();
@@ -1209,7 +1209,7 @@ class KafkaST extends BaseST {
     }
 
     @Test
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     @Tag(NODEPORT_SUPPORTED)
     @Tag(EXTERNAL_CLIENTS_USED)
     void testNodePortTls() {
@@ -1275,7 +1275,7 @@ class KafkaST extends BaseST {
     }
 
     @Test
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     @Tag(LOADBALANCER_SUPPORTED)
     @Tag(EXTERNAL_CLIENTS_USED)
     void testLoadBalancerTls() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MirrorMaker2ST.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+//import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
@@ -196,7 +196,7 @@ class MirrorMaker2ST extends BaseST {
      */
     @SuppressWarnings({"checkstyle:MethodLength"})
     @Test
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     void testMirrorMaker2TlsAndTlsClientAuth() {
         String availabilityTopicSourceName = "availability-topic-source-" + rng.nextInt(Integer.MAX_VALUE);
         String availabilityTopicTargetName = "availability-topic-target-" + rng.nextInt(Integer.MAX_VALUE);

--- a/systemtest/src/test/java/io/strimzi/systemtest/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MirrorMakerST.java
@@ -37,7 +37,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+//import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -159,7 +159,7 @@ public class MirrorMakerST extends BaseST {
      * Test mirroring messages by Mirror Maker over tls transport using mutual tls auth
      */
     @Test
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     void testMirrorMakerTlsAuthenticated() {
         String topicSourceName = TOPIC_NAME + "-source" + "-" + rng.nextInt(Integer.MAX_VALUE);
         String kafkaSourceUserName = "my-user-source";

--- a/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesST.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+//import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.TestUtils.map;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -41,7 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 @OpenShiftOnly
 @Tag(REGRESSION)
-@Tag(ACCEPTANCE)
+//@Tag(ACCEPTANCE)
 public class OpenShiftTemplatesST extends BaseST {
 
     private static final Logger LOGGER = LogManager.getLogger(OpenShiftTemplatesST.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
@@ -23,7 +23,7 @@ import io.strimzi.systemtest.resources.crd.KafkaResource;
 
 import java.util.List;
 
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+//import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -53,7 +53,7 @@ class RecoveryST extends BaseST {
     }
 
     @Test
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     void testRecoveryFromKafkaStatefulSetDeletion() {
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_RECOVERY));
         // kafka cluster already deployed
@@ -72,7 +72,7 @@ class RecoveryST extends BaseST {
     }
 
     @Test
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     void testRecoveryFromZookeeperStatefulSetDeletion() {
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_RECOVERY));
         // kafka cluster already deployed

--- a/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
@@ -26,7 +26,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.List;
 
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+//import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.Constants.SCALABILITY;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -84,7 +84,7 @@ class UserST extends BaseST {
     }
 
     @Test
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     void testUpdateUser() {
         KafkaUserResource.tlsUser(CLUSTER_NAME, USER_NAME).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
@@ -33,7 +33,7 @@ import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 
 import java.util.Random;
 
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+//import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
@@ -44,7 +44,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @Tag(BRIDGE)
-@Tag(ACCEPTANCE)
+//@Tag(ACCEPTANCE)
 @Tag(REGRESSION)
 @Tag(NODEPORT_SUPPORTED)
 @Tag(EXTERNAL_CLIENTS_USED)

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import java.util.List;
 
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+//import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -39,7 +39,7 @@ public class CruiseControlApiST extends BaseST {
     private static final String CRUISE_CONTROL_NAME = "Cruise Control";
 
     @Order(1)
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     @Test
     void testCruiseControlDeploymentStateEndpoint()  {
         String response = CruiseControlUtils.callApi(CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlUtils.CruiseControlEndpoints.STATE);

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+//import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.resources.ResourceManager.cmdKubeClient;
@@ -86,7 +86,7 @@ public class CruiseControlIsolatedST extends BaseST {
     }
 
     @Test
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     void testCruiseControlWithRebalanceResource() {
         KafkaResource.kafkaWithCruiseControl(CLUSTER_NAME, 3, 3).done();
         KafkaRebalanceResource.kafkaRebalance(CLUSTER_NAME).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
@@ -38,7 +38,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+//import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.LOADBALANCER_SUPPORTED;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -351,7 +351,7 @@ public class ListenersST extends BaseST {
     }
 
     @Test
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     @OpenShiftOnly
     void testCustomSoloCertificatesForRoute() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthTlsST.java
@@ -44,7 +44,7 @@ import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+//import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
@@ -60,7 +60,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 
 @Tag(OAUTH)
-@Tag(ACCEPTANCE)
+//@Tag(ACCEPTANCE)
 @Tag(REGRESSION)
 @Tag(NODEPORT_SUPPORTED)
 @Tag(EXTERNAL_CLIENTS_USED)

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -56,7 +56,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static io.strimzi.api.kafka.model.KafkaResources.kafkaStatefulSetName;
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+//import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.k8s.Events.Killing;
@@ -235,7 +235,7 @@ class RollingUpdateST extends BaseST {
     }
 
     @Test
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     void testKafkaAndZookeeperScaleUpScaleDown() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -294,6 +294,12 @@ class SecurityST extends BaseST {
     @Test
     @Tag(ACCEPTANCE)
     @Tag(INTERNAL_CLIENTS_USED)
+    void test10run() {
+        for (int i = 0; i < 10; i++) {
+            testAutoRenewAllCaCertsTriggeredByAnno();
+        }
+    }
+
     void testAutoRenewAllCaCertsTriggeredByAnno() {
         autoRenewSomeCaCertsTriggeredByAnno(asList(
                 clusterCaCertificateSecretName(CLUSTER_NAME),

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -60,7 +60,7 @@ import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.CONNECT_S2I;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+//import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.Constants.TRACING;
@@ -331,7 +331,7 @@ public class TracingST extends BaseST {
     }
 
     @Test
-    @Tag(ACCEPTANCE)
+    //@Tag(ACCEPTANCE)
     void testProducerConsumerStreamsService() {
         Map<String, Object> configOfSourceKafka = new HashMap<>();
         configOfSourceKafka.put("offsets.topic.replication.factor", "1");


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
`testAutoRenewAllCaCertsTriggeredByAnno` is somehow flaky on azure.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

