### PR TITLE
[systemtest][fix] Change timeouts for continuous clients producers

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -43,7 +43,7 @@ public class ClientUtils {
     }
 
     public static void waitTillContinuousClientsFinish(String producerName, String consumerName, String namespace, int messageCount) {
-        long timeout = (long) (messageCount / 2) * 1000;
+        long timeout = (long) messageCount * 1000;
         LOGGER.info("Waiting till producer {} and consumer {} finish for the following {} ms", producerName, consumerName, timeout);
         TestUtils.waitFor("continuous clients finished", Constants.GLOBAL_POLL_INTERVAL, timeout,
             () -> kubeClient().getClient().batch().jobs().inNamespace(namespace).withName(producerName).get().getStatus().getSucceeded().equals(1) &&

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -41,7 +41,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Tag(REGRESSION)
 @Tag(INTERNAL_CLIENTS_USED)
 class AlternativeReconcileTriggersST extends BaseST {
-
     private static final Logger LOGGER = LogManager.getLogger(RollingUpdateST.class);
 
     static final String NAMESPACE = "alternative-reconcile-triggers-cluster-test";
@@ -68,7 +67,7 @@ class AlternativeReconcileTriggersST extends BaseST {
         // ##############################
         // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
         KafkaTopicResource.topic(CLUSTER_NAME, continuousTopicName, 3, 3, 2).done();
-        String producerAdditionConfiguration = "delivery.timeout.ms=10000\nrequest.timeout.ms=10000";
+        String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
         KafkaClientsResource.producerStrimzi(producerName, KafkaResources.plainBootstrapAddress(CLUSTER_NAME), continuousTopicName, continuousClientsMessageCount, producerAdditionConfiguration).done();
         KafkaClientsResource.consumerStrimzi(consumerName, KafkaResources.plainBootstrapAddress(CLUSTER_NAME), continuousTopicName, continuousClientsMessageCount).done();
         // ##############################

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -267,7 +267,7 @@ public class StrimziUpgradeST extends BaseST {
                 // Add continuous topic to expectedTopicCunt which will be check after upgrade procedures
                 expectedTopicCount += 1;
             }
-            String producerAdditionConfiguration = "delivery.timeout.ms=10000\nrequest.timeout.ms=10000";
+            String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
             KafkaClientsResource.producerStrimzi(producerName, KafkaResources.plainBootstrapAddress(CLUSTER_NAME), continuousTopicName, continuousClientsMessageCount, producerAdditionConfiguration).done();
             KafkaClientsResource.consumerStrimzi(consumerName, KafkaResources.plainBootstrapAddress(CLUSTER_NAME), continuousTopicName, continuousClientsMessageCount, "", continuousConsumerGroup).done();
             // ##############################

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
@@ -109,7 +109,7 @@ public class ZookeeperUpgradeST extends BaseST {
             // ##############################
             // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
             KafkaTopicResource.topic(CLUSTER_NAME, continuousTopicName, 3, 3, 2).done();
-            String producerAdditionConfiguration = "delivery.timeout.ms=10000\nrequest.timeout.ms=10000";
+            String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
             KafkaClientsResource.producerStrimzi(producerName, KafkaResources.plainBootstrapAddress(CLUSTER_NAME), continuousTopicName, continuousClientsMessageCount, producerAdditionConfiguration).done();
             KafkaClientsResource.consumerStrimzi(consumerName, KafkaResources.plainBootstrapAddress(CLUSTER_NAME), continuousTopicName, continuousClientsMessageCount).done();
             // ##############################


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

In this PR I'm gonna change timeouts for our continuous clients producer -> it seems that 10s for `delivery.timeout.ms` and `request.timeout.ms` isn't enough, so I increased the timeout to 20s. Now the producer/consumer should finish in time.

### Checklist

- [ ] Make sure all tests pass

