### PR TITLE
Bump Cruise Control to v2.4.7 for AdminClient replica reassignment

### DIFF
--- a/docker-images/kafka/kafka-thirdparty-libs/2.4.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.4.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.5.0</strimzi-oauth.version>
-        <cruise-control.version>2.0.108</cruise-control.version>
+        <cruise-control.version>2.4.7</cruise-control.version>
         <opa-authorizer.version>0.4.1</opa-authorizer.version>
     </properties>
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.5.0</strimzi-oauth.version>
-        <cruise-control.version>2.0.108</cruise-control.version>
+        <cruise-control.version>2.4.7</cruise-control.version>
         <opa-authorizer.version>0.4.1</opa-authorizer.version>
     </properties>
 

--- a/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.0.108</cruise-control.version>
+        <cruise-control.version>2.4.7</cruise-control.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Signed-off-by: Kyle Liberti <kliberti@redhat.com>

### Type of change

- Enhancement / new feature

### Description

Picks up AdminClient API changes introduced from KIP-455 for Cruise Control replica reassignment .

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

