### PR TITLE
ST: Add k8s version to environment data for upgrade tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -242,15 +242,14 @@ public class StUtils {
     }
 
     /**
-     /**
      * Method for check if test is allowed on current Kubernetes version
-     * @param desiredKubernetesVersion kubernetes version which test needs
+     * @param maxKubernetesVersion kubernetes version which test needs
      * @return true if test is allowed, false if not
      */
-    public static boolean isAllowedOnCurrentK8sVersion(String desiredKubernetesVersion) {
-        if (desiredKubernetesVersion.equals("latest")) {
+    public static boolean isAllowedOnCurrentK8sVersion(String maxKubernetesVersion) {
+        if (maxKubernetesVersion.equals("latest")) {
             return true;
         }
-        return Double.parseDouble(kubeClient().clusterKubernetesVersion()) < Double.parseDouble(desiredKubernetesVersion);
+        return Double.parseDouble(kubeClient().clusterKubernetesVersion()) < Double.parseDouble(maxKubernetesVersion);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -240,4 +240,17 @@ public class StUtils {
         }
         return isJSON;
     }
+
+    /**
+     /**
+     * Method for check if test is allowed on current Kubernetes version
+     * @param desiredKubernetesVersion kubernetes version which test needs
+     * @return true if test is allowed, false if not
+     */
+    public static boolean isAllowedOnCurrentK8sVersion(String desiredKubernetesVersion) {
+        if (desiredKubernetesVersion.equals("latest")) {
+            return true;
+        }
+        return Double.parseDouble(kubeClient().clusterKubernetesVersion()) < Double.parseDouble(desiredKubernetesVersion);
+    }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -15,7 +15,6 @@ import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.time.Duration;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -133,7 +132,7 @@ public class PodUtils {
     public static void waitForPod(String name) {
         LOGGER.info("Waiting when Pod {} will be ready", name);
 
-        TestUtils.waitFor("pod " + name + " to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Duration.ofMinutes(6).toMillis(),
+        TestUtils.waitFor("pod " + name + " to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_CREATION,
             () -> {
                 List<ContainerStatus> statuses =  kubeClient().getPod(name).getStatus().getContainerStatuses();
                 for (ContainerStatus containerStatus : statuses) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -63,7 +64,7 @@ public class PodUtils {
         int[] counter = {0};
 
         TestUtils.waitFor("All pods matching " + selector + "to be ready",
-            Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Duration.ofMinutes(6).toMillis(),
+            Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, ResourceOperation.rollingUpdateTimeout(expectPods),
             () -> {
                 List<Pod> pods = kubeClient().listPods(selector);
                 if (pods.isEmpty() && expectPods == 0) {

--- a/systemtest/src/main/resources/StrimziUpgradeST.json
+++ b/systemtest/src/main/resources/StrimziUpgradeST.json
@@ -33,7 +33,7 @@
       "continuousClientsMessages": 0
     },
     "environmentInfo": {
-      "k8sVersion": "1.15",
+      "maxK8sVersion": "1.15",
       "status": "flaky",
       "flakyEnvVariable": "JENKINS_URL",
       "reason" : "From some reason, this test is not working on Jenkins. Locally it's fine."
@@ -73,7 +73,7 @@
       "continuousClientsMessages": 0
     },
     "environmentInfo": {
-      "k8sVersion": "1.15",
+      "maxK8sVersion": "1.15",
       "status": "stable",
       "flakyEnvVariable": "none",
       "reason" : "Strimzi 0.12.x needs kubernetes version 1.15 or lower, cause api changes in later versions to move Deployment from extensions to apps."
@@ -113,7 +113,7 @@
       "continuousClientsMessages": 0
     },
     "environmentInfo": {
-      "k8sVersion": "1.15",
+      "maxK8sVersion": "1.15",
       "status": "stable",
       "flakyEnvVariable": "none",
       "reason" : "Strimzi 0.13.x needs kubernetes version 1.15 or lower, cause api changes in later versions to move Deployment from extensions to apps."
@@ -153,7 +153,7 @@
       "continuousClientsMessages": 0
     },
     "environmentInfo": {
-      "k8sVersion": "latest",
+      "maxK8sVersion": "latest",
       "status": "stable",
       "flakyEnvVariable": "none",
       "reason" : "Test is working on all environment used by QE."
@@ -193,7 +193,7 @@
       "continuousClientsMessages": 0
     },
     "environmentInfo": {
-      "k8sVersion": "latest",
+      "maxK8sVersion": "latest",
       "status": "stable",
       "flakyEnvVariable": "none",
       "reason" : "Test is working on all environment used by QE."
@@ -233,7 +233,7 @@
       "continuousClientsMessages": 0
     },
     "environmentInfo": {
-      "k8sVersion": "latest",
+      "maxK8sVersion": "latest",
       "status": "stable",
       "flakyEnvVariable": "none",
       "reason" : "Test is working on all environment used by QE."
@@ -273,7 +273,7 @@
       "continuousClientsMessages": 0
     },
     "environmentInfo": {
-      "k8sVersion": "latest",
+      "maxK8sVersion": "latest",
       "status": "stable",
       "flakyEnvVariable": "none",
       "reason" : "Test is working on all environment used by QE."
@@ -313,7 +313,7 @@
       "continuousClientsMessages": 500
     },
     "environmentInfo": {
-      "k8sVersion": "latest",
+      "maxK8sVersion": "latest",
       "status": "stable",
       "flakyEnvVariable": "none",
       "reason" : "Test is working on all environment used by QE."

--- a/systemtest/src/main/resources/StrimziUpgradeST.json
+++ b/systemtest/src/main/resources/StrimziUpgradeST.json
@@ -33,6 +33,7 @@
       "continuousClientsMessages": 0
     },
     "environmentInfo": {
+      "k8sVersion": "1.15",
       "status": "flaky",
       "flakyEnvVariable": "JENKINS_URL",
       "reason" : "From some reason, this test is not working on Jenkins. Locally it's fine."
@@ -72,9 +73,10 @@
       "continuousClientsMessages": 0
     },
     "environmentInfo": {
+      "k8sVersion": "1.15",
       "status": "stable",
       "flakyEnvVariable": "none",
-      "reason" : "Test is working on all environment used by QE."
+      "reason" : "Strimzi 0.12.x needs kubernetes version 1.15 or lower, cause api changes in later versions to move Deployment from extensions to apps."
     }
   },
   {
@@ -111,9 +113,10 @@
       "continuousClientsMessages": 0
     },
     "environmentInfo": {
+      "k8sVersion": "1.15",
       "status": "stable",
       "flakyEnvVariable": "none",
-      "reason" : "Test is working on all environment used by QE."
+      "reason" : "Strimzi 0.13.x needs kubernetes version 1.15 or lower, cause api changes in later versions to move Deployment from extensions to apps."
     }
   },
   {
@@ -150,6 +153,7 @@
       "continuousClientsMessages": 0
     },
     "environmentInfo": {
+      "k8sVersion": "latest",
       "status": "stable",
       "flakyEnvVariable": "none",
       "reason" : "Test is working on all environment used by QE."
@@ -189,6 +193,7 @@
       "continuousClientsMessages": 0
     },
     "environmentInfo": {
+      "k8sVersion": "latest",
       "status": "stable",
       "flakyEnvVariable": "none",
       "reason" : "Test is working on all environment used by QE."
@@ -228,6 +233,7 @@
       "continuousClientsMessages": 0
     },
     "environmentInfo": {
+      "k8sVersion": "latest",
       "status": "stable",
       "flakyEnvVariable": "none",
       "reason" : "Test is working on all environment used by QE."
@@ -267,6 +273,7 @@
       "continuousClientsMessages": 0
     },
     "environmentInfo": {
+      "k8sVersion": "latest",
       "status": "stable",
       "flakyEnvVariable": "none",
       "reason" : "Test is working on all environment used by QE."
@@ -306,6 +313,7 @@
       "continuousClientsMessages": 500
     },
     "environmentInfo": {
+      "k8sVersion": "latest",
       "status": "stable",
       "flakyEnvVariable": "none",
       "reason" : "Test is working on all environment used by QE."

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -90,6 +90,7 @@ public class StrimziUpgradeST extends AbstractST {
     void testUpgradeStrimziVersion(JsonObject parameters) throws Exception {
 
         assumeTrue(StUtils.isAllowOnCurrentEnvironment(parameters.getJsonObject("environmentInfo").getString("flakyEnvVariable")));
+        assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(parameters.getJsonObject("environmentInfo").getString("k8sVersion")));
 
         try {
             performUpgrade(parameters, MESSAGE_COUNT, MESSAGE_COUNT);
@@ -130,7 +131,8 @@ public class StrimziUpgradeST extends AbstractST {
 
         try {
             for (JsonValue testParameters : parameters) {
-                if (StUtils.isAllowOnCurrentEnvironment(testParameters.asJsonObject().getJsonObject("environmentInfo").getString("flakyEnvVariable"))) {
+                if (StUtils.isAllowOnCurrentEnvironment(testParameters.asJsonObject().getJsonObject("environmentInfo").getString("flakyEnvVariable")) &&
+                    StUtils.isAllowedOnCurrentK8sVersion(testParameters.asJsonObject().getJsonObject("environmentInfo").getString("k8sVersion"))) {
                     performUpgrade(testParameters.asJsonObject(), MESSAGE_COUNT, consumedMessagesCount);
                     consumedMessagesCount = consumedMessagesCount + MESSAGE_COUNT;
                 } else {

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -90,7 +90,7 @@ public class StrimziUpgradeST extends AbstractST {
     void testUpgradeStrimziVersion(JsonObject parameters) throws Exception {
 
         assumeTrue(StUtils.isAllowOnCurrentEnvironment(parameters.getJsonObject("environmentInfo").getString("flakyEnvVariable")));
-        assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(parameters.getJsonObject("environmentInfo").getString("k8sVersion")));
+        assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(parameters.getJsonObject("environmentInfo").getString("maxK8sVersion")));
 
         try {
             performUpgrade(parameters, MESSAGE_COUNT, MESSAGE_COUNT);
@@ -132,7 +132,7 @@ public class StrimziUpgradeST extends AbstractST {
         try {
             for (JsonValue testParameters : parameters) {
                 if (StUtils.isAllowOnCurrentEnvironment(testParameters.asJsonObject().getJsonObject("environmentInfo").getString("flakyEnvVariable")) &&
-                    StUtils.isAllowedOnCurrentK8sVersion(testParameters.asJsonObject().getJsonObject("environmentInfo").getString("k8sVersion"))) {
+                    StUtils.isAllowedOnCurrentK8sVersion(testParameters.asJsonObject().getJsonObject("environmentInfo").getString("maxK8sVersion"))) {
                     performUpgrade(testParameters.asJsonObject(), MESSAGE_COUNT, consumedMessagesCount);
                     consumedMessagesCount = consumedMessagesCount + MESSAGE_COUNT;
                 } else {


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Enhancement / new feature


### Description

For some environments, which contain kubernetes with version 1.16+, we are not able to deploy Strimzi from shipped examples. With version 1.16, there were a change in kubernetes API which moved `Deployment` from `extensions` to `apps`.  Changes in this PR adds check for kubernetes version and skip tests if it's higher than the highest allowed.

For example, several upgrade tests will be skipped in OCP4.3+, but all remain same on 3.11

### Checklist

- [x] Make sure all tests pass


