### PR TITLE
[DOC] Use the new zone label in documentation

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/Rack.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Rack.java
@@ -40,7 +40,7 @@ public class Rack implements UnknownPropertyPreserving, Serializable {
 
     @Description("A key that matches labels assigned to the Kubernetes cluster nodes. " +
             "The value of the label is used to set the broker's `broker.rack` config.")
-    @Example("failure-domain.beta.kubernetes.io/zone")
+    @Example("topology.kubernetes.io/zone")
     @JsonProperty(required = true)
     public String getTopologyKey() {
         return topologyKey;

--- a/documentation/modules/overview/con-configuration-points-broker.adoc
+++ b/documentation/modules/overview/con-configuration-points-broker.adoc
@@ -72,6 +72,6 @@ spec:
       size: 10000Gi
     # ...
     rack:
-      topologyKey: failure-domain.beta.kubernetes.io/zone
+      topologyKey: topology.kubernetes.io/zone
     # ...
 ----

--- a/documentation/modules/proc-configuring-kafka-rack-awareness.adoc
+++ b/documentation/modules/proc-configuring-kafka-rack-awareness.adoc
@@ -11,6 +11,7 @@ This key needs to match one of the labels assigned to the Kubernetes cluster nod
 The label is used by Kubernetes when scheduling the Kafka broker pods to nodes.
 If the Kubernetes cluster is running on a cloud provider platform, that label should represent the availability zone where the node is running.
 Usually, the nodes are labeled with `topology.kubernetes.io/zone` label (or `failure-domain.beta.kubernetes.io/zone` on older Kubernetes versions) that can be easily used as the `topologyKey` value.
+For more details about the Kubernetes node labels, see {K8sWellKnownLabelsAnnotationsAndTaints}.
 This has the effect of spreading the broker pods across zones, and also setting the brokers' `broker.rack` configuration parameter inside Kafka broker.
 
 .Prerequisites

--- a/documentation/modules/proc-configuring-kafka-rack-awareness.adoc
+++ b/documentation/modules/proc-configuring-kafka-rack-awareness.adoc
@@ -10,7 +10,7 @@ The `rack` object has one mandatory field named `topologyKey`.
 This key needs to match one of the labels assigned to the Kubernetes cluster nodes.
 The label is used by Kubernetes when scheduling the Kafka broker pods to nodes.
 If the Kubernetes cluster is running on a cloud provider platform, that label should represent the availability zone where the node is running.
-Usually, the nodes are labeled with `failure-domain.beta.kubernetes.io/zone` that can be easily used as the `topologyKey` value.
+Usually, the nodes are labeled with `topology.kubernetes.io/zone` label (or `failure-domain.beta.kubernetes.io/zone` on older Kubernetes versions) that can be easily used as the `topologyKey` value.
 This has the effect of spreading the broker pods across zones, and also setting the brokers' `broker.rack` configuration parameter inside Kafka broker.
 
 .Prerequisites
@@ -33,7 +33,7 @@ spec:
   kafka:
     # ...
     rack:
-      topologyKey: failure-domain.beta.kubernetes.io/zone
+      topologyKey: topology.kubernetes.io/zone
     # ...
 ----
 +

--- a/documentation/modules/proc-configuring-kafka-rack-awareness.adoc
+++ b/documentation/modules/proc-configuring-kafka-rack-awareness.adoc
@@ -10,8 +10,8 @@ The `rack` object has one mandatory field named `topologyKey`.
 This key needs to match one of the labels assigned to the Kubernetes cluster nodes.
 The label is used by Kubernetes when scheduling the Kafka broker pods to nodes.
 If the Kubernetes cluster is running on a cloud provider platform, that label should represent the availability zone where the node is running.
-Usually, the nodes are labeled with `topology.kubernetes.io/zone` label (or `failure-domain.beta.kubernetes.io/zone` on older Kubernetes versions) that can be easily used as the `topologyKey` value.
-For more details about the Kubernetes node labels, see {K8sWellKnownLabelsAnnotationsAndTaints}.
+Usually, the nodes are labeled with `topology.kubernetes.io/zone` label (or `failure-domain.beta.kubernetes.io/zone` on older Kubernetes versions) that can be used as the `topologyKey` value.
+For more information about Kubernetes node labels, see {K8sWellKnownLabelsAnnotationsAndTaints}.
 This has the effect of spreading the broker pods across zones, and also setting the brokers' `broker.rack` configuration parameter inside Kafka broker.
 
 .Prerequisites

--- a/documentation/modules/ref-kafka-rack.adoc
+++ b/documentation/modules/ref-kafka-rack.adoc
@@ -11,7 +11,7 @@ The label is used by Kubernetes when scheduling the Kafka broker pods to nodes.
 
 If the Kubernetes cluster is running on a cloud provider platform, that label should represent the availability zone where the node is running.
 If the Kubernetes cluster is running on a cloud provider platform, that label should represent the availability zone where the node is running.
-Usually, the nodes are labelled with `failure-domain.beta.kubernetes.io/zone` that can be easily used as the `topologyKey` value.
+Usually, the nodes are labeled with `topology.kubernetes.io/zone` label (or `failure-domain.beta.kubernetes.io/zone` on older Kubernetes versions) that can be easily used as the `topologyKey` value.
 This will have the effect of spreading the broker pods across zones, and also setting the brokers' `broker.rack` configuration parameter inside Kafka broker.
 
 .Example of a `Kafka` resource with the `rack` feature enabled
@@ -25,11 +25,11 @@ spec:
   kafka:
     # ...
     rack:
-      topologyKey: failure-domain.beta.kubernetes.io/zone
+      topologyKey: topology.kubernetes.io/zone
     # ...
 ----
 
-In the above example, the `failure-domain.beta.kubernetes.io/zone` node label will be used for scheduling Kafka broker Pods.
+In the above example, the `topology.kubernetes.io/zone` node label will be used for scheduling Kafka broker Pods.
 Consult your Kubernetes administrator about the label which should be used.
 
 == Configuring init container image

--- a/documentation/modules/ref-kafka-rack.adoc
+++ b/documentation/modules/ref-kafka-rack.adoc
@@ -11,8 +11,11 @@ The label is used by Kubernetes when scheduling the Kafka broker pods to nodes.
 
 If the Kubernetes cluster is running on a cloud provider platform, that label should represent the availability zone where the node is running.
 If the Kubernetes cluster is running on a cloud provider platform, that label should represent the availability zone where the node is running.
-Usually, the nodes are labeled with `topology.kubernetes.io/zone` label (or `failure-domain.beta.kubernetes.io/zone` on older Kubernetes versions) that can be easily used as the `topologyKey` value.
+Usually, the nodes are labeled with `topology.kubernetes.io/zone` label (or `failure-domain.beta.kubernetes.io/zone` on older Kubernetes versions) that can be used as the `topologyKey` value.
 This will have the effect of spreading the broker pods across zones, and also setting the brokers' `broker.rack` configuration parameter inside Kafka broker.
+
+In the following example, the `topology.kubernetes.io/zone` node label is used for scheduling Kafka broker Pods.
+Consult your Kubernetes administrator about the label which should be used.
 
 .Example of a `Kafka` resource with the `rack` feature enabled
 [source,yaml,subs=attributes+]
@@ -28,9 +31,6 @@ spec:
       topologyKey: topology.kubernetes.io/zone
     # ...
 ----
-
-In the above example, the `topology.kubernetes.io/zone` node label will be used for scheduling Kafka broker Pods.
-Consult your Kubernetes administrator about the label which should be used.
 
 == Configuring init container image
 

--- a/documentation/modules/ref-sample-kafka-resource-config.adoc
+++ b/documentation/modules/ref-sample-kafka-resource-config.adoc
@@ -64,7 +64,7 @@ spec:
       type: persistent-claim <14>
       size: 10000Gi <15>
     rack: <16>
-      topologyKey: failure-domain.beta.kubernetes.io/zone
+      topologyKey: topology.kubernetes.io/zone
     metrics: <17>
       lowercaseOutputName: true
       rules: <18>

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -71,6 +71,7 @@
 :K8sResizingPersistentVolumesUsingKubernetes: link:https://kubernetes.io/blog/2018/07/12/resizing-persistent-volumes-using-kubernetes/[Resizing Persistent Volumes using Kubernetes^]
 :K8sPriorityClass: link:https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption[Pod Priority and Preemption^]
 :K8sServiceDiscovery: https://kubernetes.io/docs/concepts/services-networking/service/#discovering-services[Discovering services^]
+:K8sWellKnownLabelsAnnotationsAndTaints: link:https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/[Well-Known Labels, Annotations and Taints^]
 :Minikube: link:https://kubernetes.io/docs/tasks/tools/install-minikube/[Install and start Minikube]
 :NginxIngressController: link:https://github.com/kubernetes/ingress-nginx[NGINX Ingress Controller for Kubernetes^]
 :NginxIngressControllerTLSPassthrough: link:https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough[TLS passthrough documentation]

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -793,7 +793,7 @@ spec:
                   properties:
                     topologyKey:
                       type: string
-                      example: failure-domain.beta.kubernetes.io/zone
+                      example: topology.kubernetes.io/zone
                       description: A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config.
                   required:
                     - topologyKey

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -789,7 +789,7 @@ spec:
                   properties:
                     topologyKey:
                       type: string
-                      example: failure-domain.beta.kubernetes.io/zone
+                      example: topology.kubernetes.io/zone
                       description: A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config.
                   required:
                     - topologyKey

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1058,7 +1058,7 @@ spec:
                   properties:
                     topologyKey:
                       type: string
-                      example: failure-domain.beta.kubernetes.io/zone
+                      example: topology.kubernetes.io/zone
                       description: A key that matches labels assigned to the Kubernetes
                         cluster nodes. The value of the label is used to set the broker's
                         `broker.rack` config.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The old label `failure-domain.beta.kubernetes.io/zone` for indicating zone is deprectaed in newer Kubernetes versions in favour of the new label `topology.kubernetes.io/zone`. This PR replaces its use in our documentation with the new label (while also mentioning the old label in the text).

### Checklist

- [x] Update documentation