### PR TITLE
remove zookeeper tls sidecar monitor

### DIFF
--- a/examples/metrics/prometheus-install/prometheus-rules.yaml
+++ b/examples/metrics/prometheus-install/prometheus-rules.yaml
@@ -139,14 +139,6 @@ spec:
       annotations:
         summary: 'All `zookeeper` containers in the Zookeeper pods down or in CrashLookBackOff status'
         description: 'All `zookeeper` containers in the Zookeeper pods have been down or in CrashLookBackOff status for 3 minutes'
-    - alert: ZookeeperTlsSidecarContainersDown
-      expr: absent(container_last_seen{container_name="tls-sidecar",kubernetes_pod_name=~".+-zookeeper-[0-9]+"})
-      for: 3m
-      labels:
-        severity: major
-      annotations:
-        summary: 'All `tls-sidecar` containers in the Zookeeper pods down or in CrashLookBackOff status'
-        description: 'All `tls-sidecar` containers in the Zookeeper pods have been down or in CrashLookBackOff status for 3 minutes'
   - name: entityOperator
     rules:
     - alert: TopicOperatorContainerDown


### PR DESCRIPTION
Remove TLS sidecars from ZooKeeper pods, using native ZooKeeper TLS support instead

### Type of change

_Select the type of your PR_

- Bugfix


### Description

Remove monitor TLS sidecars from ZooKeeper pods, using native ZooKeeper TLS support instead

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

