### PR TITLE
documentation fix - move logging section to be under "kafka:" key

### DIFF
--- a/documentation/modules/con-kafka-logging.adoc
+++ b/documentation/modules/con-kafka-logging.adoc
@@ -41,10 +41,12 @@ apiVersion: {KafkaApiVersion}
 kind: Kafka
 spec:
   # ...
-  logging:
-    type: inline
-    loggers:
-      kafka.root.logger.level: "INFO"
+  kafka:
+    # ...
+    logging:
+      type: inline
+      loggers:
+        kafka.root.logger.level: "INFO"
   # ...
   zookeeper:
     # ...


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

Fix a small error in the documentation relating to where the "logging" section for "kafka.root.logger.level" is located. It seems like it should actually go underneath the "kafka:" key.

In the current example, where the "logging" key sits directly under the "spec:" key, it results in this error message on the Operator, when deployed: 
"Contains object at path spec with an unknown property: logging"

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Update documentation
