### PR TITLE
ST: Add Acceptance tag to MetricsST

### DIFF
--- a/Jenkinsfile-pr
+++ b/Jenkinsfile-pr
@@ -69,6 +69,9 @@ pipeline {
                     echo "TEST_CASE: ${env.TEST_CASE}"
                     if (env.ghprbCommentBody.contains('profile=')) {
                         env.TEST_PROFILE = env.ghprbCommentBody.split('profile=')[1].split(/\s/)[0]
+                        if (env.TEST_PROFILE != "flaky") {
+                            env.EXCLUDE_GROUPS = env.EXCLUDE_GROUPS + ",flaky"
+                        }
                     }
                     echo "TEST_PROFILE: ${env.TEST_PROFILE}"
                     if (env.ghprbCommentBody.contains('exclude=')) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
+import static io.strimzi.systemtest.Constants.FLAKY;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.resources.ResourceManager.cmdKubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -68,6 +69,7 @@ public class CruiseControlIsolatedST extends BaseST {
 
     @Test
     @Tag(ACCEPTANCE)
+    @Tag(FLAKY)
     void testCruiseControlWithRebalanceResource() {
         KafkaResource.kafkaWithCruiseControl(CLUSTER_NAME, 3, 3).done();
         KafkaRebalanceResource.kafkaRebalance(CLUSTER_NAME).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -36,6 +36,8 @@ import java.util.OptionalDouble;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 
+import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+import static io.strimzi.systemtest.Constants.FLAKY;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.METRICS;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -48,6 +50,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 @Tag(REGRESSION)
+@Tag(ACCEPTANCE)
 @Tag(METRICS)
 public class MetricsST extends BaseST {
 
@@ -235,6 +238,8 @@ public class MetricsST extends BaseST {
         assertThat(values.stream().mapToDouble(i -> i).sum(), is((double) 0));
     }
 
+    // This test is somehow influenced by other tests in this class.
+    @Tag(FLAKY)
     @Test
     void testUserOperatorMetrics() {
         userOperatorMetricsData = MetricsUtils.collectUserOperatorPodMetrics(CLUSTER_NAME);

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -37,7 +37,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
-import static io.strimzi.systemtest.Constants.FLAKY;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.METRICS;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -238,8 +237,6 @@ public class MetricsST extends BaseST {
         assertThat(values.stream().mapToDouble(i -> i).sum(), is((double) 0));
     }
 
-    // This test is somehow influenced by other tests in this class.
-    @Tag(FLAKY)
     @Test
     void testUserOperatorMetrics() {
         userOperatorMetricsData = MetricsUtils.collectUserOperatorPodMetrics(CLUSTER_NAME);


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Enhancement / new feature

### Description

This PR adds `ACCEPTANCE` tag to metrics tests to run them during acceptance builds in azure and jenkins.

I also added `FLAKY` tag to `testCruiseControlWithRebalanceResource`. @im-konge  is working on fix which will be address in https://github.com/strimzi/strimzi-kafka-operator/pull/3250

### Checklist

- [x] Make sure all tests pass

