### PR TITLE
ST: Set Bridge image based on predefined env variable vol. 2

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -111,8 +111,8 @@ public class Environment {
     private static final String TEST_CLIENT_IMAGE_DEFAULT = STRIMZI_REGISTRY + "/" + STRIMZI_ORG + "/test-client:" + STRIMZI_TAG + "-kafka-" + ST_KAFKA_VERSION;
     public static final String TEST_CLIENT_IMAGE = System.getenv().getOrDefault(TEST_CLIENT_IMAGE_ENV, TEST_CLIENT_IMAGE_DEFAULT);
     // variables for kafka bridge image
-    private static final String BRIDGET_IMAGE_DEFAULT = "latest-released";
-    public static final String BRIDGE_IMAGE = System.getenv().getOrDefault(BRIDGE_IMAGE_ENV, BRIDGET_IMAGE_DEFAULT);
+    private static final String BRIDGE_IMAGE_DEFAULT = "latest-released";
+    public static final String BRIDGE_IMAGE = System.getenv().getOrDefault(BRIDGE_IMAGE_ENV, BRIDGE_IMAGE_DEFAULT);
     // Image pull policy variables
     public static final String COMPONENTS_IMAGE_PULL_POLICY = System.getenv().getOrDefault(COMPONENTS_IMAGE_PULL_POLICY_ENV, COMPONENTS_IMAGE_PULL_POLICY_ENV_DEFAULT);
     public static final String OPERATOR_IMAGE_PULL_POLICY = System.getenv().getOrDefault(OPERATOR_IMAGE_PULL_POLICY_ENV, OPERATOR_IMAGE_PULL_POLICY_ENV_DEFAULT);
@@ -155,6 +155,6 @@ public class Environment {
     }
 
     public static boolean useLatestReleasedBridge() {
-        return Environment.BRIDGE_IMAGE.equals(Environment.BRIDGET_IMAGE_DEFAULT);
+        return Environment.BRIDGE_IMAGE.equals(Environment.BRIDGE_IMAGE_DEFAULT);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -111,7 +111,7 @@ public class Environment {
     private static final String TEST_CLIENT_IMAGE_DEFAULT = STRIMZI_REGISTRY + "/" + STRIMZI_ORG + "/test-client:" + STRIMZI_TAG + "-kafka-" + ST_KAFKA_VERSION;
     public static final String TEST_CLIENT_IMAGE = System.getenv().getOrDefault(TEST_CLIENT_IMAGE_ENV, TEST_CLIENT_IMAGE_DEFAULT);
     // variables for kafka bridge image
-    private static final String BRIDGET_IMAGE_DEFAULT = STRIMZI_REGISTRY_DEFAULT + "/" + STRIMZI_ORG_DEFAULT + "/kafka-bridge:" + STRIMZI_TAG_DEFAULT;
+    private static final String BRIDGET_IMAGE_DEFAULT = "latest-released";
     public static final String BRIDGE_IMAGE = System.getenv().getOrDefault(BRIDGE_IMAGE_ENV, BRIDGET_IMAGE_DEFAULT);
     // Image pull policy variables
     public static final String COMPONENTS_IMAGE_PULL_POLICY = System.getenv().getOrDefault(COMPONENTS_IMAGE_PULL_POLICY_ENV, COMPONENTS_IMAGE_PULL_POLICY_ENV_DEFAULT);
@@ -152,5 +152,9 @@ public class Environment {
 
     public static boolean isOlmInstall() {
         return Environment.CLUSTER_OPERATOR_INSTALL_TYPE.toUpperCase(Locale.ENGLISH).equals("OLM");
+    }
+
+    public static boolean useLatestReleasedBridge() {
+        return Environment.BRIDGE_IMAGE.equals(Environment.BRIDGET_IMAGE_DEFAULT);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
@@ -92,7 +92,7 @@ public class KubernetesResource {
                     break;
                 default:
                     if (envVar.getName().contains("KAFKA_BRIDGE_IMAGE")) {
-                        envVar.setValue(Environment.BRIDGE_IMAGE);
+                        envVar.setValue(Environment.useLatestReleasedBridge() ? envVar.getValue() : Environment.BRIDGE_IMAGE);
                     } else if (envVar.getName().contains("STRIMZI_DEFAULT")) {
                         envVar.setValue(StUtils.changeOrgAndTag(envVar.getValue()));
                     } else if (envVar.getName().contains("IMAGES")) {


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

_Select the type of your PR_

- Bugfix

### Description

This is missing commit which should be part of https://github.com/strimzi/strimzi-kafka-operator/pull/3245 but it was marked as ready for merged too early because wrong coordination offline.

This commit make sure, that bridge image will be used from `050-deployment` file. The env variable will be used only when it will be explicitly set in nightly builds for example.

### Checklist

- [x] Make sure all tests pass


