### PR TITLE
ST: Set Bridge image based on predefined env variable

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
@@ -92,7 +92,7 @@ public class KubernetesResource {
                     break;
                 default:
                     if (envVar.getName().contains("KAFKA_BRIDGE_IMAGE")) {
-                        envVar.setValue(envVar.getValue());
+                        envVar.setValue(Environment.BRIDGE_IMAGE);
                     } else if (envVar.getName().contains("STRIMZI_DEFAULT")) {
                         envVar.setValue(StUtils.changeOrgAndTag(envVar.getValue()));
                     } else if (envVar.getName().contains("IMAGES")) {


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

We have environment variable to set specific bridge image in tests to use latest tag, however, this variable was never used. This PR use bridge_image variable properly so all system tests without specific value for `BRIDGE_IMAGE` will use latest tag for bridge image.

### Checklist

- [ ] Make sure all tests pass


