### PR TITLE
ST: add option to deploy CO not jsut via yaml bundle but by OLM for all tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -214,10 +214,12 @@ All environment variables can be seen in [Environment](systemtest/src/main/java/
 | COMPONENTS_IMAGE_PULL_POLICY | Image Pull Policy for Kafka, Bridge, etc.                                         | IfNotPresent                                     |
 | STRIMZI_TEST_LOG_LEVEL    | Log level for system tests                                                           | INFO                                             |
 | OLM_OPERATOR_NAME         | Operator name in manifests CSV                                                       | strimzi                                             |
+| OLM_SOURCE_NAME           | CatalogSource name which contains desired operator                                   | strimzi-source                                     |
 | OLM_APP_BUNDLE_PREFIX     | CSV bundle name                                                                      | strimzi                                             |
 | OLM_OPERATOR_VERSION      | Version of the operator which will be installed                                      | v0.16.2                                             |
 | DEFAULT_TO_DENY_NETWORK_POLICIES | Determines how will be network policies set - to deny-all (true) or allow-all (false)    | true                                            |
 | STRIMZI_EXEC_MAX_LOG_OUTPUT_CHARACTERS | Set maximum count of characters printed from [Executor](test/src/main/java/io/strimzi/test/executor/Exec.java) stdout and stderr | 20000   |
+| CLUSTER_OPERATOR_INSTALL_TYPE | Specify how the CO will be deployed. `OLM` option will install operator via OLM, you just need to set other `OLM` env variables.    | bundle  |
 
 If you want to use your own images with a different tag or from a different repository, you can use `DOCKER_REGISTRY`, `DOCKER_ORG` and `DOCKER_TAG` environment variables.
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -249,9 +249,4 @@ public interface Constants {
      * Tag for tests where cruise control used
      */
     String CRUISE_CONTROL = "cruisecontrol";
-
-    /**
-     * Tag for tests where we can use installation via OLM
-     */
-    String OLM_SUPPORTED = "olm";
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -249,4 +249,9 @@ public interface Constants {
      * Tag for tests where cruise control used
      */
     String CRUISE_CONTROL = "cruisecontrol";
+
+    /**
+     * Tag for tests where we can use installation via OLM
+     */
+    String OLM_SUPPORTED = "olm";
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -7,6 +7,8 @@ package io.strimzi.systemtest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Locale;
+
 /**
  * Class which holds environment variables for system tests.
  */
@@ -65,14 +67,18 @@ public class Environment {
     /**
      * OLM env variables
      */
-    private static final String OLM_INSTALLATION_ENV = "OLM_INSTALLATION_RNV";
     private static final String OLM_OPERATOR_NAME_ENV = "OLM_OPERATOR_NAME";
+    private static final String OLM_SOURCE_NAME_ENV = "OLM_SOURCE_NAME";
     private static final String OLM_APP_BUNDLE_PREFIX_ENV = "OLM_APP_BUNDLE_PREFIX";
     private static final String OLM_OPERATOR_VERSION_ENV = "OLM_OPERATOR_VERSION";
     /**
      * Allows network policies
      */
     private static final String DEFAULT_TO_DENY_NETWORK_POLICIES_ENV = "DEFAULT_TO_DENY_NETWORK_POLICIES";
+    /**
+     * ClusterOperator installation type
+     */
+    private static final String CLUSTER_OPERATOR_INSTALL_TYPE_ENV = "CLUSTER_OPERATOR_INSTALL_TYPE";
 
     private static final String SKIP_TEARDOWN_ENV = "SKIP_TEARDOWN";
 
@@ -87,9 +93,11 @@ public class Environment {
     public static final String OPERATOR_IMAGE_PULL_POLICY_ENV_DEFAULT = Constants.ALWAYS_IMAGE_PULL_POLICY;
     public static final int KAFKA_CLIENTS_DEFAULT_PORT = 4242;
     public static final String OLM_OPERATOR_NAME_DEFAULT = "strimzi";
+    public static final String OLM_SOURCE_NAME_DEFAULT = "strimzi-source";
     public static final String OLM_APP_BUNDLE_PREFIX_DEFAULT = "strimzi";
-    public static final String OLM_OPERATOR_VERSION_DEFAULT = "v0.16.2";
+    public static final String OLM_OPERATOR_VERSION_DEFAULT = "v0.18.0";
     private static final String DEFAULT_TO_DENY_NETWORK_POLICIES_DEFAULT = "true";
+    private static final String CLUSTER_OPERATOR_INSTALL_TYPE_DEFAULT = "bundle";
 
     public static final String STRIMZI_ORG = System.getenv().getOrDefault(STRIMZI_ORG_ENV, STRIMZI_ORG_DEFAULT);
     public static final String STRIMZI_TAG = System.getenv().getOrDefault(STRIMZI_TAG_ENV, STRIMZI_TAG_DEFAULT);
@@ -108,13 +116,16 @@ public class Environment {
     // Image pull policy variables
     public static final String COMPONENTS_IMAGE_PULL_POLICY = System.getenv().getOrDefault(COMPONENTS_IMAGE_PULL_POLICY_ENV, COMPONENTS_IMAGE_PULL_POLICY_ENV_DEFAULT);
     public static final String OPERATOR_IMAGE_PULL_POLICY = System.getenv().getOrDefault(OPERATOR_IMAGE_PULL_POLICY_ENV, OPERATOR_IMAGE_PULL_POLICY_ENV_DEFAULT);
-
     // OLM env variables
     public static final String OLM_OPERATOR_NAME = System.getenv().getOrDefault(OLM_OPERATOR_NAME_ENV, OLM_OPERATOR_NAME_DEFAULT);
+    public static final String OLM_SOURCE_NAME = System.getenv().getOrDefault(OLM_SOURCE_NAME_ENV, OLM_SOURCE_NAME_DEFAULT);
     public static final String OLM_APP_BUNDLE_PREFIX = System.getenv().getOrDefault(OLM_APP_BUNDLE_PREFIX_ENV, OLM_APP_BUNDLE_PREFIX_DEFAULT);
     public static final String OLM_OPERATOR_VERSION = System.getenv().getOrDefault(OLM_OPERATOR_VERSION_ENV, OLM_OPERATOR_VERSION_DEFAULT);
-
+    // NetworkPolicy variable
     public static final String DEFAULT_TO_DENY_NETWORK_POLICIES = System.getenv().getOrDefault(DEFAULT_TO_DENY_NETWORK_POLICIES_ENV, DEFAULT_TO_DENY_NETWORK_POLICIES_DEFAULT);
+    // ClusterOperator installation type variable
+    public static final String CLUSTER_OPERATOR_INSTALL_TYPE = System.getenv().getOrDefault(CLUSTER_OPERATOR_INSTALL_TYPE_ENV, CLUSTER_OPERATOR_INSTALL_TYPE_DEFAULT);
+
 
     private Environment() { }
 
@@ -136,5 +147,10 @@ public class Environment {
         LOGGER.info(debugFormat, OLM_APP_BUNDLE_PREFIX_ENV, OLM_APP_BUNDLE_PREFIX);
         LOGGER.info(debugFormat, OLM_OPERATOR_VERSION_ENV, OLM_OPERATOR_VERSION);
         LOGGER.info(debugFormat, DEFAULT_TO_DENY_NETWORK_POLICIES_ENV, DEFAULT_TO_DENY_NETWORK_POLICIES);
+        LOGGER.info(debugFormat, CLUSTER_OPERATOR_INSTALL_TYPE_ENV, CLUSTER_OPERATOR_INSTALL_TYPE);
+    }
+
+    public static boolean isOlmInstall() {
+        return Environment.CLUSTER_OPERATOR_INSTALL_TYPE.toUpperCase(Locale.ENGLISH).equals("OLM");
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/OlmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/OlmResource.java
@@ -15,6 +15,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -25,9 +27,15 @@ public class OlmResource {
     private static Map<String, JsonObject> exampleResources = new HashMap<>();
 
     public static void clusterOperator(String namespace) throws Exception {
+        clusterOperator(namespace, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Constants.RECONCILIATION_INTERVAL);
+    }
+
+    public static void clusterOperator(String namespace, long operationTimeout, long reconciliationInterval) throws IOException {
         if (!KubeClusterResource.getInstance().getDefaultOlmNamespace().equals(namespace)) {
             File operatorGroupFile = File.createTempFile("operatorgroup", ".yaml");
-            String operatorGroup = TestUtils.getFileAsString(OlmResource.class.getClassLoader().getResource("olm/operator-group.yaml").getPath());
+
+            InputStream groupInputStream = OlmResource.class.getClassLoader().getResourceAsStream("olm/operator-group.yaml");
+            String operatorGroup = TestUtils.readResource(groupInputStream);
             TestUtils.writeFile(operatorGroupFile.getAbsolutePath(), operatorGroup.replace("${OPERATOR_NAMESPACE}", namespace));
             ResourceManager.cmdKubeClient().apply(operatorGroupFile);
         }
@@ -35,12 +43,17 @@ public class OlmResource {
         String csvName = Environment.OLM_APP_BUNDLE_PREFIX + "." + Environment.OLM_OPERATOR_VERSION;
 
         File subscriptionFile = File.createTempFile("subscription", ".yaml");
-        String subscription = TestUtils.getFileAsString(OlmResource.class.getClassLoader().getResource("olm/subscription.yaml").getPath());
+        InputStream subscriptionInputStream = OlmResource.class.getClassLoader().getResourceAsStream("olm/subscription.yaml");
+        String subscription = TestUtils.readResource(subscriptionInputStream);
         TestUtils.writeFile(subscriptionFile.getAbsolutePath(),
                 subscription.replace("${OPERATOR_NAMESPACE}", namespace)
                 .replace("${OLM_OPERATOR_NAME}", Environment.OLM_OPERATOR_NAME)
+                .replace("${OLM_SOURCE_NAME}", Environment.OLM_SOURCE_NAME)
+                .replace("${OLM_SOURCE_NAMESPACE}", ResourceManager.cmdKubeClient().defaultOlmNamespace())
                 .replace("${OLM_APP_BUNDLE_PREFIX}", Environment.OLM_APP_BUNDLE_PREFIX)
-                .replace("${OLM_OPERATOR_VERSION}", Environment.OLM_OPERATOR_VERSION));
+                .replace("${OLM_OPERATOR_VERSION}", Environment.OLM_OPERATOR_VERSION)
+                .replace("${STRIMZI_FULL_RECONCILIATION_INTERVAL_MS}", Long.toString(reconciliationInterval))
+                .replace("${STRIMZI_OPERATION_TIMEOUT_MS}", Long.toString(operationTimeout)));
 
         ResourceManager.cmdKubeClient().apply(subscriptionFile);
         // Make sure that operator will be deleted
@@ -68,7 +81,7 @@ public class OlmResource {
     }
 
     private static Map<String, JsonObject> parseExamplesFromCsv(String csvName, String namespace) {
-        String csvString = ResourceManager.cmdKubeClient().exec("get", "csv", csvName, "-o", "json", "-n", namespace).out();
+        String csvString = ResourceManager.cmdKubeClient().exec(true, false, "get", "csv", csvName, "-o", "json", "-n", namespace).out();
         JsonObject csv = new JsonObject(csvString);
         String almExamples = csv.getJsonObject("metadata").getJsonObject("annotations").getString("alm-examples");
         JsonArray examples = new JsonArray(almExamples);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/OlmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/OlmResource.java
@@ -60,6 +60,7 @@ public class OlmResource {
         TestUtils.waitFor("Cluster Operator deployment creation", Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_RESOURCE_CREATION,
             () -> ResourceManager.kubeClient().getDeploymentNameByPrefix(Environment.OLM_OPERATOR_NAME) != null);
         String deploymentName = ResourceManager.kubeClient().getDeploymentNameByPrefix(Environment.OLM_OPERATOR_NAME);
+        ResourceManager.setCoDeploymentName(deploymentName);
         ResourceManager.getPointerResources().push(() -> deleteOlm(deploymentName, namespace, csvName));
         // Wait for operator creation
         waitFor(deploymentName, namespace, 1);
@@ -70,7 +71,7 @@ public class OlmResource {
     public static void deleteOlm(String deploymentName, String namespace, String csvName) {
         ResourceManager.cmdKubeClient().exec("delete", "subscriptions", "-l", "app=strimzi", "-n", namespace);
         ResourceManager.cmdKubeClient().exec("delete", "operatorgroups", "-l", "app=strimzi", "-n", namespace);
-        ResourceManager.cmdKubeClient().exec("delete", "csv", csvName, "-n", namespace);
+        ResourceManager.cmdKubeClient().exec(false, "delete", "csv", csvName, "-n", namespace);
         DeploymentUtils.waitForDeploymentDeletion(deploymentName);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -74,6 +74,8 @@ public class ResourceManager {
     private static Stack<Runnable> methodResources = new Stack<>();
     private static Stack<Runnable> pointerResources = classResources;
 
+    private static String coDeploymentName = Constants.STRIMZI_DEPLOYMENT_NAME;
+
     private static ResourceManager instance;
 
     public static synchronized ResourceManager getInstance() {
@@ -433,5 +435,13 @@ public class ResourceManager {
 
     private static Deployment getDeploymentFromYaml(String yamlPath) {
         return TestUtils.configFromYaml(yamlPath, Deployment.class);
+    }
+
+    public static String getCoDeploymentName() {
+        return coDeploymentName;
+    }
+
+    public static void setCoDeploymentName(String newName) {
+        coDeploymentName = newName;
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.KafkaExporterResources;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.test.executor.Exec;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -91,7 +92,7 @@ public class MetricsUtils {
     }
 
     public static HashMap<String, String> collectClusterOperatorPodMetrics() {
-        LabelSelector coSelector = kubeClient().getDeploymentSelectors(Constants.STRIMZI_DEPLOYMENT_NAME);
+        LabelSelector coSelector = kubeClient().getDeploymentSelectors(ResourceManager.getCoDeploymentName());
         return collectMetricsFromPods(coSelector, Constants.CLUSTER_OPERATOR_METRICS_PORT, "/metrics");
     }
 

--- a/systemtest/src/main/resources/olm/subscription.yaml
+++ b/systemtest/src/main/resources/olm/subscription.yaml
@@ -7,8 +7,17 @@ metadata:
     app: strimzi
 spec:
   name: ${OLM_OPERATOR_NAME}
-  source: strimzi-source
-  sourceNamespace: openshift-marketplace
+  source: ${OLM_SOURCE_NAME}
+  sourceNamespace: ${OLM_SOURCE_NAMESPACE}
   startingCSV: ${OLM_APP_BUNDLE_PREFIX}.${OLM_OPERATOR_VERSION}
   channel: stable
   installPlanApproval: Automatic
+  config:
+    env:
+      - name: STRIMZI_LOG_LEVEL
+        value: "DEBUG"
+      - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
+        value: "${STRIMZI_FULL_RECONCILIATION_INTERVAL_MS}"
+      - name: STRIMZI_OPERATION_TIMEOUT_MS
+        value: "${STRIMZI_OPERATION_TIMEOUT_MS}"
+

--- a/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
@@ -240,14 +240,6 @@ public abstract class BaseST implements TestSeparator {
         KubeClusterResource.getInstance().deleteClusterOperatorInstallFiles();
         KubeClusterResource.getInstance().deleteNamespaces();
 
-//        KubeClusterResource.getInstance().createNamespaces(coNamespace, bindingsNamespaces);
-//        KubeClusterResource.getInstance().applyClusterOperatorInstallFiles();
-//
-//        ResourceManager.setClassResources();
-//
-//        applyRoleBindings(coNamespace, bindingsNamespaces);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(coNamespace, operationTimeout).done();
         installClusterOperator(coNamespace, bindingsNamespaces, operationTimeout, reconciliationInterval);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
@@ -346,6 +346,7 @@ public abstract class BaseST implements TestSeparator {
 
     public Map<String, String> getImagesFromConfig() {
         Map<String, String> images = new HashMap<>();
+        LOGGER.info(ResourceManager.getCoDeploymentName());
         for (Container c : kubeClient().getDeployment(ResourceManager.getCoDeploymentName()).getSpec().getTemplate().getSpec().getContainers()) {
             for (EnvVar envVar : c.getEnv()) {
                 images.put(envVar.getName(), envVar.getValue());

--- a/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
@@ -15,6 +15,7 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.interfaces.TestSeparator;
 import io.strimzi.systemtest.logs.TestExecutionWatcher;
 import io.strimzi.systemtest.resources.KubernetesResource;
+import io.strimzi.systemtest.resources.OlmResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
@@ -116,6 +117,37 @@ public abstract class BaseST implements TestSeparator {
     }
 
     /**
+     * This method install Strimzi Cluster Operator based on environment variable configuration.
+     * It can install operator by classic way (apply bundle yamls) or use OLM. For OLM you need to set all other OLM env variables.
+     * Don't use this method in tests, where specific configuration of CO is needed.
+     * @param namespace namespace where CO should be installed into
+     */
+    protected void installClusterOperator(String namespace, List<String> bindingsNamespaces, long operationTimeout, long reconciliationInterval) throws Exception {
+        if (Environment.isOlmInstall()) {
+            cluster.setNamespace(namespace);
+            cluster.createNamespace(namespace);
+            OlmResource.clusterOperator(namespace, operationTimeout, reconciliationInterval);
+        } else {
+            prepareEnvForOperator(namespace, bindingsNamespaces);
+            applyRoleBindings(namespace, bindingsNamespaces);
+            // 050-Deployment
+            KubernetesResource.clusterOperator(namespace, operationTimeout, reconciliationInterval).done();
+        }
+    }
+
+    protected void installClusterOperator(String namespace, long operationTimeout, long reconciliationInterval) throws Exception {
+        installClusterOperator(namespace, Collections.singletonList(namespace), operationTimeout, reconciliationInterval);
+    }
+
+    protected void installClusterOperator(String namespace, long operationTimeout) throws Exception {
+        installClusterOperator(namespace, operationTimeout, Constants.RECONCILIATION_INTERVAL);
+    }
+
+    protected void installClusterOperator(String namespace) throws Exception {
+        installClusterOperator(namespace, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
+    }
+
+    /**
      * Prepare environment for cluster operator which includes creation of namespaces, custom resources and operator
      * specific config files such as ServiceAccount, Roles and CRDs.
      * @param clientNamespace namespace which will be created and used as default by kube client
@@ -168,10 +200,20 @@ public abstract class BaseST implements TestSeparator {
     /**
      * Recreate namespace and CO after test failure
      * @param coNamespace namespace where CO will be deployed to
+     * @param operationTimeout timeout for CO operations
+     * @param reconciliationInterval CO reconciliation interval
+     */
+    protected void recreateTestEnv(String coNamespace, long operationTimeout, long reconciliationInterval) throws Exception {
+        recreateTestEnv(coNamespace, Collections.singletonList(coNamespace), operationTimeout, reconciliationInterval);
+    }
+
+    /**
+     * Recreate namespace and CO after test failure
+     * @param coNamespace namespace where CO will be deployed to
      * @param bindingsNamespaces array of namespaces where Bindings should be deployed to.
      */
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws InterruptedException {
-        recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
+        recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Constants.RECONCILIATION_INTERVAL);
     }
 
     /**
@@ -180,21 +222,33 @@ public abstract class BaseST implements TestSeparator {
      * @param bindingsNamespaces array of namespaces where Bindings should be deployed to.
      * @param operationTimeout timeout for CO operations
      */
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces, long operationTimeout) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces, long operationTimeout) throws Exception {
+        recreateTestEnv(coNamespace, bindingsNamespaces, operationTimeout, Constants.RECONCILIATION_INTERVAL);
+    }
+
+    /**
+     * Recreate namespace and CO after test failure
+     * @param coNamespace namespace where CO will be deployed to
+     * @param bindingsNamespaces array of namespaces where Bindings should be deployed to.
+     * @param operationTimeout timeout for CO operations
+     * @param reconciliationInterval CO reconciliation interval
+     */
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces, long operationTimeout, long reconciliationInterval) throws Exception {
         ResourceManager.deleteMethodResources();
         ResourceManager.deleteClassResources();
 
         KubeClusterResource.getInstance().deleteClusterOperatorInstallFiles();
         KubeClusterResource.getInstance().deleteNamespaces();
 
-        KubeClusterResource.getInstance().createNamespaces(coNamespace, bindingsNamespaces);
-        KubeClusterResource.getInstance().applyClusterOperatorInstallFiles();
-
-        ResourceManager.setClassResources();
-
-        applyRoleBindings(coNamespace, bindingsNamespaces);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(coNamespace, operationTimeout).done();
+//        KubeClusterResource.getInstance().createNamespaces(coNamespace, bindingsNamespaces);
+//        KubeClusterResource.getInstance().applyClusterOperatorInstallFiles();
+//
+//        ResourceManager.setClassResources();
+//
+//        applyRoleBindings(coNamespace, bindingsNamespaces);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(coNamespace, operationTimeout).done();
+        installClusterOperator(coNamespace, bindingsNamespaces, operationTimeout, reconciliationInterval);
     }
 
     /**
@@ -292,7 +346,7 @@ public abstract class BaseST implements TestSeparator {
 
     public Map<String, String> getImagesFromConfig() {
         Map<String, String> images = new HashMap<>();
-        for (Container c : kubeClient().getDeployment("strimzi-cluster-operator").getSpec().getTemplate().getSpec().getContainers()) {
+        for (Container c : kubeClient().getDeployment(ResourceManager.getCoDeploymentName()).getSpec().getTemplate().getSpec().getContainers()) {
             for (EnvVar envVar : c.getEnv()) {
                 images.put(envVar.getName(), envVar.getValue());
             }
@@ -497,8 +551,8 @@ public abstract class BaseST implements TestSeparator {
     void verifyLabelsOnCOPod() {
         LOGGER.info("Verifying labels for cluster-operator pod");
 
-        Map<String, String> coLabels = kubeClient().listPods("name", "strimzi-cluster-operator").get(0).getMetadata().getLabels();
-        assertThat(coLabels.get("name"), is("strimzi-cluster-operator"));
+        Map<String, String> coLabels = kubeClient().listPods("name", ResourceManager.getCoDeploymentName()).get(0).getMetadata().getLabels();
+        assertThat(coLabels.get("name"), is(ResourceManager.getCoDeploymentName()));
         assertThat(coLabels.get(Labels.STRIMZI_KIND_LABEL), is("cluster-operator"));
     }
 
@@ -671,7 +725,7 @@ public abstract class BaseST implements TestSeparator {
 
     protected void assertNoCoErrorsLogged(long sinceSeconds) {
         LOGGER.info("Search in strimzi-cluster-operator log for errors in last {} seconds", sinceSeconds);
-        String clusterOperatorLog = cmdKubeClient().searchInLog("deploy", "strimzi-cluster-operator", sinceSeconds, "Exception", "Error", "Throwable");
+        String clusterOperatorLog = cmdKubeClient().searchInLog("deploy", ResourceManager.getCoDeploymentName(), sinceSeconds, "Exception", "Error", "Throwable");
         assertThat(clusterOperatorLog, logHasNoUnexpectedErrors());
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -50,7 +50,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 
 import java.io.File;
@@ -762,19 +761,20 @@ class ConnectS2IST extends BaseST {
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT,  Constants.RECONCILIATION_INTERVAL).done();
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT,  Constants.RECONCILIATION_INTERVAL).done();
+        installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT, Constants.RECONCILIATION_INTERVAL);
 
         deployKafkaClients();
     }
 
     @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
         super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_SHORT);
         deployKafkaClients();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -763,11 +763,6 @@ class ConnectS2IST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT,  Constants.RECONCILIATION_INTERVAL).done();
         installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT, Constants.RECONCILIATION_INTERVAL);
 
         deployKafkaClients();

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -1014,12 +1014,6 @@ class ConnectST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        cluster.setNamespace(NAMESPACE);
-//        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT).done();
         installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT);
 
         deployKafkaClients();

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -23,7 +23,6 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
@@ -1007,20 +1006,21 @@ class ConnectST extends BaseST {
     }
 
     @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws InterruptedException {
-        super.recreateTestEnv(coNamespace, bindingsNamespaces);
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
+        super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_SHORT, Constants.RECONCILIATION_INTERVAL);
         deployKafkaClients();
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        cluster.setNamespace(NAMESPACE);
-        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT).done();
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        cluster.setNamespace(NAMESPACE);
+//        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT).done();
+        installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT);
 
         deployKafkaClients();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -1007,7 +1007,7 @@ class ConnectST extends BaseST {
 
     @Override
     protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
-        super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_SHORT, Constants.RECONCILIATION_INTERVAL);
+        super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_SHORT);
         deployKafkaClients();
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -28,7 +28,6 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaBridgeResource;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
@@ -406,23 +405,24 @@ class CustomResourceStatusST extends BaseST {
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
+//        prepareEnvForOperator(NAMESPACE);
 
         deployTestSpecificResources();
     }
 
     @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
         super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_SHORT);
         deployTestSpecificResources();
     }
 
-    void deployTestSpecificResources() {
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT).done();
+    void deployTestSpecificResources() throws Exception {
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT).done();
+        installClusterOperator(NAMESPACE);
 
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
             .editSpec()

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -407,8 +407,6 @@ class CustomResourceStatusST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-
         deployTestSpecificResources();
     }
 
@@ -419,9 +417,6 @@ class CustomResourceStatusST extends BaseST {
     }
 
     void deployTestSpecificResources() throws Exception {
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT).done();
         installClusterOperator(NAMESPACE);
 
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -42,7 +42,6 @@ import io.strimzi.systemtest.annotations.OpenShiftOnly;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -2103,13 +2102,15 @@ class KafkaST extends BaseST {
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE).done();
 
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+        installClusterOperator(NAMESPACE, 600000);
     }
 
     @Override

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -2104,13 +2104,7 @@ class KafkaST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE).done();
-
-        installClusterOperator(NAMESPACE, 600000);
+        installClusterOperator(NAMESPACE);
     }
 
     @Override

--- a/systemtest/src/test/java/io/strimzi/systemtest/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MirrorMaker2ST.java
@@ -601,12 +601,6 @@ class MirrorMaker2ST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        cluster.setNamespace(NAMESPACE);
-//        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT).done();
         installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MirrorMaker2ST.java
@@ -18,7 +18,6 @@ import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationTls;
 import io.strimzi.api.kafka.model.listener.KafkaListenerTls;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaMirrorMaker2Resource;
@@ -600,13 +599,14 @@ class MirrorMaker2ST extends BaseST {
 
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        cluster.setNamespace(NAMESPACE);
-        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT).done();
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        cluster.setNamespace(NAMESPACE);
+//        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT).done();
+        installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MirrorMakerST.java
@@ -665,11 +665,6 @@ public class MirrorMakerST extends BaseST {
     @BeforeAll
     void setupEnvironment() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE).done();
         installClusterOperator(NAMESPACE);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MirrorMakerST.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest;
 
-import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.strimzi.api.kafka.model.CertSecretSource;
@@ -31,7 +30,6 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 
 import java.util.HashMap;
@@ -665,21 +663,13 @@ public class MirrorMakerST extends BaseST {
     }
     
     @BeforeAll
-    void setupEnvironment() {
+    void setupEnvironment() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE)
-            .editSpec()
-                .editTemplate()
-                    .editSpec()
-                        .editFirstContainer()
-                            .addToEnv(new EnvVarBuilder().withName("TEST_ENV_3").withValue("test.value").build())
-                        .endContainer()
-                    .endSpec()
-                .endTemplate()
-            .endSpec().done();
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE).done();
+        installClusterOperator(NAMESPACE);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
@@ -60,9 +60,9 @@ class RecoveryST extends BaseST {
         LOGGER.info("Running deleteKafkaStatefulSet with cluster {}", CLUSTER_NAME);
         String kafkaStatefulSetName = KafkaResources.kafkaStatefulSetName(CLUSTER_NAME);
         String kafkaStatefulSetUid = kubeClient().getStatefulSetUid(kafkaStatefulSetName);
-        kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName("strimzi-cluster-operator").scale(0, true);
+        kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName(ResourceManager.getCoDeploymentName()).scale(0, true);
         kubeClient().deleteStatefulSet(kafkaStatefulSetName);
-        kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName("strimzi-cluster-operator").scale(1, true);
+        kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName(ResourceManager.getCoDeploymentName()).scale(1, true);
 
         LOGGER.info("Waiting for recovery {}", kafkaStatefulSetName);
         StatefulSetUtils.waitForStatefulSetRecovery(kafkaStatefulSetName, kafkaStatefulSetUid);
@@ -79,9 +79,9 @@ class RecoveryST extends BaseST {
         LOGGER.info("Running deleteZookeeperStatefulSet with cluster {}", CLUSTER_NAME);
         String zookeeperStatefulSetName = KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME);
         String zookeeperStatefulSetUid = kubeClient().getStatefulSetUid(zookeeperStatefulSetName);
-        kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName("strimzi-cluster-operator").scale(0, true);
+        kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName(ResourceManager.getCoDeploymentName()).scale(0, true);
         kubeClient().deleteStatefulSet(zookeeperStatefulSetName);
-        kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName("strimzi-cluster-operator").scale(1, true);
+        kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName(ResourceManager.getCoDeploymentName()).scale(1, true);
 
         LOGGER.info("Waiting for recovery {}", zookeeperStatefulSetName);
         StatefulSetUtils.waitForStatefulSetRecovery(zookeeperStatefulSetName, zookeeperStatefulSetUid);
@@ -243,7 +243,7 @@ class RecoveryST extends BaseST {
     }
 
     @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws InterruptedException {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
         super.recreateTestEnv(coNamespace, bindingsNamespaces);
         deployTestSpecificResources();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
@@ -16,7 +16,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaBridgeResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -227,13 +226,9 @@ class RecoveryST extends BaseST {
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+        installClusterOperator(NAMESPACE);
         deployTestSpecificResources();
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
@@ -17,7 +17,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
@@ -222,18 +221,21 @@ class UserST extends BaseST {
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE).done();
+//
+        installClusterOperator(NAMESPACE);
 
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
         deployTestSpecificResources();
     }
 
     @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws InterruptedException {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
         super.recreateTestEnv(coNamespace, bindingsNamespaces);
         deployTestSpecificResources();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
@@ -223,12 +223,6 @@ class UserST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE).done();
-//
         installClusterOperator(NAMESPACE);
 
         deployTestSpecificResources();

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeBaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeBaseST.java
@@ -14,7 +14,6 @@ import io.vertx.junit5.VertxExtension;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,13 +71,14 @@ public class HttpBridgeBaseST extends BaseST {
     }
 
     @BeforeAll
-    void deployClusterOperator(Vertx vertx) {
+    void deployClusterOperator(Vertx vertx) throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(getBridgeNamespace());
-
-        applyRoleBindings(getBridgeNamespace());
-        // 050-Deployment
-        KubernetesResource.clusterOperator(getBridgeNamespace()).done();
+//        prepareEnvForOperator(getBridgeNamespace());
+//
+//        applyRoleBindings(getBridgeNamespace());
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(getBridgeNamespace()).done();
+        installClusterOperator(getBridgeNamespace());
 
         // Create http client
         client = WebClient.create(vertx, new WebClientOptions()

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeBaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeBaseST.java
@@ -73,11 +73,6 @@ public class HttpBridgeBaseST extends BaseST {
     @BeforeAll
     void deployClusterOperator(Vertx vertx) throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(getBridgeNamespace());
-//
-//        applyRoleBindings(getBridgeNamespace());
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(getBridgeNamespace()).done();
         installClusterOperator(getBridgeNamespace());
 
         // Create http client

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -125,11 +125,6 @@ public class CruiseControlApiST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE).done();
         installClusterOperator(NAMESPACE);
 
         deployTestResources();

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -5,7 +5,6 @@
 package io.strimzi.systemtest.cruisecontrol;
 
 import io.strimzi.systemtest.BaseST;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.utils.specific.CruiseControlUtils;
@@ -124,19 +123,20 @@ public class CruiseControlApiST extends BaseST {
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE).done();
+        installClusterOperator(NAMESPACE);
 
         deployTestResources();
     }
 
     @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws InterruptedException {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
         super.recreateTestEnv(coNamespace, bindingsNamespaces);
         deployTestResources();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -230,11 +230,6 @@ public class CruiseControlConfigurationST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE).done();
         installClusterOperator(NAMESPACE);
 
         deployTestResources();

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -12,7 +12,6 @@ import io.strimzi.api.kafka.model.CruiseControlSpec;
 import io.strimzi.api.kafka.model.CruiseControlSpecBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.BaseST;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
@@ -229,19 +228,20 @@ public class CruiseControlConfigurationST extends BaseST {
     }
     
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE).done();
+        installClusterOperator(NAMESPACE);
 
         deployTestResources();
     }
 
     @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws InterruptedException {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
         super.recreateTestEnv(coNamespace, bindingsNamespaces);
         deployTestResources();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -99,11 +99,6 @@ public class CruiseControlIsolatedST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE).done();
         installClusterOperator(NAMESPACE);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -6,7 +6,6 @@ package io.strimzi.systemtest.cruisecontrol;
 
 import io.strimzi.api.kafka.model.KafkaTopicSpec;
 import io.strimzi.systemtest.BaseST;
-import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -6,7 +6,7 @@ package io.strimzi.systemtest.cruisecontrol;
 
 import io.strimzi.api.kafka.model.KafkaTopicSpec;
 import io.strimzi.systemtest.BaseST;
-import io.strimzi.systemtest.resources.KubernetesResource;
+import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -98,12 +98,13 @@ public class CruiseControlIsolatedST extends BaseST {
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE).done();
+        installClusterOperator(NAMESPACE);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
@@ -1185,13 +1185,6 @@ public class ListenersST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE).done();
-//        cluster.setNamespace(NAMESPACE);
         installClusterOperator(NAMESPACE);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
@@ -15,7 +15,6 @@ import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
 import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -1184,15 +1183,16 @@ public class ListenersST extends BaseST {
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
 
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
-        cluster.setNamespace(NAMESPACE);
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE).done();
+//        cluster.setNamespace(NAMESPACE);
+        installClusterOperator(NAMESPACE);
     }
 
     @Override

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
@@ -14,7 +14,6 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.BaseST;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaBridgeResource;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
@@ -356,13 +355,14 @@ class LogSettingST extends BaseST {
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE).done();
+        installClusterOperator(NAMESPACE);
 
         timeMeasuringSystem.setOperationID(startDeploymentMeasuring());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
@@ -357,11 +357,6 @@ class LogSettingST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE).done();
         installClusterOperator(NAMESPACE);
 
         timeMeasuringSystem.setOperationID(startDeploymentMeasuring());

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -165,9 +165,9 @@ class LoggingChangeST extends BaseST {
         Map<String, String> zkPods = StatefulSetUtils.ssSnapshot(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME));
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
         Map<String, String> eoPods = DeploymentUtils.depSnapshot(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME));
-        Map<String, String> operatorSnapshot = DeploymentUtils.depSnapshot("strimzi-cluster-operator");
+        Map<String, String> operatorSnapshot = DeploymentUtils.depSnapshot(ResourceManager.getCoDeploymentName());
 
-        assertThat(StUtils.checkLogForJSONFormat(operatorSnapshot, "strimzi-cluster-operator"), is(true));
+        assertThat(StUtils.checkLogForJSONFormat(operatorSnapshot, ResourceManager.getCoDeploymentName()), is(true));
         assertThat(StUtils.checkLogForJSONFormat(kafkaPods, "kafka"), is(true));
         assertThat(StUtils.checkLogForJSONFormat(zkPods, "zookeeper"), is(true));
         assertThat(StUtils.checkLogForJSONFormat(eoPods, "topic-operator"), is(true));
@@ -175,14 +175,15 @@ class LoggingChangeST extends BaseST {
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE).done();
+        installClusterOperator(NAMESPACE);
     }
 
     @Override

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -177,12 +177,6 @@ class LoggingChangeST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE).done();
         installClusterOperator(NAMESPACE);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -317,12 +317,8 @@ public class MetricsST extends BaseST {
     @BeforeAll
     void setupEnvironment() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE).done();
         installClusterOperator(NAMESPACE);
+
         KafkaResource.kafkaWithMetrics(CLUSTER_NAME, 3, 3).done();
         KafkaResource.kafkaWithMetrics(SECOND_CLUSTER, 1, 1).done();
         KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -20,7 +20,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
@@ -316,13 +315,14 @@ public class MetricsST extends BaseST {
     protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) { }
 
     @BeforeAll
-    void setupEnvironment() throws InterruptedException {
+    void setupEnvironment() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE).done();
+        installClusterOperator(NAMESPACE);
         KafkaResource.kafkaWithMetrics(CLUSTER_NAME, 3, 3).done();
         KafkaResource.kafkaWithMetrics(SECOND_CLUSTER, 1, 1).done();
         KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthBaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthBaseST.java
@@ -82,8 +82,8 @@ public class OauthBaseST extends BaseST {
 //        applyRoleBindings(NAMESPACE);
 //        // 050-Deployment
 //        KubernetesResource.clusterOperator(NAMESPACE).done();
-        KubernetesResource.applyDefaultNetworkPolicy(NAMESPACE, DefaultNetworkPolicy.DEFAULT_TO_ALLOW);
         installClusterOperator(NAMESPACE);
+        KubernetesResource.applyDefaultNetworkPolicy(NAMESPACE, DefaultNetworkPolicy.DEFAULT_TO_ALLOW);
 
         deployTestSpecificResources();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthBaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthBaseST.java
@@ -74,14 +74,16 @@ public class OauthBaseST extends BaseST {
     protected WebClient client;
 
     @BeforeAll
-    void setup() throws InterruptedException {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
+//        prepareEnvForOperator(NAMESPACE);
+//        KubernetesResource.applyDefaultNetworkPolicy(NAMESPACE, DefaultNetworkPolicy.DEFAULT_TO_ALLOW);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE).done();
         KubernetesResource.applyDefaultNetworkPolicy(NAMESPACE, DefaultNetworkPolicy.DEFAULT_TO_ALLOW);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+        installClusterOperator(NAMESPACE);
 
         deployTestSpecificResources();
     }
@@ -183,7 +185,7 @@ public class OauthBaseST extends BaseST {
     }
 
     @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws InterruptedException {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
         super.recreateTestEnv(coNamespace, bindingsNamespaces);
 
         createSecretsForDeployments();

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthBaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthBaseST.java
@@ -76,12 +76,6 @@ public class OauthBaseST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//        KubernetesResource.applyDefaultNetworkPolicy(NAMESPACE, DefaultNetworkPolicy.DEFAULT_TO_ALLOW);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE).done();
         installClusterOperator(NAMESPACE);
         KubernetesResource.applyDefaultNetworkPolicy(NAMESPACE, DefaultNetworkPolicy.DEFAULT_TO_ALLOW);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -205,11 +205,6 @@ class AlternativeReconcileTriggersST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT).done();
         installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -10,7 +10,6 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.BaseST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -199,17 +198,18 @@ class AlternativeReconcileTriggersST extends BaseST {
     }
 
     @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
         super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT).done();
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT).done();
+        installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -126,11 +126,6 @@ class KafkaRollerST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_MEDIUM).done();
         installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_MEDIUM);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -9,7 +9,6 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.BaseST;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
@@ -120,17 +119,18 @@ class KafkaRollerST extends BaseST {
     }
 
     @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
         super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_MEDIUM).done();
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_MEDIUM).done();
+        installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_MEDIUM);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -18,7 +18,6 @@ import io.strimzi.api.kafka.model.listener.KafkaListenerExternalNodePortBuilder;
 import io.strimzi.systemtest.BaseST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -736,12 +735,8 @@ class RollingUpdateST extends BaseST {
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT).done();
+        installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -563,7 +563,7 @@ class RollingUpdateST extends BaseST {
             () -> kubeClient().listPods().stream().filter(pod -> pod.getStatus().getPhase().equals("Running"))
                     .map(pod -> pod.getStatus().getPhase()).collect(Collectors.toList()).size() < kubeClient().listPods().size());
 
-        LabelSelector coLabelSelector = kubeClient().getDeployment(Constants.STRIMZI_DEPLOYMENT_NAME).getSpec().getSelector();
+        LabelSelector coLabelSelector = kubeClient().getDeployment(ResourceManager.getCoDeploymentName()).getSpec().getSelector();
         LOGGER.info("Deleting Cluster Operator pod with labels {}", coLabelSelector);
         kubeClient().deletePod(coLabelSelector);
         LOGGER.info("Cluster Operator pod deleted");
@@ -731,7 +731,7 @@ class RollingUpdateST extends BaseST {
     }
 
     @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
         super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_SHORT);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -1449,11 +1449,6 @@ class SecurityST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT).done();
         installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -21,7 +21,6 @@ import io.strimzi.systemtest.BaseST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
@@ -1448,12 +1447,13 @@ class SecurityST extends BaseST {
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT).done();
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT).done();
+        installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicST.java
@@ -11,7 +11,6 @@ import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.kafkaclients.AbstractKafkaClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -316,19 +315,20 @@ public class TopicST extends BaseST {
     }
 
     @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws InterruptedException {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
         super.recreateTestEnv(coNamespace, bindingsNamespaces);
         deployTestSpecificResources();
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE).done();
+        installClusterOperator(NAMESPACE);
 
         deployTestSpecificResources();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicST.java
@@ -323,11 +323,6 @@ public class TopicST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE).done();
         installClusterOperator(NAMESPACE);
 
         deployTestSpecificResources();

--- a/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicScalabilityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicScalabilityST.java
@@ -65,11 +65,6 @@ public class TopicScalabilityST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE).done();
         installClusterOperator(NAMESPACE);
 
         LOGGER.info("Deploying shared kafka across all test cases in {} namespace", NAMESPACE);

--- a/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicScalabilityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/topic/TopicScalabilityST.java
@@ -5,7 +5,6 @@
 package io.strimzi.systemtest.topic;
 
 import io.strimzi.systemtest.BaseST;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
@@ -58,19 +57,20 @@ public class TopicScalabilityST extends BaseST {
     }
 
     @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws InterruptedException {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
         super.recreateTestEnv(coNamespace, bindingsNamespaces);
         deployTestSpecificResources();
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE).done();
+        installClusterOperator(NAMESPACE);
 
         LOGGER.info("Deploying shared kafka across all test cases in {} namespace", NAMESPACE);
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -895,11 +895,6 @@ public class TracingST extends BaseST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-//        prepareEnvForOperator(NAMESPACE);
-//
-//        applyRoleBindings(NAMESPACE);
-//        // 050-Deployment
-//        KubernetesResource.clusterOperator(NAMESPACE).done();
         installClusterOperator(NAMESPACE);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -893,12 +893,13 @@ public class TracingST extends BaseST {
     }
 
     @BeforeAll
-    void setup() {
+    void setup() throws Exception {
         ResourceManager.setClassResources();
-        prepareEnvForOperator(NAMESPACE);
-
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+//        prepareEnvForOperator(NAMESPACE);
+//
+//        applyRoleBindings(NAMESPACE);
+//        // 050-Deployment
+//        KubernetesResource.clusterOperator(NAMESPACE).done();
+        installClusterOperator(NAMESPACE);
     }
 }

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -153,6 +153,7 @@ public final class TestUtils {
 
     public static String getFileAsString(String filePath) {
         try {
+            LOGGER.info(filePath);
             return new String(Files.readAllBytes(Paths.get(filePath)), "UTF-8");
         } catch (IOException e) {
             LOGGER.info("File with path {} not found", filePath);

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
@@ -23,6 +23,7 @@ import static java.util.stream.Collectors.toList;
 public interface KubeCmdClient<K extends KubeCmdClient<K>> {
 
     String defaultNamespace();
+    String defaultOlmNamespace();
 
     /** Deletes the resources by resource name. */
     K deleteByName(String resourceType, String resourceName);

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/Kubectl.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/Kubectl.java
@@ -33,6 +33,11 @@ public class Kubectl extends BaseCmdKubeClient<Kubectl> {
     }
 
     @Override
+    public String defaultOlmNamespace() {
+        return "operators";
+    }
+
+    @Override
     public String cmd() {
         return KUBECTL;
     }

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/Oc.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/Oc.java
@@ -52,6 +52,11 @@ public class Oc extends BaseCmdKubeClient<Oc> {
     }
 
     @Override
+    public String defaultOlmNamespace() {
+        return "openshift-marketplace";
+    }
+
+    @Override
     public Oc namespace(String namespace) {
         return new Oc(namespace);
     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds option to setup CO for most of the test cases not just via yaml bundle format, but via OperatorHub. This change should allow us to catch issues in manifests before releasing them to OperatorHub.

After these changes, we should be able to run for example `acceptance` groups with CO installed by OLM which should cover most of the basic functionality of Strimzi.

Before running the tests, we just need to set `CLUSTER_OPERATOR_INSTALL_TYPE` to `olm` (any other value will lead to installing CO via yamls) and other corresponding OLM environment variables specified in `TESTING.md`.

We should also add an option to install CO by `helm` and run tests against it.

### Checklist

- [ ] Make sure all tests pass

