### PR TITLE
Add crd and helm template builds to make all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endif
 SUBDIRS=kafka-agent mirror-maker-agent tracing-agent crd-annotations test crd-generator api mockkube certificate-manager operator-common config-model config-model-generator cluster-operator topic-operator user-operator kafka-init docker-images helm-charts/helm2 helm-charts/helm3 install examples
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
-all: prerequisites_check $(SUBDIRS)
+all: prerequisites_check $(SUBDIRS) crd_install helm_install
 clean: $(SUBDIRS) docu_clean
 $(DOCKER_TARGETS): prerequisites_check $(SUBDIRS)
 release: release_prepare release_version release_helm_version release_maven $(SUBDIRS) release_docu release_single_file release_pkg release_helm_repo docu_clean


### PR DESCRIPTION
### Type of change

Enhancement 

### Description

Currently, `make all` does not run `crd_install` and `helm_install` leading developers (mostly me) to forget to generate new templates and add them to commits when we change the CRDs. This PR adds those steps to `make all`.

### Checklist

- [X] Make sure all tests pass
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
