### PR TITLE
Enabling all Vert.x JVM related metrics through options

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -6,7 +6,6 @@ package io.strimzi.operator.cluster;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.strimzi.operator.cluster.operator.assembly.AbstractConnectOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaBridgeAssemblyOperator;
@@ -35,11 +34,6 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
-import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
-import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 
 /**
  * An "operator" for managing assemblies of various types <em>in a particular namespace</em>.
@@ -97,7 +91,6 @@ public class ClusterOperator extends AbstractVerticle {
         this.kafkaRebalanceAssemblyOperator = kafkaRebalanceAssemblyOperator;
 
         this.metricsProvider = metricsProvider;
-        setupMetrics();
     }
 
     @Override
@@ -196,16 +189,6 @@ public class ClusterOperator extends AbstractVerticle {
                     result.handle(ar);
                 });
         return result.future();
-    }
-
-    private void setupMetrics() {
-        MeterRegistry metrics = metricsProvider.meterRegistry();
-
-        new ClassLoaderMetrics().bindTo(metrics);
-        new JvmMemoryMetrics().bindTo(metrics);
-        new ProcessorMetrics().bindTo(metrics);
-        new JvmThreadMetrics().bindTo(metrics);
-        new JvmGcMetrics().bindTo(metrics);
     }
 
     public static String secretName(String cluster) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -67,6 +67,7 @@ public class Main {
         VertxOptions options = new VertxOptions().setMetricsOptions(
                 new MicrometerMetricsOptions()
                         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+                        .setJvmMetricsEnabled(true)
                         .setEnabled(true));
         Vertx vertx = Vertx.vertx(options);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -238,7 +238,6 @@ public class MetricsST extends BaseST {
     @Test
     void testUserOperatorMetrics() {
         userOperatorMetricsData = MetricsUtils.collectUserOperatorPodMetrics(CLUSTER_NAME);
-        LOGGER.info(userOperatorMetricsData);
         assertCoMetricNotNull("strimzi_reconciliations_locked_total", "KafkaUser", userOperatorMetricsData);
         assertCoMetricNotNull("strimzi_reconciliations_successful_total", "KafkaUser", userOperatorMetricsData);
         assertCoMetricNotNull("strimzi_reconciliations_duration_seconds_count", "KafkaUser", userOperatorMetricsData);
@@ -320,7 +319,15 @@ public class MetricsST extends BaseST {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
 
-        KafkaResource.kafkaWithMetrics(CLUSTER_NAME, 3, 3).done();
+        KafkaResource.kafkaWithMetrics(CLUSTER_NAME, 3, 3)
+                .editOrNewSpec()
+                    .editEntityOperator()
+                        .editUserOperator()
+                            .withReconciliationIntervalSeconds(30)
+                        .endUserOperator()
+                    .endEntityOperator()
+                .endSpec()
+                .done();
         KafkaResource.kafkaWithMetrics(SECOND_CLUSTER, 1, 1).done();
         KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).done();
         KafkaConnectResource.kafkaConnectWithMetrics(CLUSTER_NAME, 1).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -238,6 +238,7 @@ public class MetricsST extends BaseST {
     @Test
     void testUserOperatorMetrics() {
         userOperatorMetricsData = MetricsUtils.collectUserOperatorPodMetrics(CLUSTER_NAME);
+        LOGGER.info(userOperatorMetricsData);
         assertCoMetricNotNull("strimzi_reconciliations_locked_total", "KafkaUser", userOperatorMetricsData);
         assertCoMetricNotNull("strimzi_reconciliations_successful_total", "KafkaUser", userOperatorMetricsData);
         assertCoMetricNotNull("strimzi_reconciliations_duration_seconds_count", "KafkaUser", userOperatorMetricsData);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Main.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Main.java
@@ -52,6 +52,7 @@ public class Main {
         VertxOptions options = new VertxOptions().setMetricsOptions(
                 new MicrometerMetricsOptions()
                         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+                        .setJvmMetricsEnabled(true)
                         .setEnabled(true));
         Vertx vertx = Vertx.vertx(options);
         Session session = new Session(kubeClient, config);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -18,6 +18,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServer;
+import io.vertx.micrometer.backends.BackendRegistries;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.config.SslConfigs;
@@ -29,13 +30,6 @@ import java.security.Security;
 import java.time.Duration;
 import java.util.Properties;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
-import io.vertx.micrometer.backends.BackendRegistries;
-import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
-import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
-
 
 public class Session extends AbstractVerticle {
 
@@ -70,7 +64,7 @@ public class Session extends AbstractVerticle {
             sb.append("\t").append(v.key).append(": ").append(Util.maskPassword(v.key, config.get(v).toString())).append(System.lineSeparator());
         }
         LOGGER.info("Using config:{}", sb.toString());
-        setupMetrics();
+        this.metricsRegistry = (PrometheusMeterRegistry) BackendRegistries.getDefaultNow();
     }
 
     /**
@@ -237,15 +231,6 @@ public class Session extends AbstractVerticle {
                 promise.future().onComplete(start);
                 LOGGER.info("Started");
             });
-    }
-
-    public void setupMetrics() {
-        this.metricsRegistry = (PrometheusMeterRegistry) BackendRegistries.getDefaultNow();
-        new ClassLoaderMetrics().bindTo(metricsRegistry);
-        new JvmMemoryMetrics().bindTo(metricsRegistry);
-        new ProcessorMetrics().bindTo(metricsRegistry);
-        new JvmThreadMetrics().bindTo(metricsRegistry);
-        new JvmGcMetrics().bindTo(metricsRegistry);
     }
 
     /**

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -135,10 +135,6 @@
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -57,6 +57,7 @@ public class Main {
         VertxOptions options = new VertxOptions().setMetricsOptions(
                 new MicrometerMetricsOptions()
                         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+                        .setJvmMetricsEnabled(true)
                         .setEnabled(true));
         Vertx vertx = Vertx.vertx(options);
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
@@ -17,11 +17,6 @@ import org.apache.logging.log4j.Logger;
 import java.util.concurrent.TimeUnit;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.vertx.micrometer.backends.BackendRegistries;
-import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
-import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 
 /**
  * An "operator" for managing assemblies of various types <em>in a particular namespace</em>.
@@ -51,8 +46,7 @@ public class UserOperator extends AbstractVerticle {
         this.reconciliationInterval = config.getReconciliationIntervalMs();
         this.client = client;
         this.kafkaUserOperator = kafkaUserOperator;
-        metrics = (PrometheusMeterRegistry) BackendRegistries.getDefaultNow();
-        setupMetrics();
+        this.metrics = (PrometheusMeterRegistry) BackendRegistries.getDefaultNow();
     }
 
     @Override
@@ -89,17 +83,6 @@ public class UserOperator extends AbstractVerticle {
 
         client.close();
         stop.complete();
-    }
-
-    /**
-     * Setup Metrics collection
-     */
-    public void setupMetrics() {
-        new ClassLoaderMetrics().bindTo(metrics);
-        new JvmMemoryMetrics().bindTo(metrics);
-        new ProcessorMetrics().bindTo(metrics);
-        new JvmThreadMetrics().bindTo(metrics);
-        new JvmGcMetrics().bindTo(metrics);
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Refactoring

In order to enable all the JVM related metrics exported by Vert.x, it's just needed calling `.setJvmMetricsEnabled(true)` on the Vert.x options.
The current used `setupMetrics()` method with the related content is not needed.
When that flag is enabled in the Vert.x options, the code which Vert.x runs is the following:

```java
if (options.isJvmMetricsEnabled()) {
      new ClassLoaderMetrics().bindTo(backendRegistry.getMeterRegistry());
      new JvmMemoryMetrics().bindTo(backendRegistry.getMeterRegistry());
      new JvmGcMetrics().bindTo(backendRegistry.getMeterRegistry());
      new ProcessorMetrics().bindTo(backendRegistry.getMeterRegistry());
      new JvmThreadMetrics().bindTo(backendRegistry.getMeterRegistry());
}
```

which is actually the same of the `setupMetrics()`.
This PR does this refactoring.

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

