### PR TITLE
Add option to exclude topics from a rebalance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Removed the need to manually create Cruise Control metrics topics if topic auto creation is disabled.
 * Migration to Helm 3
 * Refactored the format of the `KafkaRebalance` resource's status. The state of the rebalance is now displayed in the associated `Condition`'s `type` field rather than the `status` field. This was done so that the information would display correctly in various Kubernetes tools.
+* Added performance tuning options to the `KafkaRebalance` CR and the ability to define a regular expression that will exclude matching topics from a rebalance optimization proposal.
 * Use Strimzi Kafka Bridge 0.17.0
 * Make it possible to configure labels and annotations for secrets created by the User Operator
 * Strimzi Kafka Bridge metrics integration:

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalanceSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalanceSpec.java
@@ -22,7 +22,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "goals", "skipHardGoalCheck", "concurrentPartitionMovementsPerBroker",
+@JsonPropertyOrder({ "goals", "skipHardGoalCheck", "excludedTopics", "concurrentPartitionMovementsPerBroker",
                      "concurrentIntraBrokerPartitionMovements", "concurrentLeaderMovements", "replicationThrottle" })
 @EqualsAndHashCode
 public class KafkaRebalanceSpec implements UnknownPropertyPreserving, Serializable {
@@ -32,6 +32,9 @@ public class KafkaRebalanceSpec implements UnknownPropertyPreserving, Serializab
     // Optimization goal configurations
     private List<String> goals;
     private boolean skipHardGoalCheck;
+
+    // Topic configuration
+    private String excludedTopics;
 
     // Rebalance performance tuning configurations
     private int concurrentPartitionMovementsPerBroker;
@@ -52,7 +55,7 @@ public class KafkaRebalanceSpec implements UnknownPropertyPreserving, Serializab
         this.goals = goals;
     }
 
-    @Description("Whether to allow the hard goals specified in the Kafka CR to be skipped in rebalance proposal generation. " +
+    @Description("Whether to allow the hard goals specified in the Kafka CR to be skipped in optimization proposal generation. " +
             "This can be useful when some of those hard goals are preventing a balance solution being found. " +
             "Default is false.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -62,6 +65,17 @@ public class KafkaRebalanceSpec implements UnknownPropertyPreserving, Serializab
 
     public void setSkipHardGoalCheck(boolean skipHardGoalCheck) {
         this.skipHardGoalCheck = skipHardGoalCheck;
+    }
+
+    @Description("A regular expression where any matching topics will be excluded from the calculation of optimization proposals. " +
+            "This expression will be parsed by the java.util.regex.Pattern class; for more information on the supported formar " +
+            "consult the documentation for that class.")
+    public String getExcludedTopics() {
+        return excludedTopics;
+    }
+
+    public void setExcludedTopics(String excludedTopics) {
+        this.excludedTopics = excludedTopics;
     }
 
     @Description("The upper bound of ongoing partition replica movements going into/out of each broker. Default is 5.")

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaRebalanceCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaRebalanceCrdIT.java
@@ -42,6 +42,16 @@ public class KafkaRebalanceCrdIT extends AbstractCrdIT {
         createDelete(KafkaRebalance.class, "KafkaRebalance-with-goals-skip-hard-goal-check.yaml");
     }
 
+    @Test
+    void testKafkaRebalanceWithPerformanceTuning() {
+        createDelete(KafkaRebalance.class, "KafkaRebalance-performance-tuning.yaml");
+    }
+
+    @Test
+    void testKafkaRebalanceWithExcludedTopics() {
+        createDelete(KafkaRebalance.class, "KafkaRebalance-excluded-topics.yaml");
+    }
+
     @BeforeAll
     void setupEnvironment() {
         cluster.createNamespace(NAMESPACE);

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaRebalance-excluded-topics.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaRebalance-excluded-topics.yaml
@@ -1,0 +1,6 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaRebalance
+metadata:
+  name: my-rebalance
+spec:
+  excludedTopics: test-.*

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaRebalance-performance-tuning.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaRebalance-performance-tuning.yaml
@@ -1,0 +1,9 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaRebalance
+metadata:
+  name: my-rebalance
+spec:
+  concurrentPartitionMovementsPerBroker: 10
+  concurrentIntraBrokerPartitionMovements: 10
+  concurrentLeaderMovements: 2000
+  replicationThrottle: 200000

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -285,6 +285,9 @@ public class KafkaRebalanceAssemblyOperator
         if (kafkaRebalanceSpec.isSkipHardGoalCheck()) {
             rebalanceOptionsBuilder.withSkipHardGoalCheck();
         }
+        if (kafkaRebalanceSpec.getExcludedTopics() != null) {
+            rebalanceOptionsBuilder.withExcludedTopics(kafkaRebalanceSpec.getExcludedTopics());
+        }
         if (kafkaRebalanceSpec.getConcurrentPartitionMovementsPerBroker() > 0) {
             rebalanceOptionsBuilder.withConcurrentPartitionMovementsPerBroker(kafkaRebalanceSpec.getConcurrentPartitionMovementsPerBroker());
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/PathBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/PathBuilder.java
@@ -73,6 +73,10 @@ public class PathBuilder {
                     .addParameter(CruiseControlParameters.VERBOSE, String.valueOf(options.isVerbose()))
                     .addParameter(CruiseControlParameters.SKIP_HARD_GOAL_CHECK, String.valueOf(options.isSkipHardGoalCheck()));
 
+            if (options.getExcludedTopics() != null) {
+                builder.addParameter(CruiseControlParameters.EXCLUDED_TOPICS, options.getExcludedTopics());
+            }
+
             addIfNotZero(builder, CruiseControlParameters.CONCURRENT_PARTITION_MOVEMENTS, options.getConcurrentPartitionMovementsPerBroker());
             addIfNotZero(builder, CruiseControlParameters.CONCURRENT_INTRA_PARTITION_MOVEMENTS, options.getConcurrentIntraBrokerPartitionMovements());
             addIfNotZero(builder, CruiseControlParameters.CONCURRENT_LEADER_MOVEMENTS, options.getConcurrentLeaderMovements());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/RebalanceOptions.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/RebalanceOptions.java
@@ -18,6 +18,8 @@ public class RebalanceOptions {
     private boolean skipHardGoalCheck;
     /** Sets whether the response should be JSON formatted or formated for readibility on the command line */
     private boolean json = true;
+    /** A regular expression to specify topics that should not be considered for replica movement */
+    private String excludedTopics;
     /** The upper bound of ongoing replica movements going into/out of each broker */
     private int concurrentPartitionMovementsPerBroker;
     /** The upper bound of ongoing replica movements between disks within each broker */
@@ -47,6 +49,10 @@ public class RebalanceOptions {
         return json;
     }
 
+    public String getExcludedTopics() {
+        return excludedTopics;
+    }
+
     public int getConcurrentPartitionMovementsPerBroker() {
         return concurrentPartitionMovementsPerBroker;
     }
@@ -69,6 +75,7 @@ public class RebalanceOptions {
         this.skipHardGoalCheck = builder.skipHardGoalCheck;
         this.goals = builder.goals;
         this.verbose = builder.verbose;
+        this.excludedTopics = builder.excludedTopics;
         this.concurrentPartitionMovementsPerBroker = builder.concurrentPartitionMovementsPerBroker;
         this.concurrentIntraBrokerPartitionMovements = builder.concurrentIntraPartitionMovements;
         this.concurrentLeaderMovements = builder.concurrentLeaderMovements;
@@ -81,6 +88,7 @@ public class RebalanceOptions {
         private boolean verbose;
         private boolean skipHardGoalCheck;
         private List<String> goals;
+        private String excludedTopics;
         private int concurrentPartitionMovementsPerBroker;
         private int concurrentIntraPartitionMovements;
         private int concurrentLeaderMovements;
@@ -91,6 +99,7 @@ public class RebalanceOptions {
             verbose = false;
             skipHardGoalCheck = false;
             goals = null;
+            excludedTopics = null;
             concurrentPartitionMovementsPerBroker = 0;
             concurrentIntraPartitionMovements = 0;
             concurrentLeaderMovements = 0;
@@ -114,6 +123,11 @@ public class RebalanceOptions {
 
         public RebalanceOptionsBuilder withGoals(List<String> goals) {
             this.goals = goals;
+            return this;
+        }
+
+        public RebalanceOptionsBuilder withExcludedTopics(String excludedTopics) {
+            this.excludedTopics = excludedTopics;
             return this;
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/PathBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/PathBuilderTest.java
@@ -33,6 +33,7 @@ public class PathBuilderTest {
                         CruiseControlParameters.DRY_RUN.key + "=false&" +
                         CruiseControlParameters.VERBOSE.key + "=true&" +
                         CruiseControlParameters.SKIP_HARD_GOAL_CHECK.key + "=false&" +
+                        CruiseControlParameters.EXCLUDED_TOPICS.key + "=test-.*&" +
                         CruiseControlParameters.GOALS.key + "=");
 
         StringBuilder goalStringBuilder = new StringBuilder();
@@ -68,6 +69,7 @@ public class PathBuilderTest {
                 .addParameter(CruiseControlParameters.DRY_RUN, "false")
                 .addParameter(CruiseControlParameters.VERBOSE, "true")
                 .addParameter(CruiseControlParameters.SKIP_HARD_GOAL_CHECK, "false")
+                .addParameter(CruiseControlParameters.EXCLUDED_TOPICS, "test-.*")
                 .addParameter(CruiseControlParameters.GOALS, GOALS)
                 .build();
 
@@ -82,6 +84,7 @@ public class PathBuilderTest {
         RebalanceOptions options = new RebalanceOptions.RebalanceOptionsBuilder()
                 .withVerboseResponse()
                 .withFullRun()
+                .withExcludedTopics("test-.*")
                 .withGoals(GOALS)
                 .build();
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2947,8 +2947,10 @@ Used in: xref:type-KafkaRebalance-{context}[`KafkaRebalance`]
 |Property                                        |Description
 |goals                                    1.2+<.<|A list of goals, ordered by decreasing priority, to use for generating and executing the rebalance proposal. The supported goals are available at https://github.com/linkedin/cruise-control#goals. If an empty goals list is provided, the goals declared in the default.goals Cruise Control configuration parameter are used.
 |string array
-|skipHardGoalCheck                        1.2+<.<|Whether to allow the hard goals specified in the Kafka CR to be skipped in rebalance proposal generation. This can be useful when some of those hard goals are preventing a balance solution being found. Default is false.
+|skipHardGoalCheck                        1.2+<.<|Whether to allow the hard goals specified in the Kafka CR to be skipped in optimization proposal generation. This can be useful when some of those hard goals are preventing a balance solution being found. Default is false.
 |boolean
+|excludedTopics                           1.2+<.<|A regular expression where any matching topics will be excluded from the calculation of optimization proposals. This expression will be parsed by the java.util.regex.Pattern class; for more information on the supported formar consult the documentation for that class.
+|string
 |concurrentPartitionMovementsPerBroker    1.2+<.<|The upper bound of ongoing partition replica movements going into/out of each broker. Default is 5.
 |integer
 |concurrentIntraBrokerPartitionMovements  1.2+<.<|The upper bound of ongoing partition replica movements between disks within each broker. Default is 2.

--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -80,7 +80,8 @@ m¦monitoredPartitionsPercentage
 ¦The percentage of partitions in the Kafka cluster covered by the optimization proposal. Affected by the number of `excludedTopics`.
 
 m¦excludedTopics
-¦Not yet supported. An empty list is returned.
+¦If you specified a regular expression in the `spec.excludedTopicsRegex` property in the `KafkaRebalance` resource, all topic names matching that expression are listed here. 
+These topics are excluded from the calculation of partition replica/leader movements in the optimization proposal.
 
 m¦numLeaderMovements
 ¦The number of partitions whose leaders will be switched to different replicas. This involves a change to ZooKeeper configuration.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/049-Crd-kafkarebalance.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/049-Crd-kafkarebalance.yaml
@@ -42,7 +42,10 @@ spec:
               description: A list of goals, ordered by decreasing priority, to use for generating and executing the rebalance proposal. The supported goals are available at https://github.com/linkedin/cruise-control#goals. If an empty goals list is provided, the goals declared in the default.goals Cruise Control configuration parameter are used.
             skipHardGoalCheck:
               type: boolean
-              description: Whether to allow the hard goals specified in the Kafka CR to be skipped in rebalance proposal generation. This can be useful when some of those hard goals are preventing a balance solution being found. Default is false.
+              description: Whether to allow the hard goals specified in the Kafka CR to be skipped in optimization proposal generation. This can be useful when some of those hard goals are preventing a balance solution being found. Default is false.
+            excludedTopics:
+              type: string
+              description: A regular expression where any matching topics will be excluded from the calculation of optimization proposals. This expression will be parsed by the java.util.regex.Pattern class; for more information on the supported formar consult the documentation for that class.
             concurrentPartitionMovementsPerBroker:
               type: integer
               minimum: 0

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
@@ -38,7 +38,10 @@ spec:
               description: A list of goals, ordered by decreasing priority, to use for generating and executing the rebalance proposal. The supported goals are available at https://github.com/linkedin/cruise-control#goals. If an empty goals list is provided, the goals declared in the default.goals Cruise Control configuration parameter are used.
             skipHardGoalCheck:
               type: boolean
-              description: Whether to allow the hard goals specified in the Kafka CR to be skipped in rebalance proposal generation. This can be useful when some of those hard goals are preventing a balance solution being found. Default is false.
+              description: Whether to allow the hard goals specified in the Kafka CR to be skipped in optimization proposal generation. This can be useful when some of those hard goals are preventing a balance solution being found. Default is false.
+            excludedTopics:
+              type: string
+              description: A regular expression where any matching topics will be excluded from the calculation of optimization proposals. This expression will be parsed by the java.util.regex.Pattern class; for more information on the supported formar consult the documentation for that class.
             concurrentPartitionMovementsPerBroker:
               type: integer
               minimum: 0

--- a/install/cluster-operator/049-Crd-kafkarebalance.yaml
+++ b/install/cluster-operator/049-Crd-kafkarebalance.yaml
@@ -42,9 +42,15 @@ spec:
             skipHardGoalCheck:
               type: boolean
               description: Whether to allow the hard goals specified in the Kafka
-                CR to be skipped in rebalance proposal generation. This can be useful
-                when some of those hard goals are preventing a balance solution being
-                found. Default is false.
+                CR to be skipped in optimization proposal generation. This can be
+                useful when some of those hard goals are preventing a balance solution
+                being found. Default is false.
+            excludedTopics:
+              type: string
+              description: A regular expression where any matching topics will be
+                excluded from the calculation of optimization proposals. This expression
+                will be parsed by the java.util.regex.Pattern class; for more information
+                on the supported formar consult the documentation for that class.
             concurrentPartitionMovementsPerBroker:
               type: integer
               minimum: 0

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlParameters.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlParameters.java
@@ -17,6 +17,7 @@ public enum CruiseControlParameters {
     SKIP_HARD_GOAL_CHECK("skip_hard_goal_check"),
     FETCH_COMPLETE("fetch_completed_task"),
     USER_TASK_IDS("user_task_ids"),
+    EXCLUDED_TOPICS("excluded_topics"),
     CONCURRENT_PARTITION_MOVEMENTS("concurrent_partition_movements_per_broker"),
     CONCURRENT_INTRA_PARTITION_MOVEMENTS("concurrent_intra_broker_partition_movements"),
     CONCURRENT_LEADER_MOVEMENTS("concurrent_leader_movements"),


### PR DESCRIPTION
### Type of change

Enhancement

### Description

This PR adds the ability to define a regular expression in `KafkaRebalaceSpec.spec.excludedTopics` that will exclude matching topics from a rebalance optimization proposal.

```
Spec:
  Excluded Topics:  test-.*
Status:
  Conditions:
    Last Transition Time:  2020-07-02T09:41:16.159570Z
    Status:                True
    Type:                  ProposalReady
  Observed Generation:     1
  Optimization Result:
    Data To Move MB:  0
    Excluded Brokers For Leadership:
    Excluded Brokers For Replica Move:
    Excluded Topics:
      test-topic-1
    Intra Broker Data To Move MB:         0
    Monitored Partitions Percentage:      100
    Num Intra Broker Replica Movements:   0
    Num Leader Movements:                 5
    Num Replica Movements:                34
    On Demand Balancedness Score After:   74.54047494896054
    On Demand Balancedness Score Before:  74.54047494896054
    Recent Windows:                       1
  Session Id:                             7930f7d1-4622-4ebe-8ef3-ed1aedfe69ac
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [X] Write tests
- [X] Make sure all tests pass
- [X] Update documentation
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Update CHANGELOG.md

