### PR TITLE
[systemtest][fixes] Fixes of tests and typos

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -115,7 +115,7 @@ class CustomResourceStatusST extends BaseST {
         });
 
         LOGGER.info("Wait until cluster will be in NotReady state ...");
-        KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
+        KafkaUtils.waitForKafkaNotReady(CLUSTER_NAME);
 
         LOGGER.info("Recovery cluster to Ready state ...");
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, k -> {

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -171,7 +171,7 @@ public class SpecificST extends BaseST {
 
         LOGGER.info("Kafka with version {} deployed.", nonExistingVersion);
 
-        KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
+        KafkaUtils.waitForKafkaNotReady(CLUSTER_NAME);
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(CLUSTER_NAME, NAMESPACE, nonExistingVersionMessage);
 
         KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).delete();


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR gonna fix some typos after my last cleanup PR. 

I changed the `waitForKafkaReady` to `waitForKafkaNotReady` -> this was mistaken, we should wait for Kafka is not ready in these cases, I somehow overlooked this in my last PR.

From last PR (the cleanup) I changed the way how to wait for `DeploymentConfig` deletion, readiness etc. But I didn't change it in some tests, so I done it now.

Also there was a typo in cert -> I used `cert.crt` but right one is `ca.crt`.

### Checklist

- [ ] Make sure all tests pass

