### PR TITLE
ST: run more tests against CO installed by helm

### DIFF
--- a/Jenkinsfile-pr
+++ b/Jenkinsfile-pr
@@ -89,12 +89,16 @@ pipeline {
                         env.DOCKER_REGISTRY = env.OC_VERSION == "3" ? "172.30.1.1:5000" : "default-route-openshift-image-registry.apps-crc.testing"
                         env.DOCKER_TAG="pr"
                     }
+                    if (env.ghprbCommentBody.contains('install_type=')) {
+                        env.CLUSTER_OPERATOR_INSTALL_TYPE = env.ghprbCommentBody.split('install_type=')[1].split(/\s/)[0]
+                    }
                     env.BUILD_PROJECT_STATUS = false
                     env.BUILD_DOCKER_IMAGE_STATUS = false
                     echo "TEST_ONLY: ${env.TEST_ONLY}"
                     echo "DOCKER_REGISTRY: ${env.DOCKER_REGISTRY}"
                     echo "DOCKER_ORG: ${env.DOCKER_ORG}"
                     echo "DOCKER_TAG: ${env.DOCKER_TAG}"
+                    echo "CLUSTER_OPERATOR_INSTALL_TYPE: ${env.CLUSTER_OPERATOR_INSTALL_TYPE}"
                 }
             }
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -154,6 +154,10 @@ public class Environment {
         return Environment.CLUSTER_OPERATOR_INSTALL_TYPE.toUpperCase(Locale.ENGLISH).equals("OLM");
     }
 
+    public static boolean isHelmInstall() {
+        return Environment.CLUSTER_OPERATOR_INSTALL_TYPE.toUpperCase(Locale.ENGLISH).equals("HELM");
+    }
+
     public static boolean useLatestReleasedBridge() {
         return Environment.BRIDGE_IMAGE.equals(Environment.BRIDGE_IMAGE_DEFAULT);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -43,6 +43,7 @@ import io.strimzi.systemtest.utils.kubeUtils.objects.PersistentVolumeClaimUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.k8s.HelmClient;
 import io.strimzi.test.k8s.KubeClient;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.cmdClient.KubeCmdClient;
@@ -93,6 +94,10 @@ public class ResourceManager {
 
     public static KubeCmdClient cmdKubeClient() {
         return KubeClusterResource.cmdKubeClient();
+    }
+
+    public static HelmClient helmClient() {
+        return KubeClusterResource.helmClusterClient();
     }
 
     public static Stack<Runnable> getPointerResources() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.resources.operator;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.api.model.apps.DoneableDeployment;
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.resources.KubernetesResource;
+import io.strimzi.systemtest.utils.StUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+public class BundleResource {
+    private static final Logger LOGGER = LogManager.getLogger(BundleResource.class);
+
+    public static final String PATH_TO_CO_CONFIG = "../install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml";
+
+    public static DoneableDeployment clusterOperator(String namespace, long operationTimeout) {
+        return KubernetesResource.deployNewDeployment(defaultCLusterOperator(namespace, operationTimeout, Constants.RECONCILIATION_INTERVAL).build());
+    }
+
+    public static DoneableDeployment clusterOperator(String namespace, long operationTimeout, long reconciliationInterval) {
+        return KubernetesResource.deployNewDeployment(defaultCLusterOperator(namespace, operationTimeout, reconciliationInterval).build());
+    }
+
+    public static DoneableDeployment clusterOperator(String namespace) {
+        return KubernetesResource.deployNewDeployment(defaultCLusterOperator(namespace, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Constants.RECONCILIATION_INTERVAL).build());
+    }
+
+    public static DeploymentBuilder defaultClusterOperator(String namespace) {
+        return defaultCLusterOperator(namespace, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Constants.RECONCILIATION_INTERVAL);
+    }
+
+    private static DeploymentBuilder defaultCLusterOperator(String namespace, long operationTimeout, long reconciliationInterval) {
+
+        Deployment clusterOperator = KubernetesResource.getDeploymentFromYaml(PATH_TO_CO_CONFIG);
+
+        // Get env from config file
+        List<EnvVar> envVars = clusterOperator.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
+        // Get default CO image
+        String coImage = clusterOperator.getSpec().getTemplate().getSpec().getContainers().get(0).getImage();
+
+        // Update images
+        for (EnvVar envVar : envVars) {
+            switch (envVar.getName()) {
+                case "STRIMZI_LOG_LEVEL":
+                    envVar.setValue(Environment.STRIMZI_LOG_LEVEL);
+                    break;
+                case "STRIMZI_NAMESPACE":
+                    envVar.setValue(namespace);
+                    envVar.setValueFrom(null);
+                    break;
+                case "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS":
+                    envVar.setValue(Long.toString(reconciliationInterval));
+                    break;
+                case "STRIMZI_OPERATION_TIMEOUT_MS":
+                    envVar.setValue(Long.toString(operationTimeout));
+                    break;
+                default:
+                    if (envVar.getName().contains("KAFKA_BRIDGE_IMAGE")) {
+                        envVar.setValue(Environment.useLatestReleasedBridge() ? envVar.getValue() : Environment.BRIDGE_IMAGE);
+                    } else if (envVar.getName().contains("STRIMZI_DEFAULT")) {
+                        envVar.setValue(StUtils.changeOrgAndTag(envVar.getValue()));
+                    } else if (envVar.getName().contains("IMAGES")) {
+                        envVar.setValue(StUtils.changeOrgAndTagInImageMap(envVar.getValue()));
+                    }
+            }
+        }
+
+        envVars.add(new EnvVar("STRIMZI_IMAGE_PULL_POLICY", Environment.COMPONENTS_IMAGE_PULL_POLICY, null));
+        // Apply updated env variables
+        clusterOperator.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(envVars);
+
+        return new DeploymentBuilder(clusterOperator)
+            .editSpec()
+                .withNewSelector()
+                    .addToMatchLabels("name", Constants.STRIMZI_DEPLOYMENT_NAME)
+                .endSelector()
+                .editTemplate()
+                    .editSpec()
+                        .editFirstContainer()
+                            .withImage(StUtils.changeOrgAndTag(coImage))
+                            .withImagePullPolicy(Environment.OPERATOR_IMAGE_PULL_POLICY)
+                        .endContainer()
+                    .endSpec()
+                .endTemplate()
+            .endSpec();
+    }
+
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/HelmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/HelmResource.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.resources.operator;
+
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
+import io.strimzi.test.TestUtils;
+import io.strimzi.test.k8s.KubeClusterResource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static io.strimzi.test.TestUtils.entry;
+import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
+
+public class HelmResource {
+    private static final Logger LOGGER = LogManager.getLogger(HelmResource.class);
+
+    public static final String HELM_CHART = "../helm-charts/helm3/strimzi-kafka-operator/";
+    public static final String HELM_RELEASE_NAME = "strimzi-systemtests";
+
+    public static final String REQUESTS_MEMORY = "512Mi";
+    public static final String REQUESTS_CPU = "200m";
+    public static final String LIMITS_MEMORY = "512Mi";
+    public static final String LIMITS_CPU = "1000m";
+
+    public static void clusterOperator() {
+        clusterOperator(Constants.CO_OPERATION_TIMEOUT_DEFAULT);
+    }
+
+    public static void clusterOperator(long operationTimeout) {
+        clusterOperator(operationTimeout, Constants.RECONCILIATION_INTERVAL);
+    }
+
+    public static void clusterOperator(long operationTimeout, long reconciliationInterval) {
+        Map<String, String> values = Collections.unmodifiableMap(Stream.of(
+                entry("imageRepositoryOverride", Environment.STRIMZI_REGISTRY + "/" + Environment.STRIMZI_ORG),
+                entry("imageTagOverride", Environment.STRIMZI_TAG),
+                entry("image.pullPolicy", Environment.OPERATOR_IMAGE_PULL_POLICY),
+                entry("resources.requests.memory", REQUESTS_MEMORY),
+                entry("resources.requests.cpu", REQUESTS_CPU),
+                entry("resources.limits.memory", LIMITS_MEMORY),
+                entry("resources.limits.cpu", LIMITS_CPU),
+                entry("logLevel", Environment.STRIMZI_LOG_LEVEL),
+                entry("fullReconciliationIntervalMs", Long.toString(reconciliationInterval)),
+                entry("operationTimeoutMs", Long.toString(operationTimeout)))
+                .collect(TestUtils.entriesToMap()));
+
+        // We need to delete all CRDs before install Strimzi via helm, otherwise install fail when some CRD is already created
+        cmdKubeClient().delete(KubeClusterResource.CO_INSTALL_DIR);
+        Path pathToChart = new File(HELM_CHART).toPath();
+        String oldNamespace = KubeClusterResource.getInstance().setNamespace("kube-system");
+        InputStream helmAccountAsStream = HelmResource.class.getClassLoader().getResourceAsStream("helm/helm-service-account.yaml");
+        String helmServiceAccount = TestUtils.readResource(helmAccountAsStream);
+        cmdKubeClient().applyContent(helmServiceAccount);
+        KubeClusterResource.getInstance().setNamespace(oldNamespace);
+        ResourceManager.helmClient().install(pathToChart, HELM_RELEASE_NAME, values);
+        ResourceManager.getPointerResources().push(HelmResource::deleteClusterOperator);
+        DeploymentUtils.waitForDeploymentReady(ResourceManager.getCoDeploymentName());
+    }
+
+    /**
+     * Delete CO deployed via helm chart.
+     */
+    public static void deleteClusterOperator() {
+        ResourceManager.helmClient().delete(HELM_RELEASE_NAME);
+        DeploymentUtils.waitForDeploymentDeletion(ResourceManager.getCoDeploymentName());
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/HelmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/HelmResource.java
@@ -56,8 +56,6 @@ public class HelmResource {
                 entry("operationTimeoutMs", Long.toString(operationTimeout)))
                 .collect(TestUtils.entriesToMap()));
 
-        // We need to delete all CRDs before install Strimzi via helm, otherwise install fail when some CRD is already created
-        cmdKubeClient().delete(KubeClusterResource.CO_INSTALL_DIR);
         Path pathToChart = new File(HELM_CHART).toPath();
         String oldNamespace = KubeClusterResource.getInstance().setNamespace("kube-system");
         InputStream helmAccountAsStream = HelmResource.class.getClassLoader().getResourceAsStream("helm/helm-service-account.yaml");

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/OlmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/OlmResource.java
@@ -2,10 +2,11 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.systemtest.resources;
+package io.strimzi.systemtest.resources.operator;
 
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeClusterResource;

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -108,14 +108,17 @@ public abstract class AbstractST implements TestSeparator {
      */
     protected void installClusterOperator(String namespace, List<String> bindingsNamespaces, long operationTimeout, long reconciliationInterval) throws Exception {
         if (Environment.isOlmInstall()) {
+            LOGGER.info("Going to install ClusterOperator via OLM");
             cluster.setNamespace(namespace);
             cluster.createNamespace(namespace);
             OlmResource.clusterOperator(namespace, operationTimeout, reconciliationInterval);
         } else if (Environment.isHelmInstall()) {
+            LOGGER.info("Going to install ClusterOperator via Helm");
             cluster.setNamespace(namespace);
             cluster.createNamespace(namespace);
             HelmResource.clusterOperator(operationTimeout, reconciliationInterval);
         } else {
+            LOGGER.info("Going to install ClusterOperator via Yaml bundle");
             prepareEnvForOperator(namespace, bindingsNamespaces);
             applyRoleBindings(namespace, bindingsNamespaces);
             // 050-Deployment

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -14,7 +14,6 @@ import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.operator.BundleResource;

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -17,6 +17,7 @@ import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.operator.BundleResource;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
@@ -134,7 +135,7 @@ class LoggingChangeST extends AbstractST {
         kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMapOperators);
         kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMapCO);
 
-        KubernetesResource.clusterOperator(NAMESPACE)
+        BundleResource.clusterOperator(NAMESPACE)
             .editOrNewSpec()
                 .editOrNewTemplate()
                     .editOrNewSpec()

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/AllNamespacesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/AllNamespacesST.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.systemtest.olm;
 
-import io.strimzi.systemtest.resources.OlmResource;
+import io.strimzi.systemtest.resources.operator.OlmResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAbstractST.java
@@ -13,7 +13,6 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.systemtest.AbstractST;
-import io.strimzi.systemtest.resources.OlmResource;
 import io.strimzi.systemtest.resources.operator.OlmResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaBridgeUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectS2IUtils;

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAbstractST.java
@@ -14,6 +14,7 @@ import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.resources.OlmResource;
+import io.strimzi.systemtest.resources.operator.OlmResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaBridgeUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectS2IUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/SingleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/SingleNamespaceST.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.systemtest.olm;
 
-import io.strimzi.systemtest.resources.OlmResource;
+import io.strimzi.systemtest.resources.operator.OlmResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
@@ -14,11 +14,11 @@ import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
+import io.strimzi.systemtest.resources.operator.BundleResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.NamespaceUtils;
@@ -182,7 +182,7 @@ class NamespaceDeletionRecoveryST extends AbstractST {
         prepareEnvForOperator(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+        BundleResource.clusterOperator(NAMESPACE).done();
         KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3)
             .editSpec()
                 .editKafka()
@@ -237,7 +237,7 @@ class NamespaceDeletionRecoveryST extends AbstractST {
         cluster.applyClusterOperatorInstallFiles();
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+        BundleResource.clusterOperator(NAMESPACE).done();
     }
 
     private void deleteAndRecreateNamespace() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/HelmChartST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/HelmChartST.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.specific;
 
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.systemtest.resources.operator.HelmResource;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import org.apache.logging.log4j.LogManager;
@@ -39,18 +40,17 @@ class HelmChartST extends AbstractST {
     void setup() {
         LOGGER.info("Creating resources before the test class");
         cluster.createNamespace(NAMESPACE);
-        deployClusterOperatorViaHelmChart();
+        HelmResource.clusterOperator();
     }
 
     @Override
     protected void tearDownEnvironmentAfterAll() {
-        deleteClusterOperatorViaHelmChart();
         cluster.deleteNamespaces();
     }
 
     @Override
     protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
-        deleteClusterOperatorViaHelmChart();
+        HelmResource.clusterOperator();
         cluster.deleteNamespaces();
         cluster.createNamespace(NAMESPACE);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -15,9 +15,9 @@ import io.strimzi.api.kafka.model.listener.LoadBalancerListenerBrokerOverride;
 import io.strimzi.api.kafka.model.listener.LoadBalancerListenerBrokerOverrideBuilder;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.operator.BundleResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.test.executor.Exec;
 import org.apache.logging.log4j.LogManager;
@@ -253,6 +253,6 @@ public class SpecificST extends AbstractST {
 
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+        BundleResource.clusterOperator(NAMESPACE).done();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -12,12 +12,12 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
 import io.strimzi.systemtest.logs.TestExecutionWatcher;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
+import io.strimzi.systemtest.resources.operator.BundleResource;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.FileUtils;
 import io.strimzi.systemtest.utils.StUtils;
@@ -189,7 +189,7 @@ public class StrimziUpgradeST extends AbstractST {
         applyRoleBindings(NAMESPACE);
 
         kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName(ResourceManager.getCoDeploymentName()).delete();
-        kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName(ResourceManager.getCoDeploymentName()).create(KubernetesResource.defaultClusterOperator(NAMESPACE).build());
+        kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName(ResourceManager.getCoDeploymentName()).create(BundleResource.defaultClusterOperator(NAMESPACE).build());
 
         DeploymentUtils.waitTillDepHasRolled(ResourceManager.getCoDeploymentName(), 1, operatorSnapshot);
         StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaSnapshot);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
@@ -7,11 +7,11 @@ package io.strimzi.systemtest.upgrade;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.AbstractST;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
+import io.strimzi.systemtest.resources.operator.BundleResource;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
@@ -228,6 +228,6 @@ public class ZookeeperUpgradeST extends AbstractST {
 
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+        BundleResource.clusterOperator(NAMESPACE).done();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
@@ -21,6 +21,7 @@ import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
 import io.strimzi.systemtest.resources.crd.KafkaConnectS2IResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
+import io.strimzi.systemtest.resources.operator.BundleResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -202,7 +203,7 @@ class AllNamespaceST extends AbstractNamespaceST {
         clusterRoleBindingList.forEach(clusterRoleBinding ->
                 KubernetesResource.clusterRoleBinding(clusterRoleBinding, CO_NAMESPACE));
         // 050-Deployment
-        KubernetesResource.clusterOperator("*").done();
+        BundleResource.clusterOperator("*").done();
 
         String previousNamespace = cluster.setNamespace(THIRD_NAMESPACE);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
@@ -5,12 +5,12 @@
 package io.strimzi.systemtest.watcher;
 
 import io.strimzi.systemtest.cli.KafkaCmdClient;
+import io.strimzi.systemtest.resources.operator.BundleResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 
@@ -72,7 +72,7 @@ class MultipleNamespaceST extends AbstractNamespaceST {
         applyRoleBindings(CO_NAMESPACE);
         applyRoleBindings(CO_NAMESPACE, SECOND_NAMESPACE);
         // 050-Deployment
-        KubernetesResource.clusterOperator(String.join(",", CO_NAMESPACE, SECOND_NAMESPACE)).done();
+        BundleResource.clusterOperator(String.join(",", CO_NAMESPACE, SECOND_NAMESPACE)).done();
 
         cluster.setNamespace(SECOND_NAMESPACE);
 

--- a/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
@@ -71,7 +71,6 @@ public class HelmClient {
 
     private List<String> command(String... rest) {
         List<String> result = new ArrayList<>();
-        LOGGER.info("HELM COMMAND IS: {}", helmCommand);
         result.add(helmCommand);
         result.addAll(asList(rest));
         return result;

--- a/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
@@ -28,7 +28,7 @@ public class HelmClient {
     private boolean initialized;
     private String namespace;
 
-    private static String helmCommand = HELM_CMD;
+    private String helmCommand = HELM_CMD;
 
     public HelmClient(String namespace) {
         this.namespace = namespace;
@@ -40,6 +40,7 @@ public class HelmClient {
 
     /** Install a chart given its local path, release name, and values to override */
     public HelmClient install(Path chart, String releaseName, Map<String, String> valuesMap) {
+        LOGGER.info("Installing helm-chart {}", releaseName);
         String values = Stream.of(valuesMap).flatMap(m -> m.entrySet().stream())
                 .map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue()))
                 .collect(Collectors.joining(","));
@@ -53,8 +54,8 @@ public class HelmClient {
 
     /** Delete a chart given its release name */
     public HelmClient delete(String releaseName) {
-        // wait() not required, `helm delete` blocks by default
-        Exec.exec(command("delete", releaseName));
+        LOGGER.info("Deleting helm-chart {}", releaseName);
+        Exec.exec(null, namespace(command("delete", releaseName)), 0, false, false);
         return this;
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
@@ -22,7 +22,7 @@ public class HelmClient {
     private static final Logger LOGGER = LogManager.getLogger(HelmClient.class);
 
     private static final String HELM_CMD = "helm";
-    private static final String INSTALL_TIMEOUT_SECONDS = "90";
+    private static final String INSTALL_TIMEOUT_SECONDS = "120s";
 
     private boolean initialized;
     private String namespace;
@@ -50,7 +50,7 @@ public class HelmClient {
                 .map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue()))
                 .collect(Collectors.joining(","));
         Exec.exec(wait(namespace(command("install",
-                "--name", releaseName,
+                releaseName,
                 "--set-string", values,
                 "--timeout", INSTALL_TIMEOUT_SECONDS,
                 chart.toString()))));
@@ -60,7 +60,7 @@ public class HelmClient {
     /** Delete a chart given its release name */
     public HelmClient delete(String releaseName) {
         // wait() not required, `helm delete` blocks by default
-        Exec.exec(command("delete", releaseName, "--purge"));
+        Exec.exec(command("delete", releaseName));
         return this;
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
@@ -28,7 +28,7 @@ public class HelmClient {
     private boolean initialized;
     private String namespace;
 
-    private String helmCommand = HELM_CMD;
+    private static String helmCommand = HELM_CMD;
 
     public HelmClient(String namespace) {
         this.namespace = namespace;
@@ -59,7 +59,7 @@ public class HelmClient {
         return this;
     }
 
-    public boolean clientAvailable() {
+    public static boolean clientAvailable() {
         if (Exec.isExecutableOnPath(HELM_CMD)) {
             return true;
         } else if (Exec.isExecutableOnPath(HELM_3_CMD)) {
@@ -71,6 +71,7 @@ public class HelmClient {
 
     private List<String> command(String... rest) {
         List<String> result = new ArrayList<>();
+        LOGGER.info("HELM COMMAND IS: {}", helmCommand);
         result.add(helmCommand);
         result.addAll(asList(rest));
         return result;

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -158,6 +158,14 @@ public class KubeClusterResource {
     }
 
     /**
+     * Provides approriate Helm client for running Helm operations in specific namespace
+     * @return Helm client
+     */
+    public static HelmClient helmClusterClient() {
+        return cluster.helmClient().namespace(cluster.getNamespace());
+    }
+
+    /**
      * Provides appropriate Kubernetes client with expected namespace for running cluster
      * @param inNamespace Namespace will be used as a current namespace for client
      * @return Kubernetes client with expected namespace in configuration


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR adds option to run most of the tests against cluster operator installed by HELM. Helm3 is needed to run the tests properly. Helm2 will not work. 

I am open to any suggestions regarding the naming :) 

### Checklist

- [x] Make sure all tests pass


