### PR TITLE
Switch to using yq version 3.3.1+

### DIFF
--- a/.travis/install_yq.sh
+++ b/.travis/install_yq.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-curl -L https://github.com/mikefarah/yq/releases/download/3.2.1/yq_linux_amd64 > yq && chmod +x yq
+curl -L https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64 > yq && chmod +x yq
 sudo cp yq /usr/bin/

--- a/HACKING.md
+++ b/HACKING.md
@@ -29,7 +29,7 @@ To build this project you must first install several command line utilities and 
     - Note that if you are using the Helm version 2 charts, after installing the Helm CLI, ensure you run `helm2 init` to configure to your cluster.
 - [`asciidoctor`](https://asciidoctor.org/) - Documentation generation. 
     - Use `gem` to install latest version for your platform.
-- [`yq`](https://github.com/mikefarah/yq) - YAML manipulation tool. 
+- [`yq`](https://github.com/mikefarah/yq) - (version 3.3.1 and above) YAML manipulation tool. 
     - **Warning:** There are several different `yq` YAML projects in the wild. Use [this one](https://github.com/mikefarah/yq). You need **v3** version.
 - [`docker`](https://docs.docker.com/install/) - Docker command line client
 

--- a/Jenkinsfile-pr
+++ b/Jenkinsfile-pr
@@ -118,6 +118,15 @@ pipeline {
                 }
             }
         }
+        stage('Install yq') {
+            steps {
+                timeout(time: 5, unit: 'MINUTES') {
+                    script {
+                        lib.installYq(env.WORKSPACE)
+                    }
+                }
+            }
+        }
         stage('Build project') {
             steps {
                 script {

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SUBDIRS=kafka-agent mirror-maker-agent tracing-agent crd-annotations test crd-ge
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
 all: prerequisites_check $(SUBDIRS) crd_install helm_install
-clean: $(SUBDIRS) docu_clean
+clean: prerequisites_check $(SUBDIRS) docu_clean
 $(DOCKER_TARGETS): prerequisites_check $(SUBDIRS)
 release: release_prepare release_version release_helm_version release_maven $(SUBDIRS) release_docu release_single_file release_pkg release_helm_repo docu_clean
 

--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -5,231 +5,231 @@ metadata:
   labels:
     app: strimzi
 rules:
-- apiGroups:
-  - ""
-  resources:
-  # The cluster operator needs to access and manage service accounts to grant Strimzi components cluster permissions
-  - serviceaccounts
-  verbs:
-  - get
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - "rbac.authorization.k8s.io"
-  resources:
-  # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
-  - rolebindings
-  verbs:
-  - get
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  # The cluster operator needs to access and manage config maps for Strimzi components configuration
-  - configmaps
-  # The cluster operator needs to access and manage services to expose Strimzi components to network traffic
-  - services
-  # The cluster operator needs to access and manage secrets to handle credentials
-  - secrets
-  # The cluster operator needs to access and manage persistent volume claims to bind them to Strimzi components for persistent data
-  - persistentvolumeclaims
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - "kafka.strimzi.io"
-  resources:
-  # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
-  - kafkas
-  - kafkas/status
-  # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
-  - kafkaconnects
-  - kafkaconnects/status
-  # The cluster operator runs the KafkaConnectS2IAssemblyOperator, which needs to access and manage KafkaConnectS2I resources
-  - kafkaconnects2is
-  - kafkaconnects2is/status
-  # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
-  - kafkaconnectors
-  - kafkaconnectors/status
-  # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
-  - kafkamirrormakers
-  - kafkamirrormakers/status
-  # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
-  - kafkabridges
-  - kafkabridges/status
-  # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
-  - kafkamirrormaker2s
-  - kafkamirrormaker2s/status
-  # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
-  - kafkarebalances
-  - kafkarebalances/status
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  # The cluster operator needs to access and delete pods, this is to allow it to monitor pod health and coordinate rolling updates
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  # The cluster operator needs the extensions api as the operator supports Kubernetes version 1.11+
-  # apps/v1 was introduced in Kubernetes 1.14
-  - "extensions"
-  resources:
-  # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
-  - deployments
-  - deployments/scale
-  # The cluster operator needs to access replica sets to manage Strimzi components and to determine error states
-  - replicasets
-  # The cluster operator needs to access and manage replication controllers to manage replicasets
-  - replicationcontrollers
-  # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
-  - networkpolicies
-  # The cluster operator needs to access and manage ingresses which allow external access to the services in a cluster
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - "apps"
-  resources:
-  # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
-  - deployments
-  - deployments/scale
-  - deployments/status
-  # The cluster operator needs to access and manage stateful sets to run stateful sets based Strimzi components
-  - statefulsets
-  # The cluster operator needs to access replica-sets to manage Strimzi components and to determine error states
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  # The cluster operator needs to be able to create events and delegate permissions to do so
-  - events
-  verbs:
-  - create
-- apiGroups:
-  # OpenShift S2I requirements
-  - apps.openshift.io
-  resources:
-  - deploymentconfigs
-  - deploymentconfigs/scale
-  - deploymentconfigs/status
-  - deploymentconfigs/finalizers
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  # OpenShift S2I requirements
-  - build.openshift.io
-  resources:
-  - buildconfigs
-  - builds
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - watch
-  - update
-- apiGroups:
-  # OpenShift S2I requirements
-  - image.openshift.io
-  resources:
-  - imagestreams
-  - imagestreams/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - watch
-  - patch
-  - update
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - route.openshift.io
-  resources:
-  # The cluster operator needs to access and manage routes to expose Strimzi components for external access
-  - routes
-  - routes/custom-host
-  verbs:
-  - get
-  - list
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - policy
-  resources:
-  # The cluster operator needs to access and manage pod disruption budgets this limits the number of concurrent disruptions
-  # that a Strimzi component experiences, allowing for higher availability
-  - poddisruptionbudgets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
+  - apiGroups:
+      - ""
+    resources:
+      # The cluster operator needs to access and manage service accounts to grant Strimzi components cluster permissions
+      - serviceaccounts
+    verbs:
+      - get
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
+      - rolebindings
+    verbs:
+      - get
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      # The cluster operator needs to access and manage config maps for Strimzi components configuration
+      - configmaps
+      # The cluster operator needs to access and manage services to expose Strimzi components to network traffic
+      - services
+      # The cluster operator needs to access and manage secrets to handle credentials
+      - secrets
+      # The cluster operator needs to access and manage persistent volume claims to bind them to Strimzi components for persistent data
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
+      - kafkas
+      - kafkas/status
+      # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
+      - kafkaconnects
+      - kafkaconnects/status
+      # The cluster operator runs the KafkaConnectS2IAssemblyOperator, which needs to access and manage KafkaConnectS2I resources
+      - kafkaconnects2is
+      - kafkaconnects2is/status
+      # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
+      - kafkaconnectors
+      - kafkaconnectors/status
+      # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
+      - kafkamirrormakers
+      - kafkamirrormakers/status
+      # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
+      - kafkabridges
+      - kafkabridges/status
+      # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
+      - kafkamirrormaker2s
+      - kafkamirrormaker2s/status
+      # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
+      - kafkarebalances
+      - kafkarebalances/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      # The cluster operator needs to access and delete pods, this is to allow it to monitor pod health and coordinate rolling updates
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      # The cluster operator needs the extensions api as the operator supports Kubernetes version 1.11+
+      # apps/v1 was introduced in Kubernetes 1.14
+      - "extensions"
+    resources:
+      # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
+      - deployments
+      - deployments/scale
+      # The cluster operator needs to access replica sets to manage Strimzi components and to determine error states
+      - replicasets
+      # The cluster operator needs to access and manage replication controllers to manage replicasets
+      - replicationcontrollers
+      # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
+      - networkpolicies
+      # The cluster operator needs to access and manage ingresses which allow external access to the services in a cluster
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - "apps"
+    resources:
+      # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
+      - deployments
+      - deployments/scale
+      - deployments/status
+      # The cluster operator needs to access and manage stateful sets to run stateful sets based Strimzi components
+      - statefulsets
+      # The cluster operator needs to access replica-sets to manage Strimzi components and to determine error states
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      # The cluster operator needs to be able to create events and delegate permissions to do so
+      - events
+    verbs:
+      - create
+  - apiGroups:
+      # OpenShift S2I requirements
+      - apps.openshift.io
+    resources:
+      - deploymentconfigs
+      - deploymentconfigs/scale
+      - deploymentconfigs/status
+      - deploymentconfigs/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      # OpenShift S2I requirements
+      - build.openshift.io
+    resources:
+      - buildconfigs
+      - builds
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+      - update
+  - apiGroups:
+      # OpenShift S2I requirements
+      - image.openshift.io
+    resources:
+      - imagestreams
+      - imagestreams/status
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      # The cluster operator needs to access and manage routes to expose Strimzi components for external access
+      - routes
+      - routes/custom-host
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - policy
+    resources:
+      # The cluster operator needs to access and manage pod disruption budgets this limits the number of concurrent disruptions
+      # that a Strimzi component experiences, allowing for higher availability
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update

--- a/cluster-operator/src/main/resources/cluster-roles/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -5,33 +5,33 @@ metadata:
   labels:
     app: strimzi
 rules:
-- apiGroups:
-  - "rbac.authorization.k8s.io"
-  resources:
-  # The cluster operator needs to create and manage cluster role bindings in the case of an install where a user
-  # has specified they want their cluster role bindings generated
-  - clusterrolebindings
-  verbs:
-  - get
-  - create
-  - delete
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  # The cluster operator requires "get" permissions to view storage class details
-  # This is because only a persistent volume of a supported storage class type can be resized
-  - storageclasses
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  # The cluster operator requires "list" permissions to view all nodes in a cluster
-  # The listing is used to determine the node addresses when NodePort access is configured
-  # These addresses are then exposed in the custom resource states
-  - nodes
-  verbs:
-  - list
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      # The cluster operator needs to create and manage cluster role bindings in the case of an install where a user
+      # has specified they want their cluster role bindings generated
+      - clusterrolebindings
+    verbs:
+      - get
+      - create
+      - delete
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      # The cluster operator requires "get" permissions to view storage class details
+      # This is because only a persistent volume of a supported storage class type can be resized
+      - storageclasses
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      # The cluster operator requires "list" permissions to view all nodes in a cluster
+      # The listing is used to determine the node addresses when NodePort access is configured
+      # These addresses are then exposed in the custom resource states
+      - nodes
+    verbs:
+      - list

--- a/cluster-operator/src/main/resources/cluster-roles/030-ClusterRole-strimzi-kafka-broker.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/030-ClusterRole-strimzi-kafka-broker.yaml
@@ -5,11 +5,11 @@ metadata:
   labels:
     app: strimzi
 rules:
-- apiGroups:
-  - ""
-  resources:
-  # The Kafka Brokers require "get" permissions to view the node they are on
-  # This information is used to generate a Rack ID that is used for High Availability configurations
-  - nodes
-  verbs:
-  - get
+  - apiGroups:
+      - ""
+    resources:
+      # The Kafka Brokers require "get" permissions to view the node they are on
+      # This information is used to generate a Rack ID that is used for High Availability configurations
+      - nodes
+    verbs:
+      - get

--- a/cluster-operator/src/main/resources/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml
@@ -5,39 +5,39 @@ metadata:
   labels:
     app: strimzi
 rules:
-- apiGroups:
-  - "kafka.strimzi.io"
-  resources:
-  # The entity operator runs the KafkaTopic assembly operator, which needs to access and manage KafkaTopic resources
-  - kafkatopics
-  - kafkatopics/status
-  # The entity operator runs the KafkaUser assembly operator, which needs to access and manage KafkaUser resources
-  - kafkausers
-  - kafkausers/status
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - patch
-  - update
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  # The entity operator needs to be able to create events
-  - create
-- apiGroups:
-  - ""
-  resources:
-  # The entity operator user-operator needs to access and manage secrets to store generated credentials
-  - secrets
-  verbs:
-  - get
-  - list
-  - create
-  - patch
-  - update
-  - delete
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # The entity operator runs the KafkaTopic assembly operator, which needs to access and manage KafkaTopic resources
+      - kafkatopics
+      - kafkatopics/status
+      # The entity operator runs the KafkaUser assembly operator, which needs to access and manage KafkaUser resources
+      - kafkausers
+      - kafkausers/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      # The entity operator needs to be able to create events
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      # The entity operator user-operator needs to access and manage secrets to store generated credentials
+      - secrets
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+      - update
+      - delete

--- a/cluster-operator/src/main/resources/cluster-roles/032-ClusterRole-strimzi-topic-operator.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/032-ClusterRole-strimzi-topic-operator.yaml
@@ -5,21 +5,21 @@ metadata:
   labels:
     app: strimzi
 rules:
-- apiGroups:
-  - "kafka.strimzi.io"
-  resources:
-  - kafkatopics
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - patch
-  - update
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      - kafkatopics
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -13,12 +13,12 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
-  - name: v1alpha1
-    served: true
-    storage: false
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   version: v1beta1
   scope: Namespaced
   names:
@@ -27,18 +27,18 @@ spec:
     singular: kafka
     plural: kafkas
     shortNames:
-    - k
+      - k
     categories:
-    - strimzi
+      - strimzi
   additionalPrinterColumns:
-  - name: Desired Kafka replicas
-    description: The desired number of Kafka replicas in the cluster
-    JSONPath: .spec.kafka.replicas
-    type: integer
-  - name: Desired ZK replicas
-    description: The desired number of ZooKeeper replicas in the cluster
-    JSONPath: .spec.zookeeper.replicas
-    type: integer
+    - name: Desired Kafka replicas
+      description: The desired number of Kafka replicas in the cluster
+      JSONPath: .spec.kafka.replicas
+      type: integer
+    - name: Desired ZK replicas
+      description: The desired number of ZooKeeper replicas in the cluster
+      JSONPath: .spec.zookeeper.replicas
+      type: integer
   subresources:
     status: {}
   validation:
@@ -56,8 +56,7 @@ spec:
                   description: The number of pods in the cluster.
                 image:
                   type: string
-                  description: The docker image for the pods. The default value depends
-                    on the configured `Kafka.spec.kafka.version`.
+                  description: The docker image for the pods. The default value depends on the configured `Kafka.spec.kafka.version`.
                 storage:
                   type: object
                   properties:
@@ -66,13 +65,11 @@ spec:
                       description: The storage class to use for dynamic volume allocation.
                     deleteClaim:
                       type: boolean
-                      description: Specifies if the persistent volume claim has to
-                        be deleted when the cluster is un-deployed.
+                      description: Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
                     id:
                       type: integer
                       minimum: 0
-                      description: Storage identification number. It is mandatory
-                        only for storage volumes defined in a storage of type 'jbod'.
+                      description: Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
                     overrides:
                       type: array
                       items:
@@ -80,37 +77,28 @@ spec:
                         properties:
                           class:
                             type: string
-                            description: The storage class to use for dynamic volume
-                              allocation for this broker.
+                            description: The storage class to use for dynamic volume allocation for this broker.
                           broker:
                             type: integer
                             description: Id of the kafka broker (broker identifier).
-                      description: Overrides for individual brokers. The `overrides`
-                        field allows to specify a different configuration for different
-                        brokers.
+                      description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                     selector:
                       type: object
-                      description: Specifies a specific persistent volume to use.
-                        It contains key:value pairs representing labels for selecting
-                        such a volume.
+                      description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                     size:
                       type: string
-                      description: When type=persistent-claim, defines the size of
-                        the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
+                      description: When type=persistent-claim, defines the size of the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
                     sizeLimit:
                       type: string
                       pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                      description: When type=ephemeral, defines the total amount of
-                        local storage required for this EmptyDir volume (for example
-                        1Gi).
+                      description: When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi).
                     type:
                       type: string
                       enum:
-                      - ephemeral
-                      - persistent-claim
-                      - jbod
-                      description: Storage type, must be either 'ephemeral', 'persistent-claim',
-                        or 'jbod'.
+                        - ephemeral
+                        - persistent-claim
+                        - jbod
+                      description: Storage type, must be either 'ephemeral', 'persistent-claim', or 'jbod'.
                     volumes:
                       type: array
                       items:
@@ -118,18 +106,14 @@ spec:
                         properties:
                           class:
                             type: string
-                            description: The storage class to use for dynamic volume
-                              allocation.
+                            description: The storage class to use for dynamic volume allocation.
                           deleteClaim:
                             type: boolean
-                            description: Specifies if the persistent volume claim
-                              has to be deleted when the cluster is un-deployed.
+                            description: Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
                           id:
                             type: integer
                             minimum: 0
-                            description: Storage identification number. It is mandatory
-                              only for storage volumes defined in a storage of type
-                              'jbod'.
+                            description: Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
                           overrides:
                             type: array
                             items:
@@ -137,43 +121,32 @@ spec:
                               properties:
                                 class:
                                   type: string
-                                  description: The storage class to use for dynamic
-                                    volume allocation for this broker.
+                                  description: The storage class to use for dynamic volume allocation for this broker.
                                 broker:
                                   type: integer
                                   description: Id of the kafka broker (broker identifier).
-                            description: Overrides for individual brokers. The `overrides`
-                              field allows to specify a different configuration for
-                              different brokers.
+                            description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                           selector:
                             type: object
-                            description: Specifies a specific persistent volume to
-                              use. It contains key:value pairs representing labels
-                              for selecting such a volume.
+                            description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                           size:
                             type: string
-                            description: When type=persistent-claim, defines the size
-                              of the persistent volume claim (i.e 1Gi). Mandatory
-                              when type=persistent-claim.
+                            description: When type=persistent-claim, defines the size of the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
                           sizeLimit:
                             type: string
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                            description: When type=ephemeral, defines the total amount
-                              of local storage required for this EmptyDir volume (for
-                              example 1Gi).
+                            description: When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi).
                           type:
                             type: string
                             enum:
-                            - ephemeral
-                            - persistent-claim
-                            description: Storage type, must be either 'ephemeral'
-                              or 'persistent-claim'.
+                              - ephemeral
+                              - persistent-claim
+                            description: Storage type, must be either 'ephemeral' or 'persistent-claim'.
                         required:
-                        - type
-                      description: List of volumes as Storage objects representing
-                        the JBOD disks array.
+                          - type
+                      description: List of volumes as Storage objects representing the JBOD disks array.
                   required:
-                  - type
+                    - type
                   description: Storage configuration (disk). Cannot be updated.
                 listeners:
                   type: object
@@ -186,90 +159,55 @@ spec:
                           properties:
                             accessTokenIsJwt:
                               type: boolean
-                              description: Configure whether the access token is treated
-                                as JWT. This must be set to `false` if the authorization
-                                server returns opaque tokens. Defaults to `true`.
+                              description: Configure whether the access token is treated as JWT. This must be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                             checkAccessTokenType:
                               type: boolean
-                              description: Configure whether the access token type
-                                check is performed or not. This should be set to `false`
-                                if the authorization server does not include 'typ'
-                                claim in JWT token. Defaults to `true`.
+                              description: Configure whether the access token type check is performed or not. This should be set to `false` if the authorization server does not include 'typ' claim in JWT token. Defaults to `true`.
                             checkIssuer:
                               type: boolean
-                              description: Enable or disable issuer checking. By default
-                                issuer is checked using the value configured by `validIssuerUri`.
-                                Default value is `true`.
+                              description: Enable or disable issuer checking. By default issuer is checked using the value configured by `validIssuerUri`. Default value is `true`.
                             clientId:
                               type: string
-                              description: OAuth Client ID which the Kafka broker
-                                can use to authenticate against the authorization
-                                server and use the introspect endpoint URI.
+                              description: OAuth Client ID which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
                             clientSecret:
                               type: object
                               properties:
                                 key:
                                   type: string
-                                  description: The key under which the secret value
-                                    is stored in the Kubernetes Secret.
+                                  description: The key under which the secret value is stored in the Kubernetes Secret.
                                 secretName:
                                   type: string
-                                  description: The name of the Kubernetes Secret containing
-                                    the secret value.
+                                  description: The name of the Kubernetes Secret containing the secret value.
                               required:
-                              - key
-                              - secretName
-                              description: Link to Kubernetes Secret containing the
-                                OAuth client secret which the Kafka broker can use
-                                to authenticate against the authorization server and
-                                use the introspect endpoint URI.
+                                - key
+                                - secretName
+                              description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
                             disableTlsHostnameVerification:
                               type: boolean
-                              description: Enable or disable TLS hostname verification.
-                                Default value is `false`.
+                              description: Enable or disable TLS hostname verification. Default value is `false`.
                             enableECDSA:
                               type: boolean
-                              description: Enable or disable ECDSA support by installing
-                                BouncyCastle crypto provider. Default value is `false`.
+                              description: Enable or disable ECDSA support by installing BouncyCastle crypto provider. Default value is `false`.
                             fallbackUserNameClaim:
                               type: string
-                              description: The fallback username claim to be used
-                                for the user id if the claim specified by `userNameClaim`
-                                is not present. This is useful when `client_credentials`
-                                authentication only results in the client id being
-                                provided in another claim. It only takes effect if
-                                `userNameClaim` is set.
+                              description: The fallback username claim to be used for the user id if the claim specified by `userNameClaim` is not present. This is useful when `client_credentials` authentication only results in the client id being provided in another claim. It only takes effect if `userNameClaim` is set.
                             fallbackUserNamePrefix:
                               type: string
-                              description: The prefix to use with the value of `fallbackUserNameClaim`
-                                to construct the user id. This only takes effect if
-                                `fallbackUserNameClaim` is true, and the value is
-                                present for the claim. Mapping usernames and client
-                                ids into the same user id space is useful in preventing
-                                name collisions.
+                              description: The prefix to use with the value of `fallbackUserNameClaim` to construct the user id. This only takes effect if `fallbackUserNameClaim` is true, and the value is present for the claim. Mapping usernames and client ids into the same user id space is useful in preventing name collisions.
                             introspectionEndpointUri:
                               type: string
-                              description: URI of the token introspection endpoint
-                                which can be used to validate opaque non-JWT tokens.
+                              description: URI of the token introspection endpoint which can be used to validate opaque non-JWT tokens.
                             jwksEndpointUri:
                               type: string
-                              description: URI of the JWKS certificate endpoint, which
-                                can be used for local JWT validation.
+                              description: URI of the JWKS certificate endpoint, which can be used for local JWT validation.
                             jwksExpirySeconds:
                               type: integer
                               minimum: 1
-                              description: Configures how often are the JWKS certificates
-                                considered valid. The expiry interval has to be at
-                                least 60 seconds longer then the refresh interval
-                                specified in `jwksRefreshSeconds`. Defaults to 360
-                                seconds.
+                              description: Configures how often are the JWKS certificates considered valid. The expiry interval has to be at least 60 seconds longer then the refresh interval specified in `jwksRefreshSeconds`. Defaults to 360 seconds.
                             jwksRefreshSeconds:
                               type: integer
                               minimum: 1
-                              description: Configures how often are the JWKS certificates
-                                refreshed. The refresh interval has to be at least
-                                60 seconds shorter then the expiry interval specified
-                                in `jwksExpirySeconds`. Defaults to 300 seconds.
+                              description: Configures how often are the JWKS certificates refreshed. The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in `jwksExpirySeconds`. Defaults to 300 seconds.
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -277,53 +215,36 @@ spec:
                                 properties:
                                   certificate:
                                     type: string
-                                    description: The name of the file certificate
-                                      in the Secret.
+                                    description: The name of the file certificate in the Secret.
                                   secretName:
                                     type: string
-                                    description: The name of the Secret containing
-                                      the certificate.
+                                    description: The name of the Secret containing the certificate.
                                 required:
-                                - certificate
-                                - secretName
-                              description: Trusted certificates for TLS connection
-                                to the OAuth server.
+                                  - certificate
+                                  - secretName
+                              description: Trusted certificates for TLS connection to the OAuth server.
                             type:
                               type: string
                               enum:
-                              - tls
-                              - scram-sha-512
-                              - oauth
-                              description: Authentication type. `oauth` type uses
-                                SASL OAUTHBEARER Authentication. `scram-sha-512` type
-                                uses SASL SCRAM-SHA-512 Authentication. `tls` type
-                                uses TLS Client Authentication. `tls` type is supported
-                                only on TLS listeners.
+                                - tls
+                                - scram-sha-512
+                                - oauth
+                              description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.
                             userInfoEndpointUri:
                               type: string
-                              description: 'URI of the User Info Endpoint to use as
-                                a fallback to obtaining the user id when the Introspection
-                                Endpoint does not return information that can be used
-                                for the user id. '
+                              description: 'URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. '
                             userNameClaim:
                               type: string
-                              description: Name of the claim from the JWT authentication
-                                token, Introspection Endpoint response or User Info
-                                Endpoint response which will be used to extract the
-                                user id. Defaults to `sub`.
+                              description: Name of the claim from the JWT authentication token, Introspection Endpoint response or User Info Endpoint response which will be used to extract the user id. Defaults to `sub`.
                             validIssuerUri:
                               type: string
                               description: URI of the token issuer used for authentication.
                             validTokenType:
                               type: string
-                              description: Valid value for the `token_type` attribute
-                                returned by the Introspection Endpoint. No default
-                                value, and not checked by default.
+                              description: Valid value for the `token_type` attribute returned by the Introspection Endpoint. No default value, and not checked by default.
                           required:
-                          - type
-                          description: 'Authentication configuration for this listener.
-                            Since this listener does not use TLS transport you cannot
-                            configure an authentication with `type: tls`.'
+                            - type
+                          description: 'Authentication configuration for this listener. Since this listener does not use TLS transport you cannot configure an authentication with `type: tls`.'
                         networkPolicyPeers:
                           type: array
                           items:
@@ -374,13 +295,7 @@ spec:
                                             type: string
                                   matchLabels:
                                     type: object
-                          description: List of peers which should be able to connect
-                            to this listener. Peers in this list are combined using
-                            a logical OR operation. If this field is empty or missing,
-                            all connections will be allowed for this listener. If
-                            this field is present and contains at least one item,
-                            the listener only allows the traffic which matches at
-                            least one item in this list.
+                          description: List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.
                       description: Configures plain listener on port 9092.
                     tls:
                       type: object
@@ -390,90 +305,55 @@ spec:
                           properties:
                             accessTokenIsJwt:
                               type: boolean
-                              description: Configure whether the access token is treated
-                                as JWT. This must be set to `false` if the authorization
-                                server returns opaque tokens. Defaults to `true`.
+                              description: Configure whether the access token is treated as JWT. This must be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                             checkAccessTokenType:
                               type: boolean
-                              description: Configure whether the access token type
-                                check is performed or not. This should be set to `false`
-                                if the authorization server does not include 'typ'
-                                claim in JWT token. Defaults to `true`.
+                              description: Configure whether the access token type check is performed or not. This should be set to `false` if the authorization server does not include 'typ' claim in JWT token. Defaults to `true`.
                             checkIssuer:
                               type: boolean
-                              description: Enable or disable issuer checking. By default
-                                issuer is checked using the value configured by `validIssuerUri`.
-                                Default value is `true`.
+                              description: Enable or disable issuer checking. By default issuer is checked using the value configured by `validIssuerUri`. Default value is `true`.
                             clientId:
                               type: string
-                              description: OAuth Client ID which the Kafka broker
-                                can use to authenticate against the authorization
-                                server and use the introspect endpoint URI.
+                              description: OAuth Client ID which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
                             clientSecret:
                               type: object
                               properties:
                                 key:
                                   type: string
-                                  description: The key under which the secret value
-                                    is stored in the Kubernetes Secret.
+                                  description: The key under which the secret value is stored in the Kubernetes Secret.
                                 secretName:
                                   type: string
-                                  description: The name of the Kubernetes Secret containing
-                                    the secret value.
+                                  description: The name of the Kubernetes Secret containing the secret value.
                               required:
-                              - key
-                              - secretName
-                              description: Link to Kubernetes Secret containing the
-                                OAuth client secret which the Kafka broker can use
-                                to authenticate against the authorization server and
-                                use the introspect endpoint URI.
+                                - key
+                                - secretName
+                              description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
                             disableTlsHostnameVerification:
                               type: boolean
-                              description: Enable or disable TLS hostname verification.
-                                Default value is `false`.
+                              description: Enable or disable TLS hostname verification. Default value is `false`.
                             enableECDSA:
                               type: boolean
-                              description: Enable or disable ECDSA support by installing
-                                BouncyCastle crypto provider. Default value is `false`.
+                              description: Enable or disable ECDSA support by installing BouncyCastle crypto provider. Default value is `false`.
                             fallbackUserNameClaim:
                               type: string
-                              description: The fallback username claim to be used
-                                for the user id if the claim specified by `userNameClaim`
-                                is not present. This is useful when `client_credentials`
-                                authentication only results in the client id being
-                                provided in another claim. It only takes effect if
-                                `userNameClaim` is set.
+                              description: The fallback username claim to be used for the user id if the claim specified by `userNameClaim` is not present. This is useful when `client_credentials` authentication only results in the client id being provided in another claim. It only takes effect if `userNameClaim` is set.
                             fallbackUserNamePrefix:
                               type: string
-                              description: The prefix to use with the value of `fallbackUserNameClaim`
-                                to construct the user id. This only takes effect if
-                                `fallbackUserNameClaim` is true, and the value is
-                                present for the claim. Mapping usernames and client
-                                ids into the same user id space is useful in preventing
-                                name collisions.
+                              description: The prefix to use with the value of `fallbackUserNameClaim` to construct the user id. This only takes effect if `fallbackUserNameClaim` is true, and the value is present for the claim. Mapping usernames and client ids into the same user id space is useful in preventing name collisions.
                             introspectionEndpointUri:
                               type: string
-                              description: URI of the token introspection endpoint
-                                which can be used to validate opaque non-JWT tokens.
+                              description: URI of the token introspection endpoint which can be used to validate opaque non-JWT tokens.
                             jwksEndpointUri:
                               type: string
-                              description: URI of the JWKS certificate endpoint, which
-                                can be used for local JWT validation.
+                              description: URI of the JWKS certificate endpoint, which can be used for local JWT validation.
                             jwksExpirySeconds:
                               type: integer
                               minimum: 1
-                              description: Configures how often are the JWKS certificates
-                                considered valid. The expiry interval has to be at
-                                least 60 seconds longer then the refresh interval
-                                specified in `jwksRefreshSeconds`. Defaults to 360
-                                seconds.
+                              description: Configures how often are the JWKS certificates considered valid. The expiry interval has to be at least 60 seconds longer then the refresh interval specified in `jwksRefreshSeconds`. Defaults to 360 seconds.
                             jwksRefreshSeconds:
                               type: integer
                               minimum: 1
-                              description: Configures how often are the JWKS certificates
-                                refreshed. The refresh interval has to be at least
-                                60 seconds shorter then the expiry interval specified
-                                in `jwksExpirySeconds`. Defaults to 300 seconds.
+                              description: Configures how often are the JWKS certificates refreshed. The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in `jwksExpirySeconds`. Defaults to 300 seconds.
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -481,50 +361,35 @@ spec:
                                 properties:
                                   certificate:
                                     type: string
-                                    description: The name of the file certificate
-                                      in the Secret.
+                                    description: The name of the file certificate in the Secret.
                                   secretName:
                                     type: string
-                                    description: The name of the Secret containing
-                                      the certificate.
+                                    description: The name of the Secret containing the certificate.
                                 required:
-                                - certificate
-                                - secretName
-                              description: Trusted certificates for TLS connection
-                                to the OAuth server.
+                                  - certificate
+                                  - secretName
+                              description: Trusted certificates for TLS connection to the OAuth server.
                             type:
                               type: string
                               enum:
-                              - tls
-                              - scram-sha-512
-                              - oauth
-                              description: Authentication type. `oauth` type uses
-                                SASL OAUTHBEARER Authentication. `scram-sha-512` type
-                                uses SASL SCRAM-SHA-512 Authentication. `tls` type
-                                uses TLS Client Authentication. `tls` type is supported
-                                only on TLS listeners.
+                                - tls
+                                - scram-sha-512
+                                - oauth
+                              description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.
                             userInfoEndpointUri:
                               type: string
-                              description: 'URI of the User Info Endpoint to use as
-                                a fallback to obtaining the user id when the Introspection
-                                Endpoint does not return information that can be used
-                                for the user id. '
+                              description: 'URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. '
                             userNameClaim:
                               type: string
-                              description: Name of the claim from the JWT authentication
-                                token, Introspection Endpoint response or User Info
-                                Endpoint response which will be used to extract the
-                                user id. Defaults to `sub`.
+                              description: Name of the claim from the JWT authentication token, Introspection Endpoint response or User Info Endpoint response which will be used to extract the user id. Defaults to `sub`.
                             validIssuerUri:
                               type: string
                               description: URI of the token issuer used for authentication.
                             validTokenType:
                               type: string
-                              description: Valid value for the `token_type` attribute
-                                returned by the Introspection Endpoint. No default
-                                value, and not checked by default.
+                              description: Valid value for the `token_type` attribute returned by the Introspection Endpoint. No default value, and not checked by default.
                           required:
-                          - type
+                            - type
                           description: Authentication configuration for this listener.
                         configuration:
                           type: object
@@ -534,23 +399,18 @@ spec:
                               properties:
                                 certificate:
                                   type: string
-                                  description: The name of the file certificate in
-                                    the Secret.
+                                  description: The name of the file certificate in the Secret.
                                 key:
                                   type: string
-                                  description: The name of the private key in the
-                                    Secret.
+                                  description: The name of the private key in the Secret.
                                 secretName:
                                   type: string
-                                  description: The name of the Secret containing the
-                                    certificate.
+                                  description: The name of the Secret containing the certificate.
                               required:
-                              - certificate
-                              - key
-                              - secretName
-                              description: Reference to the `Secret` which holds the
-                                certificate and private key pair. The certificate
-                                can optionally contain the whole chain.
+                                - certificate
+                                - key
+                                - secretName
+                              description: Reference to the `Secret` which holds the certificate and private key pair. The certificate can optionally contain the whole chain.
                           description: Configuration of TLS listener.
                         networkPolicyPeers:
                           type: array
@@ -602,13 +462,7 @@ spec:
                                             type: string
                                   matchLabels:
                                     type: object
-                          description: List of peers which should be able to connect
-                            to this listener. Peers in this list are combined using
-                            a logical OR operation. If this field is empty or missing,
-                            all connections will be allowed for this listener. If
-                            this field is present and contains at least one item,
-                            the listener only allows the traffic which matches at
-                            least one item in this list.
+                          description: List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.
                       description: Configures TLS listener on port 9093.
                     external:
                       type: object
@@ -618,90 +472,55 @@ spec:
                           properties:
                             accessTokenIsJwt:
                               type: boolean
-                              description: Configure whether the access token is treated
-                                as JWT. This must be set to `false` if the authorization
-                                server returns opaque tokens. Defaults to `true`.
+                              description: Configure whether the access token is treated as JWT. This must be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                             checkAccessTokenType:
                               type: boolean
-                              description: Configure whether the access token type
-                                check is performed or not. This should be set to `false`
-                                if the authorization server does not include 'typ'
-                                claim in JWT token. Defaults to `true`.
+                              description: Configure whether the access token type check is performed or not. This should be set to `false` if the authorization server does not include 'typ' claim in JWT token. Defaults to `true`.
                             checkIssuer:
                               type: boolean
-                              description: Enable or disable issuer checking. By default
-                                issuer is checked using the value configured by `validIssuerUri`.
-                                Default value is `true`.
+                              description: Enable or disable issuer checking. By default issuer is checked using the value configured by `validIssuerUri`. Default value is `true`.
                             clientId:
                               type: string
-                              description: OAuth Client ID which the Kafka broker
-                                can use to authenticate against the authorization
-                                server and use the introspect endpoint URI.
+                              description: OAuth Client ID which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
                             clientSecret:
                               type: object
                               properties:
                                 key:
                                   type: string
-                                  description: The key under which the secret value
-                                    is stored in the Kubernetes Secret.
+                                  description: The key under which the secret value is stored in the Kubernetes Secret.
                                 secretName:
                                   type: string
-                                  description: The name of the Kubernetes Secret containing
-                                    the secret value.
+                                  description: The name of the Kubernetes Secret containing the secret value.
                               required:
-                              - key
-                              - secretName
-                              description: Link to Kubernetes Secret containing the
-                                OAuth client secret which the Kafka broker can use
-                                to authenticate against the authorization server and
-                                use the introspect endpoint URI.
+                                - key
+                                - secretName
+                              description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
                             disableTlsHostnameVerification:
                               type: boolean
-                              description: Enable or disable TLS hostname verification.
-                                Default value is `false`.
+                              description: Enable or disable TLS hostname verification. Default value is `false`.
                             enableECDSA:
                               type: boolean
-                              description: Enable or disable ECDSA support by installing
-                                BouncyCastle crypto provider. Default value is `false`.
+                              description: Enable or disable ECDSA support by installing BouncyCastle crypto provider. Default value is `false`.
                             fallbackUserNameClaim:
                               type: string
-                              description: The fallback username claim to be used
-                                for the user id if the claim specified by `userNameClaim`
-                                is not present. This is useful when `client_credentials`
-                                authentication only results in the client id being
-                                provided in another claim. It only takes effect if
-                                `userNameClaim` is set.
+                              description: The fallback username claim to be used for the user id if the claim specified by `userNameClaim` is not present. This is useful when `client_credentials` authentication only results in the client id being provided in another claim. It only takes effect if `userNameClaim` is set.
                             fallbackUserNamePrefix:
                               type: string
-                              description: The prefix to use with the value of `fallbackUserNameClaim`
-                                to construct the user id. This only takes effect if
-                                `fallbackUserNameClaim` is true, and the value is
-                                present for the claim. Mapping usernames and client
-                                ids into the same user id space is useful in preventing
-                                name collisions.
+                              description: The prefix to use with the value of `fallbackUserNameClaim` to construct the user id. This only takes effect if `fallbackUserNameClaim` is true, and the value is present for the claim. Mapping usernames and client ids into the same user id space is useful in preventing name collisions.
                             introspectionEndpointUri:
                               type: string
-                              description: URI of the token introspection endpoint
-                                which can be used to validate opaque non-JWT tokens.
+                              description: URI of the token introspection endpoint which can be used to validate opaque non-JWT tokens.
                             jwksEndpointUri:
                               type: string
-                              description: URI of the JWKS certificate endpoint, which
-                                can be used for local JWT validation.
+                              description: URI of the JWKS certificate endpoint, which can be used for local JWT validation.
                             jwksExpirySeconds:
                               type: integer
                               minimum: 1
-                              description: Configures how often are the JWKS certificates
-                                considered valid. The expiry interval has to be at
-                                least 60 seconds longer then the refresh interval
-                                specified in `jwksRefreshSeconds`. Defaults to 360
-                                seconds.
+                              description: Configures how often are the JWKS certificates considered valid. The expiry interval has to be at least 60 seconds longer then the refresh interval specified in `jwksRefreshSeconds`. Defaults to 360 seconds.
                             jwksRefreshSeconds:
                               type: integer
                               minimum: 1
-                              description: Configures how often are the JWKS certificates
-                                refreshed. The refresh interval has to be at least
-                                60 seconds shorter then the expiry interval specified
-                                in `jwksExpirySeconds`. Defaults to 300 seconds.
+                              description: Configures how often are the JWKS certificates refreshed. The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in `jwksExpirySeconds`. Defaults to 300 seconds.
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -709,56 +528,39 @@ spec:
                                 properties:
                                   certificate:
                                     type: string
-                                    description: The name of the file certificate
-                                      in the Secret.
+                                    description: The name of the file certificate in the Secret.
                                   secretName:
                                     type: string
-                                    description: The name of the Secret containing
-                                      the certificate.
+                                    description: The name of the Secret containing the certificate.
                                 required:
-                                - certificate
-                                - secretName
-                              description: Trusted certificates for TLS connection
-                                to the OAuth server.
+                                  - certificate
+                                  - secretName
+                              description: Trusted certificates for TLS connection to the OAuth server.
                             type:
                               type: string
                               enum:
-                              - tls
-                              - scram-sha-512
-                              - oauth
-                              description: Authentication type. `oauth` type uses
-                                SASL OAUTHBEARER Authentication. `scram-sha-512` type
-                                uses SASL SCRAM-SHA-512 Authentication. `tls` type
-                                uses TLS Client Authentication. `tls` type is supported
-                                only on TLS listeners.
+                                - tls
+                                - scram-sha-512
+                                - oauth
+                              description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.
                             userInfoEndpointUri:
                               type: string
-                              description: 'URI of the User Info Endpoint to use as
-                                a fallback to obtaining the user id when the Introspection
-                                Endpoint does not return information that can be used
-                                for the user id. '
+                              description: 'URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. '
                             userNameClaim:
                               type: string
-                              description: Name of the claim from the JWT authentication
-                                token, Introspection Endpoint response or User Info
-                                Endpoint response which will be used to extract the
-                                user id. Defaults to `sub`.
+                              description: Name of the claim from the JWT authentication token, Introspection Endpoint response or User Info Endpoint response which will be used to extract the user id. Defaults to `sub`.
                             validIssuerUri:
                               type: string
                               description: URI of the token issuer used for authentication.
                             validTokenType:
                               type: string
-                              description: Valid value for the `token_type` attribute
-                                returned by the Introspection Endpoint. No default
-                                value, and not checked by default.
+                              description: Valid value for the `token_type` attribute returned by the Introspection Endpoint. No default value, and not checked by default.
                           required:
-                          - type
+                            - type
                           description: Authentication configuration for Kafka brokers.
                         class:
                           type: string
-                          description: Configures the `Ingress` class that defines
-                            which `Ingress` controller will be used. If not set, the
-                            `Ingress` class is set to `nginx`.
+                          description: Configures the `Ingress` class that defines which `Ingress` controller will be used. If not set, the `Ingress` class is set to `nginx`.
                         configuration:
                           type: object
                           properties:
@@ -767,20 +569,15 @@ spec:
                               properties:
                                 address:
                                   type: string
-                                  description: Additional address name for the bootstrap
-                                    service. The address will be added to the list
-                                    of subject alternative names of the TLS certificates.
+                                  description: Additional address name for the bootstrap service. The address will be added to the list of subject alternative names of the TLS certificates.
                                 dnsAnnotations:
                                   type: object
-                                  description: Annotations that will be added to the
-                                    `Ingress` resource. You can use this field to
-                                    configure DNS providers such as External DNS.
+                                  description: Annotations that will be added to the `Ingress` resource. You can use this field to configure DNS providers such as External DNS.
                                 host:
                                   type: string
-                                  description: Host for the bootstrap route. This
-                                    field will be used in the Ingress resource.
+                                  description: Host for the bootstrap route. This field will be used in the Ingress resource.
                               required:
-                              - host
+                                - host
                               description: External bootstrap ingress configuration.
                             brokers:
                               type: array
@@ -792,47 +589,36 @@ spec:
                                     description: Id of the kafka broker (broker identifier).
                                   advertisedHost:
                                     type: string
-                                    description: The host name which will be used
-                                      in the brokers' `advertised.brokers`.
+                                    description: The host name which will be used in the brokers' `advertised.brokers`.
                                   advertisedPort:
                                     type: integer
-                                    description: The port number which will be used
-                                      in the brokers' `advertised.brokers`.
+                                    description: The port number which will be used in the brokers' `advertised.brokers`.
                                   host:
                                     type: string
-                                    description: Host for the broker ingress. This
-                                      field will be used in the Ingress resource.
+                                    description: Host for the broker ingress. This field will be used in the Ingress resource.
                                   dnsAnnotations:
                                     type: object
-                                    description: Annotations that will be added to
-                                      the `Ingress` resources for individual brokers.
-                                      You can use this field to configure DNS providers
-                                      such as External DNS.
+                                    description: Annotations that will be added to the `Ingress` resources for individual brokers. You can use this field to configure DNS providers such as External DNS.
                                 required:
-                                - host
+                                  - host
                               description: External broker ingress configuration.
                             brokerCertChainAndKey:
                               type: object
                               properties:
                                 certificate:
                                   type: string
-                                  description: The name of the file certificate in
-                                    the Secret.
+                                  description: The name of the file certificate in the Secret.
                                 key:
                                   type: string
-                                  description: The name of the private key in the
-                                    Secret.
+                                  description: The name of the private key in the Secret.
                                 secretName:
                                   type: string
-                                  description: The name of the Secret containing the
-                                    certificate.
+                                  description: The name of the Secret containing the certificate.
                               required:
-                              - certificate
-                              - key
-                              - secretName
-                              description: Reference to the `Secret` which holds the
-                                certificate and private key pair. The certificate
-                                can optionally contain the whole chain.
+                                - certificate
+                                - key
+                                - secretName
+                              description: Reference to the `Secret` which holds the certificate and private key pair. The certificate can optionally contain the whole chain.
                           description: External listener configuration.
                         networkPolicyPeers:
                           type: array
@@ -884,13 +670,7 @@ spec:
                                             type: string
                                   matchLabels:
                                     type: object
-                          description: List of peers which should be able to connect
-                            to this listener. Peers in this list are combined using
-                            a logical OR operation. If this field is empty or missing,
-                            all connections will be allowed for this listener. If
-                            this field is present and contains at least one item,
-                            the listener only allows the traffic which matches at
-                            least one item in this list.
+                          description: List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.
                         overrides:
                           type: object
                           properties:
@@ -899,14 +679,10 @@ spec:
                               properties:
                                 address:
                                   type: string
-                                  description: Additional address name for the bootstrap
-                                    service. The address will be added to the list
-                                    of subject alternative names of the TLS certificates.
+                                  description: Additional address name for the bootstrap service. The address will be added to the list of subject alternative names of the TLS certificates.
                                 dnsAnnotations:
                                   type: object
-                                  description: Annotations that will be added to the
-                                    `Service` resource. You can use this field to
-                                    configure DNS providers such as External DNS.
+                                  description: Annotations that will be added to the `Service` resource. You can use this field to configure DNS providers such as External DNS.
                                 nodePort:
                                   type: integer
                                   description: Node port for the bootstrap service.
@@ -921,43 +697,31 @@ spec:
                                     description: Id of the kafka broker (broker identifier).
                                   advertisedHost:
                                     type: string
-                                    description: The host name which will be used
-                                      in the brokers' `advertised.brokers`.
+                                    description: The host name which will be used in the brokers' `advertised.brokers`.
                                   advertisedPort:
                                     type: integer
-                                    description: The port number which will be used
-                                      in the brokers' `advertised.brokers`.
+                                    description: The port number which will be used in the brokers' `advertised.brokers`.
                                   nodePort:
                                     type: integer
                                     description: Node port for the broker service.
                                   dnsAnnotations:
                                     type: object
-                                    description: Annotations that will be added to
-                                      the `Service` resources for individual brokers.
-                                      You can use this field to configure DNS providers
-                                      such as External DNS.
+                                    description: Annotations that will be added to the `Service` resources for individual brokers. You can use this field to configure DNS providers such as External DNS.
                               description: External broker services configuration.
-                          description: Overrides for external bootstrap and broker
-                            services and externally advertised addresses.
+                          description: Overrides for external bootstrap and broker services and externally advertised addresses.
                         tls:
                           type: boolean
-                          description: Enables TLS encryption on the listener. By
-                            default set to `true` for enabled TLS encryption.
+                          description: Enables TLS encryption on the listener. By default set to `true` for enabled TLS encryption.
                         type:
                           type: string
                           enum:
-                          - route
-                          - loadbalancer
-                          - nodeport
-                          - ingress
-                          description: "Type of the external listener. Currently the
-                            supported types are `route`, `loadbalancer`, and `nodeport`.
-                            \n\n* `route` type uses OpenShift Routes to expose Kafka.*
-                            `loadbalancer` type uses LoadBalancer type services to
-                            expose Kafka.* `nodeport` type uses NodePort type services
-                            to expose Kafka.."
+                            - route
+                            - loadbalancer
+                            - nodeport
+                            - ingress
+                          description: "Type of the external listener. Currently the supported types are `route`, `loadbalancer`, and `nodeport`. \n\n* `route` type uses OpenShift Routes to expose Kafka.* `loadbalancer` type uses LoadBalancer type services to expose Kafka.* `nodeport` type uses NodePort type services to expose Kafka.."
                       required:
-                      - type
+                        - type
                       description: Configures external listener on port 9094.
                   description: Configures listeners of Kafka brokers.
                 authorization:
@@ -965,47 +729,30 @@ spec:
                   properties:
                     allowOnError:
                       type: boolean
-                      description: Defines whether a Kafka client should be allowed
-                        or denied by default when the authorizer fails to query the
-                        Open Policy Agent, for example, when it is temporarily unavailable).
-                        Defaults to `false` - all actions will be denied.
+                      description: Defines whether a Kafka client should be allowed or denied by default when the authorizer fails to query the Open Policy Agent, for example, when it is temporarily unavailable). Defaults to `false` - all actions will be denied.
                     clientId:
                       type: string
-                      description: OAuth Client ID which the Kafka client can use
-                        to authenticate against the OAuth server and use the token
-                        endpoint URI.
+                      description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                     delegateToKafkaAcls:
                       type: boolean
-                      description: Whether authorization decision should be delegated
-                        to the 'Simple' authorizer if DENIED by Keycloak Authorization
-                        Services policies.Default value is `false`.
+                      description: Whether authorization decision should be delegated to the 'Simple' authorizer if DENIED by Keycloak Authorization Services policies.Default value is `false`.
                     disableTlsHostnameVerification:
                       type: boolean
-                      description: Enable or disable TLS hostname verification. Default
-                        value is `false`.
+                      description: Enable or disable TLS hostname verification. Default value is `false`.
                     expireAfterMs:
                       type: integer
-                      description: The expiration of the records kept in the local
-                        cache to avoid querying the Open Policy Agent for every request.
-                        Defines how often the cached authorization decisions are reloaded
-                        from the Open Policy Agent server. In milliseconds. Defaults
-                        to `3600000`.
+                      description: The expiration of the records kept in the local cache to avoid querying the Open Policy Agent for every request. Defines how often the cached authorization decisions are reloaded from the Open Policy Agent server. In milliseconds. Defaults to `3600000`.
                     initialCacheCapacity:
                       type: integer
-                      description: Initial capacity of the local cache used by the
-                        authorizer to avoid querying the Open Policy Agent for every
-                        request Defaults to `5000`.
+                      description: Initial capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request Defaults to `5000`.
                     maximumCacheSize:
                       type: integer
-                      description: Maximum capacity of the local cache used by the
-                        authorizer to avoid querying the Open Policy Agent for every
-                        request. Defaults to `50000`.
+                      description: Maximum capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request. Defaults to `50000`.
                     superUsers:
                       type: array
                       items:
                         type: string
-                      description: List of super users. Should contain list of user
-                        principals which should get unlimited access rights.
+                      description: List of super users. Should contain list of user principals which should get unlimited access rights.
                     tlsTrustedCertificates:
                       type: array
                       items:
@@ -1018,62 +765,42 @@ spec:
                             type: string
                             description: The name of the Secret containing the certificate.
                         required:
-                        - certificate
-                        - secretName
-                      description: Trusted certificates for TLS connection to the
-                        OAuth server.
+                          - certificate
+                          - secretName
+                      description: Trusted certificates for TLS connection to the OAuth server.
                     tokenEndpointUri:
                       type: string
                       description: Authorization server token endpoint URI.
                     type:
                       type: string
                       enum:
-                      - simple
-                      - opa
-                      - keycloak
-                      description: Authorization type. Currently, the supported types
-                        are `simple`, `keycloak`, and `opa`. `simple` authorization
-                        type uses Kafka's `kafka.security.auth.SimpleAclAuthorizer`
-                        class for authorization. `keycloak` authorization type uses
-                        Keycloak Authorization Services for authorization. `opa` authorization
-                        type uses Open Policy Agent based authorization.
+                        - simple
+                        - opa
+                        - keycloak
+                      description: Authorization type. Currently, the supported types are `simple`, `keycloak`, and `opa`. `simple` authorization type uses Kafka's `kafka.security.auth.SimpleAclAuthorizer` class for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization.
                     url:
                       type: string
                       example: http://opa:8181/v1/data/kafka/authz/allow
-                      description: The URL used to connect to the Open Policy Agent
-                        server. The URL has to include the policy which will be queried
-                        by the authorizer. This option is required.
+                      description: The URL used to connect to the Open Policy Agent server. The URL has to include the policy which will be queried by the authorizer. This option is required.
                   required:
-                  - type
+                    - type
                   description: Authorization configuration for Kafka brokers.
                 config:
                   type: object
-                  description: 'Kafka broker config properties with the following
-                    prefixes cannot be set: listeners, advertised., broker., listener.,
-                    host.name, port, inter.broker.listener.name, sasl., ssl., security.,
-                    password., principal.builder.class, log.dir, zookeeper.connect,
-                    zookeeper.set.acl, authorizer., super.user, cruise.control.metrics.topic,
-                    cruise.control.metrics.reporter.bootstrap.servers (with the exception
-                    of: zookeeper.connection.timeout.ms, ssl.cipher.suites, ssl.protocol,
-                    ssl.enabled.protocols,cruise.control.metrics.topic.num.partitions,
-                    cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms,cruise.control.metrics.topic.auto.create.retries,
-                    cruise.control.metrics.topic.auto.create.timeout.ms).'
+                  description: 'Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers (with the exception of: zookeeper.connection.timeout.ms, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols,cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms,cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms).'
                 rack:
                   type: object
                   properties:
                     topologyKey:
                       type: string
                       example: failure-domain.beta.kubernetes.io/zone
-                      description: A key that matches labels assigned to the Kubernetes
-                        cluster nodes. The value of the label is used to set the broker's
-                        `broker.rack` config.
+                      description: A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config.
                   required:
-                  - topologyKey
+                    - topologyKey
                   description: Configuration of the `broker.rack` broker config.
                 brokerRackInitImage:
                   type: string
-                  description: The image of the init container used for initializing
-                    the `broker.rack`.
+                  description: The image of the init container used for initializing the `broker.rack`.
                 affinity:
                   type: object
                   properties:
@@ -1304,23 +1031,17 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -1331,23 +1052,17 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -1369,8 +1084,7 @@ spec:
                       description: -Xmx option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
-                      description: Specifies whether the Garbage Collection logging
-                        is enabled. The default is false.
+                      description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                     javaSystemProperties:
                       type: array
                       items:
@@ -1382,8 +1096,7 @@ spec:
                           value:
                             type: string
                             description: The system property value.
-                      description: A map of additional system properties which will
-                        be passed using the `-D` option to the JVM.
+                      description: A map of additional system properties which will be passed using the `-D` option to the JVM.
                   description: JVM Options for pods.
                 jmxOptions:
                   type: object
@@ -1394,14 +1107,11 @@ spec:
                         type:
                           type: string
                           enum:
-                          - password
-                          description: Authentication type. Currently the only supported
-                            types are `password`.`password` type creates a username
-                            and protected port with no TLS.
+                            - password
+                          description: Authentication type. Currently the only supported types are `password`.`password` type creates a username and protected port with no TLS.
                       required:
-                      - type
-                      description: Authentication configuration for connecting to
-                        the Kafka JMX port.
+                        - type
+                      description: Authentication configuration for connecting to the Kafka JMX port.
                   description: JMX Options for Kafka brokers.
                 resources:
                   type: object
@@ -1413,8 +1123,7 @@ spec:
                   description: CPU and memory resources to reserve.
                 metrics:
                   type: object
-                  description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
-                    for details of the structure of this configuration.
+                  description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
                 logging:
                   type: object
                   properties:
@@ -1423,16 +1132,15 @@ spec:
                       description: A Map from logger name to logger level.
                     name:
                       type: string
-                      description: The name of the `ConfigMap` from which to get the
-                        logging configuration.
+                      description: The name of the `ConfigMap` from which to get the logging configuration.
                     type:
                       type: string
                       enum:
-                      - inline
-                      - external
+                        - inline
+                        - external
                       description: Logging type, must be either 'inline' or 'external'.
                   required:
-                  - type
+                    - type
                   description: Logging configuration for Kafka.
                 tlsSidecar:
                   type: object
@@ -1445,23 +1153,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -1470,38 +1172,31 @@ spec:
                     logLevel:
                       type: string
                       enum:
-                      - emerg
-                      - alert
-                      - crit
-                      - err
-                      - warning
-                      - notice
-                      - info
-                      - debug
-                      description: The log level for the TLS sidecar. Default value
-                        is `notice`.
+                        - emerg
+                        - alert
+                        - crit
+                        - err
+                        - warning
+                        - notice
+                        - info
+                        - debug
+                      description: The log level for the TLS sidecar. Default value is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -1527,24 +1222,17 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                         podManagementPolicy:
                           type: string
                           enum:
-                          - OrderedReady
-                          - Parallel
-                          description: PodManagementPolicy which will be used for
-                            this StatefulSet. Valid values are `Parallel` and `OrderedReady`.
-                            Defaults to `Parallel`.
+                            - OrderedReady
+                            - Parallel
+                          description: PodManagementPolicy which will be used for this StatefulSet. Valid values are `Parallel` and `OrderedReady`. Defaults to `Parallel`.
                       description: Template for Kafka `StatefulSet`.
                     pod:
                       type: object
@@ -1554,15 +1242,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -1571,8 +1254,7 @@ spec:
                             properties:
                               name:
                                 type: string
-                          description: List of references to secrets in the same namespace
-                            to use for pulling any of the images used by this Pod.
+                          description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -1615,18 +1297,11 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
-                          description: Configures pod-level security attributes and
-                            common container settings.
+                          description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
-                          description: The grace period is the duration in seconds
-                            after the processes running in the pod are sent a termination
-                            signal and the time when the processes are forcibly halted
-                            with a kill signal. Set this value longer than the expected
-                            cleanup time for your process.Value must be non-negative
-                            integer. The value zero indicates delete immediately.
-                            Defaults to 30 seconds.
+                          description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -1838,13 +1513,10 @@ spec:
                           description: The pod's affinity rules.
                         priorityClassName:
                           type: string
-                          description: The name of the Priority Class to which these
-                            pods will be assigned.
+                          description: The name of the Priority Class to which these pods will be assigned.
                         schedulerName:
                           type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -1870,15 +1542,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka bootstrap `Service`.
                     brokersService:
@@ -1889,15 +1556,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka broker `Service`.
                     externalBootstrapService:
@@ -1908,40 +1570,22 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                         externalTrafficPolicy:
                           type: string
                           enum:
-                          - Local
-                          - Cluster
-                          description: Specifies whether the service routes external
-                            traffic to node-local or cluster-wide endpoints. `Cluster`
-                            may cause a second hop to another node and obscures the
-                            client source IP. `Local` avoids a second hop for LoadBalancer
-                            and Nodeport type services and preserves the client source
-                            IP (when supported by the infrastructure). If unspecified,
-                            Kubernetes will use `Cluster` as the default.
+                            - Local
+                            - Cluster
+                          description: Specifies whether the service routes external traffic to node-local or cluster-wide endpoints. `Cluster` may cause a second hop to another node and obscures the client source IP. `Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure). If unspecified, Kubernetes will use `Cluster` as the default.
                         loadBalancerSourceRanges:
                           type: array
                           items:
                             type: string
-                          description: A list of CIDR ranges (for example `10.0.0.0/8`
-                            or `130.211.204.1/32`) from which clients can connect
-                            to load balancer type listeners. If supported by the platform,
-                            traffic through the loadbalancer is restricted to the
-                            specified CIDR ranges. This field is applicable only for
-                            loadbalancer type services and is ignored if the cloud
-                            provider does not support the feature. For more information,
-                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
+                          description: A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients can connect to load balancer type listeners. If supported by the platform, traffic through the loadbalancer is restricted to the specified CIDR ranges. This field is applicable only for loadbalancer type services and is ignored if the cloud provider does not support the feature. For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
                       description: Template for Kafka external bootstrap `Service`.
                     perPodService:
                       type: object
@@ -1951,42 +1595,23 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                         externalTrafficPolicy:
                           type: string
                           enum:
-                          - Local
-                          - Cluster
-                          description: Specifies whether the service routes external
-                            traffic to node-local or cluster-wide endpoints. `Cluster`
-                            may cause a second hop to another node and obscures the
-                            client source IP. `Local` avoids a second hop for LoadBalancer
-                            and Nodeport type services and preserves the client source
-                            IP (when supported by the infrastructure). If unspecified,
-                            Kubernetes will use `Cluster` as the default.
+                            - Local
+                            - Cluster
+                          description: Specifies whether the service routes external traffic to node-local or cluster-wide endpoints. `Cluster` may cause a second hop to another node and obscures the client source IP. `Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure). If unspecified, Kubernetes will use `Cluster` as the default.
                         loadBalancerSourceRanges:
                           type: array
                           items:
                             type: string
-                          description: A list of CIDR ranges (for example `10.0.0.0/8`
-                            or `130.211.204.1/32`) from which clients can connect
-                            to load balancer type listeners. If supported by the platform,
-                            traffic through the loadbalancer is restricted to the
-                            specified CIDR ranges. This field is applicable only for
-                            loadbalancer type services and is ignored if the cloud
-                            provider does not support the feature. For more information,
-                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
-                      description: Template for Kafka per-pod `Services` used for
-                        access from outside of Kubernetes.
+                          description: A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients can connect to load balancer type listeners. If supported by the platform, traffic through the loadbalancer is restricted to the specified CIDR ranges. This field is applicable only for loadbalancer type services and is ignored if the cloud provider does not support the feature. For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
+                      description: Template for Kafka per-pod `Services` used for access from outside of Kubernetes.
                     externalBootstrapRoute:
                       type: object
                       properties:
@@ -1995,15 +1620,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka external bootstrap `Route`.
                     perPodRoute:
@@ -2014,18 +1634,12 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
-                      description: Template for Kafka per-pod `Routes` used for access
-                        from outside of OpenShift.
+                      description: Template for Kafka per-pod `Routes` used for access from outside of OpenShift.
                     externalBootstrapIngress:
                       type: object
                       properties:
@@ -2034,15 +1648,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka external bootstrap `Ingress`.
                     perPodIngress:
@@ -2053,18 +1662,12 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
-                      description: Template for Kafka per-pod `Ingress` used for access
-                        from outside of Kubernetes.
+                      description: Template for Kafka per-pod `Ingress` used for access from outside of Kubernetes.
                     persistentVolumeClaim:
                       type: object
                       properties:
@@ -2073,15 +1676,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for all Kafka `PersistentVolumeClaims`.
                     podDisruptionBudget:
@@ -2092,26 +1690,15 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
-                          description: Metadata to apply to the `PodDistruptionBugetTemplate`
-                            resource.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Metadata to apply to the `PodDistruptionBugetTemplate` resource.
                         maxUnavailable:
                           type: integer
                           minimum: 0
-                          description: Maximum number of unavailable pods to allow
-                            automatic Pod eviction. A Pod eviction is allowed when
-                            the `maxUnavailable` number of pods or fewer are unavailable
-                            after the eviction. Setting this value to 0 prevents all
-                            voluntary evictions, so the pods must be evicted manually.
-                            Defaults to 1.
+                          description: Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
                       description: Template for Kafka `PodDisruptionBudget`.
                     kafkaContainer:
                       type: object
@@ -2127,8 +1714,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -2191,8 +1777,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -2255,8 +1840,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -2305,18 +1889,14 @@ spec:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Kafka init container.
-                  description: Template for Kafka cluster resources. The template
-                    allows users to specify how are the `StatefulSet`, `Pods` and
-                    `Services` generated.
+                  description: Template for Kafka cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
                 version:
                   type: string
-                  description: The kafka broker version. Defaults to {DefaultKafkaVersion}.
-                    Consult the user documentation to understand the process required
-                    to upgrade or downgrade the version.
+                  description: The kafka broker version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
               required:
-              - replicas
-              - storage
-              - listeners
+                - replicas
+                - storage
+                - listeners
               description: Configuration of the Kafka cluster.
             zookeeper:
               type: object
@@ -2336,13 +1916,11 @@ spec:
                       description: The storage class to use for dynamic volume allocation.
                     deleteClaim:
                       type: boolean
-                      description: Specifies if the persistent volume claim has to
-                        be deleted when the cluster is un-deployed.
+                      description: Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
                     id:
                       type: integer
                       minimum: 0
-                      description: Storage identification number. It is mandatory
-                        only for storage volumes defined in a storage of type 'jbod'.
+                      description: Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
                     overrides:
                       type: array
                       items:
@@ -2350,48 +1928,33 @@ spec:
                         properties:
                           class:
                             type: string
-                            description: The storage class to use for dynamic volume
-                              allocation for this broker.
+                            description: The storage class to use for dynamic volume allocation for this broker.
                           broker:
                             type: integer
                             description: Id of the kafka broker (broker identifier).
-                      description: Overrides for individual brokers. The `overrides`
-                        field allows to specify a different configuration for different
-                        brokers.
+                      description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                     selector:
                       type: object
-                      description: Specifies a specific persistent volume to use.
-                        It contains key:value pairs representing labels for selecting
-                        such a volume.
+                      description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                     size:
                       type: string
-                      description: When type=persistent-claim, defines the size of
-                        the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
+                      description: When type=persistent-claim, defines the size of the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
                     sizeLimit:
                       type: string
                       pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                      description: When type=ephemeral, defines the total amount of
-                        local storage required for this EmptyDir volume (for example
-                        1Gi).
+                      description: When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi).
                     type:
                       type: string
                       enum:
-                      - ephemeral
-                      - persistent-claim
+                        - ephemeral
+                        - persistent-claim
                       description: Storage type, must be either 'ephemeral' or 'persistent-claim'.
                   required:
-                  - type
+                    - type
                   description: Storage configuration (disk). Cannot be updated.
                 config:
                   type: object
-                  description: 'The ZooKeeper broker config. Properties with the following
-                    prefixes cannot be set: server., dataDir, dataLogDir, clientPort,
-                    authProvider, quorum.auth, requireClientAuthScheme, snapshot.trust.empty,
-                    standaloneEnabled, reconfigEnabled, 4lw.commands.whitelist, secureClientPort,
-                    ssl., serverCnxnFactory, sslQuorum (with the exception of: ssl.protocol,
-                    ssl.quorum.protocol, ssl.enabledProtocols, ssl.quorum.enabledProtocols,
-                    ssl.ciphersuites, ssl.quorum.ciphersuites, ssl.hostnameVerification,
-                    ssl.quorum.hostnameVerification).'
+                  description: 'The ZooKeeper broker config. Properties with the following prefixes cannot be set: server., dataDir, dataLogDir, clientPort, authProvider, quorum.auth, requireClientAuthScheme, snapshot.trust.empty, standaloneEnabled, reconfigEnabled, 4lw.commands.whitelist, secureClientPort, ssl., serverCnxnFactory, sslQuorum (with the exception of: ssl.protocol, ssl.quorum.protocol, ssl.enabledProtocols, ssl.quorum.enabledProtocols, ssl.ciphersuites, ssl.quorum.ciphersuites, ssl.hostnameVerification, ssl.quorum.hostnameVerification).'
                 affinity:
                   type: object
                   properties:
@@ -2622,23 +2185,17 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -2649,23 +2206,17 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -2687,8 +2238,7 @@ spec:
                       description: -Xmx option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
-                      description: Specifies whether the Garbage Collection logging
-                        is enabled. The default is false.
+                      description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                     javaSystemProperties:
                       type: array
                       items:
@@ -2700,8 +2250,7 @@ spec:
                           value:
                             type: string
                             description: The system property value.
-                      description: A map of additional system properties which will
-                        be passed using the `-D` option to the JVM.
+                      description: A map of additional system properties which will be passed using the `-D` option to the JVM.
                   description: JVM Options for pods.
                 resources:
                   type: object
@@ -2713,8 +2262,7 @@ spec:
                   description: CPU and memory resources to reserve.
                 metrics:
                   type: object
-                  description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
-                    for details of the structure of this configuration.
+                  description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
                 logging:
                   type: object
                   properties:
@@ -2723,16 +2271,15 @@ spec:
                       description: A Map from logger name to logger level.
                     name:
                       type: string
-                      description: The name of the `ConfigMap` from which to get the
-                        logging configuration.
+                      description: The name of the `ConfigMap` from which to get the logging configuration.
                     type:
                       type: string
                       enum:
-                      - inline
-                      - external
+                        - inline
+                        - external
                       description: Logging type, must be either 'inline' or 'external'.
                   required:
-                  - type
+                    - type
                   description: Logging configuration for ZooKeeper.
                 template:
                   type: object
@@ -2745,24 +2292,17 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                         podManagementPolicy:
                           type: string
                           enum:
-                          - OrderedReady
-                          - Parallel
-                          description: PodManagementPolicy which will be used for
-                            this StatefulSet. Valid values are `Parallel` and `OrderedReady`.
-                            Defaults to `Parallel`.
+                            - OrderedReady
+                            - Parallel
+                          description: PodManagementPolicy which will be used for this StatefulSet. Valid values are `Parallel` and `OrderedReady`. Defaults to `Parallel`.
                       description: Template for ZooKeeper `StatefulSet`.
                     pod:
                       type: object
@@ -2772,15 +2312,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -2789,8 +2324,7 @@ spec:
                             properties:
                               name:
                                 type: string
-                          description: List of references to secrets in the same namespace
-                            to use for pulling any of the images used by this Pod.
+                          description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -2833,18 +2367,11 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
-                          description: Configures pod-level security attributes and
-                            common container settings.
+                          description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
-                          description: The grace period is the duration in seconds
-                            after the processes running in the pod are sent a termination
-                            signal and the time when the processes are forcibly halted
-                            with a kill signal. Set this value longer than the expected
-                            cleanup time for your process.Value must be non-negative
-                            integer. The value zero indicates delete immediately.
-                            Defaults to 30 seconds.
+                          description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -3056,13 +2583,10 @@ spec:
                           description: The pod's affinity rules.
                         priorityClassName:
                           type: string
-                          description: The name of the Priority Class to which these
-                            pods will be assigned.
+                          description: The name of the Priority Class to which these pods will be assigned.
                         schedulerName:
                           type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -3088,15 +2612,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for ZooKeeper client `Service`.
                     nodesService:
@@ -3107,15 +2626,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for ZooKeeper nodes `Service`.
                     persistentVolumeClaim:
@@ -3126,15 +2640,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for all ZooKeeper `PersistentVolumeClaims`.
                     podDisruptionBudget:
@@ -3145,26 +2654,15 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
-                          description: Metadata to apply to the `PodDistruptionBugetTemplate`
-                            resource.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Metadata to apply to the `PodDistruptionBugetTemplate` resource.
                         maxUnavailable:
                           type: integer
                           minimum: 0
-                          description: Maximum number of unavailable pods to allow
-                            automatic Pod eviction. A Pod eviction is allowed when
-                            the `maxUnavailable` number of pods or fewer are unavailable
-                            after the eviction. Setting this value to 0 prevents all
-                            voluntary evictions, so the pods must be evicted manually.
-                            Defaults to 1.
+                          description: Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
                       description: Template for ZooKeeper `PodDisruptionBudget`.
                     zookeeperContainer:
                       type: object
@@ -3180,8 +2678,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -3244,8 +2741,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -3293,12 +2789,8 @@ spec:
                                 gmsaCredentialSpecName:
                                   type: string
                           description: Security context for the container.
-                      description: Template for the Zookeeper server TLS sidecar container.
-                        The TLS sidecar is not used anymore and this option will be
-                        ignored.
-                  description: Template for ZooKeeper cluster resources. The template
-                    allows users to specify how are the `StatefulSet`, `Pods` and
-                    `Services` generated.
+                      description: Template for the Zookeeper server TLS sidecar container. The TLS sidecar is not used anymore and this option will be ignored.
+                  description: Template for ZooKeeper cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
                 tlsSidecar:
                   type: object
                   properties:
@@ -3310,23 +2802,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -3335,38 +2821,31 @@ spec:
                     logLevel:
                       type: string
                       enum:
-                      - emerg
-                      - alert
-                      - crit
-                      - err
-                      - warning
-                      - notice
-                      - info
-                      - debug
-                      description: The log level for the TLS sidecar. Default value
-                        is `notice`.
+                        - emerg
+                        - alert
+                        - crit
+                        - err
+                        - warning
+                        - notice
+                        - info
+                        - debug
+                      description: The log level for the TLS sidecar. Default value is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -3380,11 +2859,10 @@ spec:
                         requests:
                           type: object
                       description: CPU and memory resources to reserve.
-                  description: TLS sidecar configuration. The TLS sidecar is not used
-                    anymore and this option will be ignored.
+                  description: TLS sidecar configuration. The TLS sidecar is not used anymore and this option will be ignored.
               required:
-              - replicas
-              - storage
+                - replicas
+                - storage
               description: Configuration of the ZooKeeper cluster.
             topicOperator:
               type: object
@@ -3635,23 +3113,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -3660,38 +3132,31 @@ spec:
                     logLevel:
                       type: string
                       enum:
-                      - emerg
-                      - alert
-                      - crit
-                      - err
-                      - warning
-                      - notice
-                      - info
-                      - debug
-                      description: The log level for the TLS sidecar. Default value
-                        is `notice`.
+                        - emerg
+                        - alert
+                        - crit
+                        - err
+                        - warning
+                        - notice
+                        - info
+                        - debug
+                      description: The log level for the TLS sidecar. Default value is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -3714,16 +3179,15 @@ spec:
                       description: A Map from logger name to logger level.
                     name:
                       type: string
-                      description: The name of the `ConfigMap` from which to get the
-                        logging configuration.
+                      description: The name of the `ConfigMap` from which to get the logging configuration.
                     type:
                       type: string
                       enum:
-                      - inline
-                      - external
+                        - inline
+                        - external
                       description: Logging type, must be either 'inline' or 'external'.
                   required:
-                  - type
+                    - type
                   description: Logging configuration.
                 jvmOptions:
                   type: object
@@ -3741,8 +3205,7 @@ spec:
                       description: -Xmx option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
-                      description: Specifies whether the Garbage Collection logging
-                        is enabled. The default is false.
+                      description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                     javaSystemProperties:
                       type: array
                       items:
@@ -3754,31 +3217,24 @@ spec:
                           value:
                             type: string
                             description: The system property value.
-                      description: A map of additional system properties which will
-                        be passed using the `-D` option to the JVM.
+                      description: A map of additional system properties which will be passed using the `-D` option to the JVM.
                   description: JVM Options for pods.
                 livenessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -3789,23 +3245,17 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -3837,23 +3287,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -3864,23 +3308,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -3906,16 +3344,15 @@ spec:
                           description: A Map from logger name to logger level.
                         name:
                           type: string
-                          description: The name of the `ConfigMap` from which to get
-                            the logging configuration.
+                          description: The name of the `ConfigMap` from which to get the logging configuration.
                         type:
                           type: string
                           enum:
-                          - inline
-                          - external
+                            - inline
+                            - external
                           description: Logging type, must be either 'inline' or 'external'.
                       required:
-                      - type
+                        - type
                       description: Logging configuration.
                     jvmOptions:
                       type: object
@@ -3933,8 +3370,7 @@ spec:
                           description: -Xmx option to to the JVM.
                         gcLoggingEnabled:
                           type: boolean
-                          description: Specifies whether the Garbage Collection logging
-                            is enabled. The default is false.
+                          description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                         javaSystemProperties:
                           type: array
                           items:
@@ -3946,8 +3382,7 @@ spec:
                               value:
                                 type: string
                                 description: The system property value.
-                          description: A map of additional system properties which
-                            will be passed using the `-D` option to the JVM.
+                          description: A map of additional system properties which will be passed using the `-D` option to the JVM.
                       description: JVM Options for pods.
                   description: Configuration of the Topic Operator.
                 userOperator:
@@ -3972,23 +3407,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -3999,23 +3428,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -4037,16 +3460,15 @@ spec:
                           description: A Map from logger name to logger level.
                         name:
                           type: string
-                          description: The name of the `ConfigMap` from which to get
-                            the logging configuration.
+                          description: The name of the `ConfigMap` from which to get the logging configuration.
                         type:
                           type: string
                           enum:
-                          - inline
-                          - external
+                            - inline
+                            - external
                           description: Logging type, must be either 'inline' or 'external'.
                       required:
-                      - type
+                        - type
                       description: Logging configuration.
                     jvmOptions:
                       type: object
@@ -4064,8 +3486,7 @@ spec:
                           description: -Xmx option to to the JVM.
                         gcLoggingEnabled:
                           type: boolean
-                          description: Specifies whether the Garbage Collection logging
-                            is enabled. The default is false.
+                          description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                         javaSystemProperties:
                           type: array
                           items:
@@ -4077,8 +3498,7 @@ spec:
                               value:
                                 type: string
                                 description: The system property value.
-                          description: A map of additional system properties which
-                            will be passed using the `-D` option to the JVM.
+                          description: A map of additional system properties which will be passed using the `-D` option to the JVM.
                       description: JVM Options for pods.
                   description: Configuration of the User Operator.
                 affinity:
@@ -4317,23 +3737,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -4342,38 +3756,31 @@ spec:
                     logLevel:
                       type: string
                       enum:
-                      - emerg
-                      - alert
-                      - crit
-                      - err
-                      - warning
-                      - notice
-                      - info
-                      - debug
-                      description: The log level for the TLS sidecar. Default value
-                        is `notice`.
+                        - emerg
+                        - alert
+                        - crit
+                        - err
+                        - warning
+                        - notice
+                        - info
+                        - debug
+                      description: The log level for the TLS sidecar. Default value is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -4399,15 +3806,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Entity Operator `Deployment`.
                     pod:
@@ -4418,15 +3820,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -4435,8 +3832,7 @@ spec:
                             properties:
                               name:
                                 type: string
-                          description: List of references to secrets in the same namespace
-                            to use for pulling any of the images used by this Pod.
+                          description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -4479,18 +3875,11 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
-                          description: Configures pod-level security attributes and
-                            common container settings.
+                          description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
-                          description: The grace period is the duration in seconds
-                            after the processes running in the pod are sent a termination
-                            signal and the time when the processes are forcibly halted
-                            with a kill signal. Set this value longer than the expected
-                            cleanup time for your process.Value must be non-negative
-                            integer. The value zero indicates delete immediately.
-                            Defaults to 30 seconds.
+                          description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -4702,13 +4091,10 @@ spec:
                           description: The pod's affinity rules.
                         priorityClassName:
                           type: string
-                          description: The name of the Priority Class to which these
-                            pods will be assigned.
+                          description: The name of the Priority Class to which these pods will be assigned.
                         schedulerName:
                           type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -4740,8 +4126,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -4804,8 +4189,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -4868,8 +4252,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -4918,72 +4301,49 @@ spec:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Entity User Operator container.
-                  description: Template for Entity Operator resources. The template
-                    allows users to specify how is the `Deployment` and `Pods` generated.
+                  description: Template for Entity Operator resources. The template allows users to specify how is the `Deployment` and `Pods` generated.
               description: Configuration of the Entity Operator.
             clusterCa:
               type: object
               properties:
                 generateCertificateAuthority:
                   type: boolean
-                  description: If true then Certificate Authority certificates will
-                    be generated automatically. Otherwise the user will need to provide
-                    a Secret with the CA certificate. Default is true.
+                  description: If true then Certificate Authority certificates will be generated automatically. Otherwise the user will need to provide a Secret with the CA certificate. Default is true.
                 validityDays:
                   type: integer
                   minimum: 1
-                  description: The number of days generated certificates should be
-                    valid for. The default is 365.
+                  description: The number of days generated certificates should be valid for. The default is 365.
                 renewalDays:
                   type: integer
                   minimum: 1
-                  description: The number of days in the certificate renewal period.
-                    This is the number of days before the a certificate expires during
-                    which renewal actions may be performed. When `generateCertificateAuthority`
-                    is true, this will cause the generation of a new certificate.
-                    When `generateCertificateAuthority` is true, this will cause extra
-                    logging at WARN level about the pending certificate expiry. Default
-                    is 30.
+                  description: The number of days in the certificate renewal period. This is the number of days before the a certificate expires during which renewal actions may be performed. When `generateCertificateAuthority` is true, this will cause the generation of a new certificate. When `generateCertificateAuthority` is true, this will cause extra logging at WARN level about the pending certificate expiry. Default is 30.
                 certificateExpirationPolicy:
                   type: string
                   enum:
-                  - renew-certificate
-                  - replace-key
-                  description: How should CA certificate expiration be handled when
-                    `generateCertificateAuthority=true`. The default is for a new
-                    CA certificate to be generated reusing the existing private key.
+                    - renew-certificate
+                    - replace-key
+                  description: How should CA certificate expiration be handled when `generateCertificateAuthority=true`. The default is for a new CA certificate to be generated reusing the existing private key.
               description: Configuration of the cluster certificate authority.
             clientsCa:
               type: object
               properties:
                 generateCertificateAuthority:
                   type: boolean
-                  description: If true then Certificate Authority certificates will
-                    be generated automatically. Otherwise the user will need to provide
-                    a Secret with the CA certificate. Default is true.
+                  description: If true then Certificate Authority certificates will be generated automatically. Otherwise the user will need to provide a Secret with the CA certificate. Default is true.
                 validityDays:
                   type: integer
                   minimum: 1
-                  description: The number of days generated certificates should be
-                    valid for. The default is 365.
+                  description: The number of days generated certificates should be valid for. The default is 365.
                 renewalDays:
                   type: integer
                   minimum: 1
-                  description: The number of days in the certificate renewal period.
-                    This is the number of days before the a certificate expires during
-                    which renewal actions may be performed. When `generateCertificateAuthority`
-                    is true, this will cause the generation of a new certificate.
-                    When `generateCertificateAuthority` is true, this will cause extra
-                    logging at WARN level about the pending certificate expiry. Default
-                    is 30.
+                  description: The number of days in the certificate renewal period. This is the number of days before the a certificate expires during which renewal actions may be performed. When `generateCertificateAuthority` is true, this will cause the generation of a new certificate. When `generateCertificateAuthority` is true, this will cause extra logging at WARN level about the pending certificate expiry. Default is 30.
                 certificateExpirationPolicy:
                   type: string
                   enum:
-                  - renew-certificate
-                  - replace-key
-                  description: How should CA certificate expiration be handled when
-                    `generateCertificateAuthority=true`. The default is for a new
-                    CA certificate to be generated reusing the existing private key.
+                    - renew-certificate
+                    - replace-key
+                  description: How should CA certificate expiration be handled when `generateCertificateAuthority=true`. The default is for a new CA certificate to be generated reusing the existing private key.
               description: Configuration of the clients certificate authority.
             cruiseControl:
               type: object
@@ -4993,36 +4353,23 @@ spec:
                   description: The docker image for the pods.
                 config:
                   type: object
-                  description: 'The Cruise Control configuration. For a full list
-                    of configuration options refer to https://github.com/linkedin/cruise-control/wiki/Configurations.
-                    Note that properties with the following prefixes cannot be set:
-                    bootstrap.servers, client.id, zookeeper., network., security.,
-                    failed.brokers.zk.path,webserver.http., webserver.api.urlprefix,
-                    webserver.session.path, webserver.accesslog., two.step., request.reason.required,metric.reporter.sampler.bootstrap.servers,
-                    metric.reporter.topic, partition.metric.sample.store.topic, broker.metric.sample.store.topic,capacity.config.file,
-                    self.healing., anomaly.detection., ssl.'
+                  description: 'The Cruise Control configuration. For a full list of configuration options refer to https://github.com/linkedin/cruise-control/wiki/Configurations. Note that properties with the following prefixes cannot be set: bootstrap.servers, client.id, zookeeper., network., security., failed.brokers.zk.path,webserver.http., webserver.api.urlprefix, webserver.session.path, webserver.accesslog., two.step., request.reason.required,metric.reporter.sampler.bootstrap.servers, metric.reporter.topic, partition.metric.sample.store.topic, broker.metric.sample.store.topic,capacity.config.file, self.healing., anomaly.detection., ssl.'
                 livenessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -5033,23 +4380,17 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -5071,8 +4412,7 @@ spec:
                       description: -Xmx option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
-                      description: Specifies whether the Garbage Collection logging
-                        is enabled. The default is false.
+                      description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                     javaSystemProperties:
                       type: array
                       items:
@@ -5084,8 +4424,7 @@ spec:
                           value:
                             type: string
                             description: The system property value.
-                      description: A map of additional system properties which will
-                        be passed using the `-D` option to the JVM.
+                      description: A map of additional system properties which will be passed using the `-D` option to the JVM.
                   description: JVM Options for the Cruise Control container.
                 resources:
                   type: object
@@ -5094,8 +4433,7 @@ spec:
                       type: object
                     requests:
                       type: object
-                  description: CPU and memory resources to reserve for the Cruise
-                    Control container.
+                  description: CPU and memory resources to reserve for the Cruise Control container.
                 logging:
                   type: object
                   properties:
@@ -5104,16 +4442,15 @@ spec:
                       description: A Map from logger name to logger level.
                     name:
                       type: string
-                      description: The name of the `ConfigMap` from which to get the
-                        logging configuration.
+                      description: The name of the `ConfigMap` from which to get the logging configuration.
                     type:
                       type: string
                       enum:
-                      - inline
-                      - external
+                        - inline
+                        - external
                       description: Logging type, must be either 'inline' or 'external'.
                   required:
-                  - type
+                    - type
                   description: Logging configuration (log4j1) for Cruise Control.
                 tlsSidecar:
                   type: object
@@ -5126,23 +4463,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -5151,38 +4482,31 @@ spec:
                     logLevel:
                       type: string
                       enum:
-                      - emerg
-                      - alert
-                      - crit
-                      - err
-                      - warning
-                      - notice
-                      - info
-                      - debug
-                      description: The log level for the TLS sidecar. Default value
-                        is `notice`.
+                        - emerg
+                        - alert
+                        - crit
+                        - err
+                        - warning
+                        - notice
+                        - info
+                        - debug
+                      description: The log level for the TLS sidecar. Default value is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -5208,15 +4532,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Cruise Control `Deployment`.
                     pod:
@@ -5227,15 +4546,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -5244,8 +4558,7 @@ spec:
                             properties:
                               name:
                                 type: string
-                          description: List of references to secrets in the same namespace
-                            to use for pulling any of the images used by this Pod.
+                          description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -5288,18 +4601,11 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
-                          description: Configures pod-level security attributes and
-                            common container settings.
+                          description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
-                          description: The grace period is the duration in seconds
-                            after the processes running in the pod are sent a termination
-                            signal and the time when the processes are forcibly halted
-                            with a kill signal. Set this value longer than the expected
-                            cleanup time for your process.Value must be non-negative
-                            integer. The value zero indicates delete immediately.
-                            Defaults to 30 seconds.
+                          description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -5511,13 +4817,10 @@ spec:
                           description: The pod's affinity rules.
                         priorityClassName:
                           type: string
-                          description: The name of the Priority Class to which these
-                            pods will be assigned.
+                          description: The name of the Priority Class to which these pods will be assigned.
                         schedulerName:
                           type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -5543,15 +4846,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Cruise Control API `Service`.
                     podDisruptionBudget:
@@ -5562,26 +4860,15 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
-                          description: Metadata to apply to the `PodDistruptionBugetTemplate`
-                            resource.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Metadata to apply to the `PodDistruptionBugetTemplate` resource.
                         maxUnavailable:
                           type: integer
                           minimum: 0
-                          description: Maximum number of unavailable pods to allow
-                            automatic Pod eviction. A Pod eviction is allowed when
-                            the `maxUnavailable` number of pods or fewer are unavailable
-                            after the eviction. Setting this value to 0 prevents all
-                            voluntary evictions, so the pods must be evicted manually.
-                            Defaults to 1.
+                          description: Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
                       description: Template for Cruise Control `PodDisruptionBudget`.
                     cruiseControlContainer:
                       type: object
@@ -5597,8 +4884,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -5661,8 +4947,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -5711,35 +4996,29 @@ spec:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Cruise Control TLS sidecar container.
-                  description: Template to specify how Cruise Control resources, `Deployments`
-                    and `Pods`, are generated.
+                  description: Template to specify how Cruise Control resources, `Deployments` and `Pods`, are generated.
                 brokerCapacity:
                   type: object
                   properties:
                     disk:
                       type: string
                       pattern: ^[0-9]+([.][0-9]*)?([KMGTPE]i?|e[0-9]+)?$
-                      description: Broker capacity for disk in bytes, for example,
-                        100Gi.
+                      description: Broker capacity for disk in bytes, for example, 100Gi.
                     cpuUtilization:
                       type: integer
                       minimum: 0
                       maximum: 100
-                      description: Broker capacity for CPU resource utilization as
-                        a percentage (0 - 100).
+                      description: Broker capacity for CPU resource utilization as a percentage (0 - 100).
                     inboundNetwork:
                       type: string
                       pattern: '[0-9]+([KMG]i?)?B/s'
-                      description: Broker capacity for inbound network throughput
-                        in bytes per second, for example, 10000KB/s.
+                      description: Broker capacity for inbound network throughput in bytes per second, for example, 10000KB/s.
                     outboundNetwork:
                       type: string
                       pattern: '[0-9]+([KMG]i?)?B/s'
-                      description: Broker capacity for outbound network throughput
-                        in bytes per second, for example 10000KB/s.
+                      description: Broker capacity for outbound network throughput in bytes per second, for example 10000KB/s.
                   description: The Cruise Control `brokerCapacity` configuration.
-              description: Configuration for Cruise Control deployment. Deploys a
-                Cruise Control instance when specified.
+              description: Configuration for Cruise Control deployment. Deploys a Cruise Control instance when specified.
             jmxTrans:
               type: object
               properties:
@@ -5753,44 +5032,31 @@ spec:
                     properties:
                       outputType:
                         type: string
-                        description: Template for setting the format of the data that
-                          will be pushed.For more information see https://github.com/jmxtrans/jmxtrans/wiki/OutputWriters[JmxTrans
-                          OutputWriters].
+                        description: Template for setting the format of the data that will be pushed.For more information see https://github.com/jmxtrans/jmxtrans/wiki/OutputWriters[JmxTrans OutputWriters].
                       host:
                         type: string
-                        description: The DNS/hostname of the remote host that the
-                          data is pushed to.
+                        description: The DNS/hostname of the remote host that the data is pushed to.
                       port:
                         type: integer
-                        description: The port of the remote host that the data is
-                          pushed to.
+                        description: The port of the remote host that the data is pushed to.
                       flushDelayInSeconds:
                         type: integer
-                        description: How many seconds the JmxTrans waits before pushing
-                          a new set of data out.
+                        description: How many seconds the JmxTrans waits before pushing a new set of data out.
                       typeNames:
                         type: array
                         items:
                           type: string
-                        description: Template for filtering data to be included in
-                          response to a wildcard query. For more information see https://github.com/jmxtrans/jmxtrans/wiki/Queries[JmxTrans
-                          queries].
+                        description: Template for filtering data to be included in response to a wildcard query. For more information see https://github.com/jmxtrans/jmxtrans/wiki/Queries[JmxTrans queries].
                       name:
                         type: string
-                        description: Template for setting the name of the output definition.
-                          This is used to identify where to send the results of queries
-                          should be sent.
+                        description: Template for setting the name of the output definition. This is used to identify where to send the results of queries should be sent.
                     required:
-                    - outputType
-                    - name
-                  description: Defines the output hosts that will be referenced later
-                    on. For more information on these properties see, xref:type-JmxTransOutputDefinitionTemplate-reference[`JmxTransOutputDefinitionTemplate`
-                    schema reference].
+                      - outputType
+                      - name
+                  description: Defines the output hosts that will be referenced later on. For more information on these properties see, xref:type-JmxTransOutputDefinitionTemplate-reference[`JmxTransOutputDefinitionTemplate` schema reference].
                 logLevel:
                   type: string
-                  description: Sets the logging level of the JmxTrans deployment.For
-                    more information see, https://github.com/jmxtrans/jmxtrans-agent/wiki/Troubleshooting[JmxTrans
-                    Logging Level].
+                  description: Sets the logging level of the JmxTrans deployment.For more information see, https://github.com/jmxtrans/jmxtrans-agent/wiki/Troubleshooting[JmxTrans Logging Level].
                 kafkaQueries:
                   type: array
                   items:
@@ -5798,31 +5064,22 @@ spec:
                     properties:
                       targetMBean:
                         type: string
-                        description: If using wildcards instead of a specific MBean
-                          then the data is gathered from multiple MBeans. Otherwise
-                          if specifying an MBean then data is gathered from that specified
-                          MBean.
+                        description: If using wildcards instead of a specific MBean then the data is gathered from multiple MBeans. Otherwise if specifying an MBean then data is gathered from that specified MBean.
                       attributes:
                         type: array
                         items:
                           type: string
-                        description: Determine which attributes of the targeted MBean
-                          should be included.
+                        description: Determine which attributes of the targeted MBean should be included.
                       outputs:
                         type: array
                         items:
                           type: string
-                        description: List of the names of output definitions specified
-                          in the spec.kafka.jmxTrans.outputDefinitions that have defined
-                          where JMX metrics are pushed to, and in which data format.
+                        description: List of the names of output definitions specified in the spec.kafka.jmxTrans.outputDefinitions that have defined where JMX metrics are pushed to, and in which data format.
                     required:
-                    - targetMBean
-                    - attributes
-                    - outputs
-                  description: Queries to send to the Kafka brokers to define what
-                    data should be read from each broker. For more information on
-                    these properties see, xref:type-JmxTransQueryTemplate-reference[`JmxTransQueryTemplate`
-                    schema reference].
+                      - targetMBean
+                      - attributes
+                      - outputs
+                  description: Queries to send to the Kafka brokers to define what data should be read from each broker. For more information on these properties see, xref:type-JmxTransQueryTemplate-reference[`JmxTransQueryTemplate` schema reference].
                 resources:
                   type: object
                   properties:
@@ -5842,15 +5099,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for JmxTrans `Deployment`.
                     pod:
@@ -5861,15 +5113,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -5878,8 +5125,7 @@ spec:
                             properties:
                               name:
                                 type: string
-                          description: List of references to secrets in the same namespace
-                            to use for pulling any of the images used by this Pod.
+                          description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -5922,18 +5168,11 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
-                          description: Configures pod-level security attributes and
-                            common container settings.
+                          description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
-                          description: The grace period is the duration in seconds
-                            after the processes running in the pod are sent a termination
-                            signal and the time when the processes are forcibly halted
-                            with a kill signal. Set this value longer than the expected
-                            cleanup time for your process.Value must be non-negative
-                            integer. The value zero indicates delete immediately.
-                            Defaults to 30 seconds.
+                          description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -6145,13 +5384,10 @@ spec:
                           description: The pod's affinity rules.
                         priorityClassName:
                           type: string
-                          description: The name of the Priority Class to which these
-                            pods will be assigned.
+                          description: The name of the Priority Class to which these pods will be assigned.
                         schedulerName:
                           type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -6183,8 +5419,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -6235,12 +5470,9 @@ spec:
                       description: Template for JmxTrans container.
                   description: Template for JmxTrans resources.
               required:
-              - outputDefinitions
-              - kafkaQueries
-              description: Configuration for JmxTrans. When the property is present
-                a JmxTrans deployment is created for gathering JMX metrics from each
-                Kafka broker. For more information see https://github.com/jmxtrans/jmxtrans[JmxTrans
-                GitHub].
+                - outputDefinitions
+                - kafkaQueries
+              description: Configuration for JmxTrans. When the property is present a JmxTrans deployment is created for gathering JMX metrics from each Kafka broker. For more information see https://github.com/jmxtrans/jmxtrans[JmxTrans GitHub].
             kafkaExporter:
               type: object
               properties:
@@ -6249,12 +5481,10 @@ spec:
                   description: The docker image for the pods.
                 groupRegex:
                   type: string
-                  description: Regular expression to specify which consumer groups
-                    to collect. Default value is `.*`.
+                  description: Regular expression to specify which consumer groups to collect. Default value is `.*`.
                 topicRegex:
                   type: string
-                  description: Regular expression to specify which topics to collect.
-                    Default value is `.*`.
+                  description: Regular expression to specify which topics to collect. Default value is `.*`.
                 resources:
                   type: object
                   properties:
@@ -6265,13 +5495,10 @@ spec:
                   description: CPU and memory resources to reserve.
                 logging:
                   type: string
-                  description: 'Only log messages with the given severity or above.
-                    Valid levels: [`debug`, `info`, `warn`, `error`, `fatal`]. Default
-                    log level is `info`.'
+                  description: 'Only log messages with the given severity or above. Valid levels: [`debug`, `info`, `warn`, `error`, `fatal`]. Default log level is `info`.'
                 enableSaramaLogging:
                   type: boolean
-                  description: Enable Sarama logging, a Go client library used by
-                    the Kafka Exporter.
+                  description: Enable Sarama logging, a Go client library used by the Kafka Exporter.
                 template:
                   type: object
                   properties:
@@ -6283,15 +5510,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka Exporter `Deployment`.
                     pod:
@@ -6302,15 +5524,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -6319,8 +5536,7 @@ spec:
                             properties:
                               name:
                                 type: string
-                          description: List of references to secrets in the same namespace
-                            to use for pulling any of the images used by this Pod.
+                          description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -6363,18 +5579,11 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
-                          description: Configures pod-level security attributes and
-                            common container settings.
+                          description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
-                          description: The grace period is the duration in seconds
-                            after the processes running in the pod are sent a termination
-                            signal and the time when the processes are forcibly halted
-                            with a kill signal. Set this value longer than the expected
-                            cleanup time for your process.Value must be non-negative
-                            integer. The value zero indicates delete immediately.
-                            Defaults to 30 seconds.
+                          description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -6586,13 +5795,10 @@ spec:
                           description: The pod's affinity rules.
                         priorityClassName:
                           type: string
-                          description: The name of the Priority Class to which these
-                            pods will be assigned.
+                          description: The name of the Priority Class to which these pods will be assigned.
                         schedulerName:
                           type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -6618,15 +5824,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka Exporter `Service`.
                     container:
@@ -6643,8 +5844,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -6699,23 +5899,17 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -6726,41 +5920,32 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
                       description: The timeout for each attempted health check.
                   description: Pod readiness check.
-              description: Configuration of the Kafka Exporter. Kafka Exporter can
-                provide additional metrics, for example lag of consumer group at topic/partition.
+              description: Configuration of the Kafka Exporter. Kafka Exporter can provide additional metrics, for example lag of consumer group at topic/partition.
             maintenanceTimeWindows:
               type: array
               items:
                 type: string
-              description: A list of time windows for maintenance tasks (that is,
-                certificates renewal). Each time window is defined by a cron expression.
+              description: A list of time windows for maintenance tasks (that is, certificates renewal). Each time window is defined by a cron expression.
           required:
-          - kafka
-          - zookeeper
-          description: The specification of the Kafka and ZooKeeper clusters, and
-            Topic Operator.
+            - kafka
+            - zookeeper
+          description: The specification of the Kafka and ZooKeeper clusters, and Topic Operator.
         status:
           type: object
           properties:
@@ -6771,30 +5956,23 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             listeners:
               type: array
               items:
@@ -6802,8 +5980,7 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: 'The type of the listener. Can be one of the following
-                      three types: `plain`, `tls`, and `external`.'
+                    description: 'The type of the listener. Can be one of the following three types: `plain`, `tls`, and `external`.'
                   addresses:
                     type: array
                     items:
@@ -6811,23 +5988,19 @@ spec:
                       properties:
                         host:
                           type: string
-                          description: The DNS name or IP address of the Kafka bootstrap
-                            service.
+                          description: The DNS name or IP address of the Kafka bootstrap service.
                         port:
                           type: integer
                           description: The port of the Kafka bootstrap service.
                     description: A list of the addresses for this listener.
                   bootstrapServers:
                     type: string
-                    description: A comma-separated list of `host:port` pairs for connecting
-                      to the Kafka cluster using this listener.
+                    description: A comma-separated list of `host:port` pairs for connecting to the Kafka cluster using this listener.
                   certificates:
                     type: array
                     items:
                       type: string
-                    description: A list of TLS certificates which can be used to verify
-                      the identity of the server when connecting to the given listener.
-                      Set only for `tls` and `external` listeners.
+                    description: A list of TLS certificates which can be used to verify the identity of the server when connecting to the given listener. Set only for `tls` and `external` listeners.
               description: Addresses of the internal and external listeners.
           description: The status of the Kafka and ZooKeeper clusters, and Topic Operator.
 {{- end -}}

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -13,12 +13,12 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
-  - name: v1alpha1
-    served: true
-    storage: false
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   version: v1beta1
   scope: Namespaced
   names:
@@ -27,14 +27,14 @@ spec:
     singular: kafkaconnect
     plural: kafkaconnects
     shortNames:
-    - kc
+      - kc
     categories:
-    - strimzi
+      - strimzi
   additionalPrinterColumns:
-  - name: Desired replicas
-    description: The desired number of Kafka Connect replicas
-    JSONPath: .spec.replicas
-    type: integer
+    - name: Desired replicas
+      description: The desired number of Kafka Connect replicas
+      JSONPath: .spec.replicas
+      type: integer
   subresources:
     status: {}
     scale:
@@ -52,16 +52,13 @@ spec:
               description: The number of pods in the Kafka Connect group.
             version:
               type: string
-              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}.
-                Consult the user documentation to understand the process required
-                to upgrade or downgrade the version.
+              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
             image:
               type: string
               description: The docker image for the pods.
             bootstrapServers:
               type: string
-              description: Bootstrap servers to connect to. This should be given as
-                a comma separated list of _<hostname>_:‍_<port>_ pairs.
+              description: Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
             tls:
               type: object
               properties:
@@ -77,8 +74,8 @@ spec:
                         type: string
                         description: The name of the Secret containing the certificate.
                     required:
-                    - certificate
-                    - secretName
+                      - certificate
+                      - secretName
                   description: Trusted certificates for TLS connection.
               description: TLS configuration.
             authentication:
@@ -89,22 +86,17 @@ spec:
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the access token
-                    which was obtained from the authorization server.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
                 accessTokenIsJwt:
                   type: boolean
-                  description: Configure whether access token should be treated as
-                    JWT. This should be set to `false` if the authorization server
-                    returns opaque tokens. Defaults to `true`.
+                  description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                 certificateAndKey:
                   type: object
                   properties:
@@ -118,79 +110,61 @@ spec:
                       type: string
                       description: The name of the Secret containing the certificate.
                   required:
-                  - certificate
-                  - key
-                  - secretName
-                  description: Reference to the `Secret` which holds the certificate
-                    and private key pair.
+                    - certificate
+                    - key
+                    - secretName
+                  description: Reference to the `Secret` which holds the certificate and private key pair.
                 clientId:
                   type: string
-                  description: OAuth Client ID which the Kafka client can use to authenticate
-                    against the OAuth server and use the token endpoint URI.
+                  description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                 clientSecret:
                   type: object
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the OAuth client
-                    secret which the Kafka client can use to authenticate against
-                    the OAuth server and use the token endpoint URI.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                 disableTlsHostnameVerification:
                   type: boolean
-                  description: Enable or disable TLS hostname verification. Default
-                    value is `false`.
+                  description: Enable or disable TLS hostname verification. Default value is `false`.
                 maxTokenExpirySeconds:
                   type: integer
-                  description: Set or limit time-to-live of the access tokens to the
-                    specified number of seconds. This should be set if the authorization
-                    server returns opaque tokens.
+                  description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
                 passwordSecret:
                   type: object
                   properties:
                     password:
                       type: string
-                      description: The name of the key in the Secret under which the
-                        password is stored.
+                      description: The name of the key in the Secret under which the password is stored.
                     secretName:
                       type: string
                       description: The name of the Secret containing the password.
                   required:
-                  - password
-                  - secretName
+                    - password
+                    - secretName
                   description: Reference to the `Secret` which holds the password.
                 refreshToken:
                   type: object
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the refresh token
-                    which can be used to obtain access token from the authorization
-                    server.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
                 scope:
                   type: string
-                  description: OAuth scope to use when authenticating against the
-                    authorization server. Some authorization servers require this
-                    to be set. The possible values depend on how authorization server
-                    is configured. By default `scope` is not specified when doing
-                    the token endpoint request.
+                  description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
                 tlsTrustedCertificates:
                   type: array
                   items:
@@ -203,39 +177,29 @@ spec:
                         type: string
                         description: The name of the Secret containing the certificate.
                     required:
-                    - certificate
-                    - secretName
-                  description: Trusted certificates for TLS connection to the OAuth
-                    server.
+                      - certificate
+                      - secretName
+                  description: Trusted certificates for TLS connection to the OAuth server.
                 tokenEndpointUri:
                   type: string
                   description: Authorization server token endpoint URI.
                 type:
                   type: string
                   enum:
-                  - tls
-                  - scram-sha-512
-                  - plain
-                  - oauth
-                  description: Authentication type. Currently the only supported types
-                    are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type
-                    uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL
-                    PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication.
-                    The `tls` type uses TLS Client Authentication. The `tls` type
-                    is supported only over TLS connections.
+                    - tls
+                    - scram-sha-512
+                    - plain
+                    - oauth
+                  description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                 username:
                   type: string
                   description: Username used for the authentication.
               required:
-              - type
+                - type
               description: Authentication configuration for Kafka Connect.
             config:
               type: object
-              description: 'The Kafka Connect configuration. Properties with the following
-                prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
-                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes
-                (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites,
-                ssl.protocol, ssl.enabled.protocols).'
+              description: 'The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
             resources:
               type: object
               properties:
@@ -243,30 +207,23 @@ spec:
                   type: object
                 requests:
                   type: object
-              description: The maximum limits for CPU and memory resources and the
-                requested initial resources.
+              description: The maximum limits for CPU and memory resources and the requested initial resources.
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -277,23 +234,17 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -315,8 +266,7 @@ spec:
                   description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
-                  description: Specifies whether the Garbage Collection logging is
-                    enabled. The default is false.
+                  description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -328,8 +278,7 @@ spec:
                       value:
                         type: string
                         description: The system property value.
-                  description: A map of additional system properties which will be
-                    passed using the `-D` option to the JVM.
+                  description: A map of additional system properties which will be passed using the `-D` option to the JVM.
               description: JVM Options for pods.
             affinity:
               type: object
@@ -564,32 +513,29 @@ spec:
                   description: A Map from logger name to logger level.
                 name:
                   type: string
-                  description: The name of the `ConfigMap` from which to get the logging
-                    configuration.
+                  description: The name of the `ConfigMap` from which to get the logging configuration.
                 type:
                   type: string
                   enum:
-                  - inline
-                  - external
+                    - inline
+                    - external
                   description: Logging type, must be either 'inline' or 'external'.
               required:
-              - type
+                - type
               description: Logging configuration for Kafka Connect.
             metrics:
               type: object
-              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
-                for details of the structure of this configuration.
+              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
             tracing:
               type: object
               properties:
                 type:
                   type: string
                   enum:
-                  - jaeger
-                  description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing.
+                    - jaeger
+                  description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
               required:
-              - type
+                - type
               description: The configuration of tracing in Kafka Connect.
             template:
               type: object
@@ -602,14 +548,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
@@ -620,14 +562,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
@@ -636,8 +574,7 @@ spec:
                         properties:
                           name:
                             type: string
-                      description: List of references to secrets in the same namespace
-                        to use for pulling any of the images used by this Pod.
+                      description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -680,18 +617,11 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
-                      description: Configures pod-level security attributes and common
-                        container settings.
+                      description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
-                      description: The grace period is the duration in seconds after
-                        the processes running in the pod are sent a termination signal
-                        and the time when the processes are forcibly halted with a
-                        kill signal. Set this value longer than the expected cleanup
-                        time for your process.Value must be non-negative integer.
-                        The value zero indicates delete immediately. Defaults to 30
-                        seconds.
+                      description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                     affinity:
                       type: object
                       properties:
@@ -903,12 +833,10 @@ spec:
                       description: The pod's affinity rules.
                     priorityClassName:
                       type: string
-                      description: The name of the Priority Class to which these pods
-                        will be assigned.
+                      description: The name of the Priority Class to which these pods will be assigned.
                     schedulerName:
                       type: string
-                      description: The name of the scheduler used to dispatch this
-                        `Pod`. If not specified, the default scheduler will be used.
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -934,14 +862,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect API `Service`.
                 connectContainer:
@@ -958,8 +882,7 @@ spec:
                           value:
                             type: string
                             description: The environment variable value.
-                      description: Environment variables which should be applied to
-                        the container.
+                      description: Environment variables which should be applied to the container.
                     securityContext:
                       type: object
                       properties:
@@ -1016,28 +939,17 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
-                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
-                        resource.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate` resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
-                      description: Maximum number of unavailable pods to allow automatic
-                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
-                        number of pods or fewer are unavailable after the eviction.
-                        Setting this value to 0 prevents all voluntary evictions,
-                        so the pods must be evicted manually. Defaults to 1.
+                      description: Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
                   description: Template for Kafka Connect `PodDisruptionBudget`.
-              description: Template for Kafka Connect and Kafka Connect S2I resources.
-                The template allows users to specify how the `Deployment`, `Pods`
-                and `Service` are generated.
+              description: Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
             externalConfiguration:
               type: object
               properties:
@@ -1048,9 +960,7 @@ spec:
                     properties:
                       name:
                         type: string
-                        description: Name of the environment variable which will be
-                          passed to the Kafka Connect pods. The name of the environment
-                          variable cannot start with `KAFKA_` or `STRIMZI_`.
+                        description: Name of the environment variable which will be passed to the Kafka Connect pods. The name of the environment variable cannot start with `KAFKA_` or `STRIMZI_`.
                       valueFrom:
                         type: object
                         properties:
@@ -1074,15 +984,11 @@ spec:
                               optional:
                                 type: boolean
                             description: Reference to a key in a Secret.
-                        description: Value of the environment variable which will
-                          be passed to the Kafka Connect pods. It can be passed either
-                          as a reference to Secret or ConfigMap field. The field has
-                          to specify exactly one Secret or ConfigMap.
+                        description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
                     required:
-                    - name
-                    - valueFrom
-                  description: Allows to pass data from Secret or ConfigMap to the
-                    Kafka Connect pods as environment variables.
+                      - name
+                      - valueFrom
+                  description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as environment variables.
                 volumes:
                   type: array
                   items:
@@ -1108,12 +1014,10 @@ spec:
                             type: string
                           optional:
                             type: boolean
-                        description: Reference to a key in a ConfigMap. Exactly one
-                          Secret or ConfigMap has to be specified.
+                        description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
                       name:
                         type: string
-                        description: Name of the volume which will be added to the
-                          Kafka Connect pods.
+                        description: Name of the volume which will be added to the Kafka Connect pods.
                       secret:
                         type: object
                         properties:
@@ -1134,16 +1038,13 @@ spec:
                             type: boolean
                           secretName:
                             type: string
-                        description: Reference to a key in a Secret. Exactly one Secret
-                          or ConfigMap has to be specified.
+                        description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
                     required:
-                    - name
-                  description: Allows to pass data from Secret or ConfigMap to the
-                    Kafka Connect pods as volumes.
-              description: Pass data from Secrets or ConfigMaps to the Kafka Connect
-                pods and use them to configure connectors.
+                      - name
+                  description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as volumes.
+              description: Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
           required:
-          - bootstrapServers
+            - bootstrapServers
           description: The specification of the Kafka Connect cluster.
         status:
           type: object
@@ -1155,34 +1056,26 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             url:
               type: string
-              description: The URL of the REST API endpoint for managing and monitoring
-                Kafka Connect connectors.
+              description: The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
             connectorPlugins:
               type: array
               items:
@@ -1190,16 +1083,14 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The type of the connector plugin. The available types
-                      are `sink` and `source`.
+                    description: The type of the connector plugin. The available types are `sink` and `source`.
                   version:
                     type: string
                     description: The version of the connector plugin.
                   class:
                     type: string
                     description: The class of the connector plugin.
-              description: The list of connector plugins available in this Kafka Connect
-                deployment.
+              description: The list of connector plugins available in this Kafka Connect deployment.
             podSelector:
               type: object
               properties:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -13,12 +13,12 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
-  - name: v1alpha1
-    served: true
-    storage: false
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   version: v1beta1
   scope: Namespaced
   names:
@@ -27,14 +27,14 @@ spec:
     singular: kafkaconnects2i
     plural: kafkaconnects2is
     shortNames:
-    - kcs2i
+      - kcs2i
     categories:
-    - strimzi
+      - strimzi
   additionalPrinterColumns:
-  - name: Desired replicas
-    description: The desired number of Kafka Connect replicas
-    JSONPath: .spec.replicas
-    type: integer
+    - name: Desired replicas
+      description: The desired number of Kafka Connect replicas
+      JSONPath: .spec.replicas
+      type: integer
   subresources:
     status: {}
     scale:
@@ -66,23 +66,17 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -93,23 +87,17 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -131,8 +119,7 @@ spec:
                   description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
-                  description: Specifies whether the Garbage Collection logging is
-                    enabled. The default is false.
+                  description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -144,8 +131,7 @@ spec:
                       value:
                         type: string
                         description: The system property value.
-                  description: A map of additional system properties which will be
-                    passed using the `-D` option to the JVM.
+                  description: A map of additional system properties which will be passed using the `-D` option to the JVM.
               description: JVM Options for pods.
             affinity:
               type: object
@@ -364,21 +350,19 @@ spec:
                   description: A Map from logger name to logger level.
                 name:
                   type: string
-                  description: The name of the `ConfigMap` from which to get the logging
-                    configuration.
+                  description: The name of the `ConfigMap` from which to get the logging configuration.
                 type:
                   type: string
                   enum:
-                  - inline
-                  - external
+                    - inline
+                    - external
                   description: Logging type, must be either 'inline' or 'external'.
               required:
-              - type
+                - type
               description: Logging configuration for Kafka Connect.
             metrics:
               type: object
-              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
-                for details of the structure of this configuration.
+              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
             template:
               type: object
               properties:
@@ -390,14 +374,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
@@ -408,14 +388,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
@@ -424,8 +400,7 @@ spec:
                         properties:
                           name:
                             type: string
-                      description: List of references to secrets in the same namespace
-                        to use for pulling any of the images used by this Pod.
+                      description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -468,18 +443,11 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
-                      description: Configures pod-level security attributes and common
-                        container settings.
+                      description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
-                      description: The grace period is the duration in seconds after
-                        the processes running in the pod are sent a termination signal
-                        and the time when the processes are forcibly halted with a
-                        kill signal. Set this value longer than the expected cleanup
-                        time for your process.Value must be non-negative integer.
-                        The value zero indicates delete immediately. Defaults to 30
-                        seconds.
+                      description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                     affinity:
                       type: object
                       properties:
@@ -691,12 +659,10 @@ spec:
                       description: The pod's affinity rules.
                     priorityClassName:
                       type: string
-                      description: The name of the Priority Class to which these pods
-                        will be assigned.
+                      description: The name of the Priority Class to which these pods will be assigned.
                     schedulerName:
                       type: string
-                      description: The name of the scheduler used to dispatch this
-                        `Pod`. If not specified, the default scheduler will be used.
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -722,14 +688,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect API `Service`.
                 connectContainer:
@@ -746,8 +708,7 @@ spec:
                           value:
                             type: string
                             description: The environment variable value.
-                      description: Environment variables which should be applied to
-                        the container.
+                      description: Environment variables which should be applied to the container.
                     securityContext:
                       type: object
                       properties:
@@ -804,28 +765,17 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
-                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
-                        resource.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate` resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
-                      description: Maximum number of unavailable pods to allow automatic
-                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
-                        number of pods or fewer are unavailable after the eviction.
-                        Setting this value to 0 prevents all voluntary evictions,
-                        so the pods must be evicted manually. Defaults to 1.
+                      description: Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
                   description: Template for Kafka Connect `PodDisruptionBudget`.
-              description: Template for Kafka Connect and Kafka Connect S2I resources.
-                The template allows users to specify how the `Deployment`, `Pods`
-                and `Service` are generated.
+              description: Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
             authentication:
               type: object
               properties:
@@ -834,22 +784,17 @@ spec:
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the access token
-                    which was obtained from the authorization server.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
                 accessTokenIsJwt:
                   type: boolean
-                  description: Configure whether access token should be treated as
-                    JWT. This should be set to `false` if the authorization server
-                    returns opaque tokens. Defaults to `true`.
+                  description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                 certificateAndKey:
                   type: object
                   properties:
@@ -863,79 +808,61 @@ spec:
                       type: string
                       description: The name of the Secret containing the certificate.
                   required:
-                  - certificate
-                  - key
-                  - secretName
-                  description: Reference to the `Secret` which holds the certificate
-                    and private key pair.
+                    - certificate
+                    - key
+                    - secretName
+                  description: Reference to the `Secret` which holds the certificate and private key pair.
                 clientId:
                   type: string
-                  description: OAuth Client ID which the Kafka client can use to authenticate
-                    against the OAuth server and use the token endpoint URI.
+                  description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                 clientSecret:
                   type: object
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the OAuth client
-                    secret which the Kafka client can use to authenticate against
-                    the OAuth server and use the token endpoint URI.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                 disableTlsHostnameVerification:
                   type: boolean
-                  description: Enable or disable TLS hostname verification. Default
-                    value is `false`.
+                  description: Enable or disable TLS hostname verification. Default value is `false`.
                 maxTokenExpirySeconds:
                   type: integer
-                  description: Set or limit time-to-live of the access tokens to the
-                    specified number of seconds. This should be set if the authorization
-                    server returns opaque tokens.
+                  description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
                 passwordSecret:
                   type: object
                   properties:
                     password:
                       type: string
-                      description: The name of the key in the Secret under which the
-                        password is stored.
+                      description: The name of the key in the Secret under which the password is stored.
                     secretName:
                       type: string
                       description: The name of the Secret containing the password.
                   required:
-                  - password
-                  - secretName
+                    - password
+                    - secretName
                   description: Reference to the `Secret` which holds the password.
                 refreshToken:
                   type: object
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the refresh token
-                    which can be used to obtain access token from the authorization
-                    server.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
                 scope:
                   type: string
-                  description: OAuth scope to use when authenticating against the
-                    authorization server. Some authorization servers require this
-                    to be set. The possible values depend on how authorization server
-                    is configured. By default `scope` is not specified when doing
-                    the token endpoint request.
+                  description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
                 tlsTrustedCertificates:
                   type: array
                   items:
@@ -948,43 +875,32 @@ spec:
                         type: string
                         description: The name of the Secret containing the certificate.
                     required:
-                    - certificate
-                    - secretName
-                  description: Trusted certificates for TLS connection to the OAuth
-                    server.
+                      - certificate
+                      - secretName
+                  description: Trusted certificates for TLS connection to the OAuth server.
                 tokenEndpointUri:
                   type: string
                   description: Authorization server token endpoint URI.
                 type:
                   type: string
                   enum:
-                  - tls
-                  - scram-sha-512
-                  - plain
-                  - oauth
-                  description: Authentication type. Currently the only supported types
-                    are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type
-                    uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL
-                    PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication.
-                    The `tls` type uses TLS Client Authentication. The `tls` type
-                    is supported only over TLS connections.
+                    - tls
+                    - scram-sha-512
+                    - plain
+                    - oauth
+                  description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                 username:
                   type: string
                   description: Username used for the authentication.
               required:
-              - type
+                - type
               description: Authentication configuration for Kafka Connect.
             bootstrapServers:
               type: string
-              description: Bootstrap servers to connect to. This should be given as
-                a comma separated list of _<hostname>_:‍_<port>_ pairs.
+              description: Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
             config:
               type: object
-              description: 'The Kafka Connect configuration. Properties with the following
-                prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
-                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes
-                (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites,
-                ssl.protocol, ssl.enabled.protocols).'
+              description: 'The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
             externalConfiguration:
               type: object
               properties:
@@ -995,9 +911,7 @@ spec:
                     properties:
                       name:
                         type: string
-                        description: Name of the environment variable which will be
-                          passed to the Kafka Connect pods. The name of the environment
-                          variable cannot start with `KAFKA_` or `STRIMZI_`.
+                        description: Name of the environment variable which will be passed to the Kafka Connect pods. The name of the environment variable cannot start with `KAFKA_` or `STRIMZI_`.
                       valueFrom:
                         type: object
                         properties:
@@ -1021,15 +935,11 @@ spec:
                               optional:
                                 type: boolean
                             description: Reference to a key in a Secret.
-                        description: Value of the environment variable which will
-                          be passed to the Kafka Connect pods. It can be passed either
-                          as a reference to Secret or ConfigMap field. The field has
-                          to specify exactly one Secret or ConfigMap.
+                        description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
                     required:
-                    - name
-                    - valueFrom
-                  description: Allows to pass data from Secret or ConfigMap to the
-                    Kafka Connect pods as environment variables.
+                      - name
+                      - valueFrom
+                  description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as environment variables.
                 volumes:
                   type: array
                   items:
@@ -1055,12 +965,10 @@ spec:
                             type: string
                           optional:
                             type: boolean
-                        description: Reference to a key in a ConfigMap. Exactly one
-                          Secret or ConfigMap has to be specified.
+                        description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
                       name:
                         type: string
-                        description: Name of the volume which will be added to the
-                          Kafka Connect pods.
+                        description: Name of the volume which will be added to the Kafka Connect pods.
                       secret:
                         type: object
                         properties:
@@ -1081,19 +989,14 @@ spec:
                             type: boolean
                           secretName:
                             type: string
-                        description: Reference to a key in a Secret. Exactly one Secret
-                          or ConfigMap has to be specified.
+                        description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
                     required:
-                    - name
-                  description: Allows to pass data from Secret or ConfigMap to the
-                    Kafka Connect pods as volumes.
-              description: Pass data from Secrets or ConfigMaps to the Kafka Connect
-                pods and use them to configure connectors.
+                      - name
+                  description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as volumes.
+              description: Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
             insecureSourceRepository:
               type: boolean
-              description: When true this configures the source repository with the
-                'Local' reference policy and an import policy that accepts insecure
-                source tags.
+              description: When true this configures the source repository with the 'Local' reference policy and an import policy that accepts insecure source tags.
             resources:
               type: object
               properties:
@@ -1101,8 +1004,7 @@ spec:
                   type: object
                 requests:
                   type: object
-              description: The maximum limits for CPU and memory resources and the
-                requested initial resources.
+              description: The maximum limits for CPU and memory resources and the requested initial resources.
             tls:
               type: object
               properties:
@@ -1118,8 +1020,8 @@ spec:
                         type: string
                         description: The name of the Secret containing the certificate.
                     required:
-                    - certificate
-                    - secretName
+                      - certificate
+                      - secretName
                   description: Trusted certificates for TLS connection.
               description: TLS configuration.
             tolerations:
@@ -1144,21 +1046,17 @@ spec:
                 type:
                   type: string
                   enum:
-                  - jaeger
-                  description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing.
+                    - jaeger
+                  description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
               required:
-              - type
+                - type
               description: The configuration of tracing in Kafka Connect.
             version:
               type: string
-              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}.
-                Consult the user documentation to understand the process required
-                to upgrade or downgrade the version.
+              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
           required:
-          - bootstrapServers
-          description: The specification of the Kafka Connect Source-to-Image (S2I)
-            cluster.
+            - bootstrapServers
+          description: The specification of the Kafka Connect Source-to-Image (S2I) cluster.
         status:
           type: object
           properties:
@@ -1169,34 +1067,26 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             url:
               type: string
-              description: The URL of the REST API endpoint for managing and monitoring
-                Kafka Connect connectors.
+              description: The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
             connectorPlugins:
               type: array
               items:
@@ -1204,16 +1094,14 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The type of the connector plugin. The available types
-                      are `sink` and `source`.
+                    description: The type of the connector plugin. The available types are `sink` and `source`.
                   version:
                     type: string
                     description: The version of the connector plugin.
                   class:
                     type: string
                     description: The class of the connector plugin.
-              description: The list of connector plugins available in this Kafka Connect
-                deployment.
+              description: The list of connector plugins available in this Kafka Connect deployment.
             buildConfigName:
               type: string
               description: The name of the build configuration.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
@@ -13,12 +13,12 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
-  - name: v1alpha1
-    served: true
-    storage: false
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   version: v1beta1
   scope: Namespaced
   names:
@@ -27,18 +27,18 @@ spec:
     singular: kafkatopic
     plural: kafkatopics
     shortNames:
-    - kt
+      - kt
     categories:
-    - strimzi
+      - strimzi
   additionalPrinterColumns:
-  - name: Partitions
-    description: The desired number of partitions in the topic
-    JSONPath: .spec.partitions
-    type: integer
-  - name: Replication factor
-    description: The desired number of replicas of each partition
-    JSONPath: .spec.replicas
-    type: integer
+    - name: Partitions
+      description: The desired number of partitions in the topic
+      JSONPath: .spec.partitions
+      type: integer
+    - name: Replication factor
+      description: The desired number of replicas of each partition
+      JSONPath: .spec.replicas
+      type: integer
   subresources:
     status: {}
   validation:
@@ -50,10 +50,7 @@ spec:
             partitions:
               type: integer
               minimum: 1
-              description: The number of partitions the topic should have. This cannot
-                be decreased after topic creation. It can be increased after topic
-                creation, but it is important to understand the consequences that
-                has, especially for topics with semantic partitioning.
+              description: The number of partitions the topic should have. This cannot be decreased after topic creation. It can be increased after topic creation, but it is important to understand the consequences that has, especially for topics with semantic partitioning.
             replicas:
               type: integer
               minimum: 1
@@ -64,12 +61,10 @@ spec:
               description: The topic configuration.
             topicName:
               type: string
-              description: The name of the topic. When absent this will default to
-                the metadata.name of the topic. It is recommended to not set this
-                unless the topic name is not a valid Kubernetes resource name.
+              description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
           required:
-          - partitions
-          - replicas
+            - partitions
+            - replicas
           description: The specification of the topic.
         status:
           type: object
@@ -81,29 +76,22 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
           description: The status of the topic.
 {{- end -}}

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
@@ -13,12 +13,12 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
-  - name: v1alpha1
-    served: true
-    storage: false
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   version: v1beta1
   scope: Namespaced
   names:
@@ -27,18 +27,18 @@ spec:
     singular: kafkauser
     plural: kafkausers
     shortNames:
-    - ku
+      - ku
     categories:
-    - strimzi
+      - strimzi
   additionalPrinterColumns:
-  - name: Authentication
-    description: How the user is authenticated
-    JSONPath: .spec.authentication.type
-    type: string
-  - name: Authorization
-    description: How the user is authorised
-    JSONPath: .spec.authorization.type
-    type: string
+    - name: Authentication
+      description: How the user is authenticated
+      JSONPath: .spec.authentication.type
+      type: string
+    - name: Authorization
+      description: How the user is authorised
+      JSONPath: .spec.authorization.type
+      type: string
   subresources:
     status: {}
   validation:
@@ -53,11 +53,11 @@ spec:
                 type:
                   type: string
                   enum:
-                  - tls
-                  - scram-sha-512
+                    - tls
+                    - scram-sha-512
                   description: Authentication type.
               required:
-              - type
+                - type
               description: Authentication mechanism enabled for this Kafka user.
             authorization:
               type: object
@@ -69,81 +69,63 @@ spec:
                     properties:
                       host:
                         type: string
-                        description: The host from which the action described in the
-                          ACL rule is allowed or denied.
+                        description: The host from which the action described in the ACL rule is allowed or denied.
                       operation:
                         type: string
                         enum:
-                        - Read
-                        - Write
-                        - Create
-                        - Delete
-                        - Alter
-                        - Describe
-                        - ClusterAction
-                        - AlterConfigs
-                        - DescribeConfigs
-                        - IdempotentWrite
-                        - All
-                        description: 'Operation which will be allowed or denied. Supported
-                          operations are: Read, Write, Create, Delete, Alter, Describe,
-                          ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite
-                          and All.'
+                          - Read
+                          - Write
+                          - Create
+                          - Delete
+                          - Alter
+                          - Describe
+                          - ClusterAction
+                          - AlterConfigs
+                          - DescribeConfigs
+                          - IdempotentWrite
+                          - All
+                        description: 'Operation which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All.'
                       resource:
                         type: object
                         properties:
                           name:
                             type: string
-                            description: Name of resource for which given ACL rule
-                              applies. Can be combined with `patternType` field to
-                              use prefix pattern.
+                            description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
                           patternType:
                             type: string
                             enum:
-                            - literal
-                            - prefix
-                            description: Describes the pattern used in the resource
-                              field. The supported types are `literal` and `prefix`.
-                              With `literal` pattern type, the resource field will
-                              be used as a definition of a full name. With `prefix`
-                              pattern type, the resource name will be used only as
-                              a prefix. Default value is `literal`.
+                              - literal
+                              - prefix
+                            description: Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`.
                           type:
                             type: string
                             enum:
-                            - topic
-                            - group
-                            - cluster
-                            - transactionalId
-                            description: Resource type. The available resource types
-                              are `topic`, `group`, `cluster`, and `transactionalId`.
+                              - topic
+                              - group
+                              - cluster
+                              - transactionalId
+                            description: Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`.
                         required:
-                        - type
-                        description: Indicates the resource for which given ACL rule
-                          applies.
+                          - type
+                        description: Indicates the resource for which given ACL rule applies.
                       type:
                         type: string
                         enum:
-                        - allow
-                        - deny
-                        description: The type of the rule. Currently the only supported
-                          type is `allow`. ACL rules with type `allow` are used to
-                          allow user to execute the specified operations. Default
-                          value is `allow`.
+                          - allow
+                          - deny
+                        description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                     required:
-                    - operation
-                    - resource
+                      - operation
+                      - resource
                   description: List of ACL rules which should be applied to this user.
                 type:
                   type: string
                   enum:
-                  - simple
-                  description: Authorization type. Currently the only supported type
-                    is `simple`. `simple` authorization type uses Kafka's `kafka.security.auth.SimpleAclAuthorizer`
-                    class for authorization.
+                    - simple
+                  description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.auth.SimpleAclAuthorizer` class for authorization.
               required:
-              - acls
-              - type
+                - acls
+                - type
               description: Authorization rules for this Kafka user.
             quotas:
               type: object
@@ -151,23 +133,16 @@ spec:
                 consumerByteRate:
                   type: integer
                   minimum: 0
-                  description: A quota on the maximum bytes per-second that each client
-                    group can fetch from a broker before the clients in the group
-                    are throttled. Defined on a per-broker basis.
+                  description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
                 producerByteRate:
                   type: integer
                   minimum: 0
-                  description: A quota on the maximum bytes per-second that each client
-                    group can publish to a broker before the clients in the group
-                    are throttled. Defined on a per-broker basis.
+                  description: A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
                 requestPercentage:
                   type: integer
                   minimum: 0
-                  description: A quota on the maximum CPU utilization of each client
-                    group as a percentage of network and I/O threads.
-              description: Quotas on requests to control the broker resources used
-                by clients. Network bandwidth and request rate quotas can be enforced.Kafka
-                documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
+                  description: A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
+              description: Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
           description: The specification of the user.
         status:
           type: object
@@ -179,30 +154,23 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             username:
               type: string
               description: Username.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -13,12 +13,12 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
-  - name: v1alpha1
-    served: true
-    storage: false
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   version: v1beta1
   scope: Namespaced
   names:
@@ -27,24 +27,24 @@ spec:
     singular: kafkamirrormaker
     plural: kafkamirrormakers
     shortNames:
-    - kmm
+      - kmm
     categories:
-    - strimzi
+      - strimzi
   additionalPrinterColumns:
-  - name: Desired replicas
-    description: The desired number of Kafka MirrorMaker replicas
-    JSONPath: .spec.replicas
-    type: integer
-  - name: Consumer Bootstrap Servers
-    description: The boostrap servers for the consumer
-    JSONPath: .spec.consumer.bootstrapServers
-    type: string
-    priority: 1
-  - name: Producer Bootstrap Servers
-    description: The boostrap servers for the producer
-    JSONPath: .spec.producer.bootstrapServers
-    type: string
-    priority: 1
+    - name: Desired replicas
+      description: The desired number of Kafka MirrorMaker replicas
+      JSONPath: .spec.replicas
+      type: integer
+    - name: Consumer Bootstrap Servers
+      description: The boostrap servers for the consumer
+      JSONPath: .spec.consumer.bootstrapServers
+      type: string
+      priority: 1
+    - name: Producer Bootstrap Servers
+      description: The boostrap servers for the producer
+      JSONPath: .spec.producer.bootstrapServers
+      type: string
+      priority: 1
   subresources:
     status: {}
     scale:
@@ -66,32 +66,23 @@ spec:
               description: The docker image for the pods.
             whitelist:
               type: string
-              description: List of topics which are included for mirroring. This option
-                allows any regular expression using Java-style regular expressions.
-                Mirroring two topics named A and B is achieved by using the whitelist
-                `'A\|B'`. Or, as a special case, you can mirror all topics using the
-                whitelist '*'. You can also specify multiple regular expressions separated
-                by commas.
+              description: List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the whitelist `'A\|B'`. Or, as a special case, you can mirror all topics using the whitelist '*'. You can also specify multiple regular expressions separated by commas.
             consumer:
               type: object
               properties:
                 numStreams:
                   type: integer
                   minimum: 1
-                  description: Specifies the number of consumer stream threads to
-                    create.
+                  description: Specifies the number of consumer stream threads to create.
                 offsetCommitInterval:
                   type: integer
-                  description: Specifies the offset auto-commit interval in ms. Default
-                    value is 60000.
+                  description: Specifies the offset auto-commit interval in ms. Default value is 60000.
                 groupId:
                   type: string
-                  description: A unique string that identifies the consumer group
-                    this consumer belongs to.
+                  description: A unique string that identifies the consumer group this consumer belongs to.
                 bootstrapServers:
                   type: string
-                  description: A list of host:port pairs for establishing the initial
-                    connection to the Kafka cluster.
+                  description: A list of host:port pairs for establishing the initial connection to the Kafka cluster.
                 authentication:
                   type: object
                   properties:
@@ -100,22 +91,17 @@ spec:
                       properties:
                         key:
                           type: string
-                          description: The key under which the secret value is stored
-                            in the Kubernetes Secret.
+                          description: The key under which the secret value is stored in the Kubernetes Secret.
                         secretName:
                           type: string
-                          description: The name of the Kubernetes Secret containing
-                            the secret value.
+                          description: The name of the Kubernetes Secret containing the secret value.
                       required:
-                      - key
-                      - secretName
-                      description: Link to Kubernetes Secret containing the access
-                        token which was obtained from the authorization server.
+                        - key
+                        - secretName
+                      description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
                     accessTokenIsJwt:
                       type: boolean
-                      description: Configure whether access token should be treated
-                        as JWT. This should be set to `false` if the authorization
-                        server returns opaque tokens. Defaults to `true`.
+                      description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                     certificateAndKey:
                       type: object
                       properties:
@@ -129,80 +115,61 @@ spec:
                           type: string
                           description: The name of the Secret containing the certificate.
                       required:
-                      - certificate
-                      - key
-                      - secretName
-                      description: Reference to the `Secret` which holds the certificate
-                        and private key pair.
+                        - certificate
+                        - key
+                        - secretName
+                      description: Reference to the `Secret` which holds the certificate and private key pair.
                     clientId:
                       type: string
-                      description: OAuth Client ID which the Kafka client can use
-                        to authenticate against the OAuth server and use the token
-                        endpoint URI.
+                      description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                     clientSecret:
                       type: object
                       properties:
                         key:
                           type: string
-                          description: The key under which the secret value is stored
-                            in the Kubernetes Secret.
+                          description: The key under which the secret value is stored in the Kubernetes Secret.
                         secretName:
                           type: string
-                          description: The name of the Kubernetes Secret containing
-                            the secret value.
+                          description: The name of the Kubernetes Secret containing the secret value.
                       required:
-                      - key
-                      - secretName
-                      description: Link to Kubernetes Secret containing the OAuth
-                        client secret which the Kafka client can use to authenticate
-                        against the OAuth server and use the token endpoint URI.
+                        - key
+                        - secretName
+                      description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                     disableTlsHostnameVerification:
                       type: boolean
-                      description: Enable or disable TLS hostname verification. Default
-                        value is `false`.
+                      description: Enable or disable TLS hostname verification. Default value is `false`.
                     maxTokenExpirySeconds:
                       type: integer
-                      description: Set or limit time-to-live of the access tokens
-                        to the specified number of seconds. This should be set if
-                        the authorization server returns opaque tokens.
+                      description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
                     passwordSecret:
                       type: object
                       properties:
                         password:
                           type: string
-                          description: The name of the key in the Secret under which
-                            the password is stored.
+                          description: The name of the key in the Secret under which the password is stored.
                         secretName:
                           type: string
                           description: The name of the Secret containing the password.
                       required:
-                      - password
-                      - secretName
+                        - password
+                        - secretName
                       description: Reference to the `Secret` which holds the password.
                     refreshToken:
                       type: object
                       properties:
                         key:
                           type: string
-                          description: The key under which the secret value is stored
-                            in the Kubernetes Secret.
+                          description: The key under which the secret value is stored in the Kubernetes Secret.
                         secretName:
                           type: string
-                          description: The name of the Kubernetes Secret containing
-                            the secret value.
+                          description: The name of the Kubernetes Secret containing the secret value.
                       required:
-                      - key
-                      - secretName
-                      description: Link to Kubernetes Secret containing the refresh
-                        token which can be used to obtain access token from the authorization
-                        server.
+                        - key
+                        - secretName
+                      description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
                     scope:
                       type: string
-                      description: OAuth scope to use when authenticating against
-                        the authorization server. Some authorization servers require
-                        this to be set. The possible values depend on how authorization
-                        server is configured. By default `scope` is not specified
-                        when doing the token endpoint request.
+                      description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
                     tlsTrustedCertificates:
                       type: array
                       items:
@@ -215,40 +182,29 @@ spec:
                             type: string
                             description: The name of the Secret containing the certificate.
                         required:
-                        - certificate
-                        - secretName
-                      description: Trusted certificates for TLS connection to the
-                        OAuth server.
+                          - certificate
+                          - secretName
+                      description: Trusted certificates for TLS connection to the OAuth server.
                     tokenEndpointUri:
                       type: string
                       description: Authorization server token endpoint URI.
                     type:
                       type: string
                       enum:
-                      - tls
-                      - scram-sha-512
-                      - plain
-                      - oauth
-                      description: Authentication type. Currently the only supported
-                        types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
-                        type uses SASL SCRAM-SHA-512 Authentication. `plain` type
-                        uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
-                        Authentication. The `tls` type uses TLS Client Authentication.
-                        The `tls` type is supported only over TLS connections.
+                        - tls
+                        - scram-sha-512
+                        - plain
+                        - oauth
+                      description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                     username:
                       type: string
                       description: Username used for the authentication.
                   required:
-                  - type
-                  description: Authentication configuration for connecting to the
-                    cluster.
+                    - type
+                  description: Authentication configuration for connecting to the cluster.
                 config:
                   type: object
-                  description: 'The MirrorMaker consumer config. Properties with the
-                    following prefixes cannot be set: ssl., bootstrap.servers, group.id,
-                    sasl., security., interceptor.classes (with the exception of:
-                    ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol,
-                    ssl.enabled.protocols).'
+                  description: 'The MirrorMaker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
                 tls:
                   type: object
                   properties:
@@ -264,26 +220,23 @@ spec:
                             type: string
                             description: The name of the Secret containing the certificate.
                         required:
-                        - certificate
-                        - secretName
+                          - certificate
+                          - secretName
                       description: Trusted certificates for TLS connection.
-                  description: TLS configuration for connecting MirrorMaker to the
-                    cluster.
+                  description: TLS configuration for connecting MirrorMaker to the cluster.
               required:
-              - groupId
-              - bootstrapServers
+                - groupId
+                - bootstrapServers
               description: Configuration of source cluster.
             producer:
               type: object
               properties:
                 bootstrapServers:
                   type: string
-                  description: A list of host:port pairs for establishing the initial
-                    connection to the Kafka cluster.
+                  description: A list of host:port pairs for establishing the initial connection to the Kafka cluster.
                 abortOnSendFailure:
                   type: boolean
-                  description: Flag to set the MirrorMaker to exit on a failed send.
-                    Default value is `true`.
+                  description: Flag to set the MirrorMaker to exit on a failed send. Default value is `true`.
                 authentication:
                   type: object
                   properties:
@@ -292,22 +245,17 @@ spec:
                       properties:
                         key:
                           type: string
-                          description: The key under which the secret value is stored
-                            in the Kubernetes Secret.
+                          description: The key under which the secret value is stored in the Kubernetes Secret.
                         secretName:
                           type: string
-                          description: The name of the Kubernetes Secret containing
-                            the secret value.
+                          description: The name of the Kubernetes Secret containing the secret value.
                       required:
-                      - key
-                      - secretName
-                      description: Link to Kubernetes Secret containing the access
-                        token which was obtained from the authorization server.
+                        - key
+                        - secretName
+                      description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
                     accessTokenIsJwt:
                       type: boolean
-                      description: Configure whether access token should be treated
-                        as JWT. This should be set to `false` if the authorization
-                        server returns opaque tokens. Defaults to `true`.
+                      description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                     certificateAndKey:
                       type: object
                       properties:
@@ -321,80 +269,61 @@ spec:
                           type: string
                           description: The name of the Secret containing the certificate.
                       required:
-                      - certificate
-                      - key
-                      - secretName
-                      description: Reference to the `Secret` which holds the certificate
-                        and private key pair.
+                        - certificate
+                        - key
+                        - secretName
+                      description: Reference to the `Secret` which holds the certificate and private key pair.
                     clientId:
                       type: string
-                      description: OAuth Client ID which the Kafka client can use
-                        to authenticate against the OAuth server and use the token
-                        endpoint URI.
+                      description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                     clientSecret:
                       type: object
                       properties:
                         key:
                           type: string
-                          description: The key under which the secret value is stored
-                            in the Kubernetes Secret.
+                          description: The key under which the secret value is stored in the Kubernetes Secret.
                         secretName:
                           type: string
-                          description: The name of the Kubernetes Secret containing
-                            the secret value.
+                          description: The name of the Kubernetes Secret containing the secret value.
                       required:
-                      - key
-                      - secretName
-                      description: Link to Kubernetes Secret containing the OAuth
-                        client secret which the Kafka client can use to authenticate
-                        against the OAuth server and use the token endpoint URI.
+                        - key
+                        - secretName
+                      description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                     disableTlsHostnameVerification:
                       type: boolean
-                      description: Enable or disable TLS hostname verification. Default
-                        value is `false`.
+                      description: Enable or disable TLS hostname verification. Default value is `false`.
                     maxTokenExpirySeconds:
                       type: integer
-                      description: Set or limit time-to-live of the access tokens
-                        to the specified number of seconds. This should be set if
-                        the authorization server returns opaque tokens.
+                      description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
                     passwordSecret:
                       type: object
                       properties:
                         password:
                           type: string
-                          description: The name of the key in the Secret under which
-                            the password is stored.
+                          description: The name of the key in the Secret under which the password is stored.
                         secretName:
                           type: string
                           description: The name of the Secret containing the password.
                       required:
-                      - password
-                      - secretName
+                        - password
+                        - secretName
                       description: Reference to the `Secret` which holds the password.
                     refreshToken:
                       type: object
                       properties:
                         key:
                           type: string
-                          description: The key under which the secret value is stored
-                            in the Kubernetes Secret.
+                          description: The key under which the secret value is stored in the Kubernetes Secret.
                         secretName:
                           type: string
-                          description: The name of the Kubernetes Secret containing
-                            the secret value.
+                          description: The name of the Kubernetes Secret containing the secret value.
                       required:
-                      - key
-                      - secretName
-                      description: Link to Kubernetes Secret containing the refresh
-                        token which can be used to obtain access token from the authorization
-                        server.
+                        - key
+                        - secretName
+                      description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
                     scope:
                       type: string
-                      description: OAuth scope to use when authenticating against
-                        the authorization server. Some authorization servers require
-                        this to be set. The possible values depend on how authorization
-                        server is configured. By default `scope` is not specified
-                        when doing the token endpoint request.
+                      description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
                     tlsTrustedCertificates:
                       type: array
                       items:
@@ -407,39 +336,29 @@ spec:
                             type: string
                             description: The name of the Secret containing the certificate.
                         required:
-                        - certificate
-                        - secretName
-                      description: Trusted certificates for TLS connection to the
-                        OAuth server.
+                          - certificate
+                          - secretName
+                      description: Trusted certificates for TLS connection to the OAuth server.
                     tokenEndpointUri:
                       type: string
                       description: Authorization server token endpoint URI.
                     type:
                       type: string
                       enum:
-                      - tls
-                      - scram-sha-512
-                      - plain
-                      - oauth
-                      description: Authentication type. Currently the only supported
-                        types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
-                        type uses SASL SCRAM-SHA-512 Authentication. `plain` type
-                        uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
-                        Authentication. The `tls` type uses TLS Client Authentication.
-                        The `tls` type is supported only over TLS connections.
+                        - tls
+                        - scram-sha-512
+                        - plain
+                        - oauth
+                      description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                     username:
                       type: string
                       description: Username used for the authentication.
                   required:
-                  - type
-                  description: Authentication configuration for connecting to the
-                    cluster.
+                    - type
+                  description: Authentication configuration for connecting to the cluster.
                 config:
                   type: object
-                  description: 'The MirrorMaker producer config. Properties with the
-                    following prefixes cannot be set: ssl., bootstrap.servers, sasl.,
-                    security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm,
-                    ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
+                  description: 'The MirrorMaker producer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
                 tls:
                   type: object
                   properties:
@@ -455,13 +374,12 @@ spec:
                             type: string
                             description: The name of the Secret containing the certificate.
                         required:
-                        - certificate
-                        - secretName
+                          - certificate
+                          - secretName
                       description: Trusted certificates for TLS connection.
-                  description: TLS configuration for connecting MirrorMaker to the
-                    cluster.
+                  description: TLS configuration for connecting MirrorMaker to the cluster.
               required:
-              - bootstrapServers
+                - bootstrapServers
               description: Configuration of target cluster.
             resources:
               type: object
@@ -712,8 +630,7 @@ spec:
                   description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
-                  description: Specifies whether the Garbage Collection logging is
-                    enabled. The default is false.
+                  description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -725,8 +642,7 @@ spec:
                       value:
                         type: string
                         description: The system property value.
-                  description: A map of additional system properties which will be
-                    passed using the `-D` option to the JVM.
+                  description: A map of additional system properties which will be passed using the `-D` option to the JVM.
               description: JVM Options for pods.
             logging:
               type: object
@@ -736,32 +652,29 @@ spec:
                   description: A Map from logger name to logger level.
                 name:
                   type: string
-                  description: The name of the `ConfigMap` from which to get the logging
-                    configuration.
+                  description: The name of the `ConfigMap` from which to get the logging configuration.
                 type:
                   type: string
                   enum:
-                  - inline
-                  - external
+                    - inline
+                    - external
                   description: Logging type, must be either 'inline' or 'external'.
               required:
-              - type
+                - type
               description: Logging configuration for MirrorMaker.
             metrics:
               type: object
-              description: The Prometheus JMX Exporter configuration. See {JMXExporter}
-                for details of the structure of this configuration.
+              description: The Prometheus JMX Exporter configuration. See {JMXExporter} for details of the structure of this configuration.
             tracing:
               type: object
               properties:
                 type:
                   type: string
                   enum:
-                  - jaeger
-                  description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing.
+                    - jaeger
+                  description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
               required:
-              - type
+                - type
               description: The configuration of tracing in Kafka MirrorMaker.
             template:
               type: object
@@ -774,14 +687,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka MirrorMaker `Deployment`.
                 pod:
@@ -792,14 +701,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
@@ -808,8 +713,7 @@ spec:
                         properties:
                           name:
                             type: string
-                      description: List of references to secrets in the same namespace
-                        to use for pulling any of the images used by this Pod.
+                      description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -852,18 +756,11 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
-                      description: Configures pod-level security attributes and common
-                        container settings.
+                      description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
-                      description: The grace period is the duration in seconds after
-                        the processes running in the pod are sent a termination signal
-                        and the time when the processes are forcibly halted with a
-                        kill signal. Set this value longer than the expected cleanup
-                        time for your process.Value must be non-negative integer.
-                        The value zero indicates delete immediately. Defaults to 30
-                        seconds.
+                      description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                     affinity:
                       type: object
                       properties:
@@ -1075,12 +972,10 @@ spec:
                       description: The pod's affinity rules.
                     priorityClassName:
                       type: string
-                      description: The name of the Priority Class to which these pods
-                        will be assigned.
+                      description: The name of the Priority Class to which these pods will be assigned.
                     schedulerName:
                       type: string
-                      description: The name of the scheduler used to dispatch this
-                        `Pod`. If not specified, the default scheduler will be used.
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -1112,8 +1007,7 @@ spec:
                           value:
                             type: string
                             description: The environment variable value.
-                      description: Environment variables which should be applied to
-                        the container.
+                      description: Environment variables which should be applied to the container.
                     securityContext:
                       type: object
                       properties:
@@ -1170,49 +1064,33 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
-                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
-                        resource.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate` resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
-                      description: Maximum number of unavailable pods to allow automatic
-                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
-                        number of pods or fewer are unavailable after the eviction.
-                        Setting this value to 0 prevents all voluntary evictions,
-                        so the pods must be evicted manually. Defaults to 1.
+                      description: Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
                   description: Template for Kafka MirrorMaker `PodDisruptionBudget`.
-              description: Template to specify how Kafka MirrorMaker resources, `Deployments`
-                and `Pods`, are generated.
+              description: Template to specify how Kafka MirrorMaker resources, `Deployments` and `Pods`, are generated.
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -1223,23 +1101,17 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -1247,14 +1119,12 @@ spec:
               description: Pod readiness checking.
             version:
               type: string
-              description: The Kafka MirrorMaker version. Defaults to {DefaultKafkaVersion}.
-                Consult the documentation to understand the process required to upgrade
-                or downgrade the version.
+              description: The Kafka MirrorMaker version. Defaults to {DefaultKafkaVersion}. Consult the documentation to understand the process required to upgrade or downgrade the version.
           required:
-          - replicas
-          - whitelist
-          - consumer
-          - producer
+            - replicas
+            - whitelist
+            - consumer
+            - producer
           description: The specification of Kafka MirrorMaker.
         status:
           type: object
@@ -1266,30 +1136,23 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             podSelector:
               type: object
               properties:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -13,9 +13,9 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
   version: v1alpha1
   scope: Namespaced
   names:
@@ -24,19 +24,19 @@ spec:
     singular: kafkabridge
     plural: kafkabridges
     shortNames:
-    - kb
+      - kb
     categories:
-    - strimzi
+      - strimzi
   additionalPrinterColumns:
-  - name: Desired replicas
-    description: The desired number of Kafka Bridge replicas
-    JSONPath: .spec.replicas
-    type: integer
-  - name: Bootstrap Servers
-    description: The boostrap servers
-    JSONPath: .spec.bootstrapServers
-    type: string
-    priority: 1
+    - name: Desired replicas
+      description: The desired number of Kafka Bridge replicas
+      JSONPath: .spec.replicas
+      type: integer
+    - name: Bootstrap Servers
+      description: The boostrap servers
+      JSONPath: .spec.bootstrapServers
+      type: string
+      priority: 1
   subresources:
     status: {}
     scale:
@@ -58,8 +58,7 @@ spec:
               description: The docker image for the pods.
             bootstrapServers:
               type: string
-              description: A list of host:port pairs for establishing the initial
-                connection to the Kafka cluster.
+              description: A list of host:port pairs for establishing the initial connection to the Kafka cluster.
             tls:
               type: object
               properties:
@@ -75,8 +74,8 @@ spec:
                         type: string
                         description: The name of the Secret containing the certificate.
                     required:
-                    - certificate
-                    - secretName
+                      - certificate
+                      - secretName
                   description: Trusted certificates for TLS connection.
               description: TLS configuration for connecting Kafka Bridge to the cluster.
             authentication:
@@ -87,22 +86,17 @@ spec:
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the access token
-                    which was obtained from the authorization server.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
                 accessTokenIsJwt:
                   type: boolean
-                  description: Configure whether access token should be treated as
-                    JWT. This should be set to `false` if the authorization server
-                    returns opaque tokens. Defaults to `true`.
+                  description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                 certificateAndKey:
                   type: object
                   properties:
@@ -116,79 +110,61 @@ spec:
                       type: string
                       description: The name of the Secret containing the certificate.
                   required:
-                  - certificate
-                  - key
-                  - secretName
-                  description: Reference to the `Secret` which holds the certificate
-                    and private key pair.
+                    - certificate
+                    - key
+                    - secretName
+                  description: Reference to the `Secret` which holds the certificate and private key pair.
                 clientId:
                   type: string
-                  description: OAuth Client ID which the Kafka client can use to authenticate
-                    against the OAuth server and use the token endpoint URI.
+                  description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                 clientSecret:
                   type: object
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the OAuth client
-                    secret which the Kafka client can use to authenticate against
-                    the OAuth server and use the token endpoint URI.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                 disableTlsHostnameVerification:
                   type: boolean
-                  description: Enable or disable TLS hostname verification. Default
-                    value is `false`.
+                  description: Enable or disable TLS hostname verification. Default value is `false`.
                 maxTokenExpirySeconds:
                   type: integer
-                  description: Set or limit time-to-live of the access tokens to the
-                    specified number of seconds. This should be set if the authorization
-                    server returns opaque tokens.
+                  description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
                 passwordSecret:
                   type: object
                   properties:
                     password:
                       type: string
-                      description: The name of the key in the Secret under which the
-                        password is stored.
+                      description: The name of the key in the Secret under which the password is stored.
                     secretName:
                       type: string
                       description: The name of the Secret containing the password.
                   required:
-                  - password
-                  - secretName
+                    - password
+                    - secretName
                   description: Reference to the `Secret` which holds the password.
                 refreshToken:
                   type: object
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the refresh token
-                    which can be used to obtain access token from the authorization
-                    server.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
                 scope:
                   type: string
-                  description: OAuth scope to use when authenticating against the
-                    authorization server. Some authorization servers require this
-                    to be set. The possible values depend on how authorization server
-                    is configured. By default `scope` is not specified when doing
-                    the token endpoint request.
+                  description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
                 tlsTrustedCertificates:
                   type: array
                   items:
@@ -201,31 +177,25 @@ spec:
                         type: string
                         description: The name of the Secret containing the certificate.
                     required:
-                    - certificate
-                    - secretName
-                  description: Trusted certificates for TLS connection to the OAuth
-                    server.
+                      - certificate
+                      - secretName
+                  description: Trusted certificates for TLS connection to the OAuth server.
                 tokenEndpointUri:
                   type: string
                   description: Authorization server token endpoint URI.
                 type:
                   type: string
                   enum:
-                  - tls
-                  - scram-sha-512
-                  - plain
-                  - oauth
-                  description: Authentication type. Currently the only supported types
-                    are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type
-                    uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL
-                    PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication.
-                    The `tls` type uses TLS Client Authentication. The `tls` type
-                    is supported only over TLS connections.
+                    - tls
+                    - scram-sha-512
+                    - plain
+                    - oauth
+                  description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                 username:
                   type: string
                   description: Username used for the authentication.
               required:
-              - type
+                - type
               description: Authentication configuration for connecting to the cluster.
             http:
               type: object
@@ -241,16 +211,15 @@ spec:
                       type: array
                       items:
                         type: string
-                      description: List of allowed origins. Java regular expressions
-                        can be used.
+                      description: List of allowed origins. Java regular expressions can be used.
                     allowedMethods:
                       type: array
                       items:
                         type: string
                       description: List of allowed HTTP methods.
                   required:
-                  - allowedOrigins
-                  - allowedMethods
+                    - allowedOrigins
+                    - allowedMethods
                   description: CORS configuration for the HTTP Bridge.
               description: The HTTP related configuration.
             consumer:
@@ -258,22 +227,14 @@ spec:
               properties:
                 config:
                   type: object
-                  description: 'The Kafka consumer configuration used for consumer
-                    instances created by the bridge. Properties with the following
-                    prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl.,
-                    security. (with the exception of: ssl.endpoint.identification.algorithm,
-                    ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
+                  description: 'The Kafka consumer configuration used for consumer instances created by the bridge. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
               description: Kafka consumer related configuration.
             producer:
               type: object
               properties:
                 config:
                   type: object
-                  description: 'The Kafka producer configuration used for producer
-                    instances created by the bridge. Properties with the following
-                    prefixes cannot be set: ssl., bootstrap.servers, sasl., security.
-                    (with the exception of: ssl.endpoint.identification.algorithm,
-                    ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
+                  description: 'The Kafka producer configuration used for producer instances created by the bridge. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
               description: Kafka producer related configuration.
             resources:
               type: object
@@ -299,8 +260,7 @@ spec:
                   description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
-                  description: Specifies whether the Garbage Collection logging is
-                    enabled. The default is false.
+                  description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -312,8 +272,7 @@ spec:
                       value:
                         type: string
                         description: The system property value.
-                  description: A map of additional system properties which will be
-                    passed using the `-D` option to the JVM.
+                  description: A map of additional system properties which will be passed using the `-D` option to the JVM.
               description: '**Currently not supported** JVM Options for pods.'
             logging:
               type: object
@@ -323,44 +282,35 @@ spec:
                   description: A Map from logger name to logger level.
                 name:
                   type: string
-                  description: The name of the `ConfigMap` from which to get the logging
-                    configuration.
+                  description: The name of the `ConfigMap` from which to get the logging configuration.
                 type:
                   type: string
                   enum:
-                  - inline
-                  - external
+                    - inline
+                    - external
                   description: Logging type, must be either 'inline' or 'external'.
               required:
-              - type
+                - type
               description: Logging configuration for Kafka Bridge.
             metrics:
               type: object
-              description: '**Currently not supported** The Prometheus JMX Exporter
-                configuration. See {JMXExporter} for details of the structure of this
-                configuration.'
+              description: '**Currently not supported** The Prometheus JMX Exporter configuration. See {JMXExporter} for details of the structure of this configuration.'
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -371,23 +321,17 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -404,14 +348,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Bridge `Deployment`.
                 pod:
@@ -422,14 +362,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
@@ -438,8 +374,7 @@ spec:
                         properties:
                           name:
                             type: string
-                      description: List of references to secrets in the same namespace
-                        to use for pulling any of the images used by this Pod.
+                      description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -482,18 +417,11 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
-                      description: Configures pod-level security attributes and common
-                        container settings.
+                      description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
-                      description: The grace period is the duration in seconds after
-                        the processes running in the pod are sent a termination signal
-                        and the time when the processes are forcibly halted with a
-                        kill signal. Set this value longer than the expected cleanup
-                        time for your process.Value must be non-negative integer.
-                        The value zero indicates delete immediately. Defaults to 30
-                        seconds.
+                      description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                     affinity:
                       type: object
                       properties:
@@ -705,12 +633,10 @@ spec:
                       description: The pod's affinity rules.
                     priorityClassName:
                       type: string
-                      description: The name of the Priority Class to which these pods
-                        will be assigned.
+                      description: The name of the Priority Class to which these pods will be assigned.
                     schedulerName:
                       type: string
-                      description: The name of the scheduler used to dispatch this
-                        `Pod`. If not specified, the default scheduler will be used.
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -736,14 +662,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Bridge API `Service`.
                 bridgeContainer:
@@ -760,8 +682,7 @@ spec:
                           value:
                             type: string
                             description: The environment variable value.
-                      description: Environment variables which should be applied to
-                        the container.
+                      description: Environment variables which should be applied to the container.
                     securityContext:
                       type: object
                       properties:
@@ -818,41 +739,30 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
-                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
-                        resource.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate` resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
-                      description: Maximum number of unavailable pods to allow automatic
-                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
-                        number of pods or fewer are unavailable after the eviction.
-                        Setting this value to 0 prevents all voluntary evictions,
-                        so the pods must be evicted manually. Defaults to 1.
+                      description: Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
                   description: Template for Kafka Bridge `PodDisruptionBudget`.
-              description: Template for Kafka Bridge resources. The template allows
-                users to specify how is the `Deployment` and `Pods` generated.
+              description: Template for Kafka Bridge resources. The template allows users to specify how is the `Deployment` and `Pods` generated.
             tracing:
               type: object
               properties:
                 type:
                   type: string
                   enum:
-                  - jaeger
-                  description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing.
+                    - jaeger
+                  description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
               required:
-              - type
+                - type
               description: The configuration of tracing in Kafka Bridge.
           required:
-          - bootstrapServers
+            - bootstrapServers
           description: The specification of the Kafka Bridge.
         status:
           type: object
@@ -864,34 +774,26 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             url:
               type: string
-              description: The URL at which external client applications can access
-                the Kafka Bridge.
+              description: The URL at which external client applications can access the Kafka Bridge.
             podSelector:
               type: object
               properties:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
@@ -13,9 +13,9 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
   version: v1alpha1
   scope: Namespaced
   names:
@@ -24,9 +24,9 @@ spec:
     singular: kafkaconnector
     plural: kafkaconnectors
     shortNames:
-    - kctr
+      - kctr
     categories:
-    - strimzi
+      - strimzi
   subresources:
     status: {}
     scale:
@@ -47,8 +47,7 @@ spec:
               description: The maximum number of tasks for the Kafka Connector.
             config:
               type: object
-              description: 'The Kafka Connector configuration. The following properties
-                cannot be set: connector.class, tasks.max.'
+              description: 'The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.'
             pause:
               type: boolean
               description: Whether the connector should be paused. Defaults to false.
@@ -63,34 +62,26 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             connectorStatus:
               type: object
-              description: The connector status, as reported by the Kafka Connect
-                REST API.
+              description: The connector status, as reported by the Kafka Connect REST API.
             tasksMax:
               type: integer
               description: The maximum number of tasks for the Kafka Connector.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -13,9 +13,9 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
   version: v1alpha1
   scope: Namespaced
   names:
@@ -24,14 +24,14 @@ spec:
     singular: kafkamirrormaker2
     plural: kafkamirrormaker2s
     shortNames:
-    - kmm2
+      - kmm2
     categories:
-    - strimzi
+      - strimzi
   additionalPrinterColumns:
-  - name: Desired replicas
-    description: The desired number of Kafka MirrorMaker 2.0 replicas
-    JSONPath: .spec.replicas
-    type: integer
+    - name: Desired replicas
+      description: The desired number of Kafka MirrorMaker 2.0 replicas
+      JSONPath: .spec.replicas
+      type: integer
   subresources:
     status: {}
     scale:
@@ -49,16 +49,13 @@ spec:
               description: The number of pods in the Kafka Connect group.
             version:
               type: string
-              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}.
-                Consult the user documentation to understand the process required
-                to upgrade or downgrade the version.
+              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
             image:
               type: string
               description: The docker image for the pods.
             connectCluster:
               type: string
-              description: The cluster alias used for Kafka Connect. The alias must
-                match a cluster in the list at `spec.clusters`.
+              description: The cluster alias used for Kafka Connect. The alias must match a cluster in the list at `spec.clusters`.
             clusters:
               type: array
               items:
@@ -70,15 +67,10 @@ spec:
                     description: Alias used to reference the Kafka cluster.
                   bootstrapServers:
                     type: string
-                    description: A comma-separated list of `host:port` pairs for establishing
-                      the connection to the Kafka cluster.
+                    description: A comma-separated list of `host:port` pairs for establishing the connection to the Kafka cluster.
                   config:
                     type: object
-                    description: 'The MirrorMaker 2.0 cluster config. Properties with
-                      the following prefixes cannot be set: ssl., sasl., security.,
-                      listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes,
-                      producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm,
-                      ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
+                    description: 'The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
                   tls:
                     type: object
                     properties:
@@ -89,17 +81,15 @@ spec:
                           properties:
                             certificate:
                               type: string
-                              description: The name of the file certificate in the
-                                Secret.
+                              description: The name of the file certificate in the Secret.
                             secretName:
                               type: string
                               description: The name of the Secret containing the certificate.
                           required:
-                          - certificate
-                          - secretName
+                            - certificate
+                            - secretName
                         description: Trusted certificates for TLS connection.
-                    description: TLS configuration for connecting MirrorMaker 2.0
-                      connectors to a cluster.
+                    description: TLS configuration for connecting MirrorMaker 2.0 connectors to a cluster.
                   authentication:
                     type: object
                     properties:
@@ -108,22 +98,17 @@ spec:
                         properties:
                           key:
                             type: string
-                            description: The key under which the secret value is stored
-                              in the Kubernetes Secret.
+                            description: The key under which the secret value is stored in the Kubernetes Secret.
                           secretName:
                             type: string
-                            description: The name of the Kubernetes Secret containing
-                              the secret value.
+                            description: The name of the Kubernetes Secret containing the secret value.
                         required:
-                        - key
-                        - secretName
-                        description: Link to Kubernetes Secret containing the access
-                          token which was obtained from the authorization server.
+                          - key
+                          - secretName
+                        description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
                       accessTokenIsJwt:
                         type: boolean
-                        description: Configure whether access token should be treated
-                          as JWT. This should be set to `false` if the authorization
-                          server returns opaque tokens. Defaults to `true`.
+                        description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                       certificateAndKey:
                         type: object
                         properties:
@@ -137,80 +122,61 @@ spec:
                             type: string
                             description: The name of the Secret containing the certificate.
                         required:
-                        - certificate
-                        - key
-                        - secretName
-                        description: Reference to the `Secret` which holds the certificate
-                          and private key pair.
+                          - certificate
+                          - key
+                          - secretName
+                        description: Reference to the `Secret` which holds the certificate and private key pair.
                       clientId:
                         type: string
-                        description: OAuth Client ID which the Kafka client can use
-                          to authenticate against the OAuth server and use the token
-                          endpoint URI.
+                        description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                       clientSecret:
                         type: object
                         properties:
                           key:
                             type: string
-                            description: The key under which the secret value is stored
-                              in the Kubernetes Secret.
+                            description: The key under which the secret value is stored in the Kubernetes Secret.
                           secretName:
                             type: string
-                            description: The name of the Kubernetes Secret containing
-                              the secret value.
+                            description: The name of the Kubernetes Secret containing the secret value.
                         required:
-                        - key
-                        - secretName
-                        description: Link to Kubernetes Secret containing the OAuth
-                          client secret which the Kafka client can use to authenticate
-                          against the OAuth server and use the token endpoint URI.
+                          - key
+                          - secretName
+                        description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                       disableTlsHostnameVerification:
                         type: boolean
-                        description: Enable or disable TLS hostname verification.
-                          Default value is `false`.
+                        description: Enable or disable TLS hostname verification. Default value is `false`.
                       maxTokenExpirySeconds:
                         type: integer
-                        description: Set or limit time-to-live of the access tokens
-                          to the specified number of seconds. This should be set if
-                          the authorization server returns opaque tokens.
+                        description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
                       passwordSecret:
                         type: object
                         properties:
                           password:
                             type: string
-                            description: The name of the key in the Secret under which
-                              the password is stored.
+                            description: The name of the key in the Secret under which the password is stored.
                           secretName:
                             type: string
                             description: The name of the Secret containing the password.
                         required:
-                        - password
-                        - secretName
+                          - password
+                          - secretName
                         description: Reference to the `Secret` which holds the password.
                       refreshToken:
                         type: object
                         properties:
                           key:
                             type: string
-                            description: The key under which the secret value is stored
-                              in the Kubernetes Secret.
+                            description: The key under which the secret value is stored in the Kubernetes Secret.
                           secretName:
                             type: string
-                            description: The name of the Kubernetes Secret containing
-                              the secret value.
+                            description: The name of the Kubernetes Secret containing the secret value.
                         required:
-                        - key
-                        - secretName
-                        description: Link to Kubernetes Secret containing the refresh
-                          token which can be used to obtain access token from the
-                          authorization server.
+                          - key
+                          - secretName
+                        description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
                       scope:
                         type: string
-                        description: OAuth scope to use when authenticating against
-                          the authorization server. Some authorization servers require
-                          this to be set. The possible values depend on how authorization
-                          server is configured. By default `scope` is not specified
-                          when doing the token endpoint request.
+                        description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
                       tlsTrustedCertificates:
                         type: array
                         items:
@@ -218,42 +184,34 @@ spec:
                           properties:
                             certificate:
                               type: string
-                              description: The name of the file certificate in the
-                                Secret.
+                              description: The name of the file certificate in the Secret.
                             secretName:
                               type: string
                               description: The name of the Secret containing the certificate.
                           required:
-                          - certificate
-                          - secretName
-                        description: Trusted certificates for TLS connection to the
-                          OAuth server.
+                            - certificate
+                            - secretName
+                        description: Trusted certificates for TLS connection to the OAuth server.
                       tokenEndpointUri:
                         type: string
                         description: Authorization server token endpoint URI.
                       type:
                         type: string
                         enum:
-                        - tls
-                        - scram-sha-512
-                        - plain
-                        - oauth
-                        description: Authentication type. Currently the only supported
-                          types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
-                          type uses SASL SCRAM-SHA-512 Authentication. `plain` type
-                          uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
-                          Authentication. The `tls` type uses TLS Client Authentication.
-                          The `tls` type is supported only over TLS connections.
+                          - tls
+                          - scram-sha-512
+                          - plain
+                          - oauth
+                        description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                       username:
                         type: string
                         description: Username used for the authentication.
                     required:
-                    - type
-                    description: Authentication configuration for connecting to the
-                      cluster.
+                      - type
+                    description: Authentication configuration for connecting to the cluster.
                 required:
-                - alias
-                - bootstrapServers
+                  - alias
+                  - bootstrapServers
               description: Kafka clusters for mirroring.
             mirrors:
               type: array
@@ -262,14 +220,10 @@ spec:
                 properties:
                   sourceCluster:
                     type: string
-                    description: The alias of the source cluster used by the Kafka
-                      MirrorMaker 2.0 connectors. The alias must match a cluster in
-                      the list at `spec.clusters`.
+                    description: The alias of the source cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
                   targetCluster:
                     type: string
-                    description: The alias of the target cluster used by the Kafka
-                      MirrorMaker 2.0 connectors. The alias must match a cluster in
-                      the list at `spec.clusters`.
+                    description: The alias of the target cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
                   sourceConnector:
                     type: object
                     properties:
@@ -279,14 +233,11 @@ spec:
                         description: The maximum number of tasks for the Kafka Connector.
                       config:
                         type: object
-                        description: 'The Kafka Connector configuration. The following
-                          properties cannot be set: connector.class, tasks.max.'
+                        description: 'The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.'
                       pause:
                         type: boolean
-                        description: Whether the connector should be paused. Defaults
-                          to false.
-                    description: The specification of the Kafka MirrorMaker 2.0 source
-                      connector.
+                        description: Whether the connector should be paused. Defaults to false.
+                    description: The specification of the Kafka MirrorMaker 2.0 source connector.
                   checkpointConnector:
                     type: object
                     properties:
@@ -296,14 +247,11 @@ spec:
                         description: The maximum number of tasks for the Kafka Connector.
                       config:
                         type: object
-                        description: 'The Kafka Connector configuration. The following
-                          properties cannot be set: connector.class, tasks.max.'
+                        description: 'The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.'
                       pause:
                         type: boolean
-                        description: Whether the connector should be paused. Defaults
-                          to false.
-                    description: The specification of the Kafka MirrorMaker 2.0 checkpoint
-                      connector.
+                        description: Whether the connector should be paused. Defaults to false.
+                    description: The specification of the Kafka MirrorMaker 2.0 checkpoint connector.
                   heartbeatConnector:
                     type: object
                     properties:
@@ -313,34 +261,26 @@ spec:
                         description: The maximum number of tasks for the Kafka Connector.
                       config:
                         type: object
-                        description: 'The Kafka Connector configuration. The following
-                          properties cannot be set: connector.class, tasks.max.'
+                        description: 'The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.'
                       pause:
                         type: boolean
-                        description: Whether the connector should be paused. Defaults
-                          to false.
-                    description: The specification of the Kafka MirrorMaker 2.0 heartbeat
-                      connector.
+                        description: Whether the connector should be paused. Defaults to false.
+                    description: The specification of the Kafka MirrorMaker 2.0 heartbeat connector.
                   topicsPattern:
                     type: string
-                    description: A regular expression matching the topics to be mirrored,
-                      for example, "topic1\|topic2\|topic3". Comma-separated lists
-                      are also supported.
+                    description: A regular expression matching the topics to be mirrored, for example, "topic1\|topic2\|topic3". Comma-separated lists are also supported.
                   topicsBlacklistPattern:
                     type: string
-                    description: A regular expression matching the topics to exclude
-                      from mirroring. Comma-separated lists are also supported.
+                    description: A regular expression matching the topics to exclude from mirroring. Comma-separated lists are also supported.
                   groupsPattern:
                     type: string
-                    description: A regular expression matching the consumer groups
-                      to be mirrored. Comma-separated lists are also supported.
+                    description: A regular expression matching the consumer groups to be mirrored. Comma-separated lists are also supported.
                   groupsBlacklistPattern:
                     type: string
-                    description: A regular expression matching the consumer groups
-                      to exclude from mirroring. Comma-separated lists are also supported.
+                    description: A regular expression matching the consumer groups to exclude from mirroring. Comma-separated lists are also supported.
                 required:
-                - sourceCluster
-                - targetCluster
+                  - sourceCluster
+                  - targetCluster
               description: Configuration of the MirrorMaker 2.0 connectors.
             resources:
               type: object
@@ -349,30 +289,23 @@ spec:
                   type: object
                 requests:
                   type: object
-              description: The maximum limits for CPU and memory resources and the
-                requested initial resources.
+              description: The maximum limits for CPU and memory resources and the requested initial resources.
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -383,23 +316,17 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -421,8 +348,7 @@ spec:
                   description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
-                  description: Specifies whether the Garbage Collection logging is
-                    enabled. The default is false.
+                  description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -434,8 +360,7 @@ spec:
                       value:
                         type: string
                         description: The system property value.
-                  description: A map of additional system properties which will be
-                    passed using the `-D` option to the JVM.
+                  description: A map of additional system properties which will be passed using the `-D` option to the JVM.
               description: JVM Options for pods.
             affinity:
               type: object
@@ -670,32 +595,29 @@ spec:
                   description: A Map from logger name to logger level.
                 name:
                   type: string
-                  description: The name of the `ConfigMap` from which to get the logging
-                    configuration.
+                  description: The name of the `ConfigMap` from which to get the logging configuration.
                 type:
                   type: string
                   enum:
-                  - inline
-                  - external
+                    - inline
+                    - external
                   description: Logging type, must be either 'inline' or 'external'.
               required:
-              - type
+                - type
               description: Logging configuration for Kafka Connect.
             metrics:
               type: object
-              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
-                for details of the structure of this configuration.
+              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
             tracing:
               type: object
               properties:
                 type:
                   type: string
                   enum:
-                  - jaeger
-                  description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing.
+                    - jaeger
+                  description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
               required:
-              - type
+                - type
               description: The configuration of tracing in Kafka Connect.
             template:
               type: object
@@ -708,14 +630,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
@@ -726,14 +644,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
@@ -742,8 +656,7 @@ spec:
                         properties:
                           name:
                             type: string
-                      description: List of references to secrets in the same namespace
-                        to use for pulling any of the images used by this Pod.
+                      description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -786,18 +699,11 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
-                      description: Configures pod-level security attributes and common
-                        container settings.
+                      description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
-                      description: The grace period is the duration in seconds after
-                        the processes running in the pod are sent a termination signal
-                        and the time when the processes are forcibly halted with a
-                        kill signal. Set this value longer than the expected cleanup
-                        time for your process.Value must be non-negative integer.
-                        The value zero indicates delete immediately. Defaults to 30
-                        seconds.
+                      description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                     affinity:
                       type: object
                       properties:
@@ -1009,12 +915,10 @@ spec:
                       description: The pod's affinity rules.
                     priorityClassName:
                       type: string
-                      description: The name of the Priority Class to which these pods
-                        will be assigned.
+                      description: The name of the Priority Class to which these pods will be assigned.
                     schedulerName:
                       type: string
-                      description: The name of the scheduler used to dispatch this
-                        `Pod`. If not specified, the default scheduler will be used.
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -1040,14 +944,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect API `Service`.
                 connectContainer:
@@ -1064,8 +964,7 @@ spec:
                           value:
                             type: string
                             description: The environment variable value.
-                      description: Environment variables which should be applied to
-                        the container.
+                      description: Environment variables which should be applied to the container.
                     securityContext:
                       type: object
                       properties:
@@ -1122,28 +1021,17 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
-                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
-                        resource.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate` resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
-                      description: Maximum number of unavailable pods to allow automatic
-                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
-                        number of pods or fewer are unavailable after the eviction.
-                        Setting this value to 0 prevents all voluntary evictions,
-                        so the pods must be evicted manually. Defaults to 1.
+                      description: Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
                   description: Template for Kafka Connect `PodDisruptionBudget`.
-              description: Template for Kafka Connect and Kafka Connect S2I resources.
-                The template allows users to specify how the `Deployment`, `Pods`
-                and `Service` are generated.
+              description: Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
             externalConfiguration:
               type: object
               properties:
@@ -1154,9 +1042,7 @@ spec:
                     properties:
                       name:
                         type: string
-                        description: Name of the environment variable which will be
-                          passed to the Kafka Connect pods. The name of the environment
-                          variable cannot start with `KAFKA_` or `STRIMZI_`.
+                        description: Name of the environment variable which will be passed to the Kafka Connect pods. The name of the environment variable cannot start with `KAFKA_` or `STRIMZI_`.
                       valueFrom:
                         type: object
                         properties:
@@ -1180,15 +1066,11 @@ spec:
                               optional:
                                 type: boolean
                             description: Reference to a key in a Secret.
-                        description: Value of the environment variable which will
-                          be passed to the Kafka Connect pods. It can be passed either
-                          as a reference to Secret or ConfigMap field. The field has
-                          to specify exactly one Secret or ConfigMap.
+                        description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
                     required:
-                    - name
-                    - valueFrom
-                  description: Allows to pass data from Secret or ConfigMap to the
-                    Kafka Connect pods as environment variables.
+                      - name
+                      - valueFrom
+                  description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as environment variables.
                 volumes:
                   type: array
                   items:
@@ -1214,12 +1096,10 @@ spec:
                             type: string
                           optional:
                             type: boolean
-                        description: Reference to a key in a ConfigMap. Exactly one
-                          Secret or ConfigMap has to be specified.
+                        description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
                       name:
                         type: string
-                        description: Name of the volume which will be added to the
-                          Kafka Connect pods.
+                        description: Name of the volume which will be added to the Kafka Connect pods.
                       secret:
                         type: object
                         properties:
@@ -1240,16 +1120,13 @@ spec:
                             type: boolean
                           secretName:
                             type: string
-                        description: Reference to a key in a Secret. Exactly one Secret
-                          or ConfigMap has to be specified.
+                        description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
                     required:
-                    - name
-                  description: Allows to pass data from Secret or ConfigMap to the
-                    Kafka Connect pods as volumes.
-              description: Pass data from Secrets or ConfigMaps to the Kafka Connect
-                pods and use them to configure connectors.
+                      - name
+                  description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as volumes.
+              description: Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
           required:
-          - connectCluster
+            - connectCluster
           description: The specification of the Kafka MirrorMaker 2.0 cluster.
         status:
           type: object
@@ -1261,34 +1138,26 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             url:
               type: string
-              description: The URL of the REST API endpoint for managing and monitoring
-                Kafka Connect connectors.
+              description: The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
             connectorPlugins:
               type: array
               items:
@@ -1296,22 +1165,19 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The type of the connector plugin. The available types
-                      are `sink` and `source`.
+                    description: The type of the connector plugin. The available types are `sink` and `source`.
                   version:
                     type: string
                     description: The version of the connector plugin.
                   class:
                     type: string
                     description: The class of the connector plugin.
-              description: The list of connector plugins available in this Kafka Connect
-                deployment.
+              description: The list of connector plugins available in this Kafka Connect deployment.
             connectors:
               type: array
               items:
                 type: object
-              description: List of MirrorMaker 2.0 connector statuses, as reported
-                by the Kafka Connect REST API.
+              description: List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.
             podSelector:
               type: object
               properties:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/049-Crd-kafkarebalance.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/049-Crd-kafkarebalance.yaml
@@ -13,9 +13,9 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
   version: v1alpha1
   scope: Namespaced
   names:
@@ -24,9 +24,9 @@ spec:
     singular: kafkarebalance
     plural: kafkarebalances
     shortNames:
-    - kr
+      - kr
     categories:
-    - strimzi
+      - strimzi
   subresources:
     status: {}
   validation:
@@ -39,17 +39,10 @@ spec:
               type: array
               items:
                 type: string
-              description: A list of goals, ordered by decreasing priority, to use
-                for generating and executing the rebalance proposal. The supported
-                goals are available at https://github.com/linkedin/cruise-control#goals.
-                If an empty goals list is provided, the goals declared in the default.goals
-                Cruise Control configuration parameter are used.
+              description: A list of goals, ordered by decreasing priority, to use for generating and executing the rebalance proposal. The supported goals are available at https://github.com/linkedin/cruise-control#goals. If an empty goals list is provided, the goals declared in the default.goals Cruise Control configuration parameter are used.
             skipHardGoalCheck:
               type: boolean
-              description: Whether to allow the hard goals specified in the Kafka
-                CR to be skipped in rebalance proposal generation. This can be useful
-                when some of those hard goals are preventing a balance solution being
-                found. Default is false.
+              description: Whether to allow the hard goals specified in the Kafka CR to be skipped in rebalance proposal generation. This can be useful when some of those hard goals are preventing a balance solution being found. Default is false.
           description: The specification of the Kafka rebalance.
         status:
           type: object
@@ -61,35 +54,26 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             sessionId:
               type: string
-              description: The session identifier for requests to Cruise Control pertaining
-                to this KafkaRebalance resource. This is used by the Kafka Rebalance
-                operator to track the status of ongoing rebalancing operations.
+              description: The session identifier for requests to Cruise Control pertaining to this KafkaRebalance resource. This is used by the Kafka Rebalance operator to track the status of ongoing rebalancing operations.
             optimizationResult:
               type: object
               description: A JSON object describing the optimization result.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -9,12 +9,12 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
-  - name: v1alpha1
-    served: true
-    storage: false
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   version: v1beta1
   scope: Namespaced
   names:
@@ -23,18 +23,18 @@ spec:
     singular: kafka
     plural: kafkas
     shortNames:
-    - k
+      - k
     categories:
-    - strimzi
+      - strimzi
   additionalPrinterColumns:
-  - name: Desired Kafka replicas
-    description: The desired number of Kafka replicas in the cluster
-    JSONPath: .spec.kafka.replicas
-    type: integer
-  - name: Desired ZK replicas
-    description: The desired number of ZooKeeper replicas in the cluster
-    JSONPath: .spec.zookeeper.replicas
-    type: integer
+    - name: Desired Kafka replicas
+      description: The desired number of Kafka replicas in the cluster
+      JSONPath: .spec.kafka.replicas
+      type: integer
+    - name: Desired ZK replicas
+      description: The desired number of ZooKeeper replicas in the cluster
+      JSONPath: .spec.zookeeper.replicas
+      type: integer
   subresources:
     status: {}
   validation:
@@ -52,8 +52,7 @@ spec:
                   description: The number of pods in the cluster.
                 image:
                   type: string
-                  description: The docker image for the pods. The default value depends
-                    on the configured `Kafka.spec.kafka.version`.
+                  description: The docker image for the pods. The default value depends on the configured `Kafka.spec.kafka.version`.
                 storage:
                   type: object
                   properties:
@@ -62,13 +61,11 @@ spec:
                       description: The storage class to use for dynamic volume allocation.
                     deleteClaim:
                       type: boolean
-                      description: Specifies if the persistent volume claim has to
-                        be deleted when the cluster is un-deployed.
+                      description: Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
                     id:
                       type: integer
                       minimum: 0
-                      description: Storage identification number. It is mandatory
-                        only for storage volumes defined in a storage of type 'jbod'.
+                      description: Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
                     overrides:
                       type: array
                       items:
@@ -76,37 +73,28 @@ spec:
                         properties:
                           class:
                             type: string
-                            description: The storage class to use for dynamic volume
-                              allocation for this broker.
+                            description: The storage class to use for dynamic volume allocation for this broker.
                           broker:
                             type: integer
                             description: Id of the kafka broker (broker identifier).
-                      description: Overrides for individual brokers. The `overrides`
-                        field allows to specify a different configuration for different
-                        brokers.
+                      description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                     selector:
                       type: object
-                      description: Specifies a specific persistent volume to use.
-                        It contains key:value pairs representing labels for selecting
-                        such a volume.
+                      description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                     size:
                       type: string
-                      description: When type=persistent-claim, defines the size of
-                        the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
+                      description: When type=persistent-claim, defines the size of the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
                     sizeLimit:
                       type: string
                       pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                      description: When type=ephemeral, defines the total amount of
-                        local storage required for this EmptyDir volume (for example
-                        1Gi).
+                      description: When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi).
                     type:
                       type: string
                       enum:
-                      - ephemeral
-                      - persistent-claim
-                      - jbod
-                      description: Storage type, must be either 'ephemeral', 'persistent-claim',
-                        or 'jbod'.
+                        - ephemeral
+                        - persistent-claim
+                        - jbod
+                      description: Storage type, must be either 'ephemeral', 'persistent-claim', or 'jbod'.
                     volumes:
                       type: array
                       items:
@@ -114,18 +102,14 @@ spec:
                         properties:
                           class:
                             type: string
-                            description: The storage class to use for dynamic volume
-                              allocation.
+                            description: The storage class to use for dynamic volume allocation.
                           deleteClaim:
                             type: boolean
-                            description: Specifies if the persistent volume claim
-                              has to be deleted when the cluster is un-deployed.
+                            description: Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
                           id:
                             type: integer
                             minimum: 0
-                            description: Storage identification number. It is mandatory
-                              only for storage volumes defined in a storage of type
-                              'jbod'.
+                            description: Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
                           overrides:
                             type: array
                             items:
@@ -133,43 +117,32 @@ spec:
                               properties:
                                 class:
                                   type: string
-                                  description: The storage class to use for dynamic
-                                    volume allocation for this broker.
+                                  description: The storage class to use for dynamic volume allocation for this broker.
                                 broker:
                                   type: integer
                                   description: Id of the kafka broker (broker identifier).
-                            description: Overrides for individual brokers. The `overrides`
-                              field allows to specify a different configuration for
-                              different brokers.
+                            description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                           selector:
                             type: object
-                            description: Specifies a specific persistent volume to
-                              use. It contains key:value pairs representing labels
-                              for selecting such a volume.
+                            description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                           size:
                             type: string
-                            description: When type=persistent-claim, defines the size
-                              of the persistent volume claim (i.e 1Gi). Mandatory
-                              when type=persistent-claim.
+                            description: When type=persistent-claim, defines the size of the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
                           sizeLimit:
                             type: string
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                            description: When type=ephemeral, defines the total amount
-                              of local storage required for this EmptyDir volume (for
-                              example 1Gi).
+                            description: When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi).
                           type:
                             type: string
                             enum:
-                            - ephemeral
-                            - persistent-claim
-                            description: Storage type, must be either 'ephemeral'
-                              or 'persistent-claim'.
+                              - ephemeral
+                              - persistent-claim
+                            description: Storage type, must be either 'ephemeral' or 'persistent-claim'.
                         required:
-                        - type
-                      description: List of volumes as Storage objects representing
-                        the JBOD disks array.
+                          - type
+                      description: List of volumes as Storage objects representing the JBOD disks array.
                   required:
-                  - type
+                    - type
                   description: Storage configuration (disk). Cannot be updated.
                 listeners:
                   type: object
@@ -182,90 +155,55 @@ spec:
                           properties:
                             accessTokenIsJwt:
                               type: boolean
-                              description: Configure whether the access token is treated
-                                as JWT. This must be set to `false` if the authorization
-                                server returns opaque tokens. Defaults to `true`.
+                              description: Configure whether the access token is treated as JWT. This must be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                             checkAccessTokenType:
                               type: boolean
-                              description: Configure whether the access token type
-                                check is performed or not. This should be set to `false`
-                                if the authorization server does not include 'typ'
-                                claim in JWT token. Defaults to `true`.
+                              description: Configure whether the access token type check is performed or not. This should be set to `false` if the authorization server does not include 'typ' claim in JWT token. Defaults to `true`.
                             checkIssuer:
                               type: boolean
-                              description: Enable or disable issuer checking. By default
-                                issuer is checked using the value configured by `validIssuerUri`.
-                                Default value is `true`.
+                              description: Enable or disable issuer checking. By default issuer is checked using the value configured by `validIssuerUri`. Default value is `true`.
                             clientId:
                               type: string
-                              description: OAuth Client ID which the Kafka broker
-                                can use to authenticate against the authorization
-                                server and use the introspect endpoint URI.
+                              description: OAuth Client ID which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
                             clientSecret:
                               type: object
                               properties:
                                 key:
                                   type: string
-                                  description: The key under which the secret value
-                                    is stored in the Kubernetes Secret.
+                                  description: The key under which the secret value is stored in the Kubernetes Secret.
                                 secretName:
                                   type: string
-                                  description: The name of the Kubernetes Secret containing
-                                    the secret value.
+                                  description: The name of the Kubernetes Secret containing the secret value.
                               required:
-                              - key
-                              - secretName
-                              description: Link to Kubernetes Secret containing the
-                                OAuth client secret which the Kafka broker can use
-                                to authenticate against the authorization server and
-                                use the introspect endpoint URI.
+                                - key
+                                - secretName
+                              description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
                             disableTlsHostnameVerification:
                               type: boolean
-                              description: Enable or disable TLS hostname verification.
-                                Default value is `false`.
+                              description: Enable or disable TLS hostname verification. Default value is `false`.
                             enableECDSA:
                               type: boolean
-                              description: Enable or disable ECDSA support by installing
-                                BouncyCastle crypto provider. Default value is `false`.
+                              description: Enable or disable ECDSA support by installing BouncyCastle crypto provider. Default value is `false`.
                             fallbackUserNameClaim:
                               type: string
-                              description: The fallback username claim to be used
-                                for the user id if the claim specified by `userNameClaim`
-                                is not present. This is useful when `client_credentials`
-                                authentication only results in the client id being
-                                provided in another claim. It only takes effect if
-                                `userNameClaim` is set.
+                              description: The fallback username claim to be used for the user id if the claim specified by `userNameClaim` is not present. This is useful when `client_credentials` authentication only results in the client id being provided in another claim. It only takes effect if `userNameClaim` is set.
                             fallbackUserNamePrefix:
                               type: string
-                              description: The prefix to use with the value of `fallbackUserNameClaim`
-                                to construct the user id. This only takes effect if
-                                `fallbackUserNameClaim` is true, and the value is
-                                present for the claim. Mapping usernames and client
-                                ids into the same user id space is useful in preventing
-                                name collisions.
+                              description: The prefix to use with the value of `fallbackUserNameClaim` to construct the user id. This only takes effect if `fallbackUserNameClaim` is true, and the value is present for the claim. Mapping usernames and client ids into the same user id space is useful in preventing name collisions.
                             introspectionEndpointUri:
                               type: string
-                              description: URI of the token introspection endpoint
-                                which can be used to validate opaque non-JWT tokens.
+                              description: URI of the token introspection endpoint which can be used to validate opaque non-JWT tokens.
                             jwksEndpointUri:
                               type: string
-                              description: URI of the JWKS certificate endpoint, which
-                                can be used for local JWT validation.
+                              description: URI of the JWKS certificate endpoint, which can be used for local JWT validation.
                             jwksExpirySeconds:
                               type: integer
                               minimum: 1
-                              description: Configures how often are the JWKS certificates
-                                considered valid. The expiry interval has to be at
-                                least 60 seconds longer then the refresh interval
-                                specified in `jwksRefreshSeconds`. Defaults to 360
-                                seconds.
+                              description: Configures how often are the JWKS certificates considered valid. The expiry interval has to be at least 60 seconds longer then the refresh interval specified in `jwksRefreshSeconds`. Defaults to 360 seconds.
                             jwksRefreshSeconds:
                               type: integer
                               minimum: 1
-                              description: Configures how often are the JWKS certificates
-                                refreshed. The refresh interval has to be at least
-                                60 seconds shorter then the expiry interval specified
-                                in `jwksExpirySeconds`. Defaults to 300 seconds.
+                              description: Configures how often are the JWKS certificates refreshed. The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in `jwksExpirySeconds`. Defaults to 300 seconds.
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -273,53 +211,36 @@ spec:
                                 properties:
                                   certificate:
                                     type: string
-                                    description: The name of the file certificate
-                                      in the Secret.
+                                    description: The name of the file certificate in the Secret.
                                   secretName:
                                     type: string
-                                    description: The name of the Secret containing
-                                      the certificate.
+                                    description: The name of the Secret containing the certificate.
                                 required:
-                                - certificate
-                                - secretName
-                              description: Trusted certificates for TLS connection
-                                to the OAuth server.
+                                  - certificate
+                                  - secretName
+                              description: Trusted certificates for TLS connection to the OAuth server.
                             type:
                               type: string
                               enum:
-                              - tls
-                              - scram-sha-512
-                              - oauth
-                              description: Authentication type. `oauth` type uses
-                                SASL OAUTHBEARER Authentication. `scram-sha-512` type
-                                uses SASL SCRAM-SHA-512 Authentication. `tls` type
-                                uses TLS Client Authentication. `tls` type is supported
-                                only on TLS listeners.
+                                - tls
+                                - scram-sha-512
+                                - oauth
+                              description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.
                             userInfoEndpointUri:
                               type: string
-                              description: 'URI of the User Info Endpoint to use as
-                                a fallback to obtaining the user id when the Introspection
-                                Endpoint does not return information that can be used
-                                for the user id. '
+                              description: 'URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. '
                             userNameClaim:
                               type: string
-                              description: Name of the claim from the JWT authentication
-                                token, Introspection Endpoint response or User Info
-                                Endpoint response which will be used to extract the
-                                user id. Defaults to `sub`.
+                              description: Name of the claim from the JWT authentication token, Introspection Endpoint response or User Info Endpoint response which will be used to extract the user id. Defaults to `sub`.
                             validIssuerUri:
                               type: string
                               description: URI of the token issuer used for authentication.
                             validTokenType:
                               type: string
-                              description: Valid value for the `token_type` attribute
-                                returned by the Introspection Endpoint. No default
-                                value, and not checked by default.
+                              description: Valid value for the `token_type` attribute returned by the Introspection Endpoint. No default value, and not checked by default.
                           required:
-                          - type
-                          description: 'Authentication configuration for this listener.
-                            Since this listener does not use TLS transport you cannot
-                            configure an authentication with `type: tls`.'
+                            - type
+                          description: 'Authentication configuration for this listener. Since this listener does not use TLS transport you cannot configure an authentication with `type: tls`.'
                         networkPolicyPeers:
                           type: array
                           items:
@@ -370,13 +291,7 @@ spec:
                                             type: string
                                   matchLabels:
                                     type: object
-                          description: List of peers which should be able to connect
-                            to this listener. Peers in this list are combined using
-                            a logical OR operation. If this field is empty or missing,
-                            all connections will be allowed for this listener. If
-                            this field is present and contains at least one item,
-                            the listener only allows the traffic which matches at
-                            least one item in this list.
+                          description: List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.
                       description: Configures plain listener on port 9092.
                     tls:
                       type: object
@@ -386,90 +301,55 @@ spec:
                           properties:
                             accessTokenIsJwt:
                               type: boolean
-                              description: Configure whether the access token is treated
-                                as JWT. This must be set to `false` if the authorization
-                                server returns opaque tokens. Defaults to `true`.
+                              description: Configure whether the access token is treated as JWT. This must be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                             checkAccessTokenType:
                               type: boolean
-                              description: Configure whether the access token type
-                                check is performed or not. This should be set to `false`
-                                if the authorization server does not include 'typ'
-                                claim in JWT token. Defaults to `true`.
+                              description: Configure whether the access token type check is performed or not. This should be set to `false` if the authorization server does not include 'typ' claim in JWT token. Defaults to `true`.
                             checkIssuer:
                               type: boolean
-                              description: Enable or disable issuer checking. By default
-                                issuer is checked using the value configured by `validIssuerUri`.
-                                Default value is `true`.
+                              description: Enable or disable issuer checking. By default issuer is checked using the value configured by `validIssuerUri`. Default value is `true`.
                             clientId:
                               type: string
-                              description: OAuth Client ID which the Kafka broker
-                                can use to authenticate against the authorization
-                                server and use the introspect endpoint URI.
+                              description: OAuth Client ID which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
                             clientSecret:
                               type: object
                               properties:
                                 key:
                                   type: string
-                                  description: The key under which the secret value
-                                    is stored in the Kubernetes Secret.
+                                  description: The key under which the secret value is stored in the Kubernetes Secret.
                                 secretName:
                                   type: string
-                                  description: The name of the Kubernetes Secret containing
-                                    the secret value.
+                                  description: The name of the Kubernetes Secret containing the secret value.
                               required:
-                              - key
-                              - secretName
-                              description: Link to Kubernetes Secret containing the
-                                OAuth client secret which the Kafka broker can use
-                                to authenticate against the authorization server and
-                                use the introspect endpoint URI.
+                                - key
+                                - secretName
+                              description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
                             disableTlsHostnameVerification:
                               type: boolean
-                              description: Enable or disable TLS hostname verification.
-                                Default value is `false`.
+                              description: Enable or disable TLS hostname verification. Default value is `false`.
                             enableECDSA:
                               type: boolean
-                              description: Enable or disable ECDSA support by installing
-                                BouncyCastle crypto provider. Default value is `false`.
+                              description: Enable or disable ECDSA support by installing BouncyCastle crypto provider. Default value is `false`.
                             fallbackUserNameClaim:
                               type: string
-                              description: The fallback username claim to be used
-                                for the user id if the claim specified by `userNameClaim`
-                                is not present. This is useful when `client_credentials`
-                                authentication only results in the client id being
-                                provided in another claim. It only takes effect if
-                                `userNameClaim` is set.
+                              description: The fallback username claim to be used for the user id if the claim specified by `userNameClaim` is not present. This is useful when `client_credentials` authentication only results in the client id being provided in another claim. It only takes effect if `userNameClaim` is set.
                             fallbackUserNamePrefix:
                               type: string
-                              description: The prefix to use with the value of `fallbackUserNameClaim`
-                                to construct the user id. This only takes effect if
-                                `fallbackUserNameClaim` is true, and the value is
-                                present for the claim. Mapping usernames and client
-                                ids into the same user id space is useful in preventing
-                                name collisions.
+                              description: The prefix to use with the value of `fallbackUserNameClaim` to construct the user id. This only takes effect if `fallbackUserNameClaim` is true, and the value is present for the claim. Mapping usernames and client ids into the same user id space is useful in preventing name collisions.
                             introspectionEndpointUri:
                               type: string
-                              description: URI of the token introspection endpoint
-                                which can be used to validate opaque non-JWT tokens.
+                              description: URI of the token introspection endpoint which can be used to validate opaque non-JWT tokens.
                             jwksEndpointUri:
                               type: string
-                              description: URI of the JWKS certificate endpoint, which
-                                can be used for local JWT validation.
+                              description: URI of the JWKS certificate endpoint, which can be used for local JWT validation.
                             jwksExpirySeconds:
                               type: integer
                               minimum: 1
-                              description: Configures how often are the JWKS certificates
-                                considered valid. The expiry interval has to be at
-                                least 60 seconds longer then the refresh interval
-                                specified in `jwksRefreshSeconds`. Defaults to 360
-                                seconds.
+                              description: Configures how often are the JWKS certificates considered valid. The expiry interval has to be at least 60 seconds longer then the refresh interval specified in `jwksRefreshSeconds`. Defaults to 360 seconds.
                             jwksRefreshSeconds:
                               type: integer
                               minimum: 1
-                              description: Configures how often are the JWKS certificates
-                                refreshed. The refresh interval has to be at least
-                                60 seconds shorter then the expiry interval specified
-                                in `jwksExpirySeconds`. Defaults to 300 seconds.
+                              description: Configures how often are the JWKS certificates refreshed. The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in `jwksExpirySeconds`. Defaults to 300 seconds.
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -477,50 +357,35 @@ spec:
                                 properties:
                                   certificate:
                                     type: string
-                                    description: The name of the file certificate
-                                      in the Secret.
+                                    description: The name of the file certificate in the Secret.
                                   secretName:
                                     type: string
-                                    description: The name of the Secret containing
-                                      the certificate.
+                                    description: The name of the Secret containing the certificate.
                                 required:
-                                - certificate
-                                - secretName
-                              description: Trusted certificates for TLS connection
-                                to the OAuth server.
+                                  - certificate
+                                  - secretName
+                              description: Trusted certificates for TLS connection to the OAuth server.
                             type:
                               type: string
                               enum:
-                              - tls
-                              - scram-sha-512
-                              - oauth
-                              description: Authentication type. `oauth` type uses
-                                SASL OAUTHBEARER Authentication. `scram-sha-512` type
-                                uses SASL SCRAM-SHA-512 Authentication. `tls` type
-                                uses TLS Client Authentication. `tls` type is supported
-                                only on TLS listeners.
+                                - tls
+                                - scram-sha-512
+                                - oauth
+                              description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.
                             userInfoEndpointUri:
                               type: string
-                              description: 'URI of the User Info Endpoint to use as
-                                a fallback to obtaining the user id when the Introspection
-                                Endpoint does not return information that can be used
-                                for the user id. '
+                              description: 'URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. '
                             userNameClaim:
                               type: string
-                              description: Name of the claim from the JWT authentication
-                                token, Introspection Endpoint response or User Info
-                                Endpoint response which will be used to extract the
-                                user id. Defaults to `sub`.
+                              description: Name of the claim from the JWT authentication token, Introspection Endpoint response or User Info Endpoint response which will be used to extract the user id. Defaults to `sub`.
                             validIssuerUri:
                               type: string
                               description: URI of the token issuer used for authentication.
                             validTokenType:
                               type: string
-                              description: Valid value for the `token_type` attribute
-                                returned by the Introspection Endpoint. No default
-                                value, and not checked by default.
+                              description: Valid value for the `token_type` attribute returned by the Introspection Endpoint. No default value, and not checked by default.
                           required:
-                          - type
+                            - type
                           description: Authentication configuration for this listener.
                         configuration:
                           type: object
@@ -530,23 +395,18 @@ spec:
                               properties:
                                 certificate:
                                   type: string
-                                  description: The name of the file certificate in
-                                    the Secret.
+                                  description: The name of the file certificate in the Secret.
                                 key:
                                   type: string
-                                  description: The name of the private key in the
-                                    Secret.
+                                  description: The name of the private key in the Secret.
                                 secretName:
                                   type: string
-                                  description: The name of the Secret containing the
-                                    certificate.
+                                  description: The name of the Secret containing the certificate.
                               required:
-                              - certificate
-                              - key
-                              - secretName
-                              description: Reference to the `Secret` which holds the
-                                certificate and private key pair. The certificate
-                                can optionally contain the whole chain.
+                                - certificate
+                                - key
+                                - secretName
+                              description: Reference to the `Secret` which holds the certificate and private key pair. The certificate can optionally contain the whole chain.
                           description: Configuration of TLS listener.
                         networkPolicyPeers:
                           type: array
@@ -598,13 +458,7 @@ spec:
                                             type: string
                                   matchLabels:
                                     type: object
-                          description: List of peers which should be able to connect
-                            to this listener. Peers in this list are combined using
-                            a logical OR operation. If this field is empty or missing,
-                            all connections will be allowed for this listener. If
-                            this field is present and contains at least one item,
-                            the listener only allows the traffic which matches at
-                            least one item in this list.
+                          description: List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.
                       description: Configures TLS listener on port 9093.
                     external:
                       type: object
@@ -614,90 +468,55 @@ spec:
                           properties:
                             accessTokenIsJwt:
                               type: boolean
-                              description: Configure whether the access token is treated
-                                as JWT. This must be set to `false` if the authorization
-                                server returns opaque tokens. Defaults to `true`.
+                              description: Configure whether the access token is treated as JWT. This must be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                             checkAccessTokenType:
                               type: boolean
-                              description: Configure whether the access token type
-                                check is performed or not. This should be set to `false`
-                                if the authorization server does not include 'typ'
-                                claim in JWT token. Defaults to `true`.
+                              description: Configure whether the access token type check is performed or not. This should be set to `false` if the authorization server does not include 'typ' claim in JWT token. Defaults to `true`.
                             checkIssuer:
                               type: boolean
-                              description: Enable or disable issuer checking. By default
-                                issuer is checked using the value configured by `validIssuerUri`.
-                                Default value is `true`.
+                              description: Enable or disable issuer checking. By default issuer is checked using the value configured by `validIssuerUri`. Default value is `true`.
                             clientId:
                               type: string
-                              description: OAuth Client ID which the Kafka broker
-                                can use to authenticate against the authorization
-                                server and use the introspect endpoint URI.
+                              description: OAuth Client ID which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
                             clientSecret:
                               type: object
                               properties:
                                 key:
                                   type: string
-                                  description: The key under which the secret value
-                                    is stored in the Kubernetes Secret.
+                                  description: The key under which the secret value is stored in the Kubernetes Secret.
                                 secretName:
                                   type: string
-                                  description: The name of the Kubernetes Secret containing
-                                    the secret value.
+                                  description: The name of the Kubernetes Secret containing the secret value.
                               required:
-                              - key
-                              - secretName
-                              description: Link to Kubernetes Secret containing the
-                                OAuth client secret which the Kafka broker can use
-                                to authenticate against the authorization server and
-                                use the introspect endpoint URI.
+                                - key
+                                - secretName
+                              description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
                             disableTlsHostnameVerification:
                               type: boolean
-                              description: Enable or disable TLS hostname verification.
-                                Default value is `false`.
+                              description: Enable or disable TLS hostname verification. Default value is `false`.
                             enableECDSA:
                               type: boolean
-                              description: Enable or disable ECDSA support by installing
-                                BouncyCastle crypto provider. Default value is `false`.
+                              description: Enable or disable ECDSA support by installing BouncyCastle crypto provider. Default value is `false`.
                             fallbackUserNameClaim:
                               type: string
-                              description: The fallback username claim to be used
-                                for the user id if the claim specified by `userNameClaim`
-                                is not present. This is useful when `client_credentials`
-                                authentication only results in the client id being
-                                provided in another claim. It only takes effect if
-                                `userNameClaim` is set.
+                              description: The fallback username claim to be used for the user id if the claim specified by `userNameClaim` is not present. This is useful when `client_credentials` authentication only results in the client id being provided in another claim. It only takes effect if `userNameClaim` is set.
                             fallbackUserNamePrefix:
                               type: string
-                              description: The prefix to use with the value of `fallbackUserNameClaim`
-                                to construct the user id. This only takes effect if
-                                `fallbackUserNameClaim` is true, and the value is
-                                present for the claim. Mapping usernames and client
-                                ids into the same user id space is useful in preventing
-                                name collisions.
+                              description: The prefix to use with the value of `fallbackUserNameClaim` to construct the user id. This only takes effect if `fallbackUserNameClaim` is true, and the value is present for the claim. Mapping usernames and client ids into the same user id space is useful in preventing name collisions.
                             introspectionEndpointUri:
                               type: string
-                              description: URI of the token introspection endpoint
-                                which can be used to validate opaque non-JWT tokens.
+                              description: URI of the token introspection endpoint which can be used to validate opaque non-JWT tokens.
                             jwksEndpointUri:
                               type: string
-                              description: URI of the JWKS certificate endpoint, which
-                                can be used for local JWT validation.
+                              description: URI of the JWKS certificate endpoint, which can be used for local JWT validation.
                             jwksExpirySeconds:
                               type: integer
                               minimum: 1
-                              description: Configures how often are the JWKS certificates
-                                considered valid. The expiry interval has to be at
-                                least 60 seconds longer then the refresh interval
-                                specified in `jwksRefreshSeconds`. Defaults to 360
-                                seconds.
+                              description: Configures how often are the JWKS certificates considered valid. The expiry interval has to be at least 60 seconds longer then the refresh interval specified in `jwksRefreshSeconds`. Defaults to 360 seconds.
                             jwksRefreshSeconds:
                               type: integer
                               minimum: 1
-                              description: Configures how often are the JWKS certificates
-                                refreshed. The refresh interval has to be at least
-                                60 seconds shorter then the expiry interval specified
-                                in `jwksExpirySeconds`. Defaults to 300 seconds.
+                              description: Configures how often are the JWKS certificates refreshed. The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in `jwksExpirySeconds`. Defaults to 300 seconds.
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -705,56 +524,39 @@ spec:
                                 properties:
                                   certificate:
                                     type: string
-                                    description: The name of the file certificate
-                                      in the Secret.
+                                    description: The name of the file certificate in the Secret.
                                   secretName:
                                     type: string
-                                    description: The name of the Secret containing
-                                      the certificate.
+                                    description: The name of the Secret containing the certificate.
                                 required:
-                                - certificate
-                                - secretName
-                              description: Trusted certificates for TLS connection
-                                to the OAuth server.
+                                  - certificate
+                                  - secretName
+                              description: Trusted certificates for TLS connection to the OAuth server.
                             type:
                               type: string
                               enum:
-                              - tls
-                              - scram-sha-512
-                              - oauth
-                              description: Authentication type. `oauth` type uses
-                                SASL OAUTHBEARER Authentication. `scram-sha-512` type
-                                uses SASL SCRAM-SHA-512 Authentication. `tls` type
-                                uses TLS Client Authentication. `tls` type is supported
-                                only on TLS listeners.
+                                - tls
+                                - scram-sha-512
+                                - oauth
+                              description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.
                             userInfoEndpointUri:
                               type: string
-                              description: 'URI of the User Info Endpoint to use as
-                                a fallback to obtaining the user id when the Introspection
-                                Endpoint does not return information that can be used
-                                for the user id. '
+                              description: 'URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. '
                             userNameClaim:
                               type: string
-                              description: Name of the claim from the JWT authentication
-                                token, Introspection Endpoint response or User Info
-                                Endpoint response which will be used to extract the
-                                user id. Defaults to `sub`.
+                              description: Name of the claim from the JWT authentication token, Introspection Endpoint response or User Info Endpoint response which will be used to extract the user id. Defaults to `sub`.
                             validIssuerUri:
                               type: string
                               description: URI of the token issuer used for authentication.
                             validTokenType:
                               type: string
-                              description: Valid value for the `token_type` attribute
-                                returned by the Introspection Endpoint. No default
-                                value, and not checked by default.
+                              description: Valid value for the `token_type` attribute returned by the Introspection Endpoint. No default value, and not checked by default.
                           required:
-                          - type
+                            - type
                           description: Authentication configuration for Kafka brokers.
                         class:
                           type: string
-                          description: Configures the `Ingress` class that defines
-                            which `Ingress` controller will be used. If not set, the
-                            `Ingress` class is set to `nginx`.
+                          description: Configures the `Ingress` class that defines which `Ingress` controller will be used. If not set, the `Ingress` class is set to `nginx`.
                         configuration:
                           type: object
                           properties:
@@ -763,20 +565,15 @@ spec:
                               properties:
                                 address:
                                   type: string
-                                  description: Additional address name for the bootstrap
-                                    service. The address will be added to the list
-                                    of subject alternative names of the TLS certificates.
+                                  description: Additional address name for the bootstrap service. The address will be added to the list of subject alternative names of the TLS certificates.
                                 dnsAnnotations:
                                   type: object
-                                  description: Annotations that will be added to the
-                                    `Ingress` resource. You can use this field to
-                                    configure DNS providers such as External DNS.
+                                  description: Annotations that will be added to the `Ingress` resource. You can use this field to configure DNS providers such as External DNS.
                                 host:
                                   type: string
-                                  description: Host for the bootstrap route. This
-                                    field will be used in the Ingress resource.
+                                  description: Host for the bootstrap route. This field will be used in the Ingress resource.
                               required:
-                              - host
+                                - host
                               description: External bootstrap ingress configuration.
                             brokers:
                               type: array
@@ -788,47 +585,36 @@ spec:
                                     description: Id of the kafka broker (broker identifier).
                                   advertisedHost:
                                     type: string
-                                    description: The host name which will be used
-                                      in the brokers' `advertised.brokers`.
+                                    description: The host name which will be used in the brokers' `advertised.brokers`.
                                   advertisedPort:
                                     type: integer
-                                    description: The port number which will be used
-                                      in the brokers' `advertised.brokers`.
+                                    description: The port number which will be used in the brokers' `advertised.brokers`.
                                   host:
                                     type: string
-                                    description: Host for the broker ingress. This
-                                      field will be used in the Ingress resource.
+                                    description: Host for the broker ingress. This field will be used in the Ingress resource.
                                   dnsAnnotations:
                                     type: object
-                                    description: Annotations that will be added to
-                                      the `Ingress` resources for individual brokers.
-                                      You can use this field to configure DNS providers
-                                      such as External DNS.
+                                    description: Annotations that will be added to the `Ingress` resources for individual brokers. You can use this field to configure DNS providers such as External DNS.
                                 required:
-                                - host
+                                  - host
                               description: External broker ingress configuration.
                             brokerCertChainAndKey:
                               type: object
                               properties:
                                 certificate:
                                   type: string
-                                  description: The name of the file certificate in
-                                    the Secret.
+                                  description: The name of the file certificate in the Secret.
                                 key:
                                   type: string
-                                  description: The name of the private key in the
-                                    Secret.
+                                  description: The name of the private key in the Secret.
                                 secretName:
                                   type: string
-                                  description: The name of the Secret containing the
-                                    certificate.
+                                  description: The name of the Secret containing the certificate.
                               required:
-                              - certificate
-                              - key
-                              - secretName
-                              description: Reference to the `Secret` which holds the
-                                certificate and private key pair. The certificate
-                                can optionally contain the whole chain.
+                                - certificate
+                                - key
+                                - secretName
+                              description: Reference to the `Secret` which holds the certificate and private key pair. The certificate can optionally contain the whole chain.
                           description: External listener configuration.
                         networkPolicyPeers:
                           type: array
@@ -880,13 +666,7 @@ spec:
                                             type: string
                                   matchLabels:
                                     type: object
-                          description: List of peers which should be able to connect
-                            to this listener. Peers in this list are combined using
-                            a logical OR operation. If this field is empty or missing,
-                            all connections will be allowed for this listener. If
-                            this field is present and contains at least one item,
-                            the listener only allows the traffic which matches at
-                            least one item in this list.
+                          description: List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.
                         overrides:
                           type: object
                           properties:
@@ -895,14 +675,10 @@ spec:
                               properties:
                                 address:
                                   type: string
-                                  description: Additional address name for the bootstrap
-                                    service. The address will be added to the list
-                                    of subject alternative names of the TLS certificates.
+                                  description: Additional address name for the bootstrap service. The address will be added to the list of subject alternative names of the TLS certificates.
                                 dnsAnnotations:
                                   type: object
-                                  description: Annotations that will be added to the
-                                    `Service` resource. You can use this field to
-                                    configure DNS providers such as External DNS.
+                                  description: Annotations that will be added to the `Service` resource. You can use this field to configure DNS providers such as External DNS.
                                 nodePort:
                                   type: integer
                                   description: Node port for the bootstrap service.
@@ -917,43 +693,31 @@ spec:
                                     description: Id of the kafka broker (broker identifier).
                                   advertisedHost:
                                     type: string
-                                    description: The host name which will be used
-                                      in the brokers' `advertised.brokers`.
+                                    description: The host name which will be used in the brokers' `advertised.brokers`.
                                   advertisedPort:
                                     type: integer
-                                    description: The port number which will be used
-                                      in the brokers' `advertised.brokers`.
+                                    description: The port number which will be used in the brokers' `advertised.brokers`.
                                   nodePort:
                                     type: integer
                                     description: Node port for the broker service.
                                   dnsAnnotations:
                                     type: object
-                                    description: Annotations that will be added to
-                                      the `Service` resources for individual brokers.
-                                      You can use this field to configure DNS providers
-                                      such as External DNS.
+                                    description: Annotations that will be added to the `Service` resources for individual brokers. You can use this field to configure DNS providers such as External DNS.
                               description: External broker services configuration.
-                          description: Overrides for external bootstrap and broker
-                            services and externally advertised addresses.
+                          description: Overrides for external bootstrap and broker services and externally advertised addresses.
                         tls:
                           type: boolean
-                          description: Enables TLS encryption on the listener. By
-                            default set to `true` for enabled TLS encryption.
+                          description: Enables TLS encryption on the listener. By default set to `true` for enabled TLS encryption.
                         type:
                           type: string
                           enum:
-                          - route
-                          - loadbalancer
-                          - nodeport
-                          - ingress
-                          description: "Type of the external listener. Currently the
-                            supported types are `route`, `loadbalancer`, and `nodeport`.
-                            \n\n* `route` type uses OpenShift Routes to expose Kafka.*
-                            `loadbalancer` type uses LoadBalancer type services to
-                            expose Kafka.* `nodeport` type uses NodePort type services
-                            to expose Kafka.."
+                            - route
+                            - loadbalancer
+                            - nodeport
+                            - ingress
+                          description: "Type of the external listener. Currently the supported types are `route`, `loadbalancer`, and `nodeport`. \n\n* `route` type uses OpenShift Routes to expose Kafka.* `loadbalancer` type uses LoadBalancer type services to expose Kafka.* `nodeport` type uses NodePort type services to expose Kafka.."
                       required:
-                      - type
+                        - type
                       description: Configures external listener on port 9094.
                   description: Configures listeners of Kafka brokers.
                 authorization:
@@ -961,47 +725,30 @@ spec:
                   properties:
                     allowOnError:
                       type: boolean
-                      description: Defines whether a Kafka client should be allowed
-                        or denied by default when the authorizer fails to query the
-                        Open Policy Agent, for example, when it is temporarily unavailable).
-                        Defaults to `false` - all actions will be denied.
+                      description: Defines whether a Kafka client should be allowed or denied by default when the authorizer fails to query the Open Policy Agent, for example, when it is temporarily unavailable). Defaults to `false` - all actions will be denied.
                     clientId:
                       type: string
-                      description: OAuth Client ID which the Kafka client can use
-                        to authenticate against the OAuth server and use the token
-                        endpoint URI.
+                      description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                     delegateToKafkaAcls:
                       type: boolean
-                      description: Whether authorization decision should be delegated
-                        to the 'Simple' authorizer if DENIED by Keycloak Authorization
-                        Services policies.Default value is `false`.
+                      description: Whether authorization decision should be delegated to the 'Simple' authorizer if DENIED by Keycloak Authorization Services policies.Default value is `false`.
                     disableTlsHostnameVerification:
                       type: boolean
-                      description: Enable or disable TLS hostname verification. Default
-                        value is `false`.
+                      description: Enable or disable TLS hostname verification. Default value is `false`.
                     expireAfterMs:
                       type: integer
-                      description: The expiration of the records kept in the local
-                        cache to avoid querying the Open Policy Agent for every request.
-                        Defines how often the cached authorization decisions are reloaded
-                        from the Open Policy Agent server. In milliseconds. Defaults
-                        to `3600000`.
+                      description: The expiration of the records kept in the local cache to avoid querying the Open Policy Agent for every request. Defines how often the cached authorization decisions are reloaded from the Open Policy Agent server. In milliseconds. Defaults to `3600000`.
                     initialCacheCapacity:
                       type: integer
-                      description: Initial capacity of the local cache used by the
-                        authorizer to avoid querying the Open Policy Agent for every
-                        request Defaults to `5000`.
+                      description: Initial capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request Defaults to `5000`.
                     maximumCacheSize:
                       type: integer
-                      description: Maximum capacity of the local cache used by the
-                        authorizer to avoid querying the Open Policy Agent for every
-                        request. Defaults to `50000`.
+                      description: Maximum capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request. Defaults to `50000`.
                     superUsers:
                       type: array
                       items:
                         type: string
-                      description: List of super users. Should contain list of user
-                        principals which should get unlimited access rights.
+                      description: List of super users. Should contain list of user principals which should get unlimited access rights.
                     tlsTrustedCertificates:
                       type: array
                       items:
@@ -1014,62 +761,42 @@ spec:
                             type: string
                             description: The name of the Secret containing the certificate.
                         required:
-                        - certificate
-                        - secretName
-                      description: Trusted certificates for TLS connection to the
-                        OAuth server.
+                          - certificate
+                          - secretName
+                      description: Trusted certificates for TLS connection to the OAuth server.
                     tokenEndpointUri:
                       type: string
                       description: Authorization server token endpoint URI.
                     type:
                       type: string
                       enum:
-                      - simple
-                      - opa
-                      - keycloak
-                      description: Authorization type. Currently, the supported types
-                        are `simple`, `keycloak`, and `opa`. `simple` authorization
-                        type uses Kafka's `kafka.security.auth.SimpleAclAuthorizer`
-                        class for authorization. `keycloak` authorization type uses
-                        Keycloak Authorization Services for authorization. `opa` authorization
-                        type uses Open Policy Agent based authorization.
+                        - simple
+                        - opa
+                        - keycloak
+                      description: Authorization type. Currently, the supported types are `simple`, `keycloak`, and `opa`. `simple` authorization type uses Kafka's `kafka.security.auth.SimpleAclAuthorizer` class for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization.
                     url:
                       type: string
                       example: http://opa:8181/v1/data/kafka/authz/allow
-                      description: The URL used to connect to the Open Policy Agent
-                        server. The URL has to include the policy which will be queried
-                        by the authorizer. This option is required.
+                      description: The URL used to connect to the Open Policy Agent server. The URL has to include the policy which will be queried by the authorizer. This option is required.
                   required:
-                  - type
+                    - type
                   description: Authorization configuration for Kafka brokers.
                 config:
                   type: object
-                  description: 'Kafka broker config properties with the following
-                    prefixes cannot be set: listeners, advertised., broker., listener.,
-                    host.name, port, inter.broker.listener.name, sasl., ssl., security.,
-                    password., principal.builder.class, log.dir, zookeeper.connect,
-                    zookeeper.set.acl, authorizer., super.user, cruise.control.metrics.topic,
-                    cruise.control.metrics.reporter.bootstrap.servers (with the exception
-                    of: zookeeper.connection.timeout.ms, ssl.cipher.suites, ssl.protocol,
-                    ssl.enabled.protocols,cruise.control.metrics.topic.num.partitions,
-                    cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms,cruise.control.metrics.topic.auto.create.retries,
-                    cruise.control.metrics.topic.auto.create.timeout.ms).'
+                  description: 'Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers (with the exception of: zookeeper.connection.timeout.ms, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols,cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms,cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms).'
                 rack:
                   type: object
                   properties:
                     topologyKey:
                       type: string
                       example: failure-domain.beta.kubernetes.io/zone
-                      description: A key that matches labels assigned to the Kubernetes
-                        cluster nodes. The value of the label is used to set the broker's
-                        `broker.rack` config.
+                      description: A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config.
                   required:
-                  - topologyKey
+                    - topologyKey
                   description: Configuration of the `broker.rack` broker config.
                 brokerRackInitImage:
                   type: string
-                  description: The image of the init container used for initializing
-                    the `broker.rack`.
+                  description: The image of the init container used for initializing the `broker.rack`.
                 affinity:
                   type: object
                   properties:
@@ -1300,23 +1027,17 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -1327,23 +1048,17 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -1365,8 +1080,7 @@ spec:
                       description: -Xmx option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
-                      description: Specifies whether the Garbage Collection logging
-                        is enabled. The default is false.
+                      description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                     javaSystemProperties:
                       type: array
                       items:
@@ -1378,8 +1092,7 @@ spec:
                           value:
                             type: string
                             description: The system property value.
-                      description: A map of additional system properties which will
-                        be passed using the `-D` option to the JVM.
+                      description: A map of additional system properties which will be passed using the `-D` option to the JVM.
                   description: JVM Options for pods.
                 jmxOptions:
                   type: object
@@ -1390,14 +1103,11 @@ spec:
                         type:
                           type: string
                           enum:
-                          - password
-                          description: Authentication type. Currently the only supported
-                            types are `password`.`password` type creates a username
-                            and protected port with no TLS.
+                            - password
+                          description: Authentication type. Currently the only supported types are `password`.`password` type creates a username and protected port with no TLS.
                       required:
-                      - type
-                      description: Authentication configuration for connecting to
-                        the Kafka JMX port.
+                        - type
+                      description: Authentication configuration for connecting to the Kafka JMX port.
                   description: JMX Options for Kafka brokers.
                 resources:
                   type: object
@@ -1409,8 +1119,7 @@ spec:
                   description: CPU and memory resources to reserve.
                 metrics:
                   type: object
-                  description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
-                    for details of the structure of this configuration.
+                  description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
                 logging:
                   type: object
                   properties:
@@ -1419,16 +1128,15 @@ spec:
                       description: A Map from logger name to logger level.
                     name:
                       type: string
-                      description: The name of the `ConfigMap` from which to get the
-                        logging configuration.
+                      description: The name of the `ConfigMap` from which to get the logging configuration.
                     type:
                       type: string
                       enum:
-                      - inline
-                      - external
+                        - inline
+                        - external
                       description: Logging type, must be either 'inline' or 'external'.
                   required:
-                  - type
+                    - type
                   description: Logging configuration for Kafka.
                 tlsSidecar:
                   type: object
@@ -1441,23 +1149,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -1466,38 +1168,31 @@ spec:
                     logLevel:
                       type: string
                       enum:
-                      - emerg
-                      - alert
-                      - crit
-                      - err
-                      - warning
-                      - notice
-                      - info
-                      - debug
-                      description: The log level for the TLS sidecar. Default value
-                        is `notice`.
+                        - emerg
+                        - alert
+                        - crit
+                        - err
+                        - warning
+                        - notice
+                        - info
+                        - debug
+                      description: The log level for the TLS sidecar. Default value is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -1523,24 +1218,17 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                         podManagementPolicy:
                           type: string
                           enum:
-                          - OrderedReady
-                          - Parallel
-                          description: PodManagementPolicy which will be used for
-                            this StatefulSet. Valid values are `Parallel` and `OrderedReady`.
-                            Defaults to `Parallel`.
+                            - OrderedReady
+                            - Parallel
+                          description: PodManagementPolicy which will be used for this StatefulSet. Valid values are `Parallel` and `OrderedReady`. Defaults to `Parallel`.
                       description: Template for Kafka `StatefulSet`.
                     pod:
                       type: object
@@ -1550,15 +1238,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -1567,8 +1250,7 @@ spec:
                             properties:
                               name:
                                 type: string
-                          description: List of references to secrets in the same namespace
-                            to use for pulling any of the images used by this Pod.
+                          description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -1611,18 +1293,11 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
-                          description: Configures pod-level security attributes and
-                            common container settings.
+                          description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
-                          description: The grace period is the duration in seconds
-                            after the processes running in the pod are sent a termination
-                            signal and the time when the processes are forcibly halted
-                            with a kill signal. Set this value longer than the expected
-                            cleanup time for your process.Value must be non-negative
-                            integer. The value zero indicates delete immediately.
-                            Defaults to 30 seconds.
+                          description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -1834,13 +1509,10 @@ spec:
                           description: The pod's affinity rules.
                         priorityClassName:
                           type: string
-                          description: The name of the Priority Class to which these
-                            pods will be assigned.
+                          description: The name of the Priority Class to which these pods will be assigned.
                         schedulerName:
                           type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -1866,15 +1538,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka bootstrap `Service`.
                     brokersService:
@@ -1885,15 +1552,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka broker `Service`.
                     externalBootstrapService:
@@ -1904,40 +1566,22 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                         externalTrafficPolicy:
                           type: string
                           enum:
-                          - Local
-                          - Cluster
-                          description: Specifies whether the service routes external
-                            traffic to node-local or cluster-wide endpoints. `Cluster`
-                            may cause a second hop to another node and obscures the
-                            client source IP. `Local` avoids a second hop for LoadBalancer
-                            and Nodeport type services and preserves the client source
-                            IP (when supported by the infrastructure). If unspecified,
-                            Kubernetes will use `Cluster` as the default.
+                            - Local
+                            - Cluster
+                          description: Specifies whether the service routes external traffic to node-local or cluster-wide endpoints. `Cluster` may cause a second hop to another node and obscures the client source IP. `Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure). If unspecified, Kubernetes will use `Cluster` as the default.
                         loadBalancerSourceRanges:
                           type: array
                           items:
                             type: string
-                          description: A list of CIDR ranges (for example `10.0.0.0/8`
-                            or `130.211.204.1/32`) from which clients can connect
-                            to load balancer type listeners. If supported by the platform,
-                            traffic through the loadbalancer is restricted to the
-                            specified CIDR ranges. This field is applicable only for
-                            loadbalancer type services and is ignored if the cloud
-                            provider does not support the feature. For more information,
-                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
+                          description: A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients can connect to load balancer type listeners. If supported by the platform, traffic through the loadbalancer is restricted to the specified CIDR ranges. This field is applicable only for loadbalancer type services and is ignored if the cloud provider does not support the feature. For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
                       description: Template for Kafka external bootstrap `Service`.
                     perPodService:
                       type: object
@@ -1947,42 +1591,23 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                         externalTrafficPolicy:
                           type: string
                           enum:
-                          - Local
-                          - Cluster
-                          description: Specifies whether the service routes external
-                            traffic to node-local or cluster-wide endpoints. `Cluster`
-                            may cause a second hop to another node and obscures the
-                            client source IP. `Local` avoids a second hop for LoadBalancer
-                            and Nodeport type services and preserves the client source
-                            IP (when supported by the infrastructure). If unspecified,
-                            Kubernetes will use `Cluster` as the default.
+                            - Local
+                            - Cluster
+                          description: Specifies whether the service routes external traffic to node-local or cluster-wide endpoints. `Cluster` may cause a second hop to another node and obscures the client source IP. `Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure). If unspecified, Kubernetes will use `Cluster` as the default.
                         loadBalancerSourceRanges:
                           type: array
                           items:
                             type: string
-                          description: A list of CIDR ranges (for example `10.0.0.0/8`
-                            or `130.211.204.1/32`) from which clients can connect
-                            to load balancer type listeners. If supported by the platform,
-                            traffic through the loadbalancer is restricted to the
-                            specified CIDR ranges. This field is applicable only for
-                            loadbalancer type services and is ignored if the cloud
-                            provider does not support the feature. For more information,
-                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
-                      description: Template for Kafka per-pod `Services` used for
-                        access from outside of Kubernetes.
+                          description: A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients can connect to load balancer type listeners. If supported by the platform, traffic through the loadbalancer is restricted to the specified CIDR ranges. This field is applicable only for loadbalancer type services and is ignored if the cloud provider does not support the feature. For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
+                      description: Template for Kafka per-pod `Services` used for access from outside of Kubernetes.
                     externalBootstrapRoute:
                       type: object
                       properties:
@@ -1991,15 +1616,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka external bootstrap `Route`.
                     perPodRoute:
@@ -2010,18 +1630,12 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
-                      description: Template for Kafka per-pod `Routes` used for access
-                        from outside of OpenShift.
+                      description: Template for Kafka per-pod `Routes` used for access from outside of OpenShift.
                     externalBootstrapIngress:
                       type: object
                       properties:
@@ -2030,15 +1644,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka external bootstrap `Ingress`.
                     perPodIngress:
@@ -2049,18 +1658,12 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
-                      description: Template for Kafka per-pod `Ingress` used for access
-                        from outside of Kubernetes.
+                      description: Template for Kafka per-pod `Ingress` used for access from outside of Kubernetes.
                     persistentVolumeClaim:
                       type: object
                       properties:
@@ -2069,15 +1672,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for all Kafka `PersistentVolumeClaims`.
                     podDisruptionBudget:
@@ -2088,26 +1686,15 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
-                          description: Metadata to apply to the `PodDistruptionBugetTemplate`
-                            resource.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Metadata to apply to the `PodDistruptionBugetTemplate` resource.
                         maxUnavailable:
                           type: integer
                           minimum: 0
-                          description: Maximum number of unavailable pods to allow
-                            automatic Pod eviction. A Pod eviction is allowed when
-                            the `maxUnavailable` number of pods or fewer are unavailable
-                            after the eviction. Setting this value to 0 prevents all
-                            voluntary evictions, so the pods must be evicted manually.
-                            Defaults to 1.
+                          description: Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
                       description: Template for Kafka `PodDisruptionBudget`.
                     kafkaContainer:
                       type: object
@@ -2123,8 +1710,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -2187,8 +1773,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -2251,8 +1836,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -2301,18 +1885,14 @@ spec:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Kafka init container.
-                  description: Template for Kafka cluster resources. The template
-                    allows users to specify how are the `StatefulSet`, `Pods` and
-                    `Services` generated.
+                  description: Template for Kafka cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
                 version:
                   type: string
-                  description: The kafka broker version. Defaults to {DefaultKafkaVersion}.
-                    Consult the user documentation to understand the process required
-                    to upgrade or downgrade the version.
+                  description: The kafka broker version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
               required:
-              - replicas
-              - storage
-              - listeners
+                - replicas
+                - storage
+                - listeners
               description: Configuration of the Kafka cluster.
             zookeeper:
               type: object
@@ -2332,13 +1912,11 @@ spec:
                       description: The storage class to use for dynamic volume allocation.
                     deleteClaim:
                       type: boolean
-                      description: Specifies if the persistent volume claim has to
-                        be deleted when the cluster is un-deployed.
+                      description: Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
                     id:
                       type: integer
                       minimum: 0
-                      description: Storage identification number. It is mandatory
-                        only for storage volumes defined in a storage of type 'jbod'.
+                      description: Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
                     overrides:
                       type: array
                       items:
@@ -2346,48 +1924,33 @@ spec:
                         properties:
                           class:
                             type: string
-                            description: The storage class to use for dynamic volume
-                              allocation for this broker.
+                            description: The storage class to use for dynamic volume allocation for this broker.
                           broker:
                             type: integer
                             description: Id of the kafka broker (broker identifier).
-                      description: Overrides for individual brokers. The `overrides`
-                        field allows to specify a different configuration for different
-                        brokers.
+                      description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                     selector:
                       type: object
-                      description: Specifies a specific persistent volume to use.
-                        It contains key:value pairs representing labels for selecting
-                        such a volume.
+                      description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                     size:
                       type: string
-                      description: When type=persistent-claim, defines the size of
-                        the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
+                      description: When type=persistent-claim, defines the size of the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
                     sizeLimit:
                       type: string
                       pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                      description: When type=ephemeral, defines the total amount of
-                        local storage required for this EmptyDir volume (for example
-                        1Gi).
+                      description: When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi).
                     type:
                       type: string
                       enum:
-                      - ephemeral
-                      - persistent-claim
+                        - ephemeral
+                        - persistent-claim
                       description: Storage type, must be either 'ephemeral' or 'persistent-claim'.
                   required:
-                  - type
+                    - type
                   description: Storage configuration (disk). Cannot be updated.
                 config:
                   type: object
-                  description: 'The ZooKeeper broker config. Properties with the following
-                    prefixes cannot be set: server., dataDir, dataLogDir, clientPort,
-                    authProvider, quorum.auth, requireClientAuthScheme, snapshot.trust.empty,
-                    standaloneEnabled, reconfigEnabled, 4lw.commands.whitelist, secureClientPort,
-                    ssl., serverCnxnFactory, sslQuorum (with the exception of: ssl.protocol,
-                    ssl.quorum.protocol, ssl.enabledProtocols, ssl.quorum.enabledProtocols,
-                    ssl.ciphersuites, ssl.quorum.ciphersuites, ssl.hostnameVerification,
-                    ssl.quorum.hostnameVerification).'
+                  description: 'The ZooKeeper broker config. Properties with the following prefixes cannot be set: server., dataDir, dataLogDir, clientPort, authProvider, quorum.auth, requireClientAuthScheme, snapshot.trust.empty, standaloneEnabled, reconfigEnabled, 4lw.commands.whitelist, secureClientPort, ssl., serverCnxnFactory, sslQuorum (with the exception of: ssl.protocol, ssl.quorum.protocol, ssl.enabledProtocols, ssl.quorum.enabledProtocols, ssl.ciphersuites, ssl.quorum.ciphersuites, ssl.hostnameVerification, ssl.quorum.hostnameVerification).'
                 affinity:
                   type: object
                   properties:
@@ -2618,23 +2181,17 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -2645,23 +2202,17 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -2683,8 +2234,7 @@ spec:
                       description: -Xmx option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
-                      description: Specifies whether the Garbage Collection logging
-                        is enabled. The default is false.
+                      description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                     javaSystemProperties:
                       type: array
                       items:
@@ -2696,8 +2246,7 @@ spec:
                           value:
                             type: string
                             description: The system property value.
-                      description: A map of additional system properties which will
-                        be passed using the `-D` option to the JVM.
+                      description: A map of additional system properties which will be passed using the `-D` option to the JVM.
                   description: JVM Options for pods.
                 resources:
                   type: object
@@ -2709,8 +2258,7 @@ spec:
                   description: CPU and memory resources to reserve.
                 metrics:
                   type: object
-                  description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
-                    for details of the structure of this configuration.
+                  description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
                 logging:
                   type: object
                   properties:
@@ -2719,16 +2267,15 @@ spec:
                       description: A Map from logger name to logger level.
                     name:
                       type: string
-                      description: The name of the `ConfigMap` from which to get the
-                        logging configuration.
+                      description: The name of the `ConfigMap` from which to get the logging configuration.
                     type:
                       type: string
                       enum:
-                      - inline
-                      - external
+                        - inline
+                        - external
                       description: Logging type, must be either 'inline' or 'external'.
                   required:
-                  - type
+                    - type
                   description: Logging configuration for ZooKeeper.
                 template:
                   type: object
@@ -2741,24 +2288,17 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                         podManagementPolicy:
                           type: string
                           enum:
-                          - OrderedReady
-                          - Parallel
-                          description: PodManagementPolicy which will be used for
-                            this StatefulSet. Valid values are `Parallel` and `OrderedReady`.
-                            Defaults to `Parallel`.
+                            - OrderedReady
+                            - Parallel
+                          description: PodManagementPolicy which will be used for this StatefulSet. Valid values are `Parallel` and `OrderedReady`. Defaults to `Parallel`.
                       description: Template for ZooKeeper `StatefulSet`.
                     pod:
                       type: object
@@ -2768,15 +2308,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -2785,8 +2320,7 @@ spec:
                             properties:
                               name:
                                 type: string
-                          description: List of references to secrets in the same namespace
-                            to use for pulling any of the images used by this Pod.
+                          description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -2829,18 +2363,11 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
-                          description: Configures pod-level security attributes and
-                            common container settings.
+                          description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
-                          description: The grace period is the duration in seconds
-                            after the processes running in the pod are sent a termination
-                            signal and the time when the processes are forcibly halted
-                            with a kill signal. Set this value longer than the expected
-                            cleanup time for your process.Value must be non-negative
-                            integer. The value zero indicates delete immediately.
-                            Defaults to 30 seconds.
+                          description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -3052,13 +2579,10 @@ spec:
                           description: The pod's affinity rules.
                         priorityClassName:
                           type: string
-                          description: The name of the Priority Class to which these
-                            pods will be assigned.
+                          description: The name of the Priority Class to which these pods will be assigned.
                         schedulerName:
                           type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -3084,15 +2608,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for ZooKeeper client `Service`.
                     nodesService:
@@ -3103,15 +2622,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for ZooKeeper nodes `Service`.
                     persistentVolumeClaim:
@@ -3122,15 +2636,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for all ZooKeeper `PersistentVolumeClaims`.
                     podDisruptionBudget:
@@ -3141,26 +2650,15 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
-                          description: Metadata to apply to the `PodDistruptionBugetTemplate`
-                            resource.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Metadata to apply to the `PodDistruptionBugetTemplate` resource.
                         maxUnavailable:
                           type: integer
                           minimum: 0
-                          description: Maximum number of unavailable pods to allow
-                            automatic Pod eviction. A Pod eviction is allowed when
-                            the `maxUnavailable` number of pods or fewer are unavailable
-                            after the eviction. Setting this value to 0 prevents all
-                            voluntary evictions, so the pods must be evicted manually.
-                            Defaults to 1.
+                          description: Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
                       description: Template for ZooKeeper `PodDisruptionBudget`.
                     zookeeperContainer:
                       type: object
@@ -3176,8 +2674,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -3240,8 +2737,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -3289,12 +2785,8 @@ spec:
                                 gmsaCredentialSpecName:
                                   type: string
                           description: Security context for the container.
-                      description: Template for the Zookeeper server TLS sidecar container.
-                        The TLS sidecar is not used anymore and this option will be
-                        ignored.
-                  description: Template for ZooKeeper cluster resources. The template
-                    allows users to specify how are the `StatefulSet`, `Pods` and
-                    `Services` generated.
+                      description: Template for the Zookeeper server TLS sidecar container. The TLS sidecar is not used anymore and this option will be ignored.
+                  description: Template for ZooKeeper cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
                 tlsSidecar:
                   type: object
                   properties:
@@ -3306,23 +2798,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -3331,38 +2817,31 @@ spec:
                     logLevel:
                       type: string
                       enum:
-                      - emerg
-                      - alert
-                      - crit
-                      - err
-                      - warning
-                      - notice
-                      - info
-                      - debug
-                      description: The log level for the TLS sidecar. Default value
-                        is `notice`.
+                        - emerg
+                        - alert
+                        - crit
+                        - err
+                        - warning
+                        - notice
+                        - info
+                        - debug
+                      description: The log level for the TLS sidecar. Default value is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -3376,11 +2855,10 @@ spec:
                         requests:
                           type: object
                       description: CPU and memory resources to reserve.
-                  description: TLS sidecar configuration. The TLS sidecar is not used
-                    anymore and this option will be ignored.
+                  description: TLS sidecar configuration. The TLS sidecar is not used anymore and this option will be ignored.
               required:
-              - replicas
-              - storage
+                - replicas
+                - storage
               description: Configuration of the ZooKeeper cluster.
             topicOperator:
               type: object
@@ -3631,23 +3109,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -3656,38 +3128,31 @@ spec:
                     logLevel:
                       type: string
                       enum:
-                      - emerg
-                      - alert
-                      - crit
-                      - err
-                      - warning
-                      - notice
-                      - info
-                      - debug
-                      description: The log level for the TLS sidecar. Default value
-                        is `notice`.
+                        - emerg
+                        - alert
+                        - crit
+                        - err
+                        - warning
+                        - notice
+                        - info
+                        - debug
+                      description: The log level for the TLS sidecar. Default value is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -3710,16 +3175,15 @@ spec:
                       description: A Map from logger name to logger level.
                     name:
                       type: string
-                      description: The name of the `ConfigMap` from which to get the
-                        logging configuration.
+                      description: The name of the `ConfigMap` from which to get the logging configuration.
                     type:
                       type: string
                       enum:
-                      - inline
-                      - external
+                        - inline
+                        - external
                       description: Logging type, must be either 'inline' or 'external'.
                   required:
-                  - type
+                    - type
                   description: Logging configuration.
                 jvmOptions:
                   type: object
@@ -3737,8 +3201,7 @@ spec:
                       description: -Xmx option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
-                      description: Specifies whether the Garbage Collection logging
-                        is enabled. The default is false.
+                      description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                     javaSystemProperties:
                       type: array
                       items:
@@ -3750,31 +3213,24 @@ spec:
                           value:
                             type: string
                             description: The system property value.
-                      description: A map of additional system properties which will
-                        be passed using the `-D` option to the JVM.
+                      description: A map of additional system properties which will be passed using the `-D` option to the JVM.
                   description: JVM Options for pods.
                 livenessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -3785,23 +3241,17 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -3833,23 +3283,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -3860,23 +3304,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -3902,16 +3340,15 @@ spec:
                           description: A Map from logger name to logger level.
                         name:
                           type: string
-                          description: The name of the `ConfigMap` from which to get
-                            the logging configuration.
+                          description: The name of the `ConfigMap` from which to get the logging configuration.
                         type:
                           type: string
                           enum:
-                          - inline
-                          - external
+                            - inline
+                            - external
                           description: Logging type, must be either 'inline' or 'external'.
                       required:
-                      - type
+                        - type
                       description: Logging configuration.
                     jvmOptions:
                       type: object
@@ -3929,8 +3366,7 @@ spec:
                           description: -Xmx option to to the JVM.
                         gcLoggingEnabled:
                           type: boolean
-                          description: Specifies whether the Garbage Collection logging
-                            is enabled. The default is false.
+                          description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                         javaSystemProperties:
                           type: array
                           items:
@@ -3942,8 +3378,7 @@ spec:
                               value:
                                 type: string
                                 description: The system property value.
-                          description: A map of additional system properties which
-                            will be passed using the `-D` option to the JVM.
+                          description: A map of additional system properties which will be passed using the `-D` option to the JVM.
                       description: JVM Options for pods.
                   description: Configuration of the Topic Operator.
                 userOperator:
@@ -3968,23 +3403,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -3995,23 +3424,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -4033,16 +3456,15 @@ spec:
                           description: A Map from logger name to logger level.
                         name:
                           type: string
-                          description: The name of the `ConfigMap` from which to get
-                            the logging configuration.
+                          description: The name of the `ConfigMap` from which to get the logging configuration.
                         type:
                           type: string
                           enum:
-                          - inline
-                          - external
+                            - inline
+                            - external
                           description: Logging type, must be either 'inline' or 'external'.
                       required:
-                      - type
+                        - type
                       description: Logging configuration.
                     jvmOptions:
                       type: object
@@ -4060,8 +3482,7 @@ spec:
                           description: -Xmx option to to the JVM.
                         gcLoggingEnabled:
                           type: boolean
-                          description: Specifies whether the Garbage Collection logging
-                            is enabled. The default is false.
+                          description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                         javaSystemProperties:
                           type: array
                           items:
@@ -4073,8 +3494,7 @@ spec:
                               value:
                                 type: string
                                 description: The system property value.
-                          description: A map of additional system properties which
-                            will be passed using the `-D` option to the JVM.
+                          description: A map of additional system properties which will be passed using the `-D` option to the JVM.
                       description: JVM Options for pods.
                   description: Configuration of the User Operator.
                 affinity:
@@ -4313,23 +3733,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -4338,38 +3752,31 @@ spec:
                     logLevel:
                       type: string
                       enum:
-                      - emerg
-                      - alert
-                      - crit
-                      - err
-                      - warning
-                      - notice
-                      - info
-                      - debug
-                      description: The log level for the TLS sidecar. Default value
-                        is `notice`.
+                        - emerg
+                        - alert
+                        - crit
+                        - err
+                        - warning
+                        - notice
+                        - info
+                        - debug
+                      description: The log level for the TLS sidecar. Default value is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -4395,15 +3802,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Entity Operator `Deployment`.
                     pod:
@@ -4414,15 +3816,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -4431,8 +3828,7 @@ spec:
                             properties:
                               name:
                                 type: string
-                          description: List of references to secrets in the same namespace
-                            to use for pulling any of the images used by this Pod.
+                          description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -4475,18 +3871,11 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
-                          description: Configures pod-level security attributes and
-                            common container settings.
+                          description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
-                          description: The grace period is the duration in seconds
-                            after the processes running in the pod are sent a termination
-                            signal and the time when the processes are forcibly halted
-                            with a kill signal. Set this value longer than the expected
-                            cleanup time for your process.Value must be non-negative
-                            integer. The value zero indicates delete immediately.
-                            Defaults to 30 seconds.
+                          description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -4698,13 +4087,10 @@ spec:
                           description: The pod's affinity rules.
                         priorityClassName:
                           type: string
-                          description: The name of the Priority Class to which these
-                            pods will be assigned.
+                          description: The name of the Priority Class to which these pods will be assigned.
                         schedulerName:
                           type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -4736,8 +4122,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -4800,8 +4185,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -4864,8 +4248,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -4914,72 +4297,49 @@ spec:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Entity User Operator container.
-                  description: Template for Entity Operator resources. The template
-                    allows users to specify how is the `Deployment` and `Pods` generated.
+                  description: Template for Entity Operator resources. The template allows users to specify how is the `Deployment` and `Pods` generated.
               description: Configuration of the Entity Operator.
             clusterCa:
               type: object
               properties:
                 generateCertificateAuthority:
                   type: boolean
-                  description: If true then Certificate Authority certificates will
-                    be generated automatically. Otherwise the user will need to provide
-                    a Secret with the CA certificate. Default is true.
+                  description: If true then Certificate Authority certificates will be generated automatically. Otherwise the user will need to provide a Secret with the CA certificate. Default is true.
                 validityDays:
                   type: integer
                   minimum: 1
-                  description: The number of days generated certificates should be
-                    valid for. The default is 365.
+                  description: The number of days generated certificates should be valid for. The default is 365.
                 renewalDays:
                   type: integer
                   minimum: 1
-                  description: The number of days in the certificate renewal period.
-                    This is the number of days before the a certificate expires during
-                    which renewal actions may be performed. When `generateCertificateAuthority`
-                    is true, this will cause the generation of a new certificate.
-                    When `generateCertificateAuthority` is true, this will cause extra
-                    logging at WARN level about the pending certificate expiry. Default
-                    is 30.
+                  description: The number of days in the certificate renewal period. This is the number of days before the a certificate expires during which renewal actions may be performed. When `generateCertificateAuthority` is true, this will cause the generation of a new certificate. When `generateCertificateAuthority` is true, this will cause extra logging at WARN level about the pending certificate expiry. Default is 30.
                 certificateExpirationPolicy:
                   type: string
                   enum:
-                  - renew-certificate
-                  - replace-key
-                  description: How should CA certificate expiration be handled when
-                    `generateCertificateAuthority=true`. The default is for a new
-                    CA certificate to be generated reusing the existing private key.
+                    - renew-certificate
+                    - replace-key
+                  description: How should CA certificate expiration be handled when `generateCertificateAuthority=true`. The default is for a new CA certificate to be generated reusing the existing private key.
               description: Configuration of the cluster certificate authority.
             clientsCa:
               type: object
               properties:
                 generateCertificateAuthority:
                   type: boolean
-                  description: If true then Certificate Authority certificates will
-                    be generated automatically. Otherwise the user will need to provide
-                    a Secret with the CA certificate. Default is true.
+                  description: If true then Certificate Authority certificates will be generated automatically. Otherwise the user will need to provide a Secret with the CA certificate. Default is true.
                 validityDays:
                   type: integer
                   minimum: 1
-                  description: The number of days generated certificates should be
-                    valid for. The default is 365.
+                  description: The number of days generated certificates should be valid for. The default is 365.
                 renewalDays:
                   type: integer
                   minimum: 1
-                  description: The number of days in the certificate renewal period.
-                    This is the number of days before the a certificate expires during
-                    which renewal actions may be performed. When `generateCertificateAuthority`
-                    is true, this will cause the generation of a new certificate.
-                    When `generateCertificateAuthority` is true, this will cause extra
-                    logging at WARN level about the pending certificate expiry. Default
-                    is 30.
+                  description: The number of days in the certificate renewal period. This is the number of days before the a certificate expires during which renewal actions may be performed. When `generateCertificateAuthority` is true, this will cause the generation of a new certificate. When `generateCertificateAuthority` is true, this will cause extra logging at WARN level about the pending certificate expiry. Default is 30.
                 certificateExpirationPolicy:
                   type: string
                   enum:
-                  - renew-certificate
-                  - replace-key
-                  description: How should CA certificate expiration be handled when
-                    `generateCertificateAuthority=true`. The default is for a new
-                    CA certificate to be generated reusing the existing private key.
+                    - renew-certificate
+                    - replace-key
+                  description: How should CA certificate expiration be handled when `generateCertificateAuthority=true`. The default is for a new CA certificate to be generated reusing the existing private key.
               description: Configuration of the clients certificate authority.
             cruiseControl:
               type: object
@@ -4989,36 +4349,23 @@ spec:
                   description: The docker image for the pods.
                 config:
                   type: object
-                  description: 'The Cruise Control configuration. For a full list
-                    of configuration options refer to https://github.com/linkedin/cruise-control/wiki/Configurations.
-                    Note that properties with the following prefixes cannot be set:
-                    bootstrap.servers, client.id, zookeeper., network., security.,
-                    failed.brokers.zk.path,webserver.http., webserver.api.urlprefix,
-                    webserver.session.path, webserver.accesslog., two.step., request.reason.required,metric.reporter.sampler.bootstrap.servers,
-                    metric.reporter.topic, partition.metric.sample.store.topic, broker.metric.sample.store.topic,capacity.config.file,
-                    self.healing., anomaly.detection., ssl.'
+                  description: 'The Cruise Control configuration. For a full list of configuration options refer to https://github.com/linkedin/cruise-control/wiki/Configurations. Note that properties with the following prefixes cannot be set: bootstrap.servers, client.id, zookeeper., network., security., failed.brokers.zk.path,webserver.http., webserver.api.urlprefix, webserver.session.path, webserver.accesslog., two.step., request.reason.required,metric.reporter.sampler.bootstrap.servers, metric.reporter.topic, partition.metric.sample.store.topic, broker.metric.sample.store.topic,capacity.config.file, self.healing., anomaly.detection., ssl.'
                 livenessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -5029,23 +4376,17 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -5067,8 +4408,7 @@ spec:
                       description: -Xmx option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
-                      description: Specifies whether the Garbage Collection logging
-                        is enabled. The default is false.
+                      description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                     javaSystemProperties:
                       type: array
                       items:
@@ -5080,8 +4420,7 @@ spec:
                           value:
                             type: string
                             description: The system property value.
-                      description: A map of additional system properties which will
-                        be passed using the `-D` option to the JVM.
+                      description: A map of additional system properties which will be passed using the `-D` option to the JVM.
                   description: JVM Options for the Cruise Control container.
                 resources:
                   type: object
@@ -5090,8 +4429,7 @@ spec:
                       type: object
                     requests:
                       type: object
-                  description: CPU and memory resources to reserve for the Cruise
-                    Control container.
+                  description: CPU and memory resources to reserve for the Cruise Control container.
                 logging:
                   type: object
                   properties:
@@ -5100,16 +4438,15 @@ spec:
                       description: A Map from logger name to logger level.
                     name:
                       type: string
-                      description: The name of the `ConfigMap` from which to get the
-                        logging configuration.
+                      description: The name of the `ConfigMap` from which to get the logging configuration.
                     type:
                       type: string
                       enum:
-                      - inline
-                      - external
+                        - inline
+                        - external
                       description: Logging type, must be either 'inline' or 'external'.
                   required:
-                  - type
+                    - type
                   description: Logging configuration (log4j1) for Cruise Control.
                 tlsSidecar:
                   type: object
@@ -5122,23 +4459,17 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -5147,38 +4478,31 @@ spec:
                     logLevel:
                       type: string
                       enum:
-                      - emerg
-                      - alert
-                      - crit
-                      - err
-                      - warning
-                      - notice
-                      - info
-                      - debug
-                      description: The log level for the TLS sidecar. Default value
-                        is `notice`.
+                        - emerg
+                        - alert
+                        - crit
+                        - err
+                        - warning
+                        - notice
+                        - info
+                        - debug
+                      description: The log level for the TLS sidecar. Default value is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is
-                            first checked.
+                          description: The initial delay before first the health is first checked.
                         periodSeconds:
                           type: integer
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
@@ -5204,15 +4528,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Cruise Control `Deployment`.
                     pod:
@@ -5223,15 +4542,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -5240,8 +4554,7 @@ spec:
                             properties:
                               name:
                                 type: string
-                          description: List of references to secrets in the same namespace
-                            to use for pulling any of the images used by this Pod.
+                          description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -5284,18 +4597,11 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
-                          description: Configures pod-level security attributes and
-                            common container settings.
+                          description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
-                          description: The grace period is the duration in seconds
-                            after the processes running in the pod are sent a termination
-                            signal and the time when the processes are forcibly halted
-                            with a kill signal. Set this value longer than the expected
-                            cleanup time for your process.Value must be non-negative
-                            integer. The value zero indicates delete immediately.
-                            Defaults to 30 seconds.
+                          description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -5507,13 +4813,10 @@ spec:
                           description: The pod's affinity rules.
                         priorityClassName:
                           type: string
-                          description: The name of the Priority Class to which these
-                            pods will be assigned.
+                          description: The name of the Priority Class to which these pods will be assigned.
                         schedulerName:
                           type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -5539,15 +4842,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Cruise Control API `Service`.
                     podDisruptionBudget:
@@ -5558,26 +4856,15 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
-                          description: Metadata to apply to the `PodDistruptionBugetTemplate`
-                            resource.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Metadata to apply to the `PodDistruptionBugetTemplate` resource.
                         maxUnavailable:
                           type: integer
                           minimum: 0
-                          description: Maximum number of unavailable pods to allow
-                            automatic Pod eviction. A Pod eviction is allowed when
-                            the `maxUnavailable` number of pods or fewer are unavailable
-                            after the eviction. Setting this value to 0 prevents all
-                            voluntary evictions, so the pods must be evicted manually.
-                            Defaults to 1.
+                          description: Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
                       description: Template for Cruise Control `PodDisruptionBudget`.
                     cruiseControlContainer:
                       type: object
@@ -5593,8 +4880,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -5657,8 +4943,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -5707,35 +4992,29 @@ spec:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Cruise Control TLS sidecar container.
-                  description: Template to specify how Cruise Control resources, `Deployments`
-                    and `Pods`, are generated.
+                  description: Template to specify how Cruise Control resources, `Deployments` and `Pods`, are generated.
                 brokerCapacity:
                   type: object
                   properties:
                     disk:
                       type: string
                       pattern: ^[0-9]+([.][0-9]*)?([KMGTPE]i?|e[0-9]+)?$
-                      description: Broker capacity for disk in bytes, for example,
-                        100Gi.
+                      description: Broker capacity for disk in bytes, for example, 100Gi.
                     cpuUtilization:
                       type: integer
                       minimum: 0
                       maximum: 100
-                      description: Broker capacity for CPU resource utilization as
-                        a percentage (0 - 100).
+                      description: Broker capacity for CPU resource utilization as a percentage (0 - 100).
                     inboundNetwork:
                       type: string
                       pattern: '[0-9]+([KMG]i?)?B/s'
-                      description: Broker capacity for inbound network throughput
-                        in bytes per second, for example, 10000KB/s.
+                      description: Broker capacity for inbound network throughput in bytes per second, for example, 10000KB/s.
                     outboundNetwork:
                       type: string
                       pattern: '[0-9]+([KMG]i?)?B/s'
-                      description: Broker capacity for outbound network throughput
-                        in bytes per second, for example 10000KB/s.
+                      description: Broker capacity for outbound network throughput in bytes per second, for example 10000KB/s.
                   description: The Cruise Control `brokerCapacity` configuration.
-              description: Configuration for Cruise Control deployment. Deploys a
-                Cruise Control instance when specified.
+              description: Configuration for Cruise Control deployment. Deploys a Cruise Control instance when specified.
             jmxTrans:
               type: object
               properties:
@@ -5749,44 +5028,31 @@ spec:
                     properties:
                       outputType:
                         type: string
-                        description: Template for setting the format of the data that
-                          will be pushed.For more information see https://github.com/jmxtrans/jmxtrans/wiki/OutputWriters[JmxTrans
-                          OutputWriters].
+                        description: Template for setting the format of the data that will be pushed.For more information see https://github.com/jmxtrans/jmxtrans/wiki/OutputWriters[JmxTrans OutputWriters].
                       host:
                         type: string
-                        description: The DNS/hostname of the remote host that the
-                          data is pushed to.
+                        description: The DNS/hostname of the remote host that the data is pushed to.
                       port:
                         type: integer
-                        description: The port of the remote host that the data is
-                          pushed to.
+                        description: The port of the remote host that the data is pushed to.
                       flushDelayInSeconds:
                         type: integer
-                        description: How many seconds the JmxTrans waits before pushing
-                          a new set of data out.
+                        description: How many seconds the JmxTrans waits before pushing a new set of data out.
                       typeNames:
                         type: array
                         items:
                           type: string
-                        description: Template for filtering data to be included in
-                          response to a wildcard query. For more information see https://github.com/jmxtrans/jmxtrans/wiki/Queries[JmxTrans
-                          queries].
+                        description: Template for filtering data to be included in response to a wildcard query. For more information see https://github.com/jmxtrans/jmxtrans/wiki/Queries[JmxTrans queries].
                       name:
                         type: string
-                        description: Template for setting the name of the output definition.
-                          This is used to identify where to send the results of queries
-                          should be sent.
+                        description: Template for setting the name of the output definition. This is used to identify where to send the results of queries should be sent.
                     required:
-                    - outputType
-                    - name
-                  description: Defines the output hosts that will be referenced later
-                    on. For more information on these properties see, xref:type-JmxTransOutputDefinitionTemplate-reference[`JmxTransOutputDefinitionTemplate`
-                    schema reference].
+                      - outputType
+                      - name
+                  description: Defines the output hosts that will be referenced later on. For more information on these properties see, xref:type-JmxTransOutputDefinitionTemplate-reference[`JmxTransOutputDefinitionTemplate` schema reference].
                 logLevel:
                   type: string
-                  description: Sets the logging level of the JmxTrans deployment.For
-                    more information see, https://github.com/jmxtrans/jmxtrans-agent/wiki/Troubleshooting[JmxTrans
-                    Logging Level].
+                  description: Sets the logging level of the JmxTrans deployment.For more information see, https://github.com/jmxtrans/jmxtrans-agent/wiki/Troubleshooting[JmxTrans Logging Level].
                 kafkaQueries:
                   type: array
                   items:
@@ -5794,31 +5060,22 @@ spec:
                     properties:
                       targetMBean:
                         type: string
-                        description: If using wildcards instead of a specific MBean
-                          then the data is gathered from multiple MBeans. Otherwise
-                          if specifying an MBean then data is gathered from that specified
-                          MBean.
+                        description: If using wildcards instead of a specific MBean then the data is gathered from multiple MBeans. Otherwise if specifying an MBean then data is gathered from that specified MBean.
                       attributes:
                         type: array
                         items:
                           type: string
-                        description: Determine which attributes of the targeted MBean
-                          should be included.
+                        description: Determine which attributes of the targeted MBean should be included.
                       outputs:
                         type: array
                         items:
                           type: string
-                        description: List of the names of output definitions specified
-                          in the spec.kafka.jmxTrans.outputDefinitions that have defined
-                          where JMX metrics are pushed to, and in which data format.
+                        description: List of the names of output definitions specified in the spec.kafka.jmxTrans.outputDefinitions that have defined where JMX metrics are pushed to, and in which data format.
                     required:
-                    - targetMBean
-                    - attributes
-                    - outputs
-                  description: Queries to send to the Kafka brokers to define what
-                    data should be read from each broker. For more information on
-                    these properties see, xref:type-JmxTransQueryTemplate-reference[`JmxTransQueryTemplate`
-                    schema reference].
+                      - targetMBean
+                      - attributes
+                      - outputs
+                  description: Queries to send to the Kafka brokers to define what data should be read from each broker. For more information on these properties see, xref:type-JmxTransQueryTemplate-reference[`JmxTransQueryTemplate` schema reference].
                 resources:
                   type: object
                   properties:
@@ -5838,15 +5095,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for JmxTrans `Deployment`.
                     pod:
@@ -5857,15 +5109,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -5874,8 +5121,7 @@ spec:
                             properties:
                               name:
                                 type: string
-                          description: List of references to secrets in the same namespace
-                            to use for pulling any of the images used by this Pod.
+                          description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -5918,18 +5164,11 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
-                          description: Configures pod-level security attributes and
-                            common container settings.
+                          description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
-                          description: The grace period is the duration in seconds
-                            after the processes running in the pod are sent a termination
-                            signal and the time when the processes are forcibly halted
-                            with a kill signal. Set this value longer than the expected
-                            cleanup time for your process.Value must be non-negative
-                            integer. The value zero indicates delete immediately.
-                            Defaults to 30 seconds.
+                          description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -6141,13 +5380,10 @@ spec:
                           description: The pod's affinity rules.
                         priorityClassName:
                           type: string
-                          description: The name of the Priority Class to which these
-                            pods will be assigned.
+                          description: The name of the Priority Class to which these pods will be assigned.
                         schedulerName:
                           type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -6179,8 +5415,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -6231,12 +5466,9 @@ spec:
                       description: Template for JmxTrans container.
                   description: Template for JmxTrans resources.
               required:
-              - outputDefinitions
-              - kafkaQueries
-              description: Configuration for JmxTrans. When the property is present
-                a JmxTrans deployment is created for gathering JMX metrics from each
-                Kafka broker. For more information see https://github.com/jmxtrans/jmxtrans[JmxTrans
-                GitHub].
+                - outputDefinitions
+                - kafkaQueries
+              description: Configuration for JmxTrans. When the property is present a JmxTrans deployment is created for gathering JMX metrics from each Kafka broker. For more information see https://github.com/jmxtrans/jmxtrans[JmxTrans GitHub].
             kafkaExporter:
               type: object
               properties:
@@ -6245,12 +5477,10 @@ spec:
                   description: The docker image for the pods.
                 groupRegex:
                   type: string
-                  description: Regular expression to specify which consumer groups
-                    to collect. Default value is `.*`.
+                  description: Regular expression to specify which consumer groups to collect. Default value is `.*`.
                 topicRegex:
                   type: string
-                  description: Regular expression to specify which topics to collect.
-                    Default value is `.*`.
+                  description: Regular expression to specify which topics to collect. Default value is `.*`.
                 resources:
                   type: object
                   properties:
@@ -6261,13 +5491,10 @@ spec:
                   description: CPU and memory resources to reserve.
                 logging:
                   type: string
-                  description: 'Only log messages with the given severity or above.
-                    Valid levels: [`debug`, `info`, `warn`, `error`, `fatal`]. Default
-                    log level is `info`.'
+                  description: 'Only log messages with the given severity or above. Valid levels: [`debug`, `info`, `warn`, `error`, `fatal`]. Default log level is `info`.'
                 enableSaramaLogging:
                   type: boolean
-                  description: Enable Sarama logging, a Go client library used by
-                    the Kafka Exporter.
+                  description: Enable Sarama logging, a Go client library used by the Kafka Exporter.
                 template:
                   type: object
                   properties:
@@ -6279,15 +5506,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka Exporter `Deployment`.
                     pod:
@@ -6298,15 +5520,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
@@ -6315,8 +5532,7 @@ spec:
                             properties:
                               name:
                                 type: string
-                          description: List of references to secrets in the same namespace
-                            to use for pulling any of the images used by this Pod.
+                          description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -6359,18 +5575,11 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
-                          description: Configures pod-level security attributes and
-                            common container settings.
+                          description: Configures pod-level security attributes and common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
-                          description: The grace period is the duration in seconds
-                            after the processes running in the pod are sent a termination
-                            signal and the time when the processes are forcibly halted
-                            with a kill signal. Set this value longer than the expected
-                            cleanup time for your process.Value must be non-negative
-                            integer. The value zero indicates delete immediately.
-                            Defaults to 30 seconds.
+                          description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -6582,13 +5791,10 @@ spec:
                           description: The pod's affinity rules.
                         priorityClassName:
                           type: string
-                          description: The name of the Priority Class to which these
-                            pods will be assigned.
+                          description: The name of the Priority Class to which these pods will be assigned.
                         schedulerName:
                           type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -6614,15 +5820,10 @@ spec:
                           properties:
                             labels:
                               type: object
-                              description: Labels which should be added to the resource
-                                template. Can be applied to different resources such
-                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
-                              description: Annotations which should be added to the
-                                resource template. Can be applied to different resources
-                                such as `StatefulSets`, `Deployments`, `Pods`, and
-                                `Services`.
+                              description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata which should be applied to the resource.
                       description: Template for Kafka Exporter `Service`.
                     container:
@@ -6639,8 +5840,7 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
-                          description: Environment variables which should be applied
-                            to the container.
+                          description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
                           properties:
@@ -6695,23 +5895,17 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
@@ -6722,41 +5916,32 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first
-                        checked.
+                      description: The initial delay before first the health is first checked.
                     periodSeconds:
                       type: integer
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
-                      description: Minimum consecutive successes for the probe to
-                        be considered successful after having failed. Defaults to
-                        1. Must be 1 for liveness. Minimum value is 1.
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
                       description: The timeout for each attempted health check.
                   description: Pod readiness check.
-              description: Configuration of the Kafka Exporter. Kafka Exporter can
-                provide additional metrics, for example lag of consumer group at topic/partition.
+              description: Configuration of the Kafka Exporter. Kafka Exporter can provide additional metrics, for example lag of consumer group at topic/partition.
             maintenanceTimeWindows:
               type: array
               items:
                 type: string
-              description: A list of time windows for maintenance tasks (that is,
-                certificates renewal). Each time window is defined by a cron expression.
+              description: A list of time windows for maintenance tasks (that is, certificates renewal). Each time window is defined by a cron expression.
           required:
-          - kafka
-          - zookeeper
-          description: The specification of the Kafka and ZooKeeper clusters, and
-            Topic Operator.
+            - kafka
+            - zookeeper
+          description: The specification of the Kafka and ZooKeeper clusters, and Topic Operator.
         status:
           type: object
           properties:
@@ -6767,30 +5952,23 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             listeners:
               type: array
               items:
@@ -6798,8 +5976,7 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: 'The type of the listener. Can be one of the following
-                      three types: `plain`, `tls`, and `external`.'
+                    description: 'The type of the listener. Can be one of the following three types: `plain`, `tls`, and `external`.'
                   addresses:
                     type: array
                     items:
@@ -6807,22 +5984,18 @@ spec:
                       properties:
                         host:
                           type: string
-                          description: The DNS name or IP address of the Kafka bootstrap
-                            service.
+                          description: The DNS name or IP address of the Kafka bootstrap service.
                         port:
                           type: integer
                           description: The port of the Kafka bootstrap service.
                     description: A list of the addresses for this listener.
                   bootstrapServers:
                     type: string
-                    description: A comma-separated list of `host:port` pairs for connecting
-                      to the Kafka cluster using this listener.
+                    description: A comma-separated list of `host:port` pairs for connecting to the Kafka cluster using this listener.
                   certificates:
                     type: array
                     items:
                       type: string
-                    description: A list of TLS certificates which can be used to verify
-                      the identity of the server when connecting to the given listener.
-                      Set only for `tls` and `external` listeners.
+                    description: A list of TLS certificates which can be used to verify the identity of the server when connecting to the given listener. Set only for `tls` and `external` listeners.
               description: Addresses of the internal and external listeners.
           description: The status of the Kafka and ZooKeeper clusters, and Topic Operator.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -9,12 +9,12 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
-  - name: v1alpha1
-    served: true
-    storage: false
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   version: v1beta1
   scope: Namespaced
   names:
@@ -23,14 +23,14 @@ spec:
     singular: kafkaconnect
     plural: kafkaconnects
     shortNames:
-    - kc
+      - kc
     categories:
-    - strimzi
+      - strimzi
   additionalPrinterColumns:
-  - name: Desired replicas
-    description: The desired number of Kafka Connect replicas
-    JSONPath: .spec.replicas
-    type: integer
+    - name: Desired replicas
+      description: The desired number of Kafka Connect replicas
+      JSONPath: .spec.replicas
+      type: integer
   subresources:
     status: {}
     scale:
@@ -48,16 +48,13 @@ spec:
               description: The number of pods in the Kafka Connect group.
             version:
               type: string
-              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}.
-                Consult the user documentation to understand the process required
-                to upgrade or downgrade the version.
+              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
             image:
               type: string
               description: The docker image for the pods.
             bootstrapServers:
               type: string
-              description: Bootstrap servers to connect to. This should be given as
-                a comma separated list of _<hostname>_:‍_<port>_ pairs.
+              description: Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
             tls:
               type: object
               properties:
@@ -73,8 +70,8 @@ spec:
                         type: string
                         description: The name of the Secret containing the certificate.
                     required:
-                    - certificate
-                    - secretName
+                      - certificate
+                      - secretName
                   description: Trusted certificates for TLS connection.
               description: TLS configuration.
             authentication:
@@ -85,22 +82,17 @@ spec:
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the access token
-                    which was obtained from the authorization server.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
                 accessTokenIsJwt:
                   type: boolean
-                  description: Configure whether access token should be treated as
-                    JWT. This should be set to `false` if the authorization server
-                    returns opaque tokens. Defaults to `true`.
+                  description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                 certificateAndKey:
                   type: object
                   properties:
@@ -114,79 +106,61 @@ spec:
                       type: string
                       description: The name of the Secret containing the certificate.
                   required:
-                  - certificate
-                  - key
-                  - secretName
-                  description: Reference to the `Secret` which holds the certificate
-                    and private key pair.
+                    - certificate
+                    - key
+                    - secretName
+                  description: Reference to the `Secret` which holds the certificate and private key pair.
                 clientId:
                   type: string
-                  description: OAuth Client ID which the Kafka client can use to authenticate
-                    against the OAuth server and use the token endpoint URI.
+                  description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                 clientSecret:
                   type: object
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the OAuth client
-                    secret which the Kafka client can use to authenticate against
-                    the OAuth server and use the token endpoint URI.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                 disableTlsHostnameVerification:
                   type: boolean
-                  description: Enable or disable TLS hostname verification. Default
-                    value is `false`.
+                  description: Enable or disable TLS hostname verification. Default value is `false`.
                 maxTokenExpirySeconds:
                   type: integer
-                  description: Set or limit time-to-live of the access tokens to the
-                    specified number of seconds. This should be set if the authorization
-                    server returns opaque tokens.
+                  description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
                 passwordSecret:
                   type: object
                   properties:
                     password:
                       type: string
-                      description: The name of the key in the Secret under which the
-                        password is stored.
+                      description: The name of the key in the Secret under which the password is stored.
                     secretName:
                       type: string
                       description: The name of the Secret containing the password.
                   required:
-                  - password
-                  - secretName
+                    - password
+                    - secretName
                   description: Reference to the `Secret` which holds the password.
                 refreshToken:
                   type: object
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the refresh token
-                    which can be used to obtain access token from the authorization
-                    server.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
                 scope:
                   type: string
-                  description: OAuth scope to use when authenticating against the
-                    authorization server. Some authorization servers require this
-                    to be set. The possible values depend on how authorization server
-                    is configured. By default `scope` is not specified when doing
-                    the token endpoint request.
+                  description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
                 tlsTrustedCertificates:
                   type: array
                   items:
@@ -199,39 +173,29 @@ spec:
                         type: string
                         description: The name of the Secret containing the certificate.
                     required:
-                    - certificate
-                    - secretName
-                  description: Trusted certificates for TLS connection to the OAuth
-                    server.
+                      - certificate
+                      - secretName
+                  description: Trusted certificates for TLS connection to the OAuth server.
                 tokenEndpointUri:
                   type: string
                   description: Authorization server token endpoint URI.
                 type:
                   type: string
                   enum:
-                  - tls
-                  - scram-sha-512
-                  - plain
-                  - oauth
-                  description: Authentication type. Currently the only supported types
-                    are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type
-                    uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL
-                    PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication.
-                    The `tls` type uses TLS Client Authentication. The `tls` type
-                    is supported only over TLS connections.
+                    - tls
+                    - scram-sha-512
+                    - plain
+                    - oauth
+                  description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                 username:
                   type: string
                   description: Username used for the authentication.
               required:
-              - type
+                - type
               description: Authentication configuration for Kafka Connect.
             config:
               type: object
-              description: 'The Kafka Connect configuration. Properties with the following
-                prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
-                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes
-                (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites,
-                ssl.protocol, ssl.enabled.protocols).'
+              description: 'The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
             resources:
               type: object
               properties:
@@ -239,30 +203,23 @@ spec:
                   type: object
                 requests:
                   type: object
-              description: The maximum limits for CPU and memory resources and the
-                requested initial resources.
+              description: The maximum limits for CPU and memory resources and the requested initial resources.
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -273,23 +230,17 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -311,8 +262,7 @@ spec:
                   description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
-                  description: Specifies whether the Garbage Collection logging is
-                    enabled. The default is false.
+                  description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -324,8 +274,7 @@ spec:
                       value:
                         type: string
                         description: The system property value.
-                  description: A map of additional system properties which will be
-                    passed using the `-D` option to the JVM.
+                  description: A map of additional system properties which will be passed using the `-D` option to the JVM.
               description: JVM Options for pods.
             affinity:
               type: object
@@ -560,32 +509,29 @@ spec:
                   description: A Map from logger name to logger level.
                 name:
                   type: string
-                  description: The name of the `ConfigMap` from which to get the logging
-                    configuration.
+                  description: The name of the `ConfigMap` from which to get the logging configuration.
                 type:
                   type: string
                   enum:
-                  - inline
-                  - external
+                    - inline
+                    - external
                   description: Logging type, must be either 'inline' or 'external'.
               required:
-              - type
+                - type
               description: Logging configuration for Kafka Connect.
             metrics:
               type: object
-              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
-                for details of the structure of this configuration.
+              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
             tracing:
               type: object
               properties:
                 type:
                   type: string
                   enum:
-                  - jaeger
-                  description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing.
+                    - jaeger
+                  description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
               required:
-              - type
+                - type
               description: The configuration of tracing in Kafka Connect.
             template:
               type: object
@@ -598,14 +544,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
@@ -616,14 +558,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
@@ -632,8 +570,7 @@ spec:
                         properties:
                           name:
                             type: string
-                      description: List of references to secrets in the same namespace
-                        to use for pulling any of the images used by this Pod.
+                      description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -676,18 +613,11 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
-                      description: Configures pod-level security attributes and common
-                        container settings.
+                      description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
-                      description: The grace period is the duration in seconds after
-                        the processes running in the pod are sent a termination signal
-                        and the time when the processes are forcibly halted with a
-                        kill signal. Set this value longer than the expected cleanup
-                        time for your process.Value must be non-negative integer.
-                        The value zero indicates delete immediately. Defaults to 30
-                        seconds.
+                      description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                     affinity:
                       type: object
                       properties:
@@ -899,12 +829,10 @@ spec:
                       description: The pod's affinity rules.
                     priorityClassName:
                       type: string
-                      description: The name of the Priority Class to which these pods
-                        will be assigned.
+                      description: The name of the Priority Class to which these pods will be assigned.
                     schedulerName:
                       type: string
-                      description: The name of the scheduler used to dispatch this
-                        `Pod`. If not specified, the default scheduler will be used.
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -930,14 +858,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect API `Service`.
                 connectContainer:
@@ -954,8 +878,7 @@ spec:
                           value:
                             type: string
                             description: The environment variable value.
-                      description: Environment variables which should be applied to
-                        the container.
+                      description: Environment variables which should be applied to the container.
                     securityContext:
                       type: object
                       properties:
@@ -1012,28 +935,17 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
-                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
-                        resource.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate` resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
-                      description: Maximum number of unavailable pods to allow automatic
-                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
-                        number of pods or fewer are unavailable after the eviction.
-                        Setting this value to 0 prevents all voluntary evictions,
-                        so the pods must be evicted manually. Defaults to 1.
+                      description: Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
                   description: Template for Kafka Connect `PodDisruptionBudget`.
-              description: Template for Kafka Connect and Kafka Connect S2I resources.
-                The template allows users to specify how the `Deployment`, `Pods`
-                and `Service` are generated.
+              description: Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
             externalConfiguration:
               type: object
               properties:
@@ -1044,9 +956,7 @@ spec:
                     properties:
                       name:
                         type: string
-                        description: Name of the environment variable which will be
-                          passed to the Kafka Connect pods. The name of the environment
-                          variable cannot start with `KAFKA_` or `STRIMZI_`.
+                        description: Name of the environment variable which will be passed to the Kafka Connect pods. The name of the environment variable cannot start with `KAFKA_` or `STRIMZI_`.
                       valueFrom:
                         type: object
                         properties:
@@ -1070,15 +980,11 @@ spec:
                               optional:
                                 type: boolean
                             description: Reference to a key in a Secret.
-                        description: Value of the environment variable which will
-                          be passed to the Kafka Connect pods. It can be passed either
-                          as a reference to Secret or ConfigMap field. The field has
-                          to specify exactly one Secret or ConfigMap.
+                        description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
                     required:
-                    - name
-                    - valueFrom
-                  description: Allows to pass data from Secret or ConfigMap to the
-                    Kafka Connect pods as environment variables.
+                      - name
+                      - valueFrom
+                  description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as environment variables.
                 volumes:
                   type: array
                   items:
@@ -1104,12 +1010,10 @@ spec:
                             type: string
                           optional:
                             type: boolean
-                        description: Reference to a key in a ConfigMap. Exactly one
-                          Secret or ConfigMap has to be specified.
+                        description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
                       name:
                         type: string
-                        description: Name of the volume which will be added to the
-                          Kafka Connect pods.
+                        description: Name of the volume which will be added to the Kafka Connect pods.
                       secret:
                         type: object
                         properties:
@@ -1130,16 +1034,13 @@ spec:
                             type: boolean
                           secretName:
                             type: string
-                        description: Reference to a key in a Secret. Exactly one Secret
-                          or ConfigMap has to be specified.
+                        description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
                     required:
-                    - name
-                  description: Allows to pass data from Secret or ConfigMap to the
-                    Kafka Connect pods as volumes.
-              description: Pass data from Secrets or ConfigMaps to the Kafka Connect
-                pods and use them to configure connectors.
+                      - name
+                  description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as volumes.
+              description: Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
           required:
-          - bootstrapServers
+            - bootstrapServers
           description: The specification of the Kafka Connect cluster.
         status:
           type: object
@@ -1151,34 +1052,26 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             url:
               type: string
-              description: The URL of the REST API endpoint for managing and monitoring
-                Kafka Connect connectors.
+              description: The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
             connectorPlugins:
               type: array
               items:
@@ -1186,16 +1079,14 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The type of the connector plugin. The available types
-                      are `sink` and `source`.
+                    description: The type of the connector plugin. The available types are `sink` and `source`.
                   version:
                     type: string
                     description: The version of the connector plugin.
                   class:
                     type: string
                     description: The class of the connector plugin.
-              description: The list of connector plugins available in this Kafka Connect
-                deployment.
+              description: The list of connector plugins available in this Kafka Connect deployment.
             podSelector:
               type: object
               properties:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -9,12 +9,12 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
-  - name: v1alpha1
-    served: true
-    storage: false
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   version: v1beta1
   scope: Namespaced
   names:
@@ -23,14 +23,14 @@ spec:
     singular: kafkaconnects2i
     plural: kafkaconnects2is
     shortNames:
-    - kcs2i
+      - kcs2i
     categories:
-    - strimzi
+      - strimzi
   additionalPrinterColumns:
-  - name: Desired replicas
-    description: The desired number of Kafka Connect replicas
-    JSONPath: .spec.replicas
-    type: integer
+    - name: Desired replicas
+      description: The desired number of Kafka Connect replicas
+      JSONPath: .spec.replicas
+      type: integer
   subresources:
     status: {}
     scale:
@@ -62,23 +62,17 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -89,23 +83,17 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -127,8 +115,7 @@ spec:
                   description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
-                  description: Specifies whether the Garbage Collection logging is
-                    enabled. The default is false.
+                  description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -140,8 +127,7 @@ spec:
                       value:
                         type: string
                         description: The system property value.
-                  description: A map of additional system properties which will be
-                    passed using the `-D` option to the JVM.
+                  description: A map of additional system properties which will be passed using the `-D` option to the JVM.
               description: JVM Options for pods.
             affinity:
               type: object
@@ -360,21 +346,19 @@ spec:
                   description: A Map from logger name to logger level.
                 name:
                   type: string
-                  description: The name of the `ConfigMap` from which to get the logging
-                    configuration.
+                  description: The name of the `ConfigMap` from which to get the logging configuration.
                 type:
                   type: string
                   enum:
-                  - inline
-                  - external
+                    - inline
+                    - external
                   description: Logging type, must be either 'inline' or 'external'.
               required:
-              - type
+                - type
               description: Logging configuration for Kafka Connect.
             metrics:
               type: object
-              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
-                for details of the structure of this configuration.
+              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
             template:
               type: object
               properties:
@@ -386,14 +370,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
@@ -404,14 +384,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
@@ -420,8 +396,7 @@ spec:
                         properties:
                           name:
                             type: string
-                      description: List of references to secrets in the same namespace
-                        to use for pulling any of the images used by this Pod.
+                      description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -464,18 +439,11 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
-                      description: Configures pod-level security attributes and common
-                        container settings.
+                      description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
-                      description: The grace period is the duration in seconds after
-                        the processes running in the pod are sent a termination signal
-                        and the time when the processes are forcibly halted with a
-                        kill signal. Set this value longer than the expected cleanup
-                        time for your process.Value must be non-negative integer.
-                        The value zero indicates delete immediately. Defaults to 30
-                        seconds.
+                      description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                     affinity:
                       type: object
                       properties:
@@ -687,12 +655,10 @@ spec:
                       description: The pod's affinity rules.
                     priorityClassName:
                       type: string
-                      description: The name of the Priority Class to which these pods
-                        will be assigned.
+                      description: The name of the Priority Class to which these pods will be assigned.
                     schedulerName:
                       type: string
-                      description: The name of the scheduler used to dispatch this
-                        `Pod`. If not specified, the default scheduler will be used.
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -718,14 +684,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect API `Service`.
                 connectContainer:
@@ -742,8 +704,7 @@ spec:
                           value:
                             type: string
                             description: The environment variable value.
-                      description: Environment variables which should be applied to
-                        the container.
+                      description: Environment variables which should be applied to the container.
                     securityContext:
                       type: object
                       properties:
@@ -800,28 +761,17 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
-                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
-                        resource.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate` resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
-                      description: Maximum number of unavailable pods to allow automatic
-                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
-                        number of pods or fewer are unavailable after the eviction.
-                        Setting this value to 0 prevents all voluntary evictions,
-                        so the pods must be evicted manually. Defaults to 1.
+                      description: Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
                   description: Template for Kafka Connect `PodDisruptionBudget`.
-              description: Template for Kafka Connect and Kafka Connect S2I resources.
-                The template allows users to specify how the `Deployment`, `Pods`
-                and `Service` are generated.
+              description: Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
             authentication:
               type: object
               properties:
@@ -830,22 +780,17 @@ spec:
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the access token
-                    which was obtained from the authorization server.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
                 accessTokenIsJwt:
                   type: boolean
-                  description: Configure whether access token should be treated as
-                    JWT. This should be set to `false` if the authorization server
-                    returns opaque tokens. Defaults to `true`.
+                  description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                 certificateAndKey:
                   type: object
                   properties:
@@ -859,79 +804,61 @@ spec:
                       type: string
                       description: The name of the Secret containing the certificate.
                   required:
-                  - certificate
-                  - key
-                  - secretName
-                  description: Reference to the `Secret` which holds the certificate
-                    and private key pair.
+                    - certificate
+                    - key
+                    - secretName
+                  description: Reference to the `Secret` which holds the certificate and private key pair.
                 clientId:
                   type: string
-                  description: OAuth Client ID which the Kafka client can use to authenticate
-                    against the OAuth server and use the token endpoint URI.
+                  description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                 clientSecret:
                   type: object
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the OAuth client
-                    secret which the Kafka client can use to authenticate against
-                    the OAuth server and use the token endpoint URI.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                 disableTlsHostnameVerification:
                   type: boolean
-                  description: Enable or disable TLS hostname verification. Default
-                    value is `false`.
+                  description: Enable or disable TLS hostname verification. Default value is `false`.
                 maxTokenExpirySeconds:
                   type: integer
-                  description: Set or limit time-to-live of the access tokens to the
-                    specified number of seconds. This should be set if the authorization
-                    server returns opaque tokens.
+                  description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
                 passwordSecret:
                   type: object
                   properties:
                     password:
                       type: string
-                      description: The name of the key in the Secret under which the
-                        password is stored.
+                      description: The name of the key in the Secret under which the password is stored.
                     secretName:
                       type: string
                       description: The name of the Secret containing the password.
                   required:
-                  - password
-                  - secretName
+                    - password
+                    - secretName
                   description: Reference to the `Secret` which holds the password.
                 refreshToken:
                   type: object
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the refresh token
-                    which can be used to obtain access token from the authorization
-                    server.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
                 scope:
                   type: string
-                  description: OAuth scope to use when authenticating against the
-                    authorization server. Some authorization servers require this
-                    to be set. The possible values depend on how authorization server
-                    is configured. By default `scope` is not specified when doing
-                    the token endpoint request.
+                  description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
                 tlsTrustedCertificates:
                   type: array
                   items:
@@ -944,43 +871,32 @@ spec:
                         type: string
                         description: The name of the Secret containing the certificate.
                     required:
-                    - certificate
-                    - secretName
-                  description: Trusted certificates for TLS connection to the OAuth
-                    server.
+                      - certificate
+                      - secretName
+                  description: Trusted certificates for TLS connection to the OAuth server.
                 tokenEndpointUri:
                   type: string
                   description: Authorization server token endpoint URI.
                 type:
                   type: string
                   enum:
-                  - tls
-                  - scram-sha-512
-                  - plain
-                  - oauth
-                  description: Authentication type. Currently the only supported types
-                    are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type
-                    uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL
-                    PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication.
-                    The `tls` type uses TLS Client Authentication. The `tls` type
-                    is supported only over TLS connections.
+                    - tls
+                    - scram-sha-512
+                    - plain
+                    - oauth
+                  description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                 username:
                   type: string
                   description: Username used for the authentication.
               required:
-              - type
+                - type
               description: Authentication configuration for Kafka Connect.
             bootstrapServers:
               type: string
-              description: Bootstrap servers to connect to. This should be given as
-                a comma separated list of _<hostname>_:‍_<port>_ pairs.
+              description: Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
             config:
               type: object
-              description: 'The Kafka Connect configuration. Properties with the following
-                prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
-                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes
-                (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites,
-                ssl.protocol, ssl.enabled.protocols).'
+              description: 'The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
             externalConfiguration:
               type: object
               properties:
@@ -991,9 +907,7 @@ spec:
                     properties:
                       name:
                         type: string
-                        description: Name of the environment variable which will be
-                          passed to the Kafka Connect pods. The name of the environment
-                          variable cannot start with `KAFKA_` or `STRIMZI_`.
+                        description: Name of the environment variable which will be passed to the Kafka Connect pods. The name of the environment variable cannot start with `KAFKA_` or `STRIMZI_`.
                       valueFrom:
                         type: object
                         properties:
@@ -1017,15 +931,11 @@ spec:
                               optional:
                                 type: boolean
                             description: Reference to a key in a Secret.
-                        description: Value of the environment variable which will
-                          be passed to the Kafka Connect pods. It can be passed either
-                          as a reference to Secret or ConfigMap field. The field has
-                          to specify exactly one Secret or ConfigMap.
+                        description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
                     required:
-                    - name
-                    - valueFrom
-                  description: Allows to pass data from Secret or ConfigMap to the
-                    Kafka Connect pods as environment variables.
+                      - name
+                      - valueFrom
+                  description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as environment variables.
                 volumes:
                   type: array
                   items:
@@ -1051,12 +961,10 @@ spec:
                             type: string
                           optional:
                             type: boolean
-                        description: Reference to a key in a ConfigMap. Exactly one
-                          Secret or ConfigMap has to be specified.
+                        description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
                       name:
                         type: string
-                        description: Name of the volume which will be added to the
-                          Kafka Connect pods.
+                        description: Name of the volume which will be added to the Kafka Connect pods.
                       secret:
                         type: object
                         properties:
@@ -1077,19 +985,14 @@ spec:
                             type: boolean
                           secretName:
                             type: string
-                        description: Reference to a key in a Secret. Exactly one Secret
-                          or ConfigMap has to be specified.
+                        description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
                     required:
-                    - name
-                  description: Allows to pass data from Secret or ConfigMap to the
-                    Kafka Connect pods as volumes.
-              description: Pass data from Secrets or ConfigMaps to the Kafka Connect
-                pods and use them to configure connectors.
+                      - name
+                  description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as volumes.
+              description: Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
             insecureSourceRepository:
               type: boolean
-              description: When true this configures the source repository with the
-                'Local' reference policy and an import policy that accepts insecure
-                source tags.
+              description: When true this configures the source repository with the 'Local' reference policy and an import policy that accepts insecure source tags.
             resources:
               type: object
               properties:
@@ -1097,8 +1000,7 @@ spec:
                   type: object
                 requests:
                   type: object
-              description: The maximum limits for CPU and memory resources and the
-                requested initial resources.
+              description: The maximum limits for CPU and memory resources and the requested initial resources.
             tls:
               type: object
               properties:
@@ -1114,8 +1016,8 @@ spec:
                         type: string
                         description: The name of the Secret containing the certificate.
                     required:
-                    - certificate
-                    - secretName
+                      - certificate
+                      - secretName
                   description: Trusted certificates for TLS connection.
               description: TLS configuration.
             tolerations:
@@ -1140,21 +1042,17 @@ spec:
                 type:
                   type: string
                   enum:
-                  - jaeger
-                  description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing.
+                    - jaeger
+                  description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
               required:
-              - type
+                - type
               description: The configuration of tracing in Kafka Connect.
             version:
               type: string
-              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}.
-                Consult the user documentation to understand the process required
-                to upgrade or downgrade the version.
+              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
           required:
-          - bootstrapServers
-          description: The specification of the Kafka Connect Source-to-Image (S2I)
-            cluster.
+            - bootstrapServers
+          description: The specification of the Kafka Connect Source-to-Image (S2I) cluster.
         status:
           type: object
           properties:
@@ -1165,34 +1063,26 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             url:
               type: string
-              description: The URL of the REST API endpoint for managing and monitoring
-                Kafka Connect connectors.
+              description: The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
             connectorPlugins:
               type: array
               items:
@@ -1200,16 +1090,14 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The type of the connector plugin. The available types
-                      are `sink` and `source`.
+                    description: The type of the connector plugin. The available types are `sink` and `source`.
                   version:
                     type: string
                     description: The version of the connector plugin.
                   class:
                     type: string
                     description: The class of the connector plugin.
-              description: The list of connector plugins available in this Kafka Connect
-                deployment.
+              description: The list of connector plugins available in this Kafka Connect deployment.
             buildConfigName:
               type: string
               description: The name of the build configuration.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
@@ -9,12 +9,12 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
-  - name: v1alpha1
-    served: true
-    storage: false
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   version: v1beta1
   scope: Namespaced
   names:
@@ -23,18 +23,18 @@ spec:
     singular: kafkatopic
     plural: kafkatopics
     shortNames:
-    - kt
+      - kt
     categories:
-    - strimzi
+      - strimzi
   additionalPrinterColumns:
-  - name: Partitions
-    description: The desired number of partitions in the topic
-    JSONPath: .spec.partitions
-    type: integer
-  - name: Replication factor
-    description: The desired number of replicas of each partition
-    JSONPath: .spec.replicas
-    type: integer
+    - name: Partitions
+      description: The desired number of partitions in the topic
+      JSONPath: .spec.partitions
+      type: integer
+    - name: Replication factor
+      description: The desired number of replicas of each partition
+      JSONPath: .spec.replicas
+      type: integer
   subresources:
     status: {}
   validation:
@@ -46,10 +46,7 @@ spec:
             partitions:
               type: integer
               minimum: 1
-              description: The number of partitions the topic should have. This cannot
-                be decreased after topic creation. It can be increased after topic
-                creation, but it is important to understand the consequences that
-                has, especially for topics with semantic partitioning.
+              description: The number of partitions the topic should have. This cannot be decreased after topic creation. It can be increased after topic creation, but it is important to understand the consequences that has, especially for topics with semantic partitioning.
             replicas:
               type: integer
               minimum: 1
@@ -60,12 +57,10 @@ spec:
               description: The topic configuration.
             topicName:
               type: string
-              description: The name of the topic. When absent this will default to
-                the metadata.name of the topic. It is recommended to not set this
-                unless the topic name is not a valid Kubernetes resource name.
+              description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
           required:
-          - partitions
-          - replicas
+            - partitions
+            - replicas
           description: The specification of the topic.
         status:
           type: object
@@ -77,28 +72,21 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
           description: The status of the topic.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
@@ -9,12 +9,12 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
-  - name: v1alpha1
-    served: true
-    storage: false
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   version: v1beta1
   scope: Namespaced
   names:
@@ -23,18 +23,18 @@ spec:
     singular: kafkauser
     plural: kafkausers
     shortNames:
-    - ku
+      - ku
     categories:
-    - strimzi
+      - strimzi
   additionalPrinterColumns:
-  - name: Authentication
-    description: How the user is authenticated
-    JSONPath: .spec.authentication.type
-    type: string
-  - name: Authorization
-    description: How the user is authorised
-    JSONPath: .spec.authorization.type
-    type: string
+    - name: Authentication
+      description: How the user is authenticated
+      JSONPath: .spec.authentication.type
+      type: string
+    - name: Authorization
+      description: How the user is authorised
+      JSONPath: .spec.authorization.type
+      type: string
   subresources:
     status: {}
   validation:
@@ -49,11 +49,11 @@ spec:
                 type:
                   type: string
                   enum:
-                  - tls
-                  - scram-sha-512
+                    - tls
+                    - scram-sha-512
                   description: Authentication type.
               required:
-              - type
+                - type
               description: Authentication mechanism enabled for this Kafka user.
             authorization:
               type: object
@@ -65,81 +65,63 @@ spec:
                     properties:
                       host:
                         type: string
-                        description: The host from which the action described in the
-                          ACL rule is allowed or denied.
+                        description: The host from which the action described in the ACL rule is allowed or denied.
                       operation:
                         type: string
                         enum:
-                        - Read
-                        - Write
-                        - Create
-                        - Delete
-                        - Alter
-                        - Describe
-                        - ClusterAction
-                        - AlterConfigs
-                        - DescribeConfigs
-                        - IdempotentWrite
-                        - All
-                        description: 'Operation which will be allowed or denied. Supported
-                          operations are: Read, Write, Create, Delete, Alter, Describe,
-                          ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite
-                          and All.'
+                          - Read
+                          - Write
+                          - Create
+                          - Delete
+                          - Alter
+                          - Describe
+                          - ClusterAction
+                          - AlterConfigs
+                          - DescribeConfigs
+                          - IdempotentWrite
+                          - All
+                        description: 'Operation which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All.'
                       resource:
                         type: object
                         properties:
                           name:
                             type: string
-                            description: Name of resource for which given ACL rule
-                              applies. Can be combined with `patternType` field to
-                              use prefix pattern.
+                            description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
                           patternType:
                             type: string
                             enum:
-                            - literal
-                            - prefix
-                            description: Describes the pattern used in the resource
-                              field. The supported types are `literal` and `prefix`.
-                              With `literal` pattern type, the resource field will
-                              be used as a definition of a full name. With `prefix`
-                              pattern type, the resource name will be used only as
-                              a prefix. Default value is `literal`.
+                              - literal
+                              - prefix
+                            description: Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`.
                           type:
                             type: string
                             enum:
-                            - topic
-                            - group
-                            - cluster
-                            - transactionalId
-                            description: Resource type. The available resource types
-                              are `topic`, `group`, `cluster`, and `transactionalId`.
+                              - topic
+                              - group
+                              - cluster
+                              - transactionalId
+                            description: Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`.
                         required:
-                        - type
-                        description: Indicates the resource for which given ACL rule
-                          applies.
+                          - type
+                        description: Indicates the resource for which given ACL rule applies.
                       type:
                         type: string
                         enum:
-                        - allow
-                        - deny
-                        description: The type of the rule. Currently the only supported
-                          type is `allow`. ACL rules with type `allow` are used to
-                          allow user to execute the specified operations. Default
-                          value is `allow`.
+                          - allow
+                          - deny
+                        description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                     required:
-                    - operation
-                    - resource
+                      - operation
+                      - resource
                   description: List of ACL rules which should be applied to this user.
                 type:
                   type: string
                   enum:
-                  - simple
-                  description: Authorization type. Currently the only supported type
-                    is `simple`. `simple` authorization type uses Kafka's `kafka.security.auth.SimpleAclAuthorizer`
-                    class for authorization.
+                    - simple
+                  description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.auth.SimpleAclAuthorizer` class for authorization.
               required:
-              - acls
-              - type
+                - acls
+                - type
               description: Authorization rules for this Kafka user.
             quotas:
               type: object
@@ -147,23 +129,16 @@ spec:
                 consumerByteRate:
                   type: integer
                   minimum: 0
-                  description: A quota on the maximum bytes per-second that each client
-                    group can fetch from a broker before the clients in the group
-                    are throttled. Defined on a per-broker basis.
+                  description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
                 producerByteRate:
                   type: integer
                   minimum: 0
-                  description: A quota on the maximum bytes per-second that each client
-                    group can publish to a broker before the clients in the group
-                    are throttled. Defined on a per-broker basis.
+                  description: A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
                 requestPercentage:
                   type: integer
                   minimum: 0
-                  description: A quota on the maximum CPU utilization of each client
-                    group as a percentage of network and I/O threads.
-              description: Quotas on requests to control the broker resources used
-                by clients. Network bandwidth and request rate quotas can be enforced.Kafka
-                documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
+                  description: A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
+              description: Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
           description: The specification of the user.
         status:
           type: object
@@ -175,30 +150,23 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             username:
               type: string
               description: Username.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -9,12 +9,12 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
-  - name: v1alpha1
-    served: true
-    storage: false
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   version: v1beta1
   scope: Namespaced
   names:
@@ -23,24 +23,24 @@ spec:
     singular: kafkamirrormaker
     plural: kafkamirrormakers
     shortNames:
-    - kmm
+      - kmm
     categories:
-    - strimzi
+      - strimzi
   additionalPrinterColumns:
-  - name: Desired replicas
-    description: The desired number of Kafka MirrorMaker replicas
-    JSONPath: .spec.replicas
-    type: integer
-  - name: Consumer Bootstrap Servers
-    description: The boostrap servers for the consumer
-    JSONPath: .spec.consumer.bootstrapServers
-    type: string
-    priority: 1
-  - name: Producer Bootstrap Servers
-    description: The boostrap servers for the producer
-    JSONPath: .spec.producer.bootstrapServers
-    type: string
-    priority: 1
+    - name: Desired replicas
+      description: The desired number of Kafka MirrorMaker replicas
+      JSONPath: .spec.replicas
+      type: integer
+    - name: Consumer Bootstrap Servers
+      description: The boostrap servers for the consumer
+      JSONPath: .spec.consumer.bootstrapServers
+      type: string
+      priority: 1
+    - name: Producer Bootstrap Servers
+      description: The boostrap servers for the producer
+      JSONPath: .spec.producer.bootstrapServers
+      type: string
+      priority: 1
   subresources:
     status: {}
     scale:
@@ -62,32 +62,23 @@ spec:
               description: The docker image for the pods.
             whitelist:
               type: string
-              description: List of topics which are included for mirroring. This option
-                allows any regular expression using Java-style regular expressions.
-                Mirroring two topics named A and B is achieved by using the whitelist
-                `'A\|B'`. Or, as a special case, you can mirror all topics using the
-                whitelist '*'. You can also specify multiple regular expressions separated
-                by commas.
+              description: List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the whitelist `'A\|B'`. Or, as a special case, you can mirror all topics using the whitelist '*'. You can also specify multiple regular expressions separated by commas.
             consumer:
               type: object
               properties:
                 numStreams:
                   type: integer
                   minimum: 1
-                  description: Specifies the number of consumer stream threads to
-                    create.
+                  description: Specifies the number of consumer stream threads to create.
                 offsetCommitInterval:
                   type: integer
-                  description: Specifies the offset auto-commit interval in ms. Default
-                    value is 60000.
+                  description: Specifies the offset auto-commit interval in ms. Default value is 60000.
                 groupId:
                   type: string
-                  description: A unique string that identifies the consumer group
-                    this consumer belongs to.
+                  description: A unique string that identifies the consumer group this consumer belongs to.
                 bootstrapServers:
                   type: string
-                  description: A list of host:port pairs for establishing the initial
-                    connection to the Kafka cluster.
+                  description: A list of host:port pairs for establishing the initial connection to the Kafka cluster.
                 authentication:
                   type: object
                   properties:
@@ -96,22 +87,17 @@ spec:
                       properties:
                         key:
                           type: string
-                          description: The key under which the secret value is stored
-                            in the Kubernetes Secret.
+                          description: The key under which the secret value is stored in the Kubernetes Secret.
                         secretName:
                           type: string
-                          description: The name of the Kubernetes Secret containing
-                            the secret value.
+                          description: The name of the Kubernetes Secret containing the secret value.
                       required:
-                      - key
-                      - secretName
-                      description: Link to Kubernetes Secret containing the access
-                        token which was obtained from the authorization server.
+                        - key
+                        - secretName
+                      description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
                     accessTokenIsJwt:
                       type: boolean
-                      description: Configure whether access token should be treated
-                        as JWT. This should be set to `false` if the authorization
-                        server returns opaque tokens. Defaults to `true`.
+                      description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                     certificateAndKey:
                       type: object
                       properties:
@@ -125,80 +111,61 @@ spec:
                           type: string
                           description: The name of the Secret containing the certificate.
                       required:
-                      - certificate
-                      - key
-                      - secretName
-                      description: Reference to the `Secret` which holds the certificate
-                        and private key pair.
+                        - certificate
+                        - key
+                        - secretName
+                      description: Reference to the `Secret` which holds the certificate and private key pair.
                     clientId:
                       type: string
-                      description: OAuth Client ID which the Kafka client can use
-                        to authenticate against the OAuth server and use the token
-                        endpoint URI.
+                      description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                     clientSecret:
                       type: object
                       properties:
                         key:
                           type: string
-                          description: The key under which the secret value is stored
-                            in the Kubernetes Secret.
+                          description: The key under which the secret value is stored in the Kubernetes Secret.
                         secretName:
                           type: string
-                          description: The name of the Kubernetes Secret containing
-                            the secret value.
+                          description: The name of the Kubernetes Secret containing the secret value.
                       required:
-                      - key
-                      - secretName
-                      description: Link to Kubernetes Secret containing the OAuth
-                        client secret which the Kafka client can use to authenticate
-                        against the OAuth server and use the token endpoint URI.
+                        - key
+                        - secretName
+                      description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                     disableTlsHostnameVerification:
                       type: boolean
-                      description: Enable or disable TLS hostname verification. Default
-                        value is `false`.
+                      description: Enable or disable TLS hostname verification. Default value is `false`.
                     maxTokenExpirySeconds:
                       type: integer
-                      description: Set or limit time-to-live of the access tokens
-                        to the specified number of seconds. This should be set if
-                        the authorization server returns opaque tokens.
+                      description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
                     passwordSecret:
                       type: object
                       properties:
                         password:
                           type: string
-                          description: The name of the key in the Secret under which
-                            the password is stored.
+                          description: The name of the key in the Secret under which the password is stored.
                         secretName:
                           type: string
                           description: The name of the Secret containing the password.
                       required:
-                      - password
-                      - secretName
+                        - password
+                        - secretName
                       description: Reference to the `Secret` which holds the password.
                     refreshToken:
                       type: object
                       properties:
                         key:
                           type: string
-                          description: The key under which the secret value is stored
-                            in the Kubernetes Secret.
+                          description: The key under which the secret value is stored in the Kubernetes Secret.
                         secretName:
                           type: string
-                          description: The name of the Kubernetes Secret containing
-                            the secret value.
+                          description: The name of the Kubernetes Secret containing the secret value.
                       required:
-                      - key
-                      - secretName
-                      description: Link to Kubernetes Secret containing the refresh
-                        token which can be used to obtain access token from the authorization
-                        server.
+                        - key
+                        - secretName
+                      description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
                     scope:
                       type: string
-                      description: OAuth scope to use when authenticating against
-                        the authorization server. Some authorization servers require
-                        this to be set. The possible values depend on how authorization
-                        server is configured. By default `scope` is not specified
-                        when doing the token endpoint request.
+                      description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
                     tlsTrustedCertificates:
                       type: array
                       items:
@@ -211,40 +178,29 @@ spec:
                             type: string
                             description: The name of the Secret containing the certificate.
                         required:
-                        - certificate
-                        - secretName
-                      description: Trusted certificates for TLS connection to the
-                        OAuth server.
+                          - certificate
+                          - secretName
+                      description: Trusted certificates for TLS connection to the OAuth server.
                     tokenEndpointUri:
                       type: string
                       description: Authorization server token endpoint URI.
                     type:
                       type: string
                       enum:
-                      - tls
-                      - scram-sha-512
-                      - plain
-                      - oauth
-                      description: Authentication type. Currently the only supported
-                        types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
-                        type uses SASL SCRAM-SHA-512 Authentication. `plain` type
-                        uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
-                        Authentication. The `tls` type uses TLS Client Authentication.
-                        The `tls` type is supported only over TLS connections.
+                        - tls
+                        - scram-sha-512
+                        - plain
+                        - oauth
+                      description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                     username:
                       type: string
                       description: Username used for the authentication.
                   required:
-                  - type
-                  description: Authentication configuration for connecting to the
-                    cluster.
+                    - type
+                  description: Authentication configuration for connecting to the cluster.
                 config:
                   type: object
-                  description: 'The MirrorMaker consumer config. Properties with the
-                    following prefixes cannot be set: ssl., bootstrap.servers, group.id,
-                    sasl., security., interceptor.classes (with the exception of:
-                    ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol,
-                    ssl.enabled.protocols).'
+                  description: 'The MirrorMaker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
                 tls:
                   type: object
                   properties:
@@ -260,26 +216,23 @@ spec:
                             type: string
                             description: The name of the Secret containing the certificate.
                         required:
-                        - certificate
-                        - secretName
+                          - certificate
+                          - secretName
                       description: Trusted certificates for TLS connection.
-                  description: TLS configuration for connecting MirrorMaker to the
-                    cluster.
+                  description: TLS configuration for connecting MirrorMaker to the cluster.
               required:
-              - groupId
-              - bootstrapServers
+                - groupId
+                - bootstrapServers
               description: Configuration of source cluster.
             producer:
               type: object
               properties:
                 bootstrapServers:
                   type: string
-                  description: A list of host:port pairs for establishing the initial
-                    connection to the Kafka cluster.
+                  description: A list of host:port pairs for establishing the initial connection to the Kafka cluster.
                 abortOnSendFailure:
                   type: boolean
-                  description: Flag to set the MirrorMaker to exit on a failed send.
-                    Default value is `true`.
+                  description: Flag to set the MirrorMaker to exit on a failed send. Default value is `true`.
                 authentication:
                   type: object
                   properties:
@@ -288,22 +241,17 @@ spec:
                       properties:
                         key:
                           type: string
-                          description: The key under which the secret value is stored
-                            in the Kubernetes Secret.
+                          description: The key under which the secret value is stored in the Kubernetes Secret.
                         secretName:
                           type: string
-                          description: The name of the Kubernetes Secret containing
-                            the secret value.
+                          description: The name of the Kubernetes Secret containing the secret value.
                       required:
-                      - key
-                      - secretName
-                      description: Link to Kubernetes Secret containing the access
-                        token which was obtained from the authorization server.
+                        - key
+                        - secretName
+                      description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
                     accessTokenIsJwt:
                       type: boolean
-                      description: Configure whether access token should be treated
-                        as JWT. This should be set to `false` if the authorization
-                        server returns opaque tokens. Defaults to `true`.
+                      description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                     certificateAndKey:
                       type: object
                       properties:
@@ -317,80 +265,61 @@ spec:
                           type: string
                           description: The name of the Secret containing the certificate.
                       required:
-                      - certificate
-                      - key
-                      - secretName
-                      description: Reference to the `Secret` which holds the certificate
-                        and private key pair.
+                        - certificate
+                        - key
+                        - secretName
+                      description: Reference to the `Secret` which holds the certificate and private key pair.
                     clientId:
                       type: string
-                      description: OAuth Client ID which the Kafka client can use
-                        to authenticate against the OAuth server and use the token
-                        endpoint URI.
+                      description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                     clientSecret:
                       type: object
                       properties:
                         key:
                           type: string
-                          description: The key under which the secret value is stored
-                            in the Kubernetes Secret.
+                          description: The key under which the secret value is stored in the Kubernetes Secret.
                         secretName:
                           type: string
-                          description: The name of the Kubernetes Secret containing
-                            the secret value.
+                          description: The name of the Kubernetes Secret containing the secret value.
                       required:
-                      - key
-                      - secretName
-                      description: Link to Kubernetes Secret containing the OAuth
-                        client secret which the Kafka client can use to authenticate
-                        against the OAuth server and use the token endpoint URI.
+                        - key
+                        - secretName
+                      description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                     disableTlsHostnameVerification:
                       type: boolean
-                      description: Enable or disable TLS hostname verification. Default
-                        value is `false`.
+                      description: Enable or disable TLS hostname verification. Default value is `false`.
                     maxTokenExpirySeconds:
                       type: integer
-                      description: Set or limit time-to-live of the access tokens
-                        to the specified number of seconds. This should be set if
-                        the authorization server returns opaque tokens.
+                      description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
                     passwordSecret:
                       type: object
                       properties:
                         password:
                           type: string
-                          description: The name of the key in the Secret under which
-                            the password is stored.
+                          description: The name of the key in the Secret under which the password is stored.
                         secretName:
                           type: string
                           description: The name of the Secret containing the password.
                       required:
-                      - password
-                      - secretName
+                        - password
+                        - secretName
                       description: Reference to the `Secret` which holds the password.
                     refreshToken:
                       type: object
                       properties:
                         key:
                           type: string
-                          description: The key under which the secret value is stored
-                            in the Kubernetes Secret.
+                          description: The key under which the secret value is stored in the Kubernetes Secret.
                         secretName:
                           type: string
-                          description: The name of the Kubernetes Secret containing
-                            the secret value.
+                          description: The name of the Kubernetes Secret containing the secret value.
                       required:
-                      - key
-                      - secretName
-                      description: Link to Kubernetes Secret containing the refresh
-                        token which can be used to obtain access token from the authorization
-                        server.
+                        - key
+                        - secretName
+                      description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
                     scope:
                       type: string
-                      description: OAuth scope to use when authenticating against
-                        the authorization server. Some authorization servers require
-                        this to be set. The possible values depend on how authorization
-                        server is configured. By default `scope` is not specified
-                        when doing the token endpoint request.
+                      description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
                     tlsTrustedCertificates:
                       type: array
                       items:
@@ -403,39 +332,29 @@ spec:
                             type: string
                             description: The name of the Secret containing the certificate.
                         required:
-                        - certificate
-                        - secretName
-                      description: Trusted certificates for TLS connection to the
-                        OAuth server.
+                          - certificate
+                          - secretName
+                      description: Trusted certificates for TLS connection to the OAuth server.
                     tokenEndpointUri:
                       type: string
                       description: Authorization server token endpoint URI.
                     type:
                       type: string
                       enum:
-                      - tls
-                      - scram-sha-512
-                      - plain
-                      - oauth
-                      description: Authentication type. Currently the only supported
-                        types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
-                        type uses SASL SCRAM-SHA-512 Authentication. `plain` type
-                        uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
-                        Authentication. The `tls` type uses TLS Client Authentication.
-                        The `tls` type is supported only over TLS connections.
+                        - tls
+                        - scram-sha-512
+                        - plain
+                        - oauth
+                      description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                     username:
                       type: string
                       description: Username used for the authentication.
                   required:
-                  - type
-                  description: Authentication configuration for connecting to the
-                    cluster.
+                    - type
+                  description: Authentication configuration for connecting to the cluster.
                 config:
                   type: object
-                  description: 'The MirrorMaker producer config. Properties with the
-                    following prefixes cannot be set: ssl., bootstrap.servers, sasl.,
-                    security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm,
-                    ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
+                  description: 'The MirrorMaker producer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
                 tls:
                   type: object
                   properties:
@@ -451,13 +370,12 @@ spec:
                             type: string
                             description: The name of the Secret containing the certificate.
                         required:
-                        - certificate
-                        - secretName
+                          - certificate
+                          - secretName
                       description: Trusted certificates for TLS connection.
-                  description: TLS configuration for connecting MirrorMaker to the
-                    cluster.
+                  description: TLS configuration for connecting MirrorMaker to the cluster.
               required:
-              - bootstrapServers
+                - bootstrapServers
               description: Configuration of target cluster.
             resources:
               type: object
@@ -708,8 +626,7 @@ spec:
                   description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
-                  description: Specifies whether the Garbage Collection logging is
-                    enabled. The default is false.
+                  description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -721,8 +638,7 @@ spec:
                       value:
                         type: string
                         description: The system property value.
-                  description: A map of additional system properties which will be
-                    passed using the `-D` option to the JVM.
+                  description: A map of additional system properties which will be passed using the `-D` option to the JVM.
               description: JVM Options for pods.
             logging:
               type: object
@@ -732,32 +648,29 @@ spec:
                   description: A Map from logger name to logger level.
                 name:
                   type: string
-                  description: The name of the `ConfigMap` from which to get the logging
-                    configuration.
+                  description: The name of the `ConfigMap` from which to get the logging configuration.
                 type:
                   type: string
                   enum:
-                  - inline
-                  - external
+                    - inline
+                    - external
                   description: Logging type, must be either 'inline' or 'external'.
               required:
-              - type
+                - type
               description: Logging configuration for MirrorMaker.
             metrics:
               type: object
-              description: The Prometheus JMX Exporter configuration. See {JMXExporter}
-                for details of the structure of this configuration.
+              description: The Prometheus JMX Exporter configuration. See {JMXExporter} for details of the structure of this configuration.
             tracing:
               type: object
               properties:
                 type:
                   type: string
                   enum:
-                  - jaeger
-                  description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing.
+                    - jaeger
+                  description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
               required:
-              - type
+                - type
               description: The configuration of tracing in Kafka MirrorMaker.
             template:
               type: object
@@ -770,14 +683,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka MirrorMaker `Deployment`.
                 pod:
@@ -788,14 +697,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
@@ -804,8 +709,7 @@ spec:
                         properties:
                           name:
                             type: string
-                      description: List of references to secrets in the same namespace
-                        to use for pulling any of the images used by this Pod.
+                      description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -848,18 +752,11 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
-                      description: Configures pod-level security attributes and common
-                        container settings.
+                      description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
-                      description: The grace period is the duration in seconds after
-                        the processes running in the pod are sent a termination signal
-                        and the time when the processes are forcibly halted with a
-                        kill signal. Set this value longer than the expected cleanup
-                        time for your process.Value must be non-negative integer.
-                        The value zero indicates delete immediately. Defaults to 30
-                        seconds.
+                      description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                     affinity:
                       type: object
                       properties:
@@ -1071,12 +968,10 @@ spec:
                       description: The pod's affinity rules.
                     priorityClassName:
                       type: string
-                      description: The name of the Priority Class to which these pods
-                        will be assigned.
+                      description: The name of the Priority Class to which these pods will be assigned.
                     schedulerName:
                       type: string
-                      description: The name of the scheduler used to dispatch this
-                        `Pod`. If not specified, the default scheduler will be used.
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -1108,8 +1003,7 @@ spec:
                           value:
                             type: string
                             description: The environment variable value.
-                      description: Environment variables which should be applied to
-                        the container.
+                      description: Environment variables which should be applied to the container.
                     securityContext:
                       type: object
                       properties:
@@ -1166,49 +1060,33 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
-                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
-                        resource.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate` resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
-                      description: Maximum number of unavailable pods to allow automatic
-                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
-                        number of pods or fewer are unavailable after the eviction.
-                        Setting this value to 0 prevents all voluntary evictions,
-                        so the pods must be evicted manually. Defaults to 1.
+                      description: Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
                   description: Template for Kafka MirrorMaker `PodDisruptionBudget`.
-              description: Template to specify how Kafka MirrorMaker resources, `Deployments`
-                and `Pods`, are generated.
+              description: Template to specify how Kafka MirrorMaker resources, `Deployments` and `Pods`, are generated.
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -1219,23 +1097,17 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -1243,14 +1115,12 @@ spec:
               description: Pod readiness checking.
             version:
               type: string
-              description: The Kafka MirrorMaker version. Defaults to {DefaultKafkaVersion}.
-                Consult the documentation to understand the process required to upgrade
-                or downgrade the version.
+              description: The Kafka MirrorMaker version. Defaults to {DefaultKafkaVersion}. Consult the documentation to understand the process required to upgrade or downgrade the version.
           required:
-          - replicas
-          - whitelist
-          - consumer
-          - producer
+            - replicas
+            - whitelist
+            - consumer
+            - producer
           description: The specification of Kafka MirrorMaker.
         status:
           type: object
@@ -1262,30 +1132,23 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             podSelector:
               type: object
               properties:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
   version: v1alpha1
   scope: Namespaced
   names:
@@ -20,19 +20,19 @@ spec:
     singular: kafkabridge
     plural: kafkabridges
     shortNames:
-    - kb
+      - kb
     categories:
-    - strimzi
+      - strimzi
   additionalPrinterColumns:
-  - name: Desired replicas
-    description: The desired number of Kafka Bridge replicas
-    JSONPath: .spec.replicas
-    type: integer
-  - name: Bootstrap Servers
-    description: The boostrap servers
-    JSONPath: .spec.bootstrapServers
-    type: string
-    priority: 1
+    - name: Desired replicas
+      description: The desired number of Kafka Bridge replicas
+      JSONPath: .spec.replicas
+      type: integer
+    - name: Bootstrap Servers
+      description: The boostrap servers
+      JSONPath: .spec.bootstrapServers
+      type: string
+      priority: 1
   subresources:
     status: {}
     scale:
@@ -54,8 +54,7 @@ spec:
               description: The docker image for the pods.
             bootstrapServers:
               type: string
-              description: A list of host:port pairs for establishing the initial
-                connection to the Kafka cluster.
+              description: A list of host:port pairs for establishing the initial connection to the Kafka cluster.
             tls:
               type: object
               properties:
@@ -71,8 +70,8 @@ spec:
                         type: string
                         description: The name of the Secret containing the certificate.
                     required:
-                    - certificate
-                    - secretName
+                      - certificate
+                      - secretName
                   description: Trusted certificates for TLS connection.
               description: TLS configuration for connecting Kafka Bridge to the cluster.
             authentication:
@@ -83,22 +82,17 @@ spec:
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the access token
-                    which was obtained from the authorization server.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
                 accessTokenIsJwt:
                   type: boolean
-                  description: Configure whether access token should be treated as
-                    JWT. This should be set to `false` if the authorization server
-                    returns opaque tokens. Defaults to `true`.
+                  description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                 certificateAndKey:
                   type: object
                   properties:
@@ -112,79 +106,61 @@ spec:
                       type: string
                       description: The name of the Secret containing the certificate.
                   required:
-                  - certificate
-                  - key
-                  - secretName
-                  description: Reference to the `Secret` which holds the certificate
-                    and private key pair.
+                    - certificate
+                    - key
+                    - secretName
+                  description: Reference to the `Secret` which holds the certificate and private key pair.
                 clientId:
                   type: string
-                  description: OAuth Client ID which the Kafka client can use to authenticate
-                    against the OAuth server and use the token endpoint URI.
+                  description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                 clientSecret:
                   type: object
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the OAuth client
-                    secret which the Kafka client can use to authenticate against
-                    the OAuth server and use the token endpoint URI.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                 disableTlsHostnameVerification:
                   type: boolean
-                  description: Enable or disable TLS hostname verification. Default
-                    value is `false`.
+                  description: Enable or disable TLS hostname verification. Default value is `false`.
                 maxTokenExpirySeconds:
                   type: integer
-                  description: Set or limit time-to-live of the access tokens to the
-                    specified number of seconds. This should be set if the authorization
-                    server returns opaque tokens.
+                  description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
                 passwordSecret:
                   type: object
                   properties:
                     password:
                       type: string
-                      description: The name of the key in the Secret under which the
-                        password is stored.
+                      description: The name of the key in the Secret under which the password is stored.
                     secretName:
                       type: string
                       description: The name of the Secret containing the password.
                   required:
-                  - password
-                  - secretName
+                    - password
+                    - secretName
                   description: Reference to the `Secret` which holds the password.
                 refreshToken:
                   type: object
                   properties:
                     key:
                       type: string
-                      description: The key under which the secret value is stored
-                        in the Kubernetes Secret.
+                      description: The key under which the secret value is stored in the Kubernetes Secret.
                     secretName:
                       type: string
-                      description: The name of the Kubernetes Secret containing the
-                        secret value.
+                      description: The name of the Kubernetes Secret containing the secret value.
                   required:
-                  - key
-                  - secretName
-                  description: Link to Kubernetes Secret containing the refresh token
-                    which can be used to obtain access token from the authorization
-                    server.
+                    - key
+                    - secretName
+                  description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
                 scope:
                   type: string
-                  description: OAuth scope to use when authenticating against the
-                    authorization server. Some authorization servers require this
-                    to be set. The possible values depend on how authorization server
-                    is configured. By default `scope` is not specified when doing
-                    the token endpoint request.
+                  description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
                 tlsTrustedCertificates:
                   type: array
                   items:
@@ -197,31 +173,25 @@ spec:
                         type: string
                         description: The name of the Secret containing the certificate.
                     required:
-                    - certificate
-                    - secretName
-                  description: Trusted certificates for TLS connection to the OAuth
-                    server.
+                      - certificate
+                      - secretName
+                  description: Trusted certificates for TLS connection to the OAuth server.
                 tokenEndpointUri:
                   type: string
                   description: Authorization server token endpoint URI.
                 type:
                   type: string
                   enum:
-                  - tls
-                  - scram-sha-512
-                  - plain
-                  - oauth
-                  description: Authentication type. Currently the only supported types
-                    are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type
-                    uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL
-                    PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication.
-                    The `tls` type uses TLS Client Authentication. The `tls` type
-                    is supported only over TLS connections.
+                    - tls
+                    - scram-sha-512
+                    - plain
+                    - oauth
+                  description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                 username:
                   type: string
                   description: Username used for the authentication.
               required:
-              - type
+                - type
               description: Authentication configuration for connecting to the cluster.
             http:
               type: object
@@ -237,16 +207,15 @@ spec:
                       type: array
                       items:
                         type: string
-                      description: List of allowed origins. Java regular expressions
-                        can be used.
+                      description: List of allowed origins. Java regular expressions can be used.
                     allowedMethods:
                       type: array
                       items:
                         type: string
                       description: List of allowed HTTP methods.
                   required:
-                  - allowedOrigins
-                  - allowedMethods
+                    - allowedOrigins
+                    - allowedMethods
                   description: CORS configuration for the HTTP Bridge.
               description: The HTTP related configuration.
             consumer:
@@ -254,22 +223,14 @@ spec:
               properties:
                 config:
                   type: object
-                  description: 'The Kafka consumer configuration used for consumer
-                    instances created by the bridge. Properties with the following
-                    prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl.,
-                    security. (with the exception of: ssl.endpoint.identification.algorithm,
-                    ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
+                  description: 'The Kafka consumer configuration used for consumer instances created by the bridge. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
               description: Kafka consumer related configuration.
             producer:
               type: object
               properties:
                 config:
                   type: object
-                  description: 'The Kafka producer configuration used for producer
-                    instances created by the bridge. Properties with the following
-                    prefixes cannot be set: ssl., bootstrap.servers, sasl., security.
-                    (with the exception of: ssl.endpoint.identification.algorithm,
-                    ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
+                  description: 'The Kafka producer configuration used for producer instances created by the bridge. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
               description: Kafka producer related configuration.
             resources:
               type: object
@@ -295,8 +256,7 @@ spec:
                   description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
-                  description: Specifies whether the Garbage Collection logging is
-                    enabled. The default is false.
+                  description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -308,8 +268,7 @@ spec:
                       value:
                         type: string
                         description: The system property value.
-                  description: A map of additional system properties which will be
-                    passed using the `-D` option to the JVM.
+                  description: A map of additional system properties which will be passed using the `-D` option to the JVM.
               description: '**Currently not supported** JVM Options for pods.'
             logging:
               type: object
@@ -319,44 +278,35 @@ spec:
                   description: A Map from logger name to logger level.
                 name:
                   type: string
-                  description: The name of the `ConfigMap` from which to get the logging
-                    configuration.
+                  description: The name of the `ConfigMap` from which to get the logging configuration.
                 type:
                   type: string
                   enum:
-                  - inline
-                  - external
+                    - inline
+                    - external
                   description: Logging type, must be either 'inline' or 'external'.
               required:
-              - type
+                - type
               description: Logging configuration for Kafka Bridge.
             metrics:
               type: object
-              description: '**Currently not supported** The Prometheus JMX Exporter
-                configuration. See {JMXExporter} for details of the structure of this
-                configuration.'
+              description: '**Currently not supported** The Prometheus JMX Exporter configuration. See {JMXExporter} for details of the structure of this configuration.'
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -367,23 +317,17 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -400,14 +344,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Bridge `Deployment`.
                 pod:
@@ -418,14 +358,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
@@ -434,8 +370,7 @@ spec:
                         properties:
                           name:
                             type: string
-                      description: List of references to secrets in the same namespace
-                        to use for pulling any of the images used by this Pod.
+                      description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -478,18 +413,11 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
-                      description: Configures pod-level security attributes and common
-                        container settings.
+                      description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
-                      description: The grace period is the duration in seconds after
-                        the processes running in the pod are sent a termination signal
-                        and the time when the processes are forcibly halted with a
-                        kill signal. Set this value longer than the expected cleanup
-                        time for your process.Value must be non-negative integer.
-                        The value zero indicates delete immediately. Defaults to 30
-                        seconds.
+                      description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                     affinity:
                       type: object
                       properties:
@@ -701,12 +629,10 @@ spec:
                       description: The pod's affinity rules.
                     priorityClassName:
                       type: string
-                      description: The name of the Priority Class to which these pods
-                        will be assigned.
+                      description: The name of the Priority Class to which these pods will be assigned.
                     schedulerName:
                       type: string
-                      description: The name of the scheduler used to dispatch this
-                        `Pod`. If not specified, the default scheduler will be used.
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -732,14 +658,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Bridge API `Service`.
                 bridgeContainer:
@@ -756,8 +678,7 @@ spec:
                           value:
                             type: string
                             description: The environment variable value.
-                      description: Environment variables which should be applied to
-                        the container.
+                      description: Environment variables which should be applied to the container.
                     securityContext:
                       type: object
                       properties:
@@ -814,41 +735,30 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
-                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
-                        resource.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate` resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
-                      description: Maximum number of unavailable pods to allow automatic
-                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
-                        number of pods or fewer are unavailable after the eviction.
-                        Setting this value to 0 prevents all voluntary evictions,
-                        so the pods must be evicted manually. Defaults to 1.
+                      description: Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
                   description: Template for Kafka Bridge `PodDisruptionBudget`.
-              description: Template for Kafka Bridge resources. The template allows
-                users to specify how is the `Deployment` and `Pods` generated.
+              description: Template for Kafka Bridge resources. The template allows users to specify how is the `Deployment` and `Pods` generated.
             tracing:
               type: object
               properties:
                 type:
                   type: string
                   enum:
-                  - jaeger
-                  description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing.
+                    - jaeger
+                  description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
               required:
-              - type
+                - type
               description: The configuration of tracing in Kafka Bridge.
           required:
-          - bootstrapServers
+            - bootstrapServers
           description: The specification of the Kafka Bridge.
         status:
           type: object
@@ -860,34 +770,26 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             url:
               type: string
-              description: The URL at which external client applications can access
-                the Kafka Bridge.
+              description: The URL at which external client applications can access the Kafka Bridge.
             podSelector:
               type: object
               properties:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
   version: v1alpha1
   scope: Namespaced
   names:
@@ -20,9 +20,9 @@ spec:
     singular: kafkaconnector
     plural: kafkaconnectors
     shortNames:
-    - kctr
+      - kctr
     categories:
-    - strimzi
+      - strimzi
   subresources:
     status: {}
     scale:
@@ -43,8 +43,7 @@ spec:
               description: The maximum number of tasks for the Kafka Connector.
             config:
               type: object
-              description: 'The Kafka Connector configuration. The following properties
-                cannot be set: connector.class, tasks.max.'
+              description: 'The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.'
             pause:
               type: boolean
               description: Whether the connector should be paused. Defaults to false.
@@ -59,34 +58,26 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             connectorStatus:
               type: object
-              description: The connector status, as reported by the Kafka Connect
-                REST API.
+              description: The connector status, as reported by the Kafka Connect REST API.
             tasksMax:
               type: integer
               description: The maximum number of tasks for the Kafka Connector.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
   version: v1alpha1
   scope: Namespaced
   names:
@@ -20,14 +20,14 @@ spec:
     singular: kafkamirrormaker2
     plural: kafkamirrormaker2s
     shortNames:
-    - kmm2
+      - kmm2
     categories:
-    - strimzi
+      - strimzi
   additionalPrinterColumns:
-  - name: Desired replicas
-    description: The desired number of Kafka MirrorMaker 2.0 replicas
-    JSONPath: .spec.replicas
-    type: integer
+    - name: Desired replicas
+      description: The desired number of Kafka MirrorMaker 2.0 replicas
+      JSONPath: .spec.replicas
+      type: integer
   subresources:
     status: {}
     scale:
@@ -45,16 +45,13 @@ spec:
               description: The number of pods in the Kafka Connect group.
             version:
               type: string
-              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}.
-                Consult the user documentation to understand the process required
-                to upgrade or downgrade the version.
+              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
             image:
               type: string
               description: The docker image for the pods.
             connectCluster:
               type: string
-              description: The cluster alias used for Kafka Connect. The alias must
-                match a cluster in the list at `spec.clusters`.
+              description: The cluster alias used for Kafka Connect. The alias must match a cluster in the list at `spec.clusters`.
             clusters:
               type: array
               items:
@@ -66,15 +63,10 @@ spec:
                     description: Alias used to reference the Kafka cluster.
                   bootstrapServers:
                     type: string
-                    description: A comma-separated list of `host:port` pairs for establishing
-                      the connection to the Kafka cluster.
+                    description: A comma-separated list of `host:port` pairs for establishing the connection to the Kafka cluster.
                   config:
                     type: object
-                    description: 'The MirrorMaker 2.0 cluster config. Properties with
-                      the following prefixes cannot be set: ssl., sasl., security.,
-                      listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes,
-                      producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm,
-                      ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
+                    description: 'The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
                   tls:
                     type: object
                     properties:
@@ -85,17 +77,15 @@ spec:
                           properties:
                             certificate:
                               type: string
-                              description: The name of the file certificate in the
-                                Secret.
+                              description: The name of the file certificate in the Secret.
                             secretName:
                               type: string
                               description: The name of the Secret containing the certificate.
                           required:
-                          - certificate
-                          - secretName
+                            - certificate
+                            - secretName
                         description: Trusted certificates for TLS connection.
-                    description: TLS configuration for connecting MirrorMaker 2.0
-                      connectors to a cluster.
+                    description: TLS configuration for connecting MirrorMaker 2.0 connectors to a cluster.
                   authentication:
                     type: object
                     properties:
@@ -104,22 +94,17 @@ spec:
                         properties:
                           key:
                             type: string
-                            description: The key under which the secret value is stored
-                              in the Kubernetes Secret.
+                            description: The key under which the secret value is stored in the Kubernetes Secret.
                           secretName:
                             type: string
-                            description: The name of the Kubernetes Secret containing
-                              the secret value.
+                            description: The name of the Kubernetes Secret containing the secret value.
                         required:
-                        - key
-                        - secretName
-                        description: Link to Kubernetes Secret containing the access
-                          token which was obtained from the authorization server.
+                          - key
+                          - secretName
+                        description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
                       accessTokenIsJwt:
                         type: boolean
-                        description: Configure whether access token should be treated
-                          as JWT. This should be set to `false` if the authorization
-                          server returns opaque tokens. Defaults to `true`.
+                        description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
                       certificateAndKey:
                         type: object
                         properties:
@@ -133,80 +118,61 @@ spec:
                             type: string
                             description: The name of the Secret containing the certificate.
                         required:
-                        - certificate
-                        - key
-                        - secretName
-                        description: Reference to the `Secret` which holds the certificate
-                          and private key pair.
+                          - certificate
+                          - key
+                          - secretName
+                        description: Reference to the `Secret` which holds the certificate and private key pair.
                       clientId:
                         type: string
-                        description: OAuth Client ID which the Kafka client can use
-                          to authenticate against the OAuth server and use the token
-                          endpoint URI.
+                        description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                       clientSecret:
                         type: object
                         properties:
                           key:
                             type: string
-                            description: The key under which the secret value is stored
-                              in the Kubernetes Secret.
+                            description: The key under which the secret value is stored in the Kubernetes Secret.
                           secretName:
                             type: string
-                            description: The name of the Kubernetes Secret containing
-                              the secret value.
+                            description: The name of the Kubernetes Secret containing the secret value.
                         required:
-                        - key
-                        - secretName
-                        description: Link to Kubernetes Secret containing the OAuth
-                          client secret which the Kafka client can use to authenticate
-                          against the OAuth server and use the token endpoint URI.
+                          - key
+                          - secretName
+                        description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
                       disableTlsHostnameVerification:
                         type: boolean
-                        description: Enable or disable TLS hostname verification.
-                          Default value is `false`.
+                        description: Enable or disable TLS hostname verification. Default value is `false`.
                       maxTokenExpirySeconds:
                         type: integer
-                        description: Set or limit time-to-live of the access tokens
-                          to the specified number of seconds. This should be set if
-                          the authorization server returns opaque tokens.
+                        description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
                       passwordSecret:
                         type: object
                         properties:
                           password:
                             type: string
-                            description: The name of the key in the Secret under which
-                              the password is stored.
+                            description: The name of the key in the Secret under which the password is stored.
                           secretName:
                             type: string
                             description: The name of the Secret containing the password.
                         required:
-                        - password
-                        - secretName
+                          - password
+                          - secretName
                         description: Reference to the `Secret` which holds the password.
                       refreshToken:
                         type: object
                         properties:
                           key:
                             type: string
-                            description: The key under which the secret value is stored
-                              in the Kubernetes Secret.
+                            description: The key under which the secret value is stored in the Kubernetes Secret.
                           secretName:
                             type: string
-                            description: The name of the Kubernetes Secret containing
-                              the secret value.
+                            description: The name of the Kubernetes Secret containing the secret value.
                         required:
-                        - key
-                        - secretName
-                        description: Link to Kubernetes Secret containing the refresh
-                          token which can be used to obtain access token from the
-                          authorization server.
+                          - key
+                          - secretName
+                        description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
                       scope:
                         type: string
-                        description: OAuth scope to use when authenticating against
-                          the authorization server. Some authorization servers require
-                          this to be set. The possible values depend on how authorization
-                          server is configured. By default `scope` is not specified
-                          when doing the token endpoint request.
+                        description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
                       tlsTrustedCertificates:
                         type: array
                         items:
@@ -214,42 +180,34 @@ spec:
                           properties:
                             certificate:
                               type: string
-                              description: The name of the file certificate in the
-                                Secret.
+                              description: The name of the file certificate in the Secret.
                             secretName:
                               type: string
                               description: The name of the Secret containing the certificate.
                           required:
-                          - certificate
-                          - secretName
-                        description: Trusted certificates for TLS connection to the
-                          OAuth server.
+                            - certificate
+                            - secretName
+                        description: Trusted certificates for TLS connection to the OAuth server.
                       tokenEndpointUri:
                         type: string
                         description: Authorization server token endpoint URI.
                       type:
                         type: string
                         enum:
-                        - tls
-                        - scram-sha-512
-                        - plain
-                        - oauth
-                        description: Authentication type. Currently the only supported
-                          types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
-                          type uses SASL SCRAM-SHA-512 Authentication. `plain` type
-                          uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
-                          Authentication. The `tls` type uses TLS Client Authentication.
-                          The `tls` type is supported only over TLS connections.
+                          - tls
+                          - scram-sha-512
+                          - plain
+                          - oauth
+                        description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                       username:
                         type: string
                         description: Username used for the authentication.
                     required:
-                    - type
-                    description: Authentication configuration for connecting to the
-                      cluster.
+                      - type
+                    description: Authentication configuration for connecting to the cluster.
                 required:
-                - alias
-                - bootstrapServers
+                  - alias
+                  - bootstrapServers
               description: Kafka clusters for mirroring.
             mirrors:
               type: array
@@ -258,14 +216,10 @@ spec:
                 properties:
                   sourceCluster:
                     type: string
-                    description: The alias of the source cluster used by the Kafka
-                      MirrorMaker 2.0 connectors. The alias must match a cluster in
-                      the list at `spec.clusters`.
+                    description: The alias of the source cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
                   targetCluster:
                     type: string
-                    description: The alias of the target cluster used by the Kafka
-                      MirrorMaker 2.0 connectors. The alias must match a cluster in
-                      the list at `spec.clusters`.
+                    description: The alias of the target cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
                   sourceConnector:
                     type: object
                     properties:
@@ -275,14 +229,11 @@ spec:
                         description: The maximum number of tasks for the Kafka Connector.
                       config:
                         type: object
-                        description: 'The Kafka Connector configuration. The following
-                          properties cannot be set: connector.class, tasks.max.'
+                        description: 'The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.'
                       pause:
                         type: boolean
-                        description: Whether the connector should be paused. Defaults
-                          to false.
-                    description: The specification of the Kafka MirrorMaker 2.0 source
-                      connector.
+                        description: Whether the connector should be paused. Defaults to false.
+                    description: The specification of the Kafka MirrorMaker 2.0 source connector.
                   checkpointConnector:
                     type: object
                     properties:
@@ -292,14 +243,11 @@ spec:
                         description: The maximum number of tasks for the Kafka Connector.
                       config:
                         type: object
-                        description: 'The Kafka Connector configuration. The following
-                          properties cannot be set: connector.class, tasks.max.'
+                        description: 'The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.'
                       pause:
                         type: boolean
-                        description: Whether the connector should be paused. Defaults
-                          to false.
-                    description: The specification of the Kafka MirrorMaker 2.0 checkpoint
-                      connector.
+                        description: Whether the connector should be paused. Defaults to false.
+                    description: The specification of the Kafka MirrorMaker 2.0 checkpoint connector.
                   heartbeatConnector:
                     type: object
                     properties:
@@ -309,34 +257,26 @@ spec:
                         description: The maximum number of tasks for the Kafka Connector.
                       config:
                         type: object
-                        description: 'The Kafka Connector configuration. The following
-                          properties cannot be set: connector.class, tasks.max.'
+                        description: 'The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.'
                       pause:
                         type: boolean
-                        description: Whether the connector should be paused. Defaults
-                          to false.
-                    description: The specification of the Kafka MirrorMaker 2.0 heartbeat
-                      connector.
+                        description: Whether the connector should be paused. Defaults to false.
+                    description: The specification of the Kafka MirrorMaker 2.0 heartbeat connector.
                   topicsPattern:
                     type: string
-                    description: A regular expression matching the topics to be mirrored,
-                      for example, "topic1\|topic2\|topic3". Comma-separated lists
-                      are also supported.
+                    description: A regular expression matching the topics to be mirrored, for example, "topic1\|topic2\|topic3". Comma-separated lists are also supported.
                   topicsBlacklistPattern:
                     type: string
-                    description: A regular expression matching the topics to exclude
-                      from mirroring. Comma-separated lists are also supported.
+                    description: A regular expression matching the topics to exclude from mirroring. Comma-separated lists are also supported.
                   groupsPattern:
                     type: string
-                    description: A regular expression matching the consumer groups
-                      to be mirrored. Comma-separated lists are also supported.
+                    description: A regular expression matching the consumer groups to be mirrored. Comma-separated lists are also supported.
                   groupsBlacklistPattern:
                     type: string
-                    description: A regular expression matching the consumer groups
-                      to exclude from mirroring. Comma-separated lists are also supported.
+                    description: A regular expression matching the consumer groups to exclude from mirroring. Comma-separated lists are also supported.
                 required:
-                - sourceCluster
-                - targetCluster
+                  - sourceCluster
+                  - targetCluster
               description: Configuration of the MirrorMaker 2.0 connectors.
             resources:
               type: object
@@ -345,30 +285,23 @@ spec:
                   type: object
                 requests:
                   type: object
-              description: The maximum limits for CPU and memory resources and the
-                requested initial resources.
+              description: The maximum limits for CPU and memory resources and the requested initial resources.
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -379,23 +312,17 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
+                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first
-                    checked.
+                  description: The initial delay before first the health is first checked.
                 periodSeconds:
                   type: integer
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
+                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness.
-                    Minimum value is 1.
+                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
@@ -417,8 +344,7 @@ spec:
                   description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
-                  description: Specifies whether the Garbage Collection logging is
-                    enabled. The default is false.
+                  description: Specifies whether the Garbage Collection logging is enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -430,8 +356,7 @@ spec:
                       value:
                         type: string
                         description: The system property value.
-                  description: A map of additional system properties which will be
-                    passed using the `-D` option to the JVM.
+                  description: A map of additional system properties which will be passed using the `-D` option to the JVM.
               description: JVM Options for pods.
             affinity:
               type: object
@@ -666,32 +591,29 @@ spec:
                   description: A Map from logger name to logger level.
                 name:
                   type: string
-                  description: The name of the `ConfigMap` from which to get the logging
-                    configuration.
+                  description: The name of the `ConfigMap` from which to get the logging configuration.
                 type:
                   type: string
                   enum:
-                  - inline
-                  - external
+                    - inline
+                    - external
                   description: Logging type, must be either 'inline' or 'external'.
               required:
-              - type
+                - type
               description: Logging configuration for Kafka Connect.
             metrics:
               type: object
-              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
-                for details of the structure of this configuration.
+              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
             tracing:
               type: object
               properties:
                 type:
                   type: string
                   enum:
-                  - jaeger
-                  description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing.
+                    - jaeger
+                  description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
               required:
-              - type
+                - type
               description: The configuration of tracing in Kafka Connect.
             template:
               type: object
@@ -704,14 +626,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
@@ -722,14 +640,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
@@ -738,8 +652,7 @@ spec:
                         properties:
                           name:
                             type: string
-                      description: List of references to secrets in the same namespace
-                        to use for pulling any of the images used by this Pod.
+                      description: List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -782,18 +695,11 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
-                      description: Configures pod-level security attributes and common
-                        container settings.
+                      description: Configures pod-level security attributes and common container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
-                      description: The grace period is the duration in seconds after
-                        the processes running in the pod are sent a termination signal
-                        and the time when the processes are forcibly halted with a
-                        kill signal. Set this value longer than the expected cleanup
-                        time for your process.Value must be non-negative integer.
-                        The value zero indicates delete immediately. Defaults to 30
-                        seconds.
+                      description: The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.Value must be non-negative integer. The value zero indicates delete immediately. Defaults to 30 seconds.
                     affinity:
                       type: object
                       properties:
@@ -1005,12 +911,10 @@ spec:
                       description: The pod's affinity rules.
                     priorityClassName:
                       type: string
-                      description: The name of the Priority Class to which these pods
-                        will be assigned.
+                      description: The name of the Priority Class to which these pods will be assigned.
                     schedulerName:
                       type: string
-                      description: The name of the scheduler used to dispatch this
-                        `Pod`. If not specified, the default scheduler will be used.
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -1036,14 +940,10 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for Kafka Connect API `Service`.
                 connectContainer:
@@ -1060,8 +960,7 @@ spec:
                           value:
                             type: string
                             description: The environment variable value.
-                      description: Environment variables which should be applied to
-                        the container.
+                      description: Environment variables which should be applied to the container.
                     securityContext:
                       type: object
                       properties:
@@ -1118,28 +1017,17 @@ spec:
                       properties:
                         labels:
                           type: object
-                          description: Labels which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
-                          description: Annotations which should be added to the resource
-                            template. Can be applied to different resources such as
-                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
-                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
-                        resource.
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate` resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
-                      description: Maximum number of unavailable pods to allow automatic
-                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
-                        number of pods or fewer are unavailable after the eviction.
-                        Setting this value to 0 prevents all voluntary evictions,
-                        so the pods must be evicted manually. Defaults to 1.
+                      description: Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
                   description: Template for Kafka Connect `PodDisruptionBudget`.
-              description: Template for Kafka Connect and Kafka Connect S2I resources.
-                The template allows users to specify how the `Deployment`, `Pods`
-                and `Service` are generated.
+              description: Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
             externalConfiguration:
               type: object
               properties:
@@ -1150,9 +1038,7 @@ spec:
                     properties:
                       name:
                         type: string
-                        description: Name of the environment variable which will be
-                          passed to the Kafka Connect pods. The name of the environment
-                          variable cannot start with `KAFKA_` or `STRIMZI_`.
+                        description: Name of the environment variable which will be passed to the Kafka Connect pods. The name of the environment variable cannot start with `KAFKA_` or `STRIMZI_`.
                       valueFrom:
                         type: object
                         properties:
@@ -1176,15 +1062,11 @@ spec:
                               optional:
                                 type: boolean
                             description: Reference to a key in a Secret.
-                        description: Value of the environment variable which will
-                          be passed to the Kafka Connect pods. It can be passed either
-                          as a reference to Secret or ConfigMap field. The field has
-                          to specify exactly one Secret or ConfigMap.
+                        description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
                     required:
-                    - name
-                    - valueFrom
-                  description: Allows to pass data from Secret or ConfigMap to the
-                    Kafka Connect pods as environment variables.
+                      - name
+                      - valueFrom
+                  description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as environment variables.
                 volumes:
                   type: array
                   items:
@@ -1210,12 +1092,10 @@ spec:
                             type: string
                           optional:
                             type: boolean
-                        description: Reference to a key in a ConfigMap. Exactly one
-                          Secret or ConfigMap has to be specified.
+                        description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
                       name:
                         type: string
-                        description: Name of the volume which will be added to the
-                          Kafka Connect pods.
+                        description: Name of the volume which will be added to the Kafka Connect pods.
                       secret:
                         type: object
                         properties:
@@ -1236,16 +1116,13 @@ spec:
                             type: boolean
                           secretName:
                             type: string
-                        description: Reference to a key in a Secret. Exactly one Secret
-                          or ConfigMap has to be specified.
+                        description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
                     required:
-                    - name
-                  description: Allows to pass data from Secret or ConfigMap to the
-                    Kafka Connect pods as volumes.
-              description: Pass data from Secrets or ConfigMaps to the Kafka Connect
-                pods and use them to configure connectors.
+                      - name
+                  description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as volumes.
+              description: Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
           required:
-          - connectCluster
+            - connectCluster
           description: The specification of the Kafka MirrorMaker 2.0 cluster.
         status:
           type: object
@@ -1257,34 +1134,26 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             url:
               type: string
-              description: The URL of the REST API endpoint for managing and monitoring
-                Kafka Connect connectors.
+              description: The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
             connectorPlugins:
               type: array
               items:
@@ -1292,22 +1161,19 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The type of the connector plugin. The available types
-                      are `sink` and `source`.
+                    description: The type of the connector plugin. The available types are `sink` and `source`.
                   version:
                     type: string
                     description: The version of the connector plugin.
                   class:
                     type: string
                     description: The class of the connector plugin.
-              description: The list of connector plugins available in this Kafka Connect
-                deployment.
+              description: The list of connector plugins available in this Kafka Connect deployment.
             connectors:
               type: array
               items:
                 type: object
-              description: List of MirrorMaker 2.0 connector statuses, as reported
-                by the Kafka Connect REST API.
+              description: List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.
             podSelector:
               type: object
               properties:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   group: kafka.strimzi.io
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
   version: v1alpha1
   scope: Namespaced
   names:
@@ -20,9 +20,9 @@ spec:
     singular: kafkarebalance
     plural: kafkarebalances
     shortNames:
-    - kr
+      - kr
     categories:
-    - strimzi
+      - strimzi
   subresources:
     status: {}
   validation:
@@ -35,17 +35,10 @@ spec:
               type: array
               items:
                 type: string
-              description: A list of goals, ordered by decreasing priority, to use
-                for generating and executing the rebalance proposal. The supported
-                goals are available at https://github.com/linkedin/cruise-control#goals.
-                If an empty goals list is provided, the goals declared in the default.goals
-                Cruise Control configuration parameter are used.
+              description: A list of goals, ordered by decreasing priority, to use for generating and executing the rebalance proposal. The supported goals are available at https://github.com/linkedin/cruise-control#goals. If an empty goals list is provided, the goals declared in the default.goals Cruise Control configuration parameter are used.
             skipHardGoalCheck:
               type: boolean
-              description: Whether to allow the hard goals specified in the Kafka
-                CR to be skipped in rebalance proposal generation. This can be useful
-                when some of those hard goals are preventing a balance solution being
-                found. Default is false.
+              description: Whether to allow the hard goals specified in the Kafka CR to be skipped in rebalance proposal generation. This can be useful when some of those hard goals are preventing a balance solution being found. Default is false.
           description: The specification of the Kafka rebalance.
         status:
           type: object
@@ -57,35 +50,26 @@ spec:
                 properties:
                   type:
                     type: string
-                    description: The unique identifier of a condition, used to distinguish
-                      between other conditions in the resource.
+                    description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
                   status:
                     type: string
-                    description: The status of the condition, either True, False or
-                      Unknown.
+                    description: The status of the condition, either True, False or Unknown.
                   lastTransitionTime:
                     type: string
-                    description: Last time the condition of a type changed from one
-                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone.
+                    description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
                   reason:
                     type: string
-                    description: The reason for the condition's last transition (a
-                      single word in CamelCase).
+                    description: The reason for the condition's last transition (a single word in CamelCase).
                   message:
                     type: string
-                    description: Human-readable message indicating details about the
-                      condition's last transition.
+                    description: Human-readable message indicating details about the condition's last transition.
               description: List of status conditions.
             observedGeneration:
               type: integer
-              description: The generation of the CRD that was last reconciled by the
-                operator.
+              description: The generation of the CRD that was last reconciled by the operator.
             sessionId:
               type: string
-              description: The session identifier for requests to Cruise Control pertaining
-                to this KafkaRebalance resource. This is used by the Kafka Rebalance
-                operator to track the status of ongoing rebalancing operations.
+              description: The session identifier for requests to Cruise Control pertaining to this KafkaRebalance resource. This is used by the Kafka Rebalance operator to track the status of ongoing rebalancing operations.
             optimizationResult:
               type: object
               description: A JSON object describing the optimization result.

--- a/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -5,231 +5,231 @@ metadata:
   labels:
     app: strimzi
 rules:
-- apiGroups:
-  - ""
-  resources:
-  # The cluster operator needs to access and manage service accounts to grant Strimzi components cluster permissions
-  - serviceaccounts
-  verbs:
-  - get
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - "rbac.authorization.k8s.io"
-  resources:
-  # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
-  - rolebindings
-  verbs:
-  - get
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  # The cluster operator needs to access and manage config maps for Strimzi components configuration
-  - configmaps
-  # The cluster operator needs to access and manage services to expose Strimzi components to network traffic
-  - services
-  # The cluster operator needs to access and manage secrets to handle credentials
-  - secrets
-  # The cluster operator needs to access and manage persistent volume claims to bind them to Strimzi components for persistent data
-  - persistentvolumeclaims
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - "kafka.strimzi.io"
-  resources:
-  # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
-  - kafkas
-  - kafkas/status
-  # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
-  - kafkaconnects
-  - kafkaconnects/status
-  # The cluster operator runs the KafkaConnectS2IAssemblyOperator, which needs to access and manage KafkaConnectS2I resources
-  - kafkaconnects2is
-  - kafkaconnects2is/status
-  # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
-  - kafkaconnectors
-  - kafkaconnectors/status
-  # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
-  - kafkamirrormakers
-  - kafkamirrormakers/status
-  # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
-  - kafkabridges
-  - kafkabridges/status
-  # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
-  - kafkamirrormaker2s
-  - kafkamirrormaker2s/status
-  # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
-  - kafkarebalances
-  - kafkarebalances/status
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  # The cluster operator needs to access and delete pods, this is to allow it to monitor pod health and coordinate rolling updates
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  # The cluster operator needs the extensions api as the operator supports Kubernetes version 1.11+
-  # apps/v1 was introduced in Kubernetes 1.14
-  - "extensions"
-  resources:
-  # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
-  - deployments
-  - deployments/scale
-  # The cluster operator needs to access replica sets to manage Strimzi components and to determine error states
-  - replicasets
-  # The cluster operator needs to access and manage replication controllers to manage replicasets
-  - replicationcontrollers
-  # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
-  - networkpolicies
-  # The cluster operator needs to access and manage ingresses which allow external access to the services in a cluster
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - "apps"
-  resources:
-  # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
-  - deployments
-  - deployments/scale
-  - deployments/status
-  # The cluster operator needs to access and manage stateful sets to run stateful sets based Strimzi components
-  - statefulsets
-  # The cluster operator needs to access replica-sets to manage Strimzi components and to determine error states
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  # The cluster operator needs to be able to create events and delegate permissions to do so
-  - events
-  verbs:
-  - create
-- apiGroups:
-  # OpenShift S2I requirements
-  - apps.openshift.io
-  resources:
-  - deploymentconfigs
-  - deploymentconfigs/scale
-  - deploymentconfigs/status
-  - deploymentconfigs/finalizers
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  # OpenShift S2I requirements
-  - build.openshift.io
-  resources:
-  - buildconfigs
-  - builds
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - watch
-  - update
-- apiGroups:
-  # OpenShift S2I requirements
-  - image.openshift.io
-  resources:
-  - imagestreams
-  - imagestreams/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - watch
-  - patch
-  - update
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - route.openshift.io
-  resources:
-  # The cluster operator needs to access and manage routes to expose Strimzi components for external access
-  - routes
-  - routes/custom-host
-  verbs:
-  - get
-  - list
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - policy
-  resources:
-  # The cluster operator needs to access and manage pod disruption budgets this limits the number of concurrent disruptions
-  # that a Strimzi component experiences, allowing for higher availability
-  - poddisruptionbudgets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
+  - apiGroups:
+      - ""
+    resources:
+      # The cluster operator needs to access and manage service accounts to grant Strimzi components cluster permissions
+      - serviceaccounts
+    verbs:
+      - get
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
+      - rolebindings
+    verbs:
+      - get
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      # The cluster operator needs to access and manage config maps for Strimzi components configuration
+      - configmaps
+      # The cluster operator needs to access and manage services to expose Strimzi components to network traffic
+      - services
+      # The cluster operator needs to access and manage secrets to handle credentials
+      - secrets
+      # The cluster operator needs to access and manage persistent volume claims to bind them to Strimzi components for persistent data
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
+      - kafkas
+      - kafkas/status
+      # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
+      - kafkaconnects
+      - kafkaconnects/status
+      # The cluster operator runs the KafkaConnectS2IAssemblyOperator, which needs to access and manage KafkaConnectS2I resources
+      - kafkaconnects2is
+      - kafkaconnects2is/status
+      # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
+      - kafkaconnectors
+      - kafkaconnectors/status
+      # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
+      - kafkamirrormakers
+      - kafkamirrormakers/status
+      # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
+      - kafkabridges
+      - kafkabridges/status
+      # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
+      - kafkamirrormaker2s
+      - kafkamirrormaker2s/status
+      # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
+      - kafkarebalances
+      - kafkarebalances/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      # The cluster operator needs to access and delete pods, this is to allow it to monitor pod health and coordinate rolling updates
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      # The cluster operator needs the extensions api as the operator supports Kubernetes version 1.11+
+      # apps/v1 was introduced in Kubernetes 1.14
+      - "extensions"
+    resources:
+      # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
+      - deployments
+      - deployments/scale
+      # The cluster operator needs to access replica sets to manage Strimzi components and to determine error states
+      - replicasets
+      # The cluster operator needs to access and manage replication controllers to manage replicasets
+      - replicationcontrollers
+      # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
+      - networkpolicies
+      # The cluster operator needs to access and manage ingresses which allow external access to the services in a cluster
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - "apps"
+    resources:
+      # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
+      - deployments
+      - deployments/scale
+      - deployments/status
+      # The cluster operator needs to access and manage stateful sets to run stateful sets based Strimzi components
+      - statefulsets
+      # The cluster operator needs to access replica-sets to manage Strimzi components and to determine error states
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      # The cluster operator needs to be able to create events and delegate permissions to do so
+      - events
+    verbs:
+      - create
+  - apiGroups:
+      # OpenShift S2I requirements
+      - apps.openshift.io
+    resources:
+      - deploymentconfigs
+      - deploymentconfigs/scale
+      - deploymentconfigs/status
+      - deploymentconfigs/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      # OpenShift S2I requirements
+      - build.openshift.io
+    resources:
+      - buildconfigs
+      - builds
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+      - update
+  - apiGroups:
+      # OpenShift S2I requirements
+      - image.openshift.io
+    resources:
+      - imagestreams
+      - imagestreams/status
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      # The cluster operator needs to access and manage routes to expose Strimzi components for external access
+      - routes
+      - routes/custom-host
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - policy
+    resources:
+      # The cluster operator needs to access and manage pod disruption budgets this limits the number of concurrent disruptions
+      # that a Strimzi component experiences, allowing for higher availability
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update

--- a/install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     app: strimzi
 subjects:
-- kind: ServiceAccount
-  name: strimzi-cluster-operator
-  namespace: myproject
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: myproject
 roleRef:
   kind: ClusterRole
   name: strimzi-cluster-operator-namespaced

--- a/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -5,33 +5,33 @@ metadata:
   labels:
     app: strimzi
 rules:
-- apiGroups:
-  - "rbac.authorization.k8s.io"
-  resources:
-  # The cluster operator needs to create and manage cluster role bindings in the case of an install where a user
-  # has specified they want their cluster role bindings generated
-  - clusterrolebindings
-  verbs:
-  - get
-  - create
-  - delete
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  # The cluster operator requires "get" permissions to view storage class details
-  # This is because only a persistent volume of a supported storage class type can be resized
-  - storageclasses
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  # The cluster operator requires "list" permissions to view all nodes in a cluster
-  # The listing is used to determine the node addresses when NodePort access is configured
-  # These addresses are then exposed in the custom resource states
-  - nodes
-  verbs:
-  - list
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      # The cluster operator needs to create and manage cluster role bindings in the case of an install where a user
+      # has specified they want their cluster role bindings generated
+      - clusterrolebindings
+    verbs:
+      - get
+      - create
+      - delete
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      # The cluster operator requires "get" permissions to view storage class details
+      # This is because only a persistent volume of a supported storage class type can be resized
+      - storageclasses
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      # The cluster operator requires "list" permissions to view all nodes in a cluster
+      # The listing is used to determine the node addresses when NodePort access is configured
+      # These addresses are then exposed in the custom resource states
+      - nodes
+    verbs:
+      - list

--- a/install/cluster-operator/021-ClusterRoleBinding-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/021-ClusterRoleBinding-strimzi-cluster-operator.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     app: strimzi
 subjects:
-- kind: ServiceAccount
-  name: strimzi-cluster-operator
-  namespace: myproject
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: myproject
 roleRef:
   kind: ClusterRole
   name: strimzi-cluster-operator-global

--- a/install/cluster-operator/030-ClusterRole-strimzi-kafka-broker.yaml
+++ b/install/cluster-operator/030-ClusterRole-strimzi-kafka-broker.yaml
@@ -5,11 +5,11 @@ metadata:
   labels:
     app: strimzi
 rules:
-- apiGroups:
-  - ""
-  resources:
-  # The Kafka Brokers require "get" permissions to view the node they are on
-  # This information is used to generate a Rack ID that is used for High Availability configurations
-  - nodes
-  verbs:
-  - get
+  - apiGroups:
+      - ""
+    resources:
+      # The Kafka Brokers require "get" permissions to view the node they are on
+      # This information is used to generate a Rack ID that is used for High Availability configurations
+      - nodes
+    verbs:
+      - get

--- a/install/cluster-operator/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml
+++ b/install/cluster-operator/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml
@@ -7,9 +7,9 @@ metadata:
 # The Kafka broker cluster role must be bound to the cluster operator service account so that it can delegate the cluster role to the Kafka brokers.
 # This must be done to avoid escalating privileges which would be blocked by Kubernetes.
 subjects:
-- kind: ServiceAccount
-  name: strimzi-cluster-operator
-  namespace: myproject
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: myproject
 roleRef:
   kind: ClusterRole
   name: strimzi-kafka-broker

--- a/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
@@ -5,39 +5,39 @@ metadata:
   labels:
     app: strimzi
 rules:
-- apiGroups:
-  - "kafka.strimzi.io"
-  resources:
-  # The entity operator runs the KafkaTopic assembly operator, which needs to access and manage KafkaTopic resources
-  - kafkatopics
-  - kafkatopics/status
-  # The entity operator runs the KafkaUser assembly operator, which needs to access and manage KafkaUser resources
-  - kafkausers
-  - kafkausers/status
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - patch
-  - update
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  # The entity operator needs to be able to create events
-  - create
-- apiGroups:
-  - ""
-  resources:
-  # The entity operator user-operator needs to access and manage secrets to store generated credentials
-  - secrets
-  verbs:
-  - get
-  - list
-  - create
-  - patch
-  - update
-  - delete
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # The entity operator runs the KafkaTopic assembly operator, which needs to access and manage KafkaTopic resources
+      - kafkatopics
+      - kafkatopics/status
+      # The entity operator runs the KafkaUser assembly operator, which needs to access and manage KafkaUser resources
+      - kafkausers
+      - kafkausers/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      # The entity operator needs to be able to create events
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      # The entity operator user-operator needs to access and manage secrets to store generated credentials
+      - secrets
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+      - update
+      - delete

--- a/install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+++ b/install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
@@ -7,9 +7,9 @@ metadata:
 # The Entity Operator cluster role must be bound to the cluster operator service account so that it can delegate the cluster role to the Entity Operator.
 # This must be done to avoid escalating privileges which would be blocked by Kubernetes.
 subjects:
-- kind: ServiceAccount
-  name: strimzi-cluster-operator
-  namespace: myproject
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: myproject
 roleRef:
   kind: ClusterRole
   name: strimzi-entity-operator

--- a/install/cluster-operator/032-ClusterRole-strimzi-topic-operator.yaml
+++ b/install/cluster-operator/032-ClusterRole-strimzi-topic-operator.yaml
@@ -5,21 +5,21 @@ metadata:
   labels:
     app: strimzi
 rules:
-- apiGroups:
-  - "kafka.strimzi.io"
-  resources:
-  - kafkatopics
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - patch
-  - update
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      - kafkatopics
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create

--- a/install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
+++ b/install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     app: strimzi
 subjects:
-- kind: ServiceAccount
-  name: strimzi-cluster-operator
-  namespace: myproject
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: myproject
 roleRef:
   kind: ClusterRole
   name: strimzi-topic-operator

--- a/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
@@ -18,87 +18,87 @@ spec:
     spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
-      - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
-        ports:
-        - containerPort: 8080
-          name: http
-        args:
-        - /opt/strimzi/bin/cluster_operator_run.sh
-        env:
-        - name: STRIMZI_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
-          value: "120000"
-        - name: STRIMZI_OPERATION_TIMEOUT_MS
-          value: "300000"
-        - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
-          value: strimzi/kafka:latest-kafka-2.5.0
-        - name: STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE
-          value: strimzi/kafka:latest-kafka-2.5.0
-        - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
-          value: strimzi/kafka:latest-kafka-2.5.0
-        - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
-          value: strimzi/kafka:latest-kafka-2.5.0
-        - name: STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE
-          value: strimzi/kafka:latest-kafka-2.5.0
-        - name: STRIMZI_KAFKA_IMAGES
-          value: |
-            2.4.0=strimzi/kafka:latest-kafka-2.4.0
-            2.4.1=strimzi/kafka:latest-kafka-2.4.1
-            2.5.0=strimzi/kafka:latest-kafka-2.5.0
-        - name: STRIMZI_KAFKA_CONNECT_IMAGES
-          value: |
-            2.4.0=strimzi/kafka:latest-kafka-2.4.0
-            2.4.1=strimzi/kafka:latest-kafka-2.4.1
-            2.5.0=strimzi/kafka:latest-kafka-2.5.0
-        - name: STRIMZI_KAFKA_CONNECT_S2I_IMAGES
-          value: |
-            2.4.0=strimzi/kafka:latest-kafka-2.4.0
-            2.4.1=strimzi/kafka:latest-kafka-2.4.1
-            2.5.0=strimzi/kafka:latest-kafka-2.5.0
-        - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
-          value: |
-            2.4.0=strimzi/kafka:latest-kafka-2.4.0
-            2.4.1=strimzi/kafka:latest-kafka-2.4.1
-            2.5.0=strimzi/kafka:latest-kafka-2.5.0
-        - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
-          value: |
-            2.4.0=strimzi/kafka:latest-kafka-2.4.0
-            2.4.1=strimzi/kafka:latest-kafka-2.4.1
-            2.5.0=strimzi/kafka:latest-kafka-2.5.0
-        - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
-          value: strimzi/operator:latest
-        - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
-          value: strimzi/operator:latest
-        - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
-          value: strimzi/operator:latest
-        - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
-          value: strimzi/kafka-bridge:0.16.0
-        - name: STRIMZI_DEFAULT_JMXTRANS_IMAGE
-          value: strimzi/jmxtrans:latest
-        - name: STRIMZI_LOG_LEVEL
-          value: "INFO"
-        livenessProbe:
-          httpGet:
-            path: /healthy
-            port: http
-          initialDelaySeconds: 10
-          periodSeconds: 30
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: http
-          initialDelaySeconds: 10
-          periodSeconds: 30
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 384Mi
-          requests:
-            cpu: 200m
-            memory: 384Mi
+        - name: strimzi-cluster-operator
+          image: strimzi/operator:latest
+          ports:
+            - containerPort: 8080
+              name: http
+          args:
+            - /opt/strimzi/bin/cluster_operator_run.sh
+          env:
+            - name: STRIMZI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
+              value: "120000"
+            - name: STRIMZI_OPERATION_TIMEOUT_MS
+              value: "300000"
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: strimzi/kafka:latest-kafka-2.5.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE
+              value: strimzi/kafka:latest-kafka-2.5.0
+            - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
+              value: strimzi/kafka:latest-kafka-2.5.0
+            - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
+              value: strimzi/kafka:latest-kafka-2.5.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE
+              value: strimzi/kafka:latest-kafka-2.5.0
+            - name: STRIMZI_KAFKA_IMAGES
+              value: |
+                2.4.0=strimzi/kafka:latest-kafka-2.4.0
+                2.4.1=strimzi/kafka:latest-kafka-2.4.1
+                2.5.0=strimzi/kafka:latest-kafka-2.5.0
+            - name: STRIMZI_KAFKA_CONNECT_IMAGES
+              value: |
+                2.4.0=strimzi/kafka:latest-kafka-2.4.0
+                2.4.1=strimzi/kafka:latest-kafka-2.4.1
+                2.5.0=strimzi/kafka:latest-kafka-2.5.0
+            - name: STRIMZI_KAFKA_CONNECT_S2I_IMAGES
+              value: |
+                2.4.0=strimzi/kafka:latest-kafka-2.4.0
+                2.4.1=strimzi/kafka:latest-kafka-2.4.1
+                2.5.0=strimzi/kafka:latest-kafka-2.5.0
+            - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
+              value: |
+                2.4.0=strimzi/kafka:latest-kafka-2.4.0
+                2.4.1=strimzi/kafka:latest-kafka-2.4.1
+                2.5.0=strimzi/kafka:latest-kafka-2.5.0
+            - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
+              value: |
+                2.4.0=strimzi/kafka:latest-kafka-2.4.0
+                2.4.1=strimzi/kafka:latest-kafka-2.4.1
+                2.5.0=strimzi/kafka:latest-kafka-2.5.0
+            - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
+              value: strimzi/operator:latest
+            - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
+              value: strimzi/operator:latest
+            - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
+              value: strimzi/operator:latest
+            - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
+              value: strimzi/kafka-bridge:0.16.0
+            - name: STRIMZI_DEFAULT_JMXTRANS_IMAGE
+              value: strimzi/jmxtrans:latest
+            - name: STRIMZI_LOG_LEVEL
+              value: "INFO"
+          livenessProbe:
+            httpGet:
+              path: /healthy
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 384Mi
+            requests:
+              cpu: 200m
+              memory: 384Mi
   strategy:
     type: Recreate

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -158,6 +158,10 @@ def installHelm(String workspace) {
     sh(script: "${workspace}/.travis/setup-helm.sh")
 }
 
+def installYq(String workspace) {
+    sh(script: "${workspace}/.travis/install_yq.sh")
+}
+
 def buildStrimziImages() {
     sh(script: "make docker_build")
     sh(script: "make docker_tag")

--- a/prerequisites-check.sh
+++ b/prerequisites-check.sh
@@ -23,7 +23,7 @@ fi
 
 yq_array=($(echo "$YQ_VERSION" | tr '.' '\n'))
 
-yq_err_msg="${RED}yq version is ${YQ_VERSION}, version must be 3.3.1 of above. Please download the latest version from https://github.com/mikefarah/yq/releases${NO_COLOUR}"
+yq_err_msg="${RED}yq version is ${YQ_VERSION}, version must be 3.3.1 or above. Please download the latest version from https://github.com/mikefarah/yq/releases${NO_COLOUR}"
 
 if [[ yq_array[0] -lt 3  ]]; then
   echo -e $yq_err_msg

--- a/prerequisites-check.sh
+++ b/prerequisites-check.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+set -e
+
+source multi-platform-support.sh
 
 RED="\033[0;31m"
 NO_COLOUR="\033[0m"
@@ -13,7 +16,22 @@ check_command_present git
 check_command_present docker
 
 YQ_VERSION="$(yq --version | ${SED} 's/^.* //g')"
-if [[ ${YQ_VERSION} != "3."* ]]; then
-  echo -e "${RED}yq vesion is ${YQ_VERSION}, version must be 3.*${NO_COLOUR}"
+# After version 3.3.1, yq --version sends the string to STDERR instead of STDOUT
+if [ -z "$YQ_VERSION" ]; then
+    YQ_VERSION="$(yq --version 2> >($GREP -Po '\d.\d.\d'))"
+fi
+
+yq_array=($(echo "$YQ_VERSION" | tr '.' '\n'))
+
+yq_err_msg="${RED}yq version is ${YQ_VERSION}, version must be 3.3.1 of above. Please download the latest version from https://github.com/mikefarah/yq/releases${NO_COLOUR}"
+
+if [[ yq_array[0] -lt 3  ]]; then
+  echo -e $yq_err_msg
   exit 1
+elif [[ yq_array[1] -lt 3 ]]; then
+  echo -e $yq_err_msg
+  exit 1
+elif [[ yq_array[2] -lt 1 ]]; then
+  echo -e $yq_err_msg
+  exit 1 
 fi


### PR DESCRIPTION
### Type of change

Refactor

### Description

Upgrade the `yq` version to 3.3.1+ as this fixes issues with yaml indentation and other formatting issues. This will change the formatting of the generated helm files and other yaml.  

Versions of `yq` after 3.3.1 change the output of the `--version` command to go to STDERR instead of STDOUT (see [yq issue 472](https://github.com/mikefarah/yq/issues/472)). This causes the current `prerequisites-check.sh` script to fail. This PR makes so that either STDOUT or STDERR are captured. It also adds multi-platform support to the `prerequistes-check.sh`.
