### PR TITLE
Fix typo in the launch script

### DIFF
--- a/docker-images/test-client/scripts/launch_java.sh
+++ b/docker-images/test-client/scripts/launch_java.sh
@@ -38,6 +38,6 @@ JAVA_OPTS="${JAVA_OPTS} $(get_gc_opts)"
 JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
 if [ "$JAVA_MAJOR_VERSION" -ge "9" ] ; then
   JAVA_OPTS="${JAVA_OPTS} --illegal-access=deny"
-fiq
+fi
 
 exec java $JAVA_OPTS -jar $JAR $@


### PR DESCRIPTION
### Type of change
- Bugfix

### Description
There is a typo in the launch script

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

