### PR TITLE
[systemtest][cruise-control] Change testManuallyCreateMetricsReporterTopic

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -200,19 +200,6 @@ public class KafkaResource {
         return kafkaClient().inNamespace(ResourceManager.kubeClient().getNamespace()).createOrReplace(kafka);
     }
 
-    public static Kafka kafkaWithCruiseControlWithoutWaitAutoCreateTopicsDisable(String name, int kafkaReplicas, int zookeeperReplicas) {
-        Kafka kafka = getKafkaFromYaml(PATH_TO_KAFKA_CRUISE_CONTROL_CONFIG);
-        kafka = defaultKafka(kafka, name, kafkaReplicas, zookeeperReplicas)
-                    .editSpec()
-                        .editKafka()
-                            .addToConfig("auto.create.topics.enable", "false")
-                        .endKafka()
-                    .endSpec()
-                .build();
-
-        return kafkaClient().inNamespace(ResourceManager.kubeClient().getNamespace()).createOrReplace(kafka);
-    }
-
     /**
      * This method is used for delete specific Kafka cluster without wait for all resources deletion.
      * It can be use for example for delete Kafka cluster CR with unsupported Kafka version.

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -73,12 +73,6 @@ public class KafkaTopicUtils {
         );
     }
 
-    public static void deleteKafkaTopicWithWait(String topicName) {
-        LOGGER.info("Deleting topic {} in namespace {}", topicName, kubeClient().getNamespace());
-        KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(topicName).delete();
-        waitForKafkaTopicDeletion(topicName);
-    }
-
     public static void waitForKafkaTopicDeletion(String topicName) {
         LOGGER.info("Waiting for KafkaTopic {} deletion", topicName);
         TestUtils.waitFor("KafkaTopic deletion " + topicName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -73,6 +73,12 @@ public class KafkaTopicUtils {
         );
     }
 
+    public static void deleteKafkaTopicWithWait(String topicName) {
+        LOGGER.info("Deleting topic {} in namespace {}", topicName, kubeClient().getNamespace());
+        KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(topicName).delete();
+        waitForKafkaTopicDeletion(topicName);
+    }
+
     public static void waitForKafkaTopicDeletion(String topicName) {
         LOGGER.info("Waiting for KafkaTopic {} deletion", topicName);
         TestUtils.waitFor("KafkaTopic deletion " + topicName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -96,7 +96,7 @@ public class CruiseControlIsolatedST extends BaseST {
 
         LOGGER.info("Checking partitions and replicas for {}", CRUISE_CONTROL_MODEL_TRAINING_SAMPLES_TOPIC);
         assertThat(modelTrainingTopic.getPartitions(), is(32));
-//        assertThat(modelTrainingTopic.getReplicas(), is(1));
+//        assertThat(modelTrainingTopic.getReplicas(), is(2));
 
         LOGGER.info("Checking partitions and replicas for {}", CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC);
         assertThat(partitionMetricsTopic.getPartitions(), is(32));

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest.cruisecontrol;
 
-import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopicSpec;
 import io.strimzi.systemtest.BaseST;
 import io.strimzi.systemtest.resources.KubernetesResource;
@@ -13,16 +12,11 @@ import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaRebalanceUtils;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-
-import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -4,32 +4,32 @@
  */
 package io.strimzi.systemtest.cruisecontrol;
 
-import io.strimzi.api.kafka.model.CruiseControlResources;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.KafkaTopicSpec;
 import io.strimzi.systemtest.BaseST;
-import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaRebalanceUtils;
-import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
-import io.strimzi.systemtest.utils.specific.CruiseControlUtils;
-import io.strimzi.test.WaitException;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.resources.ResourceManager.cmdKubeClient;
-import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 @Tag(REGRESSION)
 @Tag(CRUISE_CONTROL)
@@ -42,47 +42,65 @@ public class CruiseControlIsolatedST extends BaseST {
     private static final String CRUISE_CONTROL_MODEL_TRAINING_SAMPLES_TOPIC = "strimzi.cruisecontrol.modeltrainingsamples"; // partitions 32 , rf - 2
     private static final String CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC = "strimzi.cruisecontrol.partitionmetricsamples"; // partitions 32 , rf - 2
 
-
     @Test
-    @Disabled
-    void testManuallyCreateMetricsReporterTopic() {
-        KafkaResource.kafkaWithCruiseControlWithoutWaitAutoCreateTopicsDisable(CLUSTER_NAME, 3, 3);
-
-        PodUtils.verifyThatRunningPodsAreStable(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME));
-        PodUtils.verifyThatRunningPodsAreStable(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
-        PodUtils.verifyThatRunningPodsAreStable(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME));
-
-        LOGGER.info("Verifying that metrics reporter topic is not present because of selected config 'auto.create.topics.enable=false'");
-
-        assertThrows(WaitException.class, () -> CruiseControlUtils.verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(Constants.GLOBAL_CRUISE_CONTROL_EXCEPT_FAIL_TIMEOUT));
-
-        PodUtils.waitUntilPodIsPresent(CruiseControlResources.deploymentName(CLUSTER_NAME));
-        PodUtils.waitUntilPodIsInCrashLoopBackOff(kubeClient().listPodsByPrefixInName(CruiseControlResources.deploymentName(CLUSTER_NAME)).get(0).getMetadata().getName());
-
-        LOGGER.info("Verifying that samples topics are not present because of " +
-            "'Cruise Control cannot find partitions for the metrics reporter that topic matches strimzi.cruisecontrol.metrics in the target cluster'");
-
-        assertThrows(WaitException.class, () -> CruiseControlUtils.verifyThatCruiseControlSamplesTopicsArePresent(Constants.GLOBAL_CRUISE_CONTROL_EXCEPT_FAIL_TIMEOUT));
-
-        // Since log compaction may remove records needed by Cruise Control, all topics created by Cruise Control must
-        // be configured with cleanup.policy=delete to disable log compaction.
-        // More in docs 8.5.2. Topic creation and configuration
-        KafkaTopicResource.topic(CLUSTER_NAME, CRUISE_CONTROL_METRICS_TOPIC)
-            .editSpec()
-                .addToConfig("cleanup.policy", "delete")
+    void testAutoCreationOfCruiseControlTopics() throws InterruptedException {
+        KafkaResource.kafkaWithCruiseControl(CLUSTER_NAME, 3, 3)
+            .editOrNewSpec()
+                .editKafka()
+                    .addToConfig("auto.create.topics.enable", "false")
+                .endKafka()
+                .editCruiseControl()
+                    .addToConfig("auto.create.topics.enable", "false")
+                .endCruiseControl()
             .endSpec()
             .done();
 
-        CruiseControlUtils.verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(Constants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
+        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
 
-        LOGGER.info("Implicitly creating samples topics {},{} because of explicitly created {} topic",
-            CRUISE_CONTROL_MODEL_TRAINING_SAMPLES_TOPIC, CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC, CRUISE_CONTROL_METRICS_TOPIC);
+        LOGGER.info("Removing auto-created CC topics");
+        KafkaTopicUtils.deleteKafkaTopicWithWait(CRUISE_CONTROL_METRICS_TOPIC);
+        KafkaTopicUtils.deleteKafkaTopicWithWait(CRUISE_CONTROL_MODEL_TRAINING_SAMPLES_TOPIC);
+        KafkaTopicUtils.deleteKafkaTopicWithWait(CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC);
 
-        CruiseControlUtils.verifyThatCruiseControlSamplesTopicsArePresent(Constants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
+        //wait some time to know if CC topics will be created by metrics reporter
+        Thread.sleep(60_000);
 
-        LOGGER.info("Verifying that Cruise control pod is running and ready (stable)");
+        LOGGER.info("Checking if CC topics are not recreated");
+        assertThat(KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(CRUISE_CONTROL_METRICS_TOPIC).get() == null, is(true));
+        assertThat(KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(CRUISE_CONTROL_MODEL_TRAINING_SAMPLES_TOPIC).get() == null, is(true));
+        assertThat(KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC).get() == null, is(true));
 
-        PodUtils.verifyThatRunningPodsAreStable(CruiseControlResources.deploymentName(CLUSTER_NAME));
+        LOGGER.info("Changing the CC config to auto.create.topics.enable=true and removing config of Kafka");
+        //firstly we need to configure the Kafka settings, because it will be rolled sooner than CC and it will create the topics with default values for Kafka
+        KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka -> {
+            kafka.getSpec().getKafka().getConfig().remove("auto.create.topics.enable", "false");
+            kafka.getSpec().getCruiseControl().getConfig().put("auto.create.topics.enable", "true");
+        });
+        StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaPods);
+        DeploymentUtils.waitForDeploymentAndPodsReady(CLUSTER_NAME + "-cruise-control", 1);
+
+        KafkaTopicUtils.waitForKafkaTopicCreation(CRUISE_CONTROL_METRICS_TOPIC);
+        KafkaTopicUtils.waitForKafkaTopicCreation(CRUISE_CONTROL_MODEL_TRAINING_SAMPLES_TOPIC);
+        KafkaTopicUtils.waitForKafkaTopicCreation(CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC);
+
+        KafkaTopicSpec metricsTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE)
+            .withName(CRUISE_CONTROL_METRICS_TOPIC).get().getSpec();
+        KafkaTopicSpec modelTrainingTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE)
+            .withName(CRUISE_CONTROL_MODEL_TRAINING_SAMPLES_TOPIC).get().getSpec();
+        KafkaTopicSpec partitionMetricsTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE)
+            .withName(CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC).get().getSpec();
+
+        LOGGER.info("Checking partitions and replicas for {}", CRUISE_CONTROL_METRICS_TOPIC);
+        assertThat(metricsTopic.getPartitions(), is(1));
+        assertThat(metricsTopic.getReplicas(), is(1));
+
+        LOGGER.info("Checking partitions and replicas for {}", CRUISE_CONTROL_MODEL_TRAINING_SAMPLES_TOPIC);
+        assertThat(modelTrainingTopic.getPartitions(), is(32));
+//        assertThat(modelTrainingTopic.getReplicas(), is(1));
+
+        LOGGER.info("Checking partitions and replicas for {}", CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC);
+        assertThat(partitionMetricsTopic.getPartitions(), is(32));
+//        assertThat(partitionMetricsTopic.getReplicas(), is(2));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Test update

### Description

After discussion with @ppatierno we decide to change our test `testManuallyCreateMetricsReporterTopic` to be more relevant. So now it is testing ability to recreate CC topics after deletion. The main problem here was that if you not set `auto.create.topics.enable` to `false` in Kafka, it will continuously create CC topics but with `partitions: 1, replication.factor: 1` -> the default setting for all Kafka topics. So I disabled it in both Kafka and CC, then remove this setting from Kafka and after that, I set the `auto.create.topics.enable` to `true` for CC. Interesting thing is that CC will create the `strimzi.cruisecontrol.modeltrainingsamples` and `strimzi.cruisecontrol.partitionmetricsamples` with settings: `partitions: 32, replication.factor: 2` only **if the topics are not created yet** -> the Kafka sometimes creates the topic even if you remove the `auto.create.topics.enable` from the config. If the topics are present, CC server will only change the `partitions: 32` and `replication.factor` will leave on `1`. That's why the asserts about `replication.factor` are commented.

Other than this feature I removed our method for creating CC with this config from `KafkaResource` -> I don't think it's really needed here, because it's used only in one test. Maybe we can add it in future if it will be worth.

I added the method for KafkaTopic deletion with wait to `KafkaTopicUtils`.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

