### PR TITLE
[systemtest][fix] Fix CC acceptance test

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/enums/KafkaRebalanceState.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/enums/KafkaRebalanceState.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.enums;
+
+public enum KafkaRebalanceState {
+    New,
+    PendingProposal,
+    ProposalReady,
+    Rebalancing,
+    Ready,
+    NotReady,
+    Stopped
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
@@ -11,7 +11,6 @@ import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
-import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.enums.KafkaRebalanceState;
 
@@ -29,7 +28,6 @@ public class ResourceOperation {
             case KafkaConnectS2I.RESOURCE_KIND:
             case KafkaMirrorMaker2.RESOURCE_KIND:
             case Constants.DEPLOYMENT_CONFIG:
-            case KafkaRebalance.RESOURCE_KIND:
                 timeout = Duration.ofMinutes(10).toMillis();
                 break;
             case KafkaMirrorMaker.RESOURCE_KIND:

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.enums.KafkaRebalanceState;
 
 import java.time.Duration;
 
@@ -28,6 +29,7 @@ public class ResourceOperation {
             case KafkaConnectS2I.RESOURCE_KIND:
             case KafkaMirrorMaker2.RESOURCE_KIND:
             case Constants.DEPLOYMENT_CONFIG:
+            case KafkaRebalance.RESOURCE_KIND:
                 timeout = Duration.ofMinutes(10).toMillis();
                 break;
             case KafkaMirrorMaker.RESOURCE_KIND:
@@ -39,11 +41,25 @@ public class ResourceOperation {
                 timeout = Duration.ofMinutes(8).toMillis();
                 break;
             case KafkaConnector.RESOURCE_KIND:
-            case KafkaRebalance.RESOURCE_KIND:
                 timeout = Duration.ofMinutes(4).toMillis();
                 break;
             default:
                 timeout = Duration.ofMinutes(2).toMillis();
+        }
+
+        return timeout;
+    }
+
+    public static long getTimeoutForKafkaRebalanceState(KafkaRebalanceState state) {
+        long timeout;
+        switch (state) {
+            case ProposalReady:
+            case Ready:
+            case Rebalancing:
+                timeout = Duration.ofMinutes(10).toMillis();
+                break;
+            default:
+                timeout = Duration.ofMinutes(6).toMillis();
         }
 
         return timeout;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
@@ -4,9 +4,9 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
-import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.enums.KafkaRebalanceState;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
@@ -23,19 +23,8 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 public class KafkaRebalanceUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(KafkaRebalanceUtils.class);
-    private static final long READINESS_TIMEOUT = ResourceOperation.getTimeoutForResourceReadiness(KafkaRebalance.RESOURCE_KIND);
 
     private KafkaRebalanceUtils() {}
-
-    public enum KafkaRebalanceState {
-        New,
-        PendingProposal,
-        ProposalReady,
-        Rebalancing,
-        Ready,
-        NotReady,
-        Stopped
-    }
 
     private static Condition rebalanceStateCondition(String resourceName) {
 
@@ -60,7 +49,8 @@ public class KafkaRebalanceUtils {
     public static void waitForKafkaRebalanceCustomResourceState(String resourceName, KafkaRebalanceState state) {
         LOGGER.info("Waiting for KafkaRebalance to be in the {} state", state);
 
-        TestUtils.waitFor("KafkaRebalance to be in the " + state.name(), Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, READINESS_TIMEOUT,
+        TestUtils.waitFor("KafkaRebalance to be in the " + state.name(), Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,
+            ResourceOperation.getTimeoutForKafkaRebalanceState(state),
             () -> rebalanceStateCondition(resourceName).getType().equals(state.toString()),
             () -> ResourceManager.logCurrentResourceStatus(KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(kubeClient().getNamespace())
                 .withName(resourceName).get())

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -6,6 +6,7 @@ package io.strimzi.systemtest.cruisecontrol;
 
 import io.strimzi.api.kafka.model.KafkaTopicSpec;
 import io.strimzi.systemtest.BaseST;
+import io.strimzi.systemtest.enums.KafkaRebalanceState;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -71,13 +72,13 @@ public class CruiseControlIsolatedST extends BaseST {
         KafkaResource.kafkaWithCruiseControl(CLUSTER_NAME, 3, 3).done();
         KafkaRebalanceResource.kafkaRebalance(CLUSTER_NAME).done();
 
-        LOGGER.info("Verifying that KafkaRebalance resource is in {} state", KafkaRebalanceUtils.KafkaRebalanceState.PendingProposal);
+        LOGGER.info("Verifying that KafkaRebalance resource is in {} state", KafkaRebalanceState.PendingProposal);
 
-        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(CLUSTER_NAME, KafkaRebalanceUtils.KafkaRebalanceState.PendingProposal);
+        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(CLUSTER_NAME, KafkaRebalanceState.PendingProposal);
 
-        LOGGER.info("Verifying that KafkaRebalance resource is in {} state", KafkaRebalanceUtils.KafkaRebalanceState.ProposalReady);
+        LOGGER.info("Verifying that KafkaRebalance resource is in {} state", KafkaRebalanceState.ProposalReady);
 
-        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(CLUSTER_NAME, KafkaRebalanceUtils.KafkaRebalanceState.ProposalReady);
+        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(CLUSTER_NAME, KafkaRebalanceState.ProposalReady);
 
         LOGGER.info("Triggering the rebalance with annotation {} of KafkaRebalance resource", "strimzi.io/rebalance=approve");
 
@@ -87,13 +88,13 @@ public class CruiseControlIsolatedST extends BaseST {
 
         LOGGER.info("Response from the annotation process {}", response);
 
-        LOGGER.info("Verifying that annotation triggers the {} state", KafkaRebalanceUtils.KafkaRebalanceState.Rebalancing);
+        LOGGER.info("Verifying that annotation triggers the {} state", KafkaRebalanceState.Rebalancing);
 
-        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(CLUSTER_NAME, KafkaRebalanceUtils.KafkaRebalanceState.Rebalancing);
+        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(CLUSTER_NAME, KafkaRebalanceState.Rebalancing);
 
-        LOGGER.info("Verifying that KafkaRebalance is in the {} state", KafkaRebalanceUtils.KafkaRebalanceState.Ready);
+        LOGGER.info("Verifying that KafkaRebalance is in the {} state", KafkaRebalanceState.Ready);
 
-        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(CLUSTER_NAME, KafkaRebalanceUtils.KafkaRebalanceState.Ready);
+        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(CLUSTER_NAME, KafkaRebalanceState.Ready);
     }
 
     @BeforeAll


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR gonna fix `testCruiseControlWithRebalanceResource` which was failing in our acceptance profile. Problem here was, that after my previous PR where I changed the timeouts for the resources, only 4 minutes on waiting for `ProposalReady` wasn't enough. So I added new method just for KafkaRebalance resource (to get the right timeout) to the `ResourceOperation` class, where it returns timeout depended on each state.

Also I moved enum in `KafkaRebalanceUtils` to be in separate class, in the `enums` folder.

### Checklist

- [x] Make sure all tests pass


