### PR TITLE
Remove CPUCapacity Goal from default master goals and hard goals list

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
@@ -30,7 +30,11 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
                 CruiseControl.DISK_CAPACITY_GOAL,
                 CruiseControl.NETWORK_INBOUND_CAPACITY_GOAL,
                 CruiseControl.NETWORK_OUTBOUND_CAPACITY_GOAL,
-                CruiseControl.CPU_CAPACITY_GOAL,
+                // TODO: The CPU metric are currently not reported correctly when running on Kubernetes
+                //       we should add this back in once fixed upstream,
+                //       CC issue: https://github.com/linkedin/cruise-control/issues/1242
+                //       Strimzi issue: https://github.com/strimzi/strimzi-kafka-operator/issues/3215
+                //CruiseControl.CPU_CAPACITY_GOAL,
                 CruiseControl.REPLICA_DISTRIBUTION_GOAL,
                 CruiseControl.POTENTIAL_NETWORK_OUTAGE_GOAL,
                 CruiseControl.DISK_USAGE_DISTRIBUTION_GOAL,
@@ -46,6 +50,27 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
 
     public static final String CRUISE_CONTROL_GOALS = String.join(",", CRUISE_CONTROL_GOALS_LIST);
 
+    /**
+     * A list of case insensitive goals that Cruise Control will use as hard goals that must all be met for an optimization
+     * proposal to be valid.
+     */
+    protected static final List<String> CRUISE_CONTROL_HARD_GOALS_LIST = Collections.unmodifiableList(
+            Arrays.asList(
+                    CruiseControl.RACK_AWARENESS_GOAL,
+                    CruiseControl.REPLICA_CAPACITY_GOAL,
+                    CruiseControl.DISK_CAPACITY_GOAL,
+                    CruiseControl.NETWORK_INBOUND_CAPACITY_GOAL,
+                    CruiseControl.NETWORK_OUTBOUND_CAPACITY_GOAL
+                    // TODO: The CPU metric are currently not reported correctly when running on Kubernetes
+                    //       we should add this back in once fixed upstream,
+                    //       CC issue: https://github.com/linkedin/cruise-control/issues/1242
+                    //       Strimzi issue: https://github.com/strimzi/strimzi-kafka-operator/issues/3215
+                    //CruiseControl.CPU_CAPACITY_GOAL
+            )
+    );
+
+    public static final String CRUISE_CONTROL_HARD_GOALS = String.join(",", CRUISE_CONTROL_HARD_GOALS_LIST);
+
     protected static final List<String> CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS_LIST = Collections.unmodifiableList(
         Arrays.asList(
                 CruiseControl.RACK_AWARENESS_GOAL,
@@ -57,7 +82,9 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
     public static final String CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS =
             String.join(",", CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS_LIST);
 
+    public static final String CRUISE_CONTROL_GOALS_CONFIG_KEY = "goals";
     public static final String CRUISE_CONTROL_DEFAULT_GOALS_CONFIG_KEY = "default.goals";
+    public static final String CRUISE_CONTROL_HARD_GOALS_CONFIG_KEY = "hard.goals";
     public static final String CRUISE_CONTROL_SELF_HEALING_CONFIG_KEY = "self.healing.goals";
     public static final String CRUISE_CONTROL_ANOMALY_DETECTION_CONFIG_KEY = "anomaly.detection.goals";
 
@@ -76,8 +103,9 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
         config.put("broker.metrics.window.ms", Integer.toString(300_000));
         config.put("num.broker.metrics.windows", "20");
         config.put("completed.user.task.retention.time.ms", Long.toString(TimeUnit.DAYS.toMillis(1)));
-        config.put("default.goals", CRUISE_CONTROL_GOALS);
-        config.put("goals", CRUISE_CONTROL_GOALS);
+        config.put(CRUISE_CONTROL_GOALS_CONFIG_KEY, CRUISE_CONTROL_GOALS);
+        config.put(CRUISE_CONTROL_DEFAULT_GOALS_CONFIG_KEY, CRUISE_CONTROL_GOALS);
+        config.put(CRUISE_CONTROL_HARD_GOALS_CONFIG_KEY, CRUISE_CONTROL_HARD_GOALS);
         CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP = Collections.unmodifiableMap(config);
 
         FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(CruiseControlSpec.FORBIDDEN_PREFIXES);

--- a/docker-images/kafka/cruise-control-scripts/cruise_control_config_generator.sh
+++ b/docker-images/kafka/cruise-control-scripts/cruise_control_config_generator.sh
@@ -21,8 +21,6 @@ cat <<EOF > $CC_CAPACITY_FILE
 }
 EOF
 
-cat $CC_CAPACITY_FILE
-
 # Generate cluster config
 cat <<EOF > $CC_CLUSTER_CONFIG_FILE
 {

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -107,7 +107,7 @@ Unless you change the Cruise Control xref:proc-deploying-cruise-control-{context
 [source]
 RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; ReplicaDistributionGoal; PotentialNwOutGoal; DiskUsageDistributionGoal; NetworkInboundUsageDistributionGoal; NetworkOutboundUsageDistributionGoal; TopicReplicaDistributionGoal; LeaderReplicaDistributionGoal; LeaderBytesInDistributionGoal; PreferredLeaderElectionGoal
 
-Six of these goals are preset as xref:hard-soft-goals[hard goals].
+Five of these goals are preset as xref:hard-soft-goals[hard goals].
 
 To reduce complexity, we recommend that you use the inherited master optimization goals, unless you need to _completely_ exclude one or more goals from use in `KafkaRebalance` resources. The priority order of the master optimization goals can be modified, if desired, in the configuration for xref:default-goals[default optimization goals].
 

--- a/examples/cruise-control/kafka-rebalance-with-goals.yaml
+++ b/examples/cruise-control/kafka-rebalance-with-goals.yaml
@@ -10,5 +10,4 @@ spec:
     - DiskCapacityGoal
     - RackAwareGoal
     - NetworkOutboundCapacityGoal
-    - CpuCapacityGoal
     - ReplicaCapacityGoal

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -77,7 +77,8 @@ public class CruiseControlApiST extends BaseST {
         assertThat(response, containsString("DiskCapacityGoal"));
         assertThat(response, containsString("NetworkInboundCapacityGoal"));
         assertThat(response, containsString("NetworkOutboundCapacityGoal"));
-        assertThat(response, containsString("CpuCapacityGoal"));
+        // TODO: This Goal is currently not working properly on Kubernetes. It will be added in once this issue is fixed: https://github.com/linkedin/cruise-control/issues/1242
+        //assertThat(response, containsString("CpuCapacityGoal"));
         assertThat(response, containsString("ReplicaDistributionGoal"));
         assertThat(response, containsString("DiskUsageDistributionGoal"));
         assertThat(response, containsString("NetworkInboundUsageDistributionGoal"));


### PR DESCRIPTION
### Type of change

Bugfix

### Description

This PR removes the Cruise Control CPUCapacity Goal from the master (`goals`) and `hard.goals` lists. The CPUCapacity goal is not currently supported as the CC metrics reporter does not report the CPU metrics correctly when running on Kubernetes. This is reflected in the docs but the goal class was not removed from default lists in the `CruiseControlConfig`. This means that a user who specifies custom goals that do not included CPUCapacity will hit an error unless they define their own `hard.goals` without it or use `skipHardGoalsCheck: true`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [X] Make sure all tests pass
- [X] Update documentation
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Update CHANGELOG.md

