### PR TITLE
[systemtest] Add tests for checking tini and KafkaConnectS2I logging

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
@@ -335,12 +335,8 @@ class LogSettingST extends BaseST {
 
     @Test
     @Order(14)
-    void checkPodsAndContainersForTiniProcess() {
-        /*
-        Reason why I used [/] in my grep command is, that when we only do 'grep /usr/bin/tini' the grep process will be printed
-        with the tini process, if we do the [/], it will take only the process that will continue with usr/bin/tini and exclude
-        the grep process. Second choice is adding the `grep -v 'grep /usr/bin/tini'`.
-         */
+    void testCheckContainersHaveProcessOneAsTini() {
+        //Used [/] in the grep command so that grep process does not return itself
         String command = "ps -ef | grep '[/]usr/bin/tini' | awk '{ print $2}'";
 
         for (Pod pod : kubeClient().listPods()) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
@@ -252,7 +252,7 @@ class LogSettingST extends BaseST {
         assertThat("UO GC logging is enabled", checkGcLoggingDeployments(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), "user-operator"), is(true));
 
         assertThat("Connect GC logging is enabled", checkGcLoggingDeployments(KafkaConnectResources.deploymentName(CONNECT_NAME)), is(true));
-        assertThat("ConnectS2I GC logging is enabled", checkGcLoggingDeployments(KafkaConnectS2IResources.deploymentName(CONNECTS2I_NAME)), is(true));
+        assertThat("ConnectS2I GC logging is enabled", checkGcLoggingDeploymentConfig(KafkaConnectS2IResources.deploymentName(CONNECTS2I_NAME)), is(true));
         assertThat("Mirror-maker GC logging is enabled", checkGcLoggingDeployments(KafkaMirrorMakerResources.deploymentName(MM_NAME)), is(true));
         assertThat("Mirror-maker-2 GC logging is enabled", checkGcLoggingDeployments(KafkaMirrorMaker2Resources.deploymentName(MM2_NAME)), is(true));
     }
@@ -268,7 +268,6 @@ class LogSettingST extends BaseST {
         String kafkaName = KafkaResources.kafkaStatefulSetName(CLUSTER_NAME);
         String zkName = KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME);
         Map<String, String> connectPods = DeploymentUtils.depSnapshot(connectName);
-        Map<String, String> connectS2IPods = DeploymentUtils.depSnapshot(connectS2IName);
         Map<String, String> mmPods = DeploymentUtils.depSnapshot(mmName);
         Map<String, String> mm2Pods = DeploymentUtils.depSnapshot(mm2Name);
         Map<String, String> eoPods = DeploymentUtils.depSnapshot(eoName);
@@ -308,7 +307,7 @@ class LogSettingST extends BaseST {
         assertThat("UO GC logging is disabled", checkGcLoggingDeployments(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), "user-operator"), is(false));
 
         assertThat("Connect GC logging is disabled", checkGcLoggingDeployments(KafkaConnectResources.deploymentName(CONNECT_NAME)), is(false));
-        assertThat("ConnectS2I GC logging is disabled", checkGcLoggingDeployments(KafkaConnectS2IResources.deploymentName(CONNECTS2I_NAME)), is(false));
+        assertThat("ConnectS2I GC logging is disabled", checkGcLoggingDeploymentConfig(KafkaConnectS2IResources.deploymentName(CONNECTS2I_NAME)), is(false));
         assertThat("Mirror-maker GC logging is disabled", checkGcLoggingDeployments(KafkaMirrorMakerResources.deploymentName(MM_NAME)), is(false));
         assertThat("Mirror-maker2 GC logging is disabled", checkGcLoggingDeployments(KafkaMirrorMaker2Resources.deploymentName(MM2_NAME)), is(false));
     }
@@ -395,6 +394,13 @@ class LogSettingST extends BaseST {
     private Boolean checkGcLoggingDeployments(String deploymentName) {
         LOGGER.info("Checking deployment: {}", deploymentName);
         Container container = kubeClient().getDeployment(deploymentName).getSpec().getTemplate().getSpec().getContainers().get(0);
+        LOGGER.info("Checking container with name: {}", container.getName());
+        return checkEnvVarValue(container);
+    }
+
+    private Boolean checkGcLoggingDeploymentConfig(String depConfName) {
+        LOGGER.info("Checking deployment config: {}", depConfName);
+        Container container = kubeClient().getDeploymentConfig(depConfName).getSpec().getTemplate().getSpec().getContainers().get(0);
         LOGGER.info("Checking container with name: {}", container.getName());
         return checkEnvVarValue(container);
     }

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -231,9 +231,7 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
 
     @Override
     public ExecResult execInPodContainer(String pod, String container, String... command) {
-        List<String> cmd = namespacedCommand("exec", pod, "-c", container, "--");
-        cmd.addAll(asList(command));
-        return Exec.exec(cmd);
+        return execInPodContainer(true, pod, container, command);
     }
 
     @Override

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -237,6 +237,13 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     }
 
     @Override
+    public ExecResult execInPodContainer(boolean logToOutput, String pod, String container, String... command) {
+        List<String> cmd = namespacedCommand("exec", pod, "-c", container, "--");
+        cmd.addAll(asList(command));
+        return Exec.exec(null, cmd, 0, logToOutput);
+    }
+
+    @Override
     public ExecResult exec(String... command) {
         return exec(true, command);
     }

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
@@ -100,6 +100,8 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
      */
     ExecResult execInPodContainer(String pod, String container, String... command);
 
+    ExecResult execInPodContainer(boolean logToOutput, String pod, String container, String... command);
+
     /**
      * Execute the given {@code command}.
      * @param command The command


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement / new feature

### Description

In this PR I'm gonna add test for checking if TINI is present in pod containers as process with PID 1. Unfortunately this is not the case for KafkaConnectS2I at the moment, because TINI is assigned to PID 8 - "bug" #3282.

Also I added test for checking KafkaConnectS2I logging as we didn't have it until now.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

