### PR TITLE
[systemtest][cleanup] Kafka resource, DeploymentConfig util and ST cleanup 

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -9,11 +9,9 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaList;
-import io.strimzi.api.kafka.model.CruiseControlResources;
 import io.strimzi.api.kafka.model.DoneableKafka;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
-import io.strimzi.api.kafka.model.KafkaExporterResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.listener.KafkaListenerExternal;
 import io.strimzi.api.kafka.model.listener.KafkaListenerExternalConfiguration;
@@ -29,8 +27,6 @@ import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -234,29 +230,17 @@ public class KafkaResource {
      * Wait until the ZK, Kafka and EO are all ready
      */
     private static Kafka waitFor(Kafka kafka) {
-        String kafkaCrName = kafka.getMetadata().getName();
-        String namespace = kafka.getMetadata().getNamespace();
+        long timeout = Constants.TIMEOUT_FOR_RESOURCE_READINESS;
 
-        LOGGER.info("Waiting for Kafka {} in namespace {}", kafkaCrName, namespace);
-
-        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(kafkaCrName), kafka.getSpec().getZookeeper().getReplicas());
-        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(kafkaCrName), kafka.getSpec().getKafka().getReplicas());
-
-        // EO should not be deployed if it does not contain UO and TO
-        if (kafka.getSpec().getEntityOperator().getTopicOperator() != null || kafka.getSpec().getEntityOperator().getUserOperator() != null) {
-            DeploymentUtils.waitForDeploymentReady(KafkaResources.entityOperatorDeploymentName(kafkaCrName));
-        }
         // Kafka Exporter is not setup every time
         if (kafka.getSpec().getKafkaExporter() != null) {
-            DeploymentUtils.waitForDeploymentReady(KafkaExporterResources.deploymentName(kafkaCrName));
+            timeout += Constants.TIMEOUT_FOR_RESOURCE_CREATION;
         }
         // Cruise Control is not setup every time
         if (kafka.getSpec().getCruiseControl() != null) {
-            LOGGER.info("Waiting for Cruise Control pods");
-            DeploymentUtils.waitForDeploymentReady(CruiseControlResources.deploymentName(kafkaCrName));
-            LOGGER.info("Cruise Control pods are ready");
+            timeout += Constants.TIMEOUT_FOR_RESOURCE_CREATION;
         }
-        return kafka;
+        return ResourceManager.waitForResourceStatus(kafkaClient(), kafka, "Ready", timeout);
     }
 
     private static Kafka deleteLater(Kafka kafka) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -37,15 +37,15 @@ public class KafkaUtils {
 
     private KafkaUtils() {}
 
-    public static void waitUntilKafkaCRIsReady(String clusterName) {
-        waitUntilKafkaStatus(clusterName, "Ready");
+    public static void waitForKafkaReady(String clusterName) {
+        waitForKafkaStatus(clusterName, "Ready");
     }
 
-    public static void waitUntilKafkaCRIsNotReady(String clusterName) {
-        waitUntilKafkaStatus(clusterName, "NotReady");
+    public static void waitForKafkaNotReady(String clusterName) {
+        waitForKafkaStatus(clusterName, "NotReady");
     }
 
-    public static void waitUntilKafkaStatus(String clusterName, String state) {
+    public static void waitForKafkaStatus(String clusterName, String state) {
         Kafka kafka = KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
         ResourceManager.waitForResourceStatus(KafkaResource.kafkaClient(), kafka, state);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentConfigUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentConfigUtils.java
@@ -32,7 +32,6 @@ public class DeploymentConfigUtils {
         return PodUtils.podSnapshot(selector);
     }
 
-
     /**
      * Method to check that all pods for expected DeploymentConfig were rolled
      * @param name DeploymentConfig name
@@ -54,7 +53,6 @@ public class DeploymentConfigUtils {
             return false;
         }
     }
-
 
     /**
      * Method to wait when DeploymentConfig will be recreated after rolling update
@@ -108,26 +106,18 @@ public class DeploymentConfigUtils {
         return depConfigSnapshot(depConfigName);
     }
 
-    public static void waitForDeploymentConfigStatus(String depConfigName, String status) {
-        LOGGER.info("Wait for {}: {} will have desired state: {}", "DeploymentConfig", depConfigName, status);
+    public static void waitForDeploymentConfigReady(String depConfigName) {
+        LOGGER.info("Wait for DeploymentConfig: {} will be ready", depConfigName);
 
-        TestUtils.waitFor(String.format("Wait for %s: %s will have desired state: %s", "DeploymentConfig", depConfigName, status),
+        TestUtils.waitFor(String.format("Wait for DeploymentConfig: %s will be ready", depConfigName),
             Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> kubeClient().getDeploymentConfig(depConfigName).getStatus().getConditions().get(0).getType().equals(status),
+            () -> kubeClient().getDeploymentConfigStatus(depConfigName),
             () -> {
                 if (kubeClient().getDeploymentConfig(depConfigName) != null) {
                     LOGGER.info(kubeClient().getDeploymentConfig(depConfigName));
                 }
             });
 
-        LOGGER.info("{}: {} is in desired state: {}", "DeploymentConfig", depConfigName, status);
-    }
-
-    public static void waitForDeploymentConfigReady(String depConfigName) {
-        waitForDeploymentConfigStatus(depConfigName, "Ready");
-    }
-
-    public static void waitForDeploymentConfigNotReady(String depConfigName) {
-        waitForDeploymentConfigStatus(depConfigName, "NotReady");
+        LOGGER.info("Wait for DeploymentConfig: {} is ready", depConfigName);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentConfigUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentConfigUtils.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.utils.kubeUtils.controllers;
+
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.test.TestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+
+public class DeploymentConfigUtils {
+
+    private static final Logger LOGGER = LogManager.getLogger(DeploymentConfigUtils.class);
+
+    /**
+     * Returns a map of pod name to resource version for the pods currently in the given DeploymentConfig.
+     * @param name The DeploymentConfig name.
+     * @return A map of pod name to resource version for pods in the given DeploymentConfig.
+     */
+    public static Map<String, String> depConfigSnapshot(String name) {
+        LabelSelector selector = new LabelSelectorBuilder().addToMatchLabels(kubeClient().getDeploymentConfigSelectors(name)).build();
+        return PodUtils.podSnapshot(selector);
+    }
+
+
+    /**
+     * Method to check that all pods for expected DeploymentConfig were rolled
+     * @param name DeploymentConfig name
+     * @param snapshot Snapshot of pods for DeploymentConfig before the rolling update
+     * @return true when the pods for DeploymentConfig are recreated
+     */
+    public static boolean depConfigHasRolled(String name, Map<String, String> snapshot) {
+        LOGGER.debug("Existing snapshot: {}", new TreeMap<>(snapshot));
+        LabelSelector selector = new LabelSelectorBuilder().addToMatchLabels(kubeClient().getDeploymentConfigSelectors(name)).build();
+        Map<String, String> map = PodUtils.podSnapshot(selector);
+        LOGGER.debug("Current  snapshot: {}", new TreeMap<>(map));
+        int current = map.size();
+        map.keySet().retainAll(snapshot.keySet());
+        if (current == snapshot.size() && map.isEmpty()) {
+            LOGGER.info("All pods seem to have rolled");
+            return true;
+        } else {
+            LOGGER.debug("Some pods still need to roll: {}", map);
+            return false;
+        }
+    }
+
+
+    /**
+     * Method to wait when DeploymentConfig will be recreated after rolling update
+     * @param depConfigName DeploymentConfig name
+     * @param snapshot Snapshot of pods for DeploymentConfig before the rolling update
+     * @return The snapshot of the DeploymentConfig after rolling update with Uid for every pod
+     */
+    public static Map<String, String> waitTillDepConfigHasRolled(String depConfigName, Map<String, String> snapshot) {
+        LOGGER.info("Waiting for DeploymentConfig {} rolling update", depConfigName);
+        TestUtils.waitFor("DeploymentConfig roll of " + depConfigName,
+            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, Constants.WAIT_FOR_ROLLING_UPDATE_TIMEOUT, () -> depConfigHasRolled(depConfigName, snapshot));
+        waitForDeploymentConfigReady(depConfigName);
+        LOGGER.info("DeploymentConfig {} rolling update finished", depConfigName);
+        return depConfigSnapshot(depConfigName);
+    }
+
+    /**
+     * Wait until the given DeploymentConfig has been deleted.
+     * @param name The name of the DeploymentConfig.
+     */
+    public static void waitForDeploymentConfigDeletion(String name) {
+        LOGGER.debug("Waiting for DeploymentConfig {} deletion", name);
+        TestUtils.waitFor("DeploymentConfig " + name + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.TIMEOUT_FOR_RESOURCE_DELETION,
+            () -> {
+                if (kubeClient().getDeploymentConfig(name) == null) {
+                    return true;
+                } else {
+                    LOGGER.warn("Deployment {} is not deleted yet! Triggering force delete by cmd client!", name);
+                    cmdKubeClient().deleteByName("deploymentconfig", name);
+                    return false;
+                }
+            });
+        LOGGER.debug("DeploymentConfig {} was deleted", name);
+    }
+
+    /**
+     * Wait until the given DeploymentConfig is ready.
+     * @param depConfigName The name of the DeploymentConfig.
+     */
+    public static Map<String, String> waitForDeploymentConfigAndPodsReady(String depConfigName, int expectPods) {
+        waitForDeploymentConfigReady(depConfigName);
+
+        LOGGER.info("Waiting for Pod(s) of DeploymentConfig {} to be ready", depConfigName);
+
+        LabelSelector deploymentConfigSelector =
+            new LabelSelectorBuilder().addToMatchLabels(kubeClient().getDeploymentConfigSelectors(depConfigName)).build();
+
+        PodUtils.waitForPodsReady(deploymentConfigSelector, expectPods, true);
+        LOGGER.info("DeploymentConfig {} is ready", depConfigName);
+
+        return depConfigSnapshot(depConfigName);
+    }
+
+    public static void waitForDeploymentConfigStatus(String depConfigName, String status) {
+        LOGGER.info("Wait for {}: {} will have desired state: {}", "DeploymentConfig", depConfigName, status);
+
+        TestUtils.waitFor(String.format("Wait for %s: %s will have desired state: %s", "DeploymentConfig", depConfigName, status),
+            Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+            () -> kubeClient().getDeploymentConfig(depConfigName).getStatus().getConditions().get(0).getType().equals(status),
+            () -> {
+                if (kubeClient().getDeploymentConfig(depConfigName) != null) {
+                    LOGGER.info(kubeClient().getDeploymentConfig(depConfigName));
+                }
+            });
+
+        LOGGER.info("{}: {} is in desired state: {}", "DeploymentConfig", depConfigName, status);
+    }
+
+    public static void waitForDeploymentConfigReady(String depConfigName) {
+        waitForDeploymentConfigStatus(depConfigName, "Ready");
+    }
+
+    public static void waitForDeploymentConfigNotReady(String depConfigName) {
+        waitForDeploymentConfigStatus(depConfigName, "NotReady");
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
@@ -5,21 +5,17 @@
 package io.strimzi.systemtest.utils.kubeUtils.controllers;
 
 import io.fabric8.kubernetes.api.model.LabelSelector;
-import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodCondition;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentCondition;
-import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectS2IUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -33,221 +29,6 @@ public class DeploymentUtils {
     private static final Logger LOGGER = LogManager.getLogger(DeploymentUtils.class);
 
     private DeploymentUtils() { }
-
-    /**
-     * Returns a map of pod name to resource version for the pods currently in the given deployment.
-     * @param name The Deployment name.
-     * @return A map of pod name to resource version for pods in the given Deployment.
-     */
-    public static Map<String, String> depSnapshot(String name) {
-        Deployment deployment = kubeClient().getDeployment(name);
-        LabelSelector selector = deployment.getSpec().getSelector();
-        return PodUtils.podSnapshot(selector);
-    }
-
-    /**
-     * Returns a map of pod name to resource version for the pods currently in the given DeploymentConfig.
-     * @param name The DeploymentConfig name.
-     * @return A map of pod name to resource version for pods in the given DeploymentConfig.
-     */
-    public static Map<String, String> depConfigSnapshot(String name) {
-        LabelSelector selector = new LabelSelectorBuilder().addToMatchLabels(kubeClient().getDeploymentConfigSelectors(name)).build();
-        return PodUtils.podSnapshot(selector);
-    }
-
-    /**
-     * Method to check that all pods for expected Deployment were rolled
-     * @param name Deployment name
-     * @param snapshot Snapshot of pods for Deployment before the rolling update
-     * @return true when the pods for Deployment are recreated
-     */
-    public static boolean depHasRolled(String name, Map<String, String> snapshot) {
-        LOGGER.debug("Existing snapshot: {}", new TreeMap<>(snapshot));
-        Map<String, String> map = PodUtils.podSnapshot(kubeClient().getDeployment(name).getSpec().getSelector());
-        LOGGER.debug("Current  snapshot: {}", new TreeMap<>(map));
-        int current = map.size();
-        map.keySet().retainAll(snapshot.keySet());
-        if (current == snapshot.size() && map.isEmpty()) {
-            LOGGER.debug("All pods seem to have rolled");
-            return true;
-        } else {
-            LOGGER.debug("Some pods still need to roll: {}", map);
-            return false;
-        }
-    }
-
-    /**
-     * Method to check that all pods for expected DeploymentConfig were rolled
-     * @param name DeploymentConfig name
-     * @param snapshot Snapshot of pods for DeploymentConfig before the rolling update
-     * @return true when the pods for DeploymentConfig are recreated
-     */
-    public static boolean depConfigHasRolled(String name, Map<String, String> snapshot) {
-        LOGGER.debug("Existing snapshot: {}", new TreeMap<>(snapshot));
-        LabelSelector selector = new LabelSelectorBuilder().addToMatchLabels(kubeClient().getDeploymentConfigSelectors(name)).build();
-        Map<String, String> map = PodUtils.podSnapshot(selector);
-        LOGGER.debug("Current  snapshot: {}", new TreeMap<>(map));
-        int current = map.size();
-        map.keySet().retainAll(snapshot.keySet());
-        if (current == snapshot.size() && map.isEmpty()) {
-            LOGGER.info("All pods seem to have rolled");
-            return true;
-        } else {
-            LOGGER.debug("Some pods still need to roll: {}", map);
-            return false;
-        }
-    }
-
-    /**
-     * Method to wait when Deployment will be recreated after rolling update
-     * @param name Deployment name
-     * @param expectedPods Expected number of pods
-     * @param snapshot Snapshot of pods for Deployment before the rolling update
-     * @return The snapshot of the Deployment after rolling update with Uid for every pod
-     */
-    public static Map<String, String> waitTillDepHasRolled(String name, int expectedPods, Map<String, String> snapshot) {
-        LOGGER.info("Waiting for Deployment {} rolling update", name);
-        TestUtils.waitFor("Deployment " + name + " rolling update",
-            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, Constants.WAIT_FOR_ROLLING_UPDATE_TIMEOUT, () -> depHasRolled(name, snapshot));
-        waitForDeploymentReady(name);
-        PodUtils.waitForPodsReady(kubeClient().getDeployment(name).getSpec().getSelector(), expectedPods, true);
-        LOGGER.info("Deployment {} rolling update finished", name);
-        return depSnapshot(name);
-    }
-
-    /**
-     * Method to wait when DeploymentConfig will be recreated after rolling update
-     * @param clusterName DeploymentConfig name
-     * @param snapshot Snapshot of pods for DeploymentConfig before the rolling update
-     * @return The snapshot of the DeploymentConfig after rolling update with Uid for every pod
-     */
-    public static Map<String, String> waitTillDepConfigHasRolled(String clusterName, Map<String, String> snapshot) {
-        String name = KafkaConnectS2IResources.deploymentName(clusterName);
-        LOGGER.info("Waiting for DeploymentConfig {} rolling update", name);
-        TestUtils.waitFor("DeploymentConfig roll of " + name,
-            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, Constants.WAIT_FOR_ROLLING_UPDATE_TIMEOUT, () -> depConfigHasRolled(name, snapshot));
-        KafkaConnectS2IUtils.waitForConnectS2IStatus(clusterName, "Ready");
-        LOGGER.info("DeploymentConfig {} rolling update finished", name);
-        return depConfigSnapshot(name);
-    }
-
-    public static void waitForPodUpdate(String podName, Date startTime) {
-        TestUtils.waitFor(podName + " update", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS, () ->
-            startTime.before(kubeClient().getCreationTimestampForPod(podName))
-        );
-    }
-
-    /**
-     * Wait until the given Deployment has been recovered.
-     * @param name The name of the Deployment.
-     */
-    public static void waitForDeploymentRecovery(String name, String deploymentUid) {
-        LOGGER.info("Waiting for Deployment {}-{} recovery in namespace {}", name, deploymentUid, kubeClient().getNamespace());
-        TestUtils.waitFor("deployment " + name + " to be recovered", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> !kubeClient().getDeploymentUid(name).equals(deploymentUid));
-        LOGGER.info("Deployment {} was recovered", name);
-    }
-
-    /**
-     * Wait until the given Deployment is ready.
-     * @param name The name of the Deployment.
-     */
-    public static void waitForDeploymentReady(String name) {
-        LOGGER.info("Waiting for Deployment {}", name);
-        TestUtils.waitFor("deployment " + name, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> kubeClient().getDeploymentStatus(name),
-            () -> DeploymentUtils.logCurrentDeploymentStatus(kubeClient().getDeployment(name)));
-        LOGGER.info("Deployment {} is ready", name);
-    }
-
-    /**
-     * Wait until the given Deployment is ready.
-     * @param name The name of the Deployment.
-     * @param expectPods The expected number of pods.
-     */
-    public static void waitForDeploymentAndPodsReady(String name, int expectPods) {
-        LOGGER.debug("Waiting for Deployment {}", name);
-        TestUtils.waitFor("deployment " + name + " pods to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> kubeClient().getDeploymentStatus(name),
-            () -> DeploymentUtils.logCurrentDeploymentStatus(kubeClient().getDeployment(name)));
-        LOGGER.info("Waiting for {} Pod(s) of Deployment {} to be ready", expectPods, name);
-        PodUtils.waitForPodsReady(kubeClient().getDeploymentSelectors(name), expectPods, true,
-            () -> DeploymentUtils.logCurrentDeploymentStatus(kubeClient().getDeployment(name)));
-        LOGGER.info("Deployment {} is ready", name);
-    }
-
-    /**
-     * Wait until the given Deployment has been deleted.
-     * @param name The name of the Deployment.
-     */
-    public static void waitForDeploymentDeletion(String name) {
-        LOGGER.debug("Waiting for Deployment {} deletion", name);
-        TestUtils.waitFor("Deployment " + name + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.TIMEOUT_FOR_RESOURCE_DELETION,
-            () -> {
-                if (kubeClient().getDeployment(name) == null) {
-                    return true;
-                } else {
-                    LOGGER.warn("Deployment {} is not deleted yet! Triggering force delete by cmd client!", name);
-                    cmdKubeClient().deleteByName("deployment", name);
-                    return false;
-                }
-            });
-        LOGGER.debug("Deployment {} was deleted", name);
-    }
-
-    /**
-     * Wait until the given DeploymentConfig has been deleted.
-     * @param name The name of the DeploymentConfig.
-     */
-    public static void waitForDeploymentConfigDeletion(String name) {
-        LOGGER.debug("Waiting for DeploymentConfig {} deletion", name);
-        TestUtils.waitFor("DeploymentConfig " + name + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.TIMEOUT_FOR_RESOURCE_DELETION,
-            () -> {
-                if (kubeClient().getDeploymentConfig(name) == null) {
-                    return true;
-                } else {
-                    LOGGER.warn("Deployment {} is not deleted yet! Triggering force delete by cmd client!", name);
-                    cmdKubeClient().deleteByName("deploymentconfig", name);
-                    return false;
-                }
-            });
-        LOGGER.debug("DeploymentConfig {} was deleted", name);
-    }
-
-    public static void waitForNoRollingUpdate(String deploymentName, Map<String, String> pods) {
-        // alternative to sync hassling AtomicInteger one could use an integer array instead
-        // not need to be final because reference to the array does not get another array assigned
-        int[] i = {0};
-
-        TestUtils.waitFor("stability of rolling update will be not triggered", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> {
-                if (!DeploymentUtils.depHasRolled(deploymentName, pods)) {
-                    LOGGER.info("{} pods not rolling waiting, remaining seconds for stability {}", pods.toString(),
-                            Constants.GLOBAL_RECONCILIATION_COUNT - i[0]);
-                    return i[0]++ == Constants.GLOBAL_RECONCILIATION_COUNT;
-                } else {
-                    throw new RuntimeException(pods.toString() + " pods are rolling!");
-                }
-            }
-        );
-    }
-
-    /**
-     * Wait until the given DeploymentConfig is ready.
-     * @param name The name of the DeploymentConfig.
-     */
-    public static Map<String, String> waitForDeploymentConfigReady(String name, int expectPods) {
-        LOGGER.info("Waiting until DeploymentConfig {} is ready", name);
-        TestUtils.waitFor("DeploymentConfig " + name + " to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> kubeClient().getDeploymentConfigStatus(name));
-
-        LOGGER.info("Waiting for Pod(s) of DeploymentConfig {} to be ready", name);
-        LabelSelector deploymentConfigSelector =
-                new LabelSelectorBuilder().addToMatchLabels(kubeClient().getDeploymentConfigSelectors(name)).build();
-        PodUtils.waitForPodsReady(deploymentConfigSelector, expectPods, true);
-        LOGGER.info("DeploymentConfig {} is ready", name);
-        return depConfigSnapshot(name);
-    }
 
     /**
      * Log actual status of deployment with pods
@@ -281,5 +62,138 @@ public class DeploymentUtils {
         }
 
         LOGGER.info("{}", String.join("", log));
+    }
+
+    public static void waitForNoRollingUpdate(String deploymentName, Map<String, String> pods) {
+        // alternative to sync hassling AtomicInteger one could use an integer array instead
+        // not need to be final because reference to the array does not get another array assigned
+        int[] i = {0};
+
+        TestUtils.waitFor("stability of rolling update will be not triggered", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> {
+                if (!DeploymentUtils.depHasRolled(deploymentName, pods)) {
+                    LOGGER.info("{} pods not rolling waiting, remaining seconds for stability {}", pods.toString(),
+                        Constants.GLOBAL_RECONCILIATION_COUNT - i[0]);
+                    return i[0]++ == Constants.GLOBAL_RECONCILIATION_COUNT;
+                } else {
+                    throw new RuntimeException(pods.toString() + " pods are rolling!");
+                }
+            }
+        );
+    }
+
+    /**
+     * Returns a map of pod name to resource version for the pods currently in the given deployment.
+     * @param name The Deployment name.
+     * @return A map of pod name to resource version for pods in the given Deployment.
+     */
+    public static Map<String, String> depSnapshot(String name) {
+        Deployment deployment = kubeClient().getDeployment(name);
+        LabelSelector selector = deployment.getSpec().getSelector();
+        return PodUtils.podSnapshot(selector);
+    }
+
+    /**
+     * Method to check that all pods for expected Deployment were rolled
+     * @param name Deployment name
+     * @param snapshot Snapshot of pods for Deployment before the rolling update
+     * @return true when the pods for Deployment are recreated
+     */
+    public static boolean depHasRolled(String name, Map<String, String> snapshot) {
+        LOGGER.debug("Existing snapshot: {}", new TreeMap<>(snapshot));
+        Map<String, String> map = PodUtils.podSnapshot(kubeClient().getDeployment(name).getSpec().getSelector());
+        LOGGER.debug("Current  snapshot: {}", new TreeMap<>(map));
+        int current = map.size();
+        map.keySet().retainAll(snapshot.keySet());
+        if (current == snapshot.size() && map.isEmpty()) {
+            LOGGER.debug("All pods seem to have rolled");
+            return true;
+        } else {
+            LOGGER.debug("Some pods still need to roll: {}", map);
+            return false;
+        }
+    }
+
+    /**
+     * Method to wait when Deployment will be recreated after rolling update
+     * @param name Deployment name
+     * @param expectedPods Expected number of pods
+     * @param snapshot Snapshot of pods for Deployment before the rolling update
+     * @return The snapshot of the Deployment after rolling update with Uid for every pod
+     */
+    public static Map<String, String> waitTillDepHasRolled(String name, int expectedPods, Map<String, String> snapshot) {
+        LOGGER.info("Waiting for Deployment {} rolling update", name);
+        TestUtils.waitFor("Deployment " + name + " rolling update",
+            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, Constants.WAIT_FOR_ROLLING_UPDATE_TIMEOUT, () -> depHasRolled(name, snapshot));
+        waitForDeploymentReady(name);
+        PodUtils.waitForPodsReady(kubeClient().getDeployment(name).getSpec().getSelector(), expectedPods, true);
+        LOGGER.info("Deployment {} rolling update finished", name);
+        return depSnapshot(name);
+    }
+
+    /**
+     * Wait until the given Deployment has been recovered.
+     * @param name The name of the Deployment.
+     */
+    public static void waitForDeploymentRecovery(String name, String deploymentUid) {
+        LOGGER.info("Waiting for Deployment {}-{} recovery in namespace {}", name, deploymentUid, kubeClient().getNamespace());
+        TestUtils.waitFor("deployment " + name + " to be recovered", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+            () -> !kubeClient().getDeploymentUid(name).equals(deploymentUid));
+        LOGGER.info("Deployment {} was recovered", name);
+    }
+
+    public static void waitForDeploymentStatus(String deploymentName, String status) {
+        LOGGER.info("Wait for {}: {} will have desired state: {}", Constants.DEPLOYMENT, deploymentName, status);
+
+        TestUtils.waitFor(String.format("Wait for %s: %s will have desired state: %s", Constants.DEPLOYMENT, deploymentName, status),
+            Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+            () -> kubeClient().getDeploymentConfig(deploymentName).getStatus().getConditions().get(0).getType().equals(status),
+            () -> {
+                if (kubeClient().getDeploymentConfig(deploymentName) != null) {
+                    LOGGER.info(kubeClient().getDeploymentConfig(deploymentName));
+                }
+            });
+
+        LOGGER.info("{}: {} is in desired state: {}", Constants.DEPLOYMENT, deploymentName, status);
+    }
+
+    public static void waitForDeploymentReady(String deploymentName) {
+        waitForDeploymentStatus(deploymentName, "Ready");
+    }
+
+    public static void waitForDeploymentNotReady(String deploymentName) {
+        waitForDeploymentStatus(deploymentName, "NotReady");
+    }
+
+    /**
+     * Wait until the given Deployment is ready.
+     * @param deploymentName The name of the Deployment.
+     * @param expectPods The expected number of pods.
+     */
+    public static void waitForDeploymentAndPodsReady(String deploymentName, int expectPods) {
+        waitForDeploymentStatus(deploymentName, "Ready");
+        LOGGER.info("Waiting for {} Pod(s) of Deployment {} to be ready", expectPods, deploymentName);
+        PodUtils.waitForPodsReady(kubeClient().getDeploymentSelectors(deploymentName), expectPods, true,
+            () -> DeploymentUtils.logCurrentDeploymentStatus(kubeClient().getDeployment(deploymentName)));
+        LOGGER.info("Deployment {} is ready", deploymentName);
+    }
+
+    /**
+     * Wait until the given Deployment has been deleted.
+     * @param name The name of the Deployment.
+     */
+    public static void waitForDeploymentDeletion(String name) {
+        LOGGER.debug("Waiting for Deployment {} deletion", name);
+        TestUtils.waitFor("Deployment " + name + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.TIMEOUT_FOR_RESOURCE_DELETION,
+            () -> {
+                if (kubeClient().getDeployment(name) == null) {
+                    return true;
+                } else {
+                    LOGGER.warn("Deployment {} is not deleted yet! Triggering force delete by cmd client!", name);
+                    cmdKubeClient().deleteByName("deployment", name);
+                    return false;
+                }
+            });
+        LOGGER.debug("Deployment {} was deleted", name);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest;
 
-import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
@@ -15,7 +14,7 @@ import io.strimzi.systemtest.resources.crd.KafkaMirrorMakerResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaMirrorMakerUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -66,7 +65,7 @@ public abstract class AbstractNamespaceST extends BaseST {
         KafkaMirrorMakerResource.kafkaMirrorMaker(CLUSTER_NAME, kafkaSourceName, kafkaTargetName, "my-group", 1, false).done();
 
         LOGGER.info("Waiting for creation {} in namespace {}", CLUSTER_NAME + "-mirror-maker", SECOND_NAMESPACE);
-        DeploymentUtils.waitForDeploymentAndPodsReady(KafkaMirrorMakerResources.deploymentName(CLUSTER_NAME), 1);
+        KafkaMirrorMakerUtils.waitForKafkaMirrorMakerReady(CLUSTER_NAME);
         cluster.setNamespace(previousNamespace);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -35,6 +35,7 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectS2IUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentConfigUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
@@ -688,7 +689,7 @@ class ConnectST extends BaseST {
         KafkaConnectS2IUtils.waitForConnectS2INotReady(CLUSTER_NAME);
 
         KafkaConnectS2IResource.kafkaConnectS2IClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).delete();
-        DeploymentUtils.waitForDeploymentConfigDeletion(KafkaConnectS2IResources.deploymentName(CLUSTER_NAME));
+        DeploymentConfigUtils.waitForDeploymentConfigDeletion(KafkaConnectS2IResources.deploymentName(CLUSTER_NAME));
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -10,7 +10,6 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.strimzi.api.kafka.model.KafkaBridgeResources;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
-import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaResources;
@@ -93,7 +92,7 @@ class CustomResourceStatusST extends BaseST {
     @Tag(NODEPORT_SUPPORTED)
     void testKafkaStatus() {
         LOGGER.info("Checking status of deployed kafka cluster");
-        KafkaUtils.waitUntilKafkaCRIsReady(CLUSTER_NAME);
+        KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(TOPIC_NAME)
@@ -116,7 +115,7 @@ class CustomResourceStatusST extends BaseST {
         });
 
         LOGGER.info("Wait until cluster will be in NotReady state ...");
-        KafkaUtils.waitUntilKafkaCRIsNotReady(CLUSTER_NAME);
+        KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
 
         LOGGER.info("Recovery cluster to Ready state ...");
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, k -> {
@@ -124,7 +123,7 @@ class CustomResourceStatusST extends BaseST {
                     .addToRequests("cpu", new Quantity("100m"))
                     .build());
         });
-        KafkaUtils.waitUntilKafkaCRIsReady(CLUSTER_NAME);
+        KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
         assertKafkaStatus(3, "my-cluster-kafka-bootstrap.status-cluster-test.svc");
     }
 
@@ -361,7 +360,7 @@ class CustomResourceStatusST extends BaseST {
 
     @Test
     void testKafkaMirrorMaker2WrongBootstrap() {
-        KafkaMirrorMaker2 kafkaMirrorMaker2 = KafkaMirrorMaker2Resource.kafkaMirrorMaker2WithoutWait(
+        KafkaMirrorMaker2Resource.kafkaMirrorMaker2WithoutWait(
                 KafkaMirrorMaker2Resource.defaultKafkaMirrorMaker2(CLUSTER_NAME,
             "non-existing-source", "non-existing-target", 1, false).build());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -444,7 +444,7 @@ class KafkaST extends BaseST {
         StatefulSetUtils.waitTillSsHasRolled(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME), 2, zkSnapshot);
         StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 2, kafkaSnapshot);
         DeploymentUtils.waitTillDepHasRolled(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), 1, eoPod);
-        KafkaUtils.waitUntilKafkaCRIsReady(CLUSTER_NAME);
+        KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
 
         LOGGER.info("Verify values after update");
         checkReadinessLivenessProbe(kafkaStatefulSetName(CLUSTER_NAME), "kafka", updatedInitialDelaySeconds, updatedTimeoutSeconds,
@@ -851,7 +851,7 @@ class KafkaST extends BaseST {
         //Updating first topic using pod CLI
         KafkaCmdClient.updateTopicPartitionsCountUsingPodCli(CLUSTER_NAME, 0, topicName, 2);
 
-        KafkaUtils.waitUntilKafkaCRIsReady(CLUSTER_NAME);
+        KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
 
         assertThat(KafkaCmdClient.describeTopicUsingPodCli(CLUSTER_NAME, 0, topicName),
                 hasItems("PartitionCount:2"));
@@ -865,7 +865,7 @@ class KafkaST extends BaseST {
             topic.getSpec().setPartitions(2);
         });
 
-        KafkaUtils.waitUntilKafkaCRIsReady(CLUSTER_NAME);
+        KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
 
         assertThat(KafkaCmdClient.describeTopicUsingPodCli(CLUSTER_NAME, 0, cliTopicName),
                 hasItems("PartitionCount:2"));
@@ -2043,7 +2043,7 @@ class KafkaST extends BaseST {
 
         PersistentVolumeClaimUtils.waitUntilPVCLabelsChange(pvcLabel, labelAnnotationKey);
         PersistentVolumeClaimUtils.waitUntilPVCAnnotationChange(pvcAnnotation, labelAnnotationKey);
-        KafkaUtils.waitUntilKafkaCRIsReady(CLUSTER_NAME);
+        KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
 
         pvcs = kubeClient().listPersistentVolumeClaims();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmBaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmBaseST.java
@@ -38,7 +38,7 @@ public class OlmBaseST extends BaseST {
     void doTestDeployExampleKafka() {
         JsonObject kafkaResource = OlmResource.getExampleResources().get(Kafka.RESOURCE_KIND);
         cmdKubeClient().applyContent(kafkaResource.toString());
-        KafkaUtils.waitUntilKafkaCRIsReady(kafkaResource.getJsonObject("metadata").getString("name"));
+        KafkaUtils.waitForKafkaReady(kafkaResource.getJsonObject("metadata").getString("name"));
     }
 
     void doTestDeployExampleKafkaUser() {
@@ -56,7 +56,7 @@ public class OlmBaseST extends BaseST {
     void doTestDeployExampleKafkaConnect() {
         JsonObject kafkaConnectResource = OlmResource.getExampleResources().get(KafkaConnect.RESOURCE_KIND);
         cmdKubeClient().applyContent(kafkaConnectResource.toString());
-        KafkaConnectUtils.waitForConnectStatus(kafkaConnectResource.getJsonObject("metadata").getString("name"), "Ready");
+        KafkaConnectUtils.waitForConnectReady(kafkaConnectResource.getJsonObject("metadata").getString("name"));
     }
 
     void doTestDeployExampleKafkaConnectS2I() {
@@ -67,7 +67,7 @@ public class OlmBaseST extends BaseST {
         examples.put(KafkaConnectS2I.RESOURCE_KIND, kafkaConnectS2IResource);
         OlmResource.setExampleResources(examples);
         cmdKubeClient().applyContent(kafkaConnectS2IResource.toString());
-        KafkaConnectS2IUtils.waitForConnectS2IStatus(kafkaConnectS2IResource.getJsonObject("metadata").getString("name"), "Ready");
+        KafkaConnectS2IUtils.waitForConnectS2IReady(kafkaConnectS2IResource.getJsonObject("metadata").getString("name"));
     }
 
     void doTestDeployExampleKafkaBridge() {
@@ -77,11 +77,11 @@ public class OlmBaseST extends BaseST {
     }
 
     void doTestDeployExampleKafkaMirrorMaker() {
-        JsonObject kafkaMirroMakerResource = OlmResource.getExampleResources().get(KafkaMirrorMaker.RESOURCE_KIND);
-        cmdKubeClient().applyContent(kafkaMirroMakerResource.toString()
+        JsonObject kafkaMirrorMakerResource = OlmResource.getExampleResources().get(KafkaMirrorMaker.RESOURCE_KIND);
+        cmdKubeClient().applyContent(kafkaMirrorMakerResource.toString()
                 .replace("my-source-cluster-kafka-bootstrap", "my-cluster-kafka-bootstrap")
                 .replace("my-target-cluster-kafka-bootstrap", "my-cluster-kafka-bootstrap"));
-        KafkaMirrorMakerUtils.waitForKafkaMirrorMakerReady(kafkaMirroMakerResource.getJsonObject("metadata").getString("name"));
+        KafkaMirrorMakerUtils.waitForKafkaMirrorMakerReady(kafkaMirrorMakerResource.getJsonObject("metadata").getString("name"));
     }
 
     void doTestDeployExampleKafkaMirrorMaker2() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -604,7 +604,7 @@ class RollingUpdateST extends BaseST {
         });
 
         StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaPods);
-        KafkaUtils.waitUntilKafkaCRIsReady(CLUSTER_NAME);
+        KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
 
         String bootstrapAddressDns = ((KafkaListenerExternalNodePort) Crds.kafkaOperation(kubeClient().getClient())
                 .inNamespace(kubeClient().getNamespace()).withName(CLUSTER_NAME).get().getSpec().getKafka()

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -16,8 +16,6 @@ import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaUser;
-import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
-import io.strimzi.api.kafka.model.status.KafkaMirrorMakerStatus;
 import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.systemtest.BaseST;
 import io.strimzi.systemtest.Constants;
@@ -32,6 +30,7 @@ import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaMirrorMakerUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
@@ -258,7 +257,6 @@ class SecurityST extends BaseST {
         }
         if (!kafkaShouldRoll) {
             assertThat("Kafka pods should not roll, but did.", StatefulSetUtils.ssSnapshot(kafkaStatefulSetName(CLUSTER_NAME)), is(kafkaPods));
-
         }
         if (!eoShouldRoll) {
             assertThat("EO pod should not roll, but did.", DeploymentUtils.depSnapshot(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME)), is(eoPod));
@@ -376,6 +374,7 @@ class SecurityST extends BaseST {
             LOGGER.info("Wait for kafka to rolling restart (2)...");
             kafkaPods = StatefulSetUtils.waitTillSsHasRolled(kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaPods);
         }
+
         if (eoShouldRoll) {
             LOGGER.info("Wait for EO to rolling restart (2)...");
             eoPod = DeploymentUtils.waitTillDepHasRolled(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), 1, eoPod);
@@ -419,12 +418,13 @@ class SecurityST extends BaseST {
 
         if (!zkShouldRoll) {
             assertThat("ZK pods should not roll, but did.", StatefulSetUtils.ssSnapshot(zookeeperStatefulSetName(CLUSTER_NAME)), is(zkPods));
-
         }
+
         if (!kafkaShouldRoll) {
             assertThat("Kafka pods should not roll, but did.", StatefulSetUtils.ssSnapshot(kafkaStatefulSetName(CLUSTER_NAME)), is(kafkaPods));
 
         }
+
         if (!eoShouldRoll) {
             assertThat("EO pod should not roll, but did.", DeploymentUtils.depSnapshot(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME)), is(eoPod));
         }
@@ -483,7 +483,6 @@ class SecurityST extends BaseST {
                     .endZookeeper()
                 .endSpec()
                 .done();
-
     }
 
     @Test
@@ -664,7 +663,6 @@ class SecurityST extends BaseST {
             internalKafkaClient.sendMessagesTls(),
             internalKafkaClient.receiveMessagesTls()
         );
-
     }
 
     @Test
@@ -733,7 +731,6 @@ class SecurityST extends BaseST {
         internalKafkaClient.setPodName(deniedKafkaClientsPodName);
         internalKafkaClient.setTopicName(topic1);
         internalKafkaClient.setConsumerGroup(CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
-
 
         LOGGER.info("Verifying that {} pod is not able to exchange messages", deniedKafkaClientsPodName);
         assertThrows(AssertionError.class, () ->  {
@@ -867,13 +864,7 @@ class SecurityST extends BaseST {
 
         LOGGER.info("KafkaConnect with config {} will connect to {}:9093", "ssl.endpoint.identification.algorithm", ipOfBootstrapService);
 
-        TestUtils.waitFor("KafkaConnect status will be 'Ready'", Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> KafkaConnectResource.kafkaConnectClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus()
-                        .getConditions().get(0).getType().equals("Ready"));
-
-        KafkaConnectStatus kafkaStatus = KafkaConnectResource.kafkaConnectClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
-
-        assertThat("KafkaConnect status should be " + "Ready", kafkaStatus.getConditions().get(0).getType(), is("Ready"));
+        KafkaConnectUtils.waitForConnectReady(CLUSTER_NAME);
 
         KafkaConnectResource.deleteKafkaConnectWithoutWait(CLUSTER_NAME);
         DeploymentUtils.waitForDeploymentDeletion(KafkaConnectResources.deploymentName(CLUSTER_NAME));
@@ -941,12 +932,7 @@ class SecurityST extends BaseST {
             mm.getSpec().getProducer().getConfig().put("ssl.endpoint.identification.algorithm", ""); // disable hostname verification
         });
 
-        TestUtils.waitFor("KafkaMirrorMaker status will be 'Ready'", Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getConditions().get(0).getType().equals("Ready"));
-
-        KafkaMirrorMakerStatus kafkaMirrorMakerStatus = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
-
-        assertThat("KafkaMirrorMaker status should be " + "Ready", kafkaMirrorMakerStatus.getConditions().get(0).getType(), is("Ready"));
+        KafkaMirrorMakerUtils.waitForKafkaMirrorMakerReady(CLUSTER_NAME);
 
         KafkaMirrorMakerResource.deleteKafkaMirrorMakerWithoutWait(CLUSTER_NAME);
         DeploymentUtils.waitForDeploymentDeletion(KafkaMirrorMakerResources.deploymentName(CLUSTER_NAME));
@@ -1258,7 +1244,6 @@ class SecurityST extends BaseST {
 
     @Test
     void testKafkaAndKafkaConnectTlsVersion() {
-
         Map<String, Object> configWithNewestVersionOfTls = new HashMap<>();
 
         final String tlsVersion12 = "TLSv1.2";
@@ -1271,9 +1256,9 @@ class SecurityST extends BaseST {
 
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3)
                 .editSpec()
-                .editKafka()
-                .withConfig(configWithNewestVersionOfTls)
-                .endKafka()
+                    .editKafka()
+                        .withConfig(configWithNewestVersionOfTls)
+                    .endKafka()
                 .endSpec()
                 .done();
 
@@ -1299,7 +1284,7 @@ class SecurityST extends BaseST {
 
         KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.defaultKafkaConnect(CLUSTER_NAME, CLUSTER_NAME, 1)
                 .editSpec()
-                .withConfig(configWithLowestVersionOfTls)
+                    .withConfig(configWithLowestVersionOfTls)
                 .endSpec()
                 .build());
 
@@ -1326,7 +1311,7 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Verifying that Kafka Connect status is Ready because of same TLS version");
 
-        KafkaConnectUtils.waitForConnectStatus(CLUSTER_NAME, "Ready");
+        KafkaConnectUtils.waitForConnectReady(CLUSTER_NAME);
 
         KafkaConnectResource.deleteKafkaConnectWithoutWait(CLUSTER_NAME);
         DeploymentUtils.waitForDeploymentDeletion(KafkaConnectResources.deploymentName(CLUSTER_NAME));
@@ -1345,9 +1330,9 @@ class SecurityST extends BaseST {
 
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3)
                 .editSpec()
-                .editKafka()
-                .withConfig(configWithCipherSuitesSha384)
-                .endKafka()
+                    .editKafka()
+                        .withConfig(configWithCipherSuitesSha384)
+                    .endKafka()
                 .endSpec()
                 .done();
 
@@ -1366,13 +1351,13 @@ class SecurityST extends BaseST {
 
         KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.defaultKafkaConnect(CLUSTER_NAME, CLUSTER_NAME, 1)
                 .editSpec()
-                .withConfig(configWithCipherSuitesSha256)
+                    .withConfig(configWithCipherSuitesSha256)
                 .endSpec()
                 .build());
 
         LOGGER.info("Verifying that Kafka Connect status is NotReady because of different cipher suites complexity of algorithm");
 
-        KafkaConnectUtils.waitForConnectStatus(CLUSTER_NAME, "NotReady");
+        KafkaConnectUtils.waitForConnectNotReady(CLUSTER_NAME);
 
         LOGGER.info("Replacing Kafka Connect config to the cipher suites same as the Kafka broker has.");
 
@@ -1389,7 +1374,7 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Verifying that Kafka Connect status is Ready because of the same cipher suites complexity of algorithm");
 
-        KafkaConnectUtils.waitForConnectStatus(CLUSTER_NAME, "Ready");
+        KafkaConnectUtils.waitForConnectReady(CLUSTER_NAME);
 
         KafkaConnectResource.deleteKafkaConnectWithoutWait(CLUSTER_NAME);
         DeploymentUtils.waitForDeploymentDeletion(KafkaConnectResources.deploymentName(CLUSTER_NAME));

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -26,9 +26,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.Collections;
-import java.util.concurrent.ExecutionException;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
@@ -173,7 +171,7 @@ public class SpecificST extends BaseST {
 
         LOGGER.info("Kafka with version {} deployed.", nonExistingVersion);
 
-        KafkaUtils.waitUntilKafkaCRIsNotReady(CLUSTER_NAME);
+        KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(CLUSTER_NAME, NAMESPACE, nonExistingVersionMessage);
 
         KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).delete();
@@ -181,8 +179,7 @@ public class SpecificST extends BaseST {
 
     @Test
     @Tag(LOADBALANCER_SUPPORTED)
-    void testLoadBalancerSourceRanges() throws IOException, InterruptedException, ExecutionException, TimeoutException {
-
+    void testLoadBalancerSourceRanges() {
         String networkInterfaces = Exec.exec("ip", "route").out();
         Pattern ipv4InterfacesPattern = Pattern.compile("[0-9]+.[0-9]+.[0-9]+.[0-9]+\\/[0-9]+ dev (eth0|enp11s0u1).*");
         Matcher ipv4InterfacesMatcher = ipv4InterfacesPattern.matcher(networkInterfaces);

--- a/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicST.java
@@ -152,7 +152,7 @@ public class TopicST extends BaseST {
 
         LOGGER.info("Verify that corresponding {} KafkaTopic custom resources were created and topic is in Ready state", 1);
         KafkaTopicUtils.waitForKafkaTopicCreation(TOPIC_NAME);
-        KafkaTopicUtils.waitForKafkaTopicStatus(TOPIC_NAME, "Ready");
+        KafkaTopicUtils.waitForKafkaTopicReady(TOPIC_NAME);
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicScalabilityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicScalabilityST.java
@@ -44,7 +44,7 @@ public class TopicScalabilityST extends BaseST {
             String currentTopic = topicName + i;
             LOGGER.debug("Verifying that {} topic CR has Ready status", currentTopic);
 
-            KafkaTopicUtils.waitForKafkaTopicStatus(currentTopic, "Ready");
+            KafkaTopicUtils.waitForKafkaTopicReady(currentTopic);
         }
 
         LOGGER.info("Verifying that we created {} topics", NUMBER_OF_TOPICS);


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR gonna:

- change wait for Kafka CR to be ready (we will not wait for `StatefulSet` and `Deployments` anymore) -> the Kafka CR is `Ready` when all `StatefulSets` and `Deployments` (like EO, CruiseControl..) are ready (also with pods).

- change names of three Kafka util methods to be same as others -> to match the pattern

- split `DeploymentUtils` to two classes -> `DeploymentUtils` and `DeploymentConfigUtils` -> now we will have separated classes so it will be more readable and cleaner.

- clean STs

This is also prerequisite for #3187 -> I'm gonna split one problem to several PRs so it will better for review.

### Checklist

- [x] Make sure all tests pass


