### PR TITLE
Add template support to KafkaUser resource to manage secret metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Migration to Helm 3
 * Refactored the format of the `KafkaRebalance` resource's status. The state of the rebalance is now displayed in the associated `Condition`'s `type` field rather than the `status` field. This was done so that the information would display correctly in various Kubernetes tools.
 * Use Strimzi Kafka Bridge 0.17.0
-* Make it possible to configure labels and annotations for secrets created by User Operator
+* Make it possible to configure labels and annotations for secrets created by the User Operator
 
 ### Deprecations and removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Migration to Helm 3
 * Refactored the format of the `KafkaRebalance` resource's status. The state of the rebalance is now displayed in the associated `Condition`'s `type` field rather than the `status` field. This was done so that the information would display correctly in various Kubernetes tools.
 * Use Strimzi Kafka Bridge 0.17.0
+* Make it possible to configure labels and annotations for secrets created by User Operator
 
 ### Deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserSpec.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.template.KafkaUserTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -30,6 +31,7 @@ public class KafkaUserSpec  implements UnknownPropertyPreserving, Serializable {
     private KafkaUserAuthentication authentication;
     private KafkaUserAuthorization authorization;
     private KafkaUserQuotas quotas;
+    private KafkaUserTemplate template;
     private Map<String, Object> additionalProperties;
 
     @Description("Authentication mechanism enabled for this Kafka user.")
@@ -62,6 +64,16 @@ public class KafkaUserSpec  implements UnknownPropertyPreserving, Serializable {
 
     public void setQuotas(KafkaUserQuotas kafkaUserQuotas) {
         this.quotas = kafkaUserQuotas;
+    }
+
+    @Description("Authorization rules for this Kafka user.")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public KafkaUserTemplate getTemplate() {
+        return template;
+    }
+
+    public void setTemplate(KafkaUserTemplate template) {
+        this.template = template;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserSpec.java
@@ -66,7 +66,7 @@ public class KafkaUserSpec  implements UnknownPropertyPreserving, Serializable {
         this.quotas = kafkaUserQuotas;
     }
 
-    @Description("Authorization rules for this Kafka user.")
+    @Description("Template to specify how Kafka User `Secrets` are generated.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public KafkaUserTemplate getTemplate() {
         return template;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaUserTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaUserTemplate.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Representation of a template for a KafkaUser resources.
+ * Representation of a template for a KafkaUser resource.
  */
 @Buildable(
         editableEnabled = false,
@@ -35,7 +35,7 @@ public class KafkaUserTemplate implements Serializable, UnknownPropertyPreservin
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for KafkaUser resources. " +
-            "The template allows users to specify how is the `Secret` with password or certificates are generated.")
+            "The template allows users to specify how the `Secret` with password or TLS certificates is generated.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public ResourceTemplate getSecret() {
         return secret;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaUserTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaUserTemplate.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.template;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.Constants;
+import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.DescriptionFile;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation of a template for a KafkaUser resources.
+ */
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"secret"})
+@DescriptionFile
+@EqualsAndHashCode
+public class KafkaUserTemplate implements Serializable, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
+
+    private ResourceTemplate secret;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @Description("Template for KafkaUser resources. " +
+            "The template allows users to specify how is the `Secret` with password or certificates are generated.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getSecret() {
+        return secret;
+    }
+
+    public void setSecret(ResourceTemplate secret) {
+        this.secret = secret;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -36,6 +36,7 @@ import io.strimzi.api.kafka.model.authentication.KafkaClientAuthentication;
 import io.strimzi.api.kafka.model.template.KafkaBridgeTemplate;
 import io.strimzi.api.kafka.model.tracing.Tracing;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -192,7 +193,7 @@ public class KafkaBridgeCluster extends AbstractModel {
             ModelUtils.parsePodTemplate(kafkaBridgeCluster, template.getPod());
 
             if (template.getApiService() != null && template.getApiService().getMetadata() != null)  {
-                kafkaBridgeCluster.templateServiceLabels = mergeLabelsOrAnnotations(template.getApiService().getMetadata().getLabels(),
+                kafkaBridgeCluster.templateServiceLabels = Util.mergeLabelsOrAnnotations(template.getApiService().getMetadata().getLabels(),
                         ModelUtils.getCustomLabelsOrAnnotations(CO_ENV_VAR_CUSTOM_LABELS));
                 kafkaBridgeCluster.templateServiceAnnotations = template.getApiService().getMetadata().getAnnotations();
             }
@@ -234,7 +235,7 @@ public class KafkaBridgeCluster extends AbstractModel {
             ports.add(createServicePort(METRICS_PORT_NAME, METRICS_PORT, METRICS_PORT, "TCP"));
         }
 
-        return createDiscoverableService("ClusterIP", ports, mergeLabelsOrAnnotations(getDiscoveryAnnotation(port), templateServiceAnnotations, ModelUtils.getCustomLabelsOrAnnotations(CO_ENV_VAR_CUSTOM_ANNOTATIONS)));
+        return createDiscoverableService("ClusterIP", ports, Util.mergeLabelsOrAnnotations(getDiscoveryAnnotation(port), templateServiceAnnotations, ModelUtils.getCustomLabelsOrAnnotations(CO_ENV_VAR_CUSTOM_ANNOTATIONS)));
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -99,6 +99,7 @@ import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.PasswordGenerator;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.StatusUtils;
 import io.vertx.core.json.JsonArray;
@@ -714,7 +715,7 @@ public class KafkaCluster extends AbstractModel {
             }
 
             if (template.getPersistentVolumeClaim() != null && template.getPersistentVolumeClaim().getMetadata() != null) {
-                result.templatePersistentVolumeClaimLabels = mergeLabelsOrAnnotations(template.getPersistentVolumeClaim().getMetadata().getLabels(),
+                result.templatePersistentVolumeClaimLabels = Util.mergeLabelsOrAnnotations(template.getPersistentVolumeClaim().getMetadata().getLabels(),
                         result.templateStatefulSetLabels);
                 result.templatePersistentVolumeClaimAnnotations = template.getPersistentVolumeClaim().getMetadata().getAnnotations();
             }
@@ -876,7 +877,7 @@ public class KafkaCluster extends AbstractModel {
      */
     public Service generateService() {
         return createDiscoverableService("ClusterIP", getServicePorts(),
-                mergeLabelsOrAnnotations(getInternalDiscoveryAnnotation(), prometheusAnnotations(),
+                Util.mergeLabelsOrAnnotations(getInternalDiscoveryAnnotation(), prometheusAnnotations(),
                 templateServiceAnnotations));
     }
 
@@ -980,7 +981,7 @@ public class KafkaCluster extends AbstractModel {
 
             Service service = createService(externalBootstrapServiceName, getExternalServiceType(), ports,
                     getLabelsWithStrimziName(externalBootstrapServiceName, templateExternalBootstrapServiceLabels), getSelectorLabels(),
-                    mergeLabelsOrAnnotations(dnsAnnotations, templateExternalBootstrapServiceAnnotations), loadBalancerIP);
+                    Util.mergeLabelsOrAnnotations(dnsAnnotations, templateExternalBootstrapServiceAnnotations), loadBalancerIP);
 
             if (isExposedWithLoadBalancer()) {
                 if (templateExternalBootstrapServiceLoadBalancerSourceRanges != null) {
@@ -1063,7 +1064,7 @@ public class KafkaCluster extends AbstractModel {
 
             Service service = createService(perPodServiceName, getExternalServiceType(), ports,
                     getLabelsWithStrimziName(perPodServiceName, templatePerPodServiceLabels), selector,
-                    mergeLabelsOrAnnotations(dnsAnnotations, templatePerPodServiceAnnotations), loadBalancerIP);
+                    Util.mergeLabelsOrAnnotations(dnsAnnotations, templatePerPodServiceAnnotations), loadBalancerIP);
 
             if (isExposedWithLoadBalancer()) {
                 if (templatePerPodServiceLoadBalancerSourceRanges != null) {
@@ -1146,7 +1147,7 @@ public class KafkaCluster extends AbstractModel {
                     .withNewMetadata()
                         .withName(serviceName)
                         .withLabels(getLabelsWithStrimziName(serviceName, templateExternalBootstrapRouteLabels).toMap())
-                        .withAnnotations(mergeLabelsOrAnnotations(null, templateExternalBootstrapRouteAnnotations))
+                        .withAnnotations(Util.mergeLabelsOrAnnotations(null, templateExternalBootstrapRouteAnnotations))
                         .withNamespace(namespace)
                         .withOwnerReferences(createOwnerReference())
                     .endMetadata()
@@ -1227,7 +1228,7 @@ public class KafkaCluster extends AbstractModel {
                     .withNewMetadata()
                         .withName(perPodServiceName)
                         .withLabels(getLabelsWithStrimziName(perPodServiceName, templatePerPodIngressLabels).toMap())
-                        .withAnnotations(mergeLabelsOrAnnotations(generateInternalIngressAnnotations(listener), templatePerPodIngressAnnotations, dnsAnnotations))
+                        .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(listener), templatePerPodIngressAnnotations, dnsAnnotations))
                         .withNamespace(namespace)
                         .withOwnerReferences(createOwnerReference())
                     .endMetadata()
@@ -1284,7 +1285,7 @@ public class KafkaCluster extends AbstractModel {
                     .withNewMetadata()
                         .withName(serviceName)
                         .withLabels(getLabelsWithStrimziName(serviceName, templateExternalBootstrapIngressLabels).toMap())
-                        .withAnnotations(mergeLabelsOrAnnotations(generateInternalIngressAnnotations(listener), templateExternalBootstrapIngressAnnotations, dnsAnnotations))
+                        .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(listener), templateExternalBootstrapIngressAnnotations, dnsAnnotations))
                         .withNamespace(namespace)
                         .withOwnerReferences(createOwnerReference())
                     .endMetadata()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -53,6 +53,7 @@ import io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvVarSource;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationVolumeSource;
 import io.strimzi.api.kafka.model.template.KafkaConnectTemplate;
 import io.strimzi.api.kafka.model.tracing.Tracing;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 
 import java.util.ArrayList;
@@ -289,7 +290,7 @@ public class KafkaConnectCluster extends AbstractModel {
             ports.add(createServicePort(METRICS_PORT_NAME, METRICS_PORT, METRICS_PORT, "TCP"));
         }
 
-        return createService("ClusterIP", ports, mergeLabelsOrAnnotations(prometheusAnnotations(), templateServiceAnnotations));
+        return createService("ClusterIP", ports, Util.mergeLabelsOrAnnotations(prometheusAnnotations(), templateServiceAnnotations));
     }
 
     protected List<ContainerPort> getContainerPortList() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -31,6 +31,7 @@ import io.fabric8.openshift.api.model.TagReferencePolicyBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
 import io.strimzi.api.kafka.model.KafkaConnectS2ISpec;
+import io.strimzi.operator.common.Util;
 
 import java.util.List;
 import java.util.Map;
@@ -119,7 +120,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                 .withNewMetadata()
                     .withName(name)
                     .withLabels(getLabelsWithStrimziName(name, templateDeploymentLabels).toMap())
-                    .withAnnotations(mergeLabelsOrAnnotations(null, templateDeploymentAnnotations))
+                    .withAnnotations(Util.mergeLabelsOrAnnotations(null, templateDeploymentAnnotations))
                     .withNamespace(namespace)
                     .withOwnerReferences(createOwnerReference())
                 .endMetadata()
@@ -128,7 +129,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                     .withSelector(getSelectorLabels().toMap())
                     .withNewTemplate()
                         .withNewMetadata()
-                            .withAnnotations(mergeLabelsOrAnnotations(annotations, templatePodAnnotations))
+                            .withAnnotations(Util.mergeLabelsOrAnnotations(annotations, templatePodAnnotations))
                             .withLabels(getLabelsWithStrimziName(name, templatePodLabels).toMap())
                         .endMetadata()
                         .withNewSpec()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -27,6 +27,7 @@ import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.api.kafka.model.template.KafkaExporterTemplate;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.common.Util;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -162,7 +163,7 @@ public class KafkaExporter extends AbstractModel {
         List<ServicePort> ports = new ArrayList<>(1);
 
         ports.add(createServicePort(METRICS_PORT_NAME, METRICS_PORT, METRICS_PORT, "TCP"));
-        return createService("ClusterIP", ports, mergeLabelsOrAnnotations(prometheusAnnotations(), templateServiceAnnotations));
+        return createService("ClusterIP", ports, Util.mergeLabelsOrAnnotations(prometheusAnnotations(), templateServiceAnnotations));
     }
 
     protected List<ContainerPort> getContainerPortList() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -45,6 +45,7 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.api.kafka.model.template.ZookeeperClusterTemplate;
 import io.strimzi.certs.CertAndKey;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.StatusUtils;
 
@@ -298,7 +299,7 @@ public class ZookeeperCluster extends AbstractModel {
             }
 
             if (template.getPersistentVolumeClaim() != null && template.getPersistentVolumeClaim().getMetadata() != null) {
-                zk.templatePersistentVolumeClaimLabels = mergeLabelsOrAnnotations(template.getPersistentVolumeClaim().getMetadata().getLabels(),
+                zk.templatePersistentVolumeClaimLabels = Util.mergeLabelsOrAnnotations(template.getPersistentVolumeClaim().getMetadata().getLabels(),
                         zk.templateStatefulSetLabels);
                 zk.templatePersistentVolumeClaimAnnotations = template.getPersistentVolumeClaim().getMetadata().getAnnotations();
             }
@@ -356,7 +357,7 @@ public class ZookeeperCluster extends AbstractModel {
         }
         ports.add(createServicePort(CLIENT_TLS_PORT_NAME, CLIENT_TLS_PORT, CLIENT_TLS_PORT, "TCP"));
 
-        return createService("ClusterIP", ports, mergeLabelsOrAnnotations(prometheusAnnotations(), templateServiceAnnotations));
+        return createService("ClusterIP", ports, Util.mergeLabelsOrAnnotations(prometheusAnnotations(), templateServiceAnnotations));
     }
 
     public static String policyName(String cluster) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -74,6 +74,7 @@ import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.PasswordGenerator;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.Test;
@@ -206,7 +207,7 @@ public class KafkaClusterTest {
         assertThat(headful.getSpec().getPorts().get(3).getPort(), is(new Integer(KafkaCluster.METRICS_PORT)));
         assertThat(headful.getSpec().getPorts().get(3).getProtocol(), is("TCP"));
 
-        assertThat(headful.getMetadata().getAnnotations(), is(AbstractModel.mergeLabelsOrAnnotations(kc.getInternalDiscoveryAnnotation(), kc.prometheusAnnotations())));
+        assertThat(headful.getMetadata().getAnnotations(), is(Util.mergeLabelsOrAnnotations(kc.getInternalDiscoveryAnnotation(), kc.prometheusAnnotations())));
 
         assertThat(headful.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(true));
         assertThat(headful.getMetadata().getLabels().get(Labels.STRIMZI_DISCOVERY_LABEL), is("true"));

--- a/documentation/api/io.strimzi.api.kafka.model.template.KafkaUserTemplate.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.template.KafkaUserTemplate.adoc
@@ -1,4 +1,4 @@
-`KafkaUserTemplate` can be used specify additional labels and annotation for the secret with user password or certificate created by the User Operator.
+`KafkaUserTemplate` is used specify additional labels and annotations for the secret created by the User Operator.
 
 .An example showing the `KafkaUserTemplate`
 [source,yaml,subs=attributes+]

--- a/documentation/api/io.strimzi.api.kafka.model.template.KafkaUserTemplate.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.template.KafkaUserTemplate.adoc
@@ -1,0 +1,23 @@
+`KafkaUserTemplate` can be used specify additional labels and annotation for the secret with user password or certificate created by the User Operator.
+
+.An example showing the `KafkaUserTemplate`
+[source,yaml,subs=attributes+]
+----
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaUser
+metadata:
+  name: my-user
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  authentication:
+    type: tls
+  template:
+    secret:
+      metadata:
+        labels:
+          label1: value1
+        annotations:
+          anno1: value1
+  # ...
+----

--- a/documentation/assemblies/assembly-customizing-kubernetes-resources.adoc
+++ b/documentation/assemblies/assembly-customizing-kubernetes-resources.adoc
@@ -29,6 +29,7 @@ The API reference provides more details about the customizable fields.
 `KafkaMirrorMaker.spec`:: See xref:type-KafkaMirrorMakerTemplate-reference[]
 `KafkaMirrorMaker2.spec`:: See xref:type-KafkaMirrorMaker2Template-reference[]
 `KafkaBridge.spec`:: See xref:type-KafkaBridgeTemplate-reference[]
+`KafkaUser.spec`:: See xref:type-KafkaUserTemplate-reference[]
 
 In the following example, the `template` property is used to modify the labels in a Kafka broker's `StatefulSet`:
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1061,7 +1061,7 @@ include::../api/io.strimzi.api.kafka.model.template.PodTemplate.adoc[leveloffset
 [id='type-ResourceTemplate-{context}']
 ### `ResourceTemplate` schema reference
 
-Used in: xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`], xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], xref:type-JmxTransTemplate-{context}[`JmxTransTemplate`], xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`], xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`], xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`], xref:type-KafkaExporterTemplate-{context}[`KafkaExporterTemplate`], xref:type-KafkaMirrorMakerTemplate-{context}[`KafkaMirrorMakerTemplate`], xref:type-ZookeeperClusterTemplate-{context}[`ZookeeperClusterTemplate`]
+Used in: xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`], xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], xref:type-JmxTransTemplate-{context}[`JmxTransTemplate`], xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`], xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`], xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`], xref:type-KafkaExporterTemplate-{context}[`KafkaExporterTemplate`], xref:type-KafkaMirrorMakerTemplate-{context}[`KafkaMirrorMakerTemplate`], xref:type-KafkaUserTemplate-{context}[`KafkaUserTemplate`], xref:type-ZookeeperClusterTemplate-{context}[`ZookeeperClusterTemplate`]
 
 
 [options="header"]
@@ -2170,6 +2170,8 @@ Used in: xref:type-KafkaUser-{context}[`KafkaUser`]
 |xref:type-KafkaUserAuthorizationSimple-{context}[`KafkaUserAuthorizationSimple`]
 |quotas          1.2+<.<|Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
 |xref:type-KafkaUserQuotas-{context}[`KafkaUserQuotas`]
+|template        1.2+<.<|Authorization rules for this Kafka user.
+|xref:type-KafkaUserTemplate-{context}[`KafkaUserTemplate`]
 |====
 
 [id='type-KafkaUserTlsClientAuthentication-{context}']
@@ -2326,6 +2328,20 @@ include::../api/io.strimzi.api.kafka.model.KafkaUserQuotas.adoc[leveloffset=+1]
 |integer
 |requestPercentage  1.2+<.<|A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
 |integer
+|====
+
+[id='type-KafkaUserTemplate-{context}']
+### `KafkaUserTemplate` schema reference
+
+Used in: xref:type-KafkaUserSpec-{context}[`KafkaUserSpec`]
+
+include::../api/io.strimzi.api.kafka.model.template.KafkaUserTemplate.adoc[leveloffset=+1]
+
+[options="header"]
+|====
+|Property       |Description
+|secret  1.2+<.<|Template for KafkaUser resources. The template allows users to specify how is the `Secret` with password or certificates are generated.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |====
 
 [id='type-KafkaUserStatus-{context}']

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2170,7 +2170,7 @@ Used in: xref:type-KafkaUser-{context}[`KafkaUser`]
 |xref:type-KafkaUserAuthorizationSimple-{context}[`KafkaUserAuthorizationSimple`]
 |quotas          1.2+<.<|Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
 |xref:type-KafkaUserQuotas-{context}[`KafkaUserQuotas`]
-|template        1.2+<.<|Authorization rules for this Kafka user.
+|template        1.2+<.<|Template to specify how Kafka User `Secrets` are generated.
 |xref:type-KafkaUserTemplate-{context}[`KafkaUserTemplate`]
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2340,7 +2340,7 @@ include::../api/io.strimzi.api.kafka.model.template.KafkaUserTemplate.adoc[level
 [options="header"]
 |====
 |Property       |Description
-|secret  1.2+<.<|Template for KafkaUser resources. The template allows users to specify how is the `Secret` with password or certificates are generated.
+|secret  1.2+<.<|Template for KafkaUser resources. The template allows users to specify how the `Secret` with password or TLS certificates is generated.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |====
 

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
@@ -160,7 +160,7 @@ spec:
                           description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for KafkaUser resources. The template allows users to specify how is the `Secret` with password or certificates are generated.
-              description: Authorization rules for this Kafka user.
+              description: Template to specify how Kafka User `Secrets` are generated.
           description: The specification of the user.
         status:
           type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
@@ -159,7 +159,7 @@ spec:
                           type: object
                           description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
-                  description: Template for KafkaUser resources. The template allows users to specify how is the `Secret` with password or certificates are generated.
+                  description: Template for KafkaUser resources. The template allows users to specify how the `Secret` with password or TLS certificates is generated.
               description: Template to specify how Kafka User `Secrets` are generated.
           description: The specification of the user.
         status:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
@@ -143,6 +143,24 @@ spec:
                   minimum: 0
                   description: A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
               description: Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
+            template:
+              type: object
+              properties:
+                secret:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for KafkaUser resources. The template allows users to specify how is the `Secret` with password or certificates are generated.
+              description: Authorization rules for this Kafka user.
           description: The specification of the user.
         status:
           type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
@@ -155,7 +155,7 @@ spec:
                           type: object
                           description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
-                  description: Template for KafkaUser resources. The template allows users to specify how is the `Secret` with password or certificates are generated.
+                  description: Template for KafkaUser resources. The template allows users to specify how the `Secret` with password or TLS certificates is generated.
               description: Template to specify how Kafka User `Secrets` are generated.
           description: The specification of the user.
         status:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
@@ -139,6 +139,24 @@ spec:
                   minimum: 0
                   description: A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
               description: Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
+            template:
+              type: object
+              properties:
+                secret:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for KafkaUser resources. The template allows users to specify how is the `Secret` with password or certificates are generated.
+              description: Authorization rules for this Kafka user.
           description: The specification of the user.
         status:
           type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
@@ -156,7 +156,7 @@ spec:
                           description: Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for KafkaUser resources. The template allows users to specify how is the `Secret` with password or certificates are generated.
-              description: Authorization rules for this Kafka user.
+              description: Template to specify how Kafka User `Secrets` are generated.
           description: The specification of the user.
         status:
           type: object

--- a/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -163,6 +163,30 @@ spec:
               description: Quotas on requests to control the broker resources used
                 by clients. Network bandwidth and request rate quotas can be enforced.Kafka
                 documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
+            template:
+              type: object
+              properties:
+                secret:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for KafkaUser resources. The template allows
+                    users to specify how is the `Secret` with password or certificates
+                    are generated.
+              description: Authorization rules for this Kafka user.
           description: The specification of the user.
         status:
           type: object

--- a/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -184,8 +184,8 @@ spec:
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for KafkaUser resources. The template allows
-                    users to specify how is the `Secret` with password or certificates
-                    are generated.
+                    users to specify how the `Secret` with password or TLS certificates
+                    is generated.
               description: Template to specify how Kafka User `Secrets` are generated.
           description: The specification of the user.
         status:

--- a/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -186,7 +186,7 @@ spec:
                   description: Template for KafkaUser resources. The template allows
                     users to specify how is the `Secret` with password or certificates
                     are generated.
-              description: Authorization rules for this Kafka user.
+              description: Template to specify how Kafka User `Secrets` are generated.
           description: The specification of the user.
         status:
           type: object

--- a/install/user-operator/04-Crd-kafkauser.yaml
+++ b/install/user-operator/04-Crd-kafkauser.yaml
@@ -163,6 +163,30 @@ spec:
               description: Quotas on requests to control the broker resources used
                 by clients. Network bandwidth and request rate quotas can be enforced.Kafka
                 documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
+            template:
+              type: object
+              properties:
+                secret:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for KafkaUser resources. The template allows
+                    users to specify how is the `Secret` with password or certificates
+                    are generated.
+              description: Authorization rules for this Kafka user.
           description: The specification of the user.
         status:
           type: object

--- a/install/user-operator/04-Crd-kafkauser.yaml
+++ b/install/user-operator/04-Crd-kafkauser.yaml
@@ -184,8 +184,8 @@ spec:
                             `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata which should be applied to the resource.
                   description: Template for KafkaUser resources. The template allows
-                    users to specify how is the `Secret` with password or certificates
-                    are generated.
+                    users to specify how the `Secret` with password or TLS certificates
+                    is generated.
               description: Template to specify how Kafka User `Secrets` are generated.
           description: The specification of the user.
         status:

--- a/install/user-operator/04-Crd-kafkauser.yaml
+++ b/install/user-operator/04-Crd-kafkauser.yaml
@@ -186,7 +186,7 @@ spec:
                   description: Template for KafkaUser resources. The template allows
                     users to specify how is the `Secret` with password or certificates
                     are generated.
-              description: Authorization rules for this Kafka user.
+              description: Template to specify how Kafka User `Secrets` are generated.
           description: The specification of the user.
         status:
           type: object

--- a/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
@@ -4,8 +4,11 @@
  */
 package io.strimzi.operator.common;
 
+import io.strimzi.operator.cluster.model.InvalidResourceException;
+import io.strimzi.operator.common.model.Labels;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static io.strimzi.operator.common.Util.parseMap;
@@ -85,5 +88,35 @@ public class UtilTest {
         assertThat(Util.maskPassword(noPassword, "123456"), is("123456"));
         assertThat(Util.maskPassword(passwordAtTheEnd, "123456"), is("********"));
         assertThat(Util.maskPassword(passwordInTheMiddle, "123456"), is("********"));
+    }
+
+    @Test
+    public void testMergeLabelsOrAnnotations()  {
+        Map<String, String> base = new HashMap<>();
+        base.put("label1", "value1");
+        base.put(Labels.STRIMZI_DOMAIN + "label2", "value2");
+
+        Map<String, String> overrides1 = new HashMap<>();
+        overrides1.put("override1", "value1");
+        overrides1.put(Labels.KUBERNETES_DOMAIN + "override2", "value2");
+
+        Map<String, String> overrides2 = new HashMap<>();
+        overrides2.put("override3", "value3");
+
+        Map<String, String> forbiddenOverrides = new HashMap<>();
+        forbiddenOverrides.put(Labels.STRIMZI_DOMAIN + "override4", "value4");
+
+        Map<String, String> expected = new HashMap<>();
+        expected.put("label1", "value1");
+        expected.put(Labels.STRIMZI_DOMAIN + "label2", "value2");
+        expected.put("override1", "value1");
+        expected.put("override3", "value3");
+
+        assertThat(Util.mergeLabelsOrAnnotations(base, overrides1, overrides2), is(expected));
+        assertThat(Util.mergeLabelsOrAnnotations(base, overrides1, null, overrides2), is(expected));
+        assertThat(Util.mergeLabelsOrAnnotations(base, null), is(base));
+        assertThat(Util.mergeLabelsOrAnnotations(base), is(base));
+        assertThat(Util.mergeLabelsOrAnnotations(null, overrides2), is(overrides2));
+        assertThrows(InvalidResourceException.class, () -> Util.mergeLabelsOrAnnotations(base, forbiddenOverrides));
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds template support to the KafkaUser resource to manage metadata (labels & annos) of the user secret created by the UO. As part of this change, the `mergeLabelsOrAnnotations` method was moved from `AbstractModel` to `Utils` class in `operator-common` so that it can be reused in the UO. I also wrote new tests for this method.

This should close #3237.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

