### PR TITLE
[systemtest][enhancement] Variable timeout part 2 - resource rolling update

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
@@ -62,4 +62,8 @@ public class ResourceOperation {
 
         return timeout;
     }
+
+    public static long getTimeoutForRollingUpdate(int expectPods) {
+        return Duration.ofMinutes(6).toMillis() * expectPods;
+    }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
@@ -63,7 +63,10 @@ public class ResourceOperation {
         return timeout;
     }
 
-    public static long getTimeoutForRollingUpdate(int expectPods) {
-        return Duration.ofMinutes(6).toMillis() * expectPods;
+    /**
+     * rollingUpdateTimeout returns a reasonable timeout in milliseconds for a number of pods in a to roll on update
+     */
+    public static long rollingUpdateTimeout(int numberOfPods) {
+        return Duration.ofMinutes(6).toMillis() * numberOfPods;
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
@@ -64,7 +64,7 @@ public class ResourceOperation {
     }
 
     /**
-     * rollingUpdateTimeout returns a reasonable timeout in milliseconds for a number of pods in a to roll on update
+     * rollingUpdateTimeout returns a reasonable timeout in milliseconds for a number of pods in a quorum to roll on update
      */
     public static long rollingUpdateTimeout(int numberOfPods) {
         return Duration.ofMinutes(5).toMillis() * numberOfPods;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
@@ -67,6 +67,6 @@ public class ResourceOperation {
      * rollingUpdateTimeout returns a reasonable timeout in milliseconds for a number of pods in a to roll on update
      */
     public static long rollingUpdateTimeout(int numberOfPods) {
-        return Duration.ofMinutes(6).toMillis() * numberOfPods;
+        return Duration.ofMinutes(5).toMillis() * numberOfPods;
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentConfigUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentConfigUtils.java
@@ -65,7 +65,7 @@ public class DeploymentConfigUtils {
     public static Map<String, String> waitTillDepConfigHasRolled(String depConfigName, Map<String, String> snapshot) {
         LOGGER.info("Waiting for DeploymentConfig {} rolling update", depConfigName);
         TestUtils.waitFor("DeploymentConfig roll of " + depConfigName,
-            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.getTimeoutForRollingUpdate(snapshot.size()), () -> depConfigHasRolled(depConfigName, snapshot));
+            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.rollingUpdateTimeout(snapshot.size()), () -> depConfigHasRolled(depConfigName, snapshot));
         waitForDeploymentConfigReady(depConfigName);
         LOGGER.info("DeploymentConfig {} rolling update finished", depConfigName);
         return depConfigSnapshot(depConfigName);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentConfigUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentConfigUtils.java
@@ -65,7 +65,7 @@ public class DeploymentConfigUtils {
     public static Map<String, String> waitTillDepConfigHasRolled(String depConfigName, Map<String, String> snapshot) {
         LOGGER.info("Waiting for DeploymentConfig {} rolling update", depConfigName);
         TestUtils.waitFor("DeploymentConfig roll of " + depConfigName,
-            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, Constants.WAIT_FOR_ROLLING_UPDATE_TIMEOUT, () -> depConfigHasRolled(depConfigName, snapshot));
+            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.getTimeoutForRollingUpdate(snapshot.size()), () -> depConfigHasRolled(depConfigName, snapshot));
         waitForDeploymentConfigReady(depConfigName);
         LOGGER.info("DeploymentConfig {} rolling update finished", depConfigName);
         return depConfigSnapshot(depConfigName);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
@@ -128,7 +128,7 @@ public class DeploymentUtils {
     public static Map<String, String> waitTillDepHasRolled(String name, int expectedPods, Map<String, String> snapshot) {
         LOGGER.info("Waiting for Deployment {} rolling update", name);
         TestUtils.waitFor("Deployment " + name + " rolling update",
-            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, Constants.WAIT_FOR_ROLLING_UPDATE_TIMEOUT, () -> depHasRolled(name, snapshot));
+            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.getTimeoutForRollingUpdate(expectedPods), () -> depHasRolled(name, snapshot));
         waitForDeploymentReady(name);
         PodUtils.waitForPodsReady(kubeClient().getDeployment(name).getSpec().getSelector(), expectedPods, true);
         LOGGER.info("Deployment {} rolling update finished", name);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
@@ -128,7 +128,7 @@ public class DeploymentUtils {
     public static Map<String, String> waitTillDepHasRolled(String name, int expectedPods, Map<String, String> snapshot) {
         LOGGER.info("Waiting for Deployment {} rolling update", name);
         TestUtils.waitFor("Deployment " + name + " rolling update",
-            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.getTimeoutForRollingUpdate(expectedPods), () -> depHasRolled(name, snapshot));
+            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.rollingUpdateTimeout(expectedPods), () -> depHasRolled(name, snapshot));
         waitForDeploymentReady(name);
         PodUtils.waitForPodsReady(kubeClient().getDeployment(name).getSpec().getSelector(), expectedPods, true);
         LOGGER.info("Deployment {} rolling update finished", name);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
@@ -102,7 +102,7 @@ public class StatefulSetUtils {
     public static Map<String, String> waitTillSsHasRolled(String name, Map<String, String> snapshot) {
         LOGGER.info("Waiting for StatefulSet {} rolling update", name);
         TestUtils.waitFor("StatefulSet " + name + " rolling update",
-            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.getTimeoutForRollingUpdate(snapshot.size()), () -> {
+            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.rollingUpdateTimeout(snapshot.size()), () -> {
                 try {
                     return ssHasRolled(name, snapshot);
                 } catch (Exception e) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
@@ -102,7 +102,7 @@ public class StatefulSetUtils {
     public static Map<String, String> waitTillSsHasRolled(String name, Map<String, String> snapshot) {
         LOGGER.info("Waiting for StatefulSet {} rolling update", name);
         TestUtils.waitFor("StatefulSet " + name + " rolling update",
-            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, Constants.WAIT_FOR_ROLLING_UPDATE_TIMEOUT * 2, () -> {
+            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.getTimeoutForRollingUpdate(snapshot.size()), () -> {
                 try {
                     return ssHasRolled(name, snapshot);
                 } catch (Exception e) {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In this PR I'm gonna change the waiting for resource rolling update. Until now we had fixed 14 minutes, but we found out that this timeout is not long enough - especially when we have 3 pods, all three had error and need approx 6 minutes to kill the pod and bring it up again.

So we decided to change it this way -> we "calculating" the timeout based of number of pods * 6 minutes. This will (hopefully) ensures, that tests will pass without errors or exception on waiting for rolling update.

### Checklist

- [x] Make sure all tests pass


