### PR TITLE
Try to fix Helm2 and 3 on Jenkins builds

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -62,6 +62,9 @@ jobs:
 
       - bash: ".travis/setup-kubernetes.sh"
         displayName: "Setup Minikube cluster"
+
+      - bash: ".travis/setup-helm.sh"
+        displayName: "Setup Helm"
         env:
           TEST_HELM2_VERSION: 'v2.16.3'
           TEST_HELM3_VERSION: 'v3.2.0'

--- a/.azure/pull-request-pipeline.yaml
+++ b/.azure/pull-request-pipeline.yaml
@@ -45,6 +45,9 @@ jobs:
 
       - bash: ".travis/setup-kubernetes.sh"
         displayName: "Setup Minikube cluster"
+
+      - bash: ".travis/setup-helm.sh"
+        displayName: "Setup Helm"
         env:
           TEST_HELM2_VERSION: 'v2.16.3'
           TEST_HELM3_VERSION: 'v3.2.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
 - mvn -q install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 before_script:
 - "./.travis/setup-kubernetes.sh"
+- "./.travis/setup-helm.sh"
 script:
 - "./.travis/build.sh"
 cache:

--- a/.travis/setup-helm.sh
+++ b/.travis/setup-helm.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -x
+
+function install_helm2 {
+    install_nsenter
+
+    export HELM_INSTALL_DIR=/usr/bin
+    curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
+    # we need to modify the script with a different path because on the Azure pipelines the HELM_INSTALL_DIR env var is not honoured
+    sed -i 's#/usr/local/bin#/usr/bin#g' get_helm.sh
+    chmod 700 get_helm.sh
+
+    echo "Installing helm 2..."
+    sudo ./get_helm.sh --version "${TEST_HELM2_VERSION}"
+    sudo mv ${HELM_INSTALL_DIR}/helm ${HELM_INSTALL_DIR}/helm2
+
+    echo "Verifying the installation of helm2 binary..."
+    # run a proper helm command instead of, for example, "which helm", to verify that we can call the binary
+    helm2 --help
+    helmCommandOutput=$?
+
+    if [ $helmCommandOutput != 0 ]; then
+        echo "helm2 binary hasn't been installed properly - exiting..."
+        exit 1
+    fi
+}
+
+function install_helm3 {
+    install_nsenter
+
+    export HELM_INSTALL_DIR=/usr/bin
+    curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
+    # we need to modify the script with a different path because on the Azure pipelines the HELM_INSTALL_DIR env var is not honoured
+    sed -i 's#/usr/local/bin#/usr/bin#g' get_helm.sh
+    chmod 700 get_helm.sh
+
+    echo "Installing helm 3..."
+    sudo ./get_helm.sh --version "${TEST_HELM3_VERSION}"
+    sudo mv ${HELM_INSTALL_DIR}/helm ${HELM_INSTALL_DIR}/helm3
+
+    echo "Verifying the installation of helm3 binary..."
+    # run a proper helm command instead of, for example, "which helm", to verify that we can call the binary
+    helm3 --help
+    helmCommandOutput=$?
+
+    if [ $helmCommandOutput != 0 ]; then
+        echo "helm3 binary hasn't been installed properly - exiting..."
+        exit 1
+    fi
+}
+
+install_helm2
+install_helm3

--- a/.travis/setup-kubernetes.sh
+++ b/.travis/setup-kubernetes.sh
@@ -20,54 +20,6 @@ function install_nsenter {
     sudo cp nsenter /usr/bin
 }
 
-function install_helm2 {
-    install_nsenter
-
-    export HELM_INSTALL_DIR=/usr/bin
-    curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
-    # we need to modify the script with a different path because on the Azure pipelines the HELM_INSTALL_DIR env var is not honoured
-    sed -i 's#/usr/local/bin#/usr/bin#g' get_helm.sh
-    chmod 700 get_helm.sh
-
-    echo "Installing helm 2..."
-    sudo ./get_helm.sh --version "${TEST_HELM2_VERSION}"
-    sudo mv ${HELM_INSTALL_DIR}/helm ${HELM_INSTALL_DIR}/helm2
-
-    echo "Verifying the installation of helm2 binary..."
-    # run a proper helm command instead of, for example, "which helm", to verify that we can call the binary
-    helm2 --help
-    helmCommandOutput=$?
-
-    if [ $helmCommandOutput != 0 ]; then
-        echo "helm2 binary hasn't been installed properly - exiting..."
-        exit 1
-    fi
-}
-
-function install_helm3 {
-    install_nsenter
-
-    export HELM_INSTALL_DIR=/usr/bin
-    curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
-    # we need to modify the script with a different path because on the Azure pipelines the HELM_INSTALL_DIR env var is not honoured
-    sed -i 's#/usr/local/bin#/usr/bin#g' get_helm.sh
-    chmod 700 get_helm.sh
-
-    echo "Installing helm 3..."
-    sudo ./get_helm.sh --version "${TEST_HELM3_VERSION}"
-    sudo mv ${HELM_INSTALL_DIR}/helm ${HELM_INSTALL_DIR}/helm3
-
-    echo "Verifying the installation of helm3 binary..."
-    # run a proper helm command instead of, for example, "which helm", to verify that we can call the binary
-    helm3 --help
-    helmCommandOutput=$?
-
-    if [ $helmCommandOutput != 0 ]; then
-        echo "helm3 binary hasn't been installed properly - exiting..."
-        exit 1
-    fi
-}
-
 function wait_for_minikube {
     i="0"
 
@@ -104,8 +56,6 @@ function label_node {
 
 if [ "$TEST_CLUSTER" = "minikube" ]; then
     install_kubectl
-    install_helm2
-    install_helm3
     if [ "${TEST_MINIKUBE_VERSION:-latest}" = "latest" ]; then
         TEST_MINIKUBE_URL=https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
     else

--- a/Jenkinsfile-pr
+++ b/Jenkinsfile-pr
@@ -41,6 +41,8 @@ pipeline {
         OPERATOR_IMAGE_PULL_POLICY = "IfNotPresent"
         COMPONENTS_IMAGE_PULL_POLICY = "IfNotPresent"
         JAVA_VERSION = "11"
+        TEST_HELM2_VERSION = "v2.16.3"
+        TEST_HELM3_VERSION = "v3.2.0"
     }
     stages {
         stage('Clean WS') {
@@ -103,6 +105,15 @@ pipeline {
                         } else {
                             lib.startCRC()
                         }
+                    }
+                }
+            }
+        }
+        stage('Install Helm') {
+            steps {
+                timeout(time: 10, unit: 'MINUTES') {
+                    script {
+                        lib.InstallHelm(env.WORKSPACE)
                     }
                 }
             }

--- a/Jenkinsfile-pr
+++ b/Jenkinsfile-pr
@@ -113,7 +113,7 @@ pipeline {
             steps {
                 timeout(time: 10, unit: 'MINUTES') {
                     script {
-                        lib.InstallHelm(env.WORKSPACE)
+                        lib.installHelm(env.WORKSPACE)
                     }
                 }
             }

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -154,6 +154,9 @@ def clearImages() {
     sh "docker rmi -f \$(docker images -q) 2>/dev/null || echo 'No more images to remove.'"
 }
 
+def installHelm(String workspace) {
+    sh(script: "${workspace}/.travis/install-helm.sh")
+}
 
 def buildStrimziImages() {
     sh(script: "make docker_build")

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -155,7 +155,7 @@ def clearImages() {
 }
 
 def installHelm(String workspace) {
-    sh(script: "${workspace}/.travis/install-helm.sh")
+    sh(script: "${workspace}/.travis/setup-helm.sh")
 }
 
 def buildStrimziImages() {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Helm 3 support seems to have broken the Jenkins build which use Helm2 preinstalled in the image. This PR separates the Helm installation from the Minikube setup and tries to use it on Jenkins as well.