### PR TITLE
Fixed regex for Packet metrics

### DIFF
--- a/examples/metrics/kafka-metrics.yaml
+++ b/examples/metrics/kafka-metrics.yaml
@@ -150,7 +150,7 @@ spec:
         type: GAUGE
         labels:
           replicaId: "$2"
-      - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+)><>(Packets.*)"
+      - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+)><>(Packets\\w+)"
         name: "zookeeper_$4"
         type: COUNTER
         labels:


### PR DESCRIPTION
### Type of change

Bugfix

### Description

Fixed regular expression used for Packet metrics

There's a previously identified "upstream" bug in this regexp as seen [here](https://github.com/prometheus/jmx_exporter/issues/477)

This floods Prometheus keys and eventually drags down anything that tries to list available stuff from it (Grafana and the like). We've hotfixed this on our Strimzi installation but I would like to, if nothing else, raise awareness of the issue
