### PR TITLE
[DOC] Improvements to Prometheus Operator deployment procedure

### DIFF
--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
@@ -10,17 +10,19 @@ To deploy the Prometheus Operator to your Kafka cluster, apply the YAML bundle r
 
 .Procedure
 
-. Download the resource file from the repository and replace the example `namespace` with your own:
+. Download the `bundle.yaml` resources file from the repository and replace the example `namespace` with your own:
 +
 On Linux, use:
 +
-[source,shell,subs=+quotes]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml | sed -e 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
+[source,shell,subs="+quotes,attributes+"]
+curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/{PrometheusSupport}/bundle.yaml | sed -e 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
 +
 On MacOS, use:
 +
-[source,shell,subs=+quotes]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml | sed -e '' 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
+[source,shell,subs="+quotes,attributes+"]
+curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/{PrometheusSupport}/bundle.yaml | sed -e '' 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
++
+Choose a release that is compatible with your version of Kubernetes.
 
 . (Optional) If it is not required, you can manually remove the `spec.template.spec.securityContext` property from the `prometheus-operator-deployment.yaml` file.
 
@@ -29,4 +31,6 @@ curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bund
 [source,shell,subs="+attributes"]
 kubectl apply -f prometheus-operator-deployment.yaml
 +
+ifdef::Downloading[]
 NOTE: The Prometheus Operator installation works with Kubernetes 1.18+. To check which version to use with a different Kubernetes version, refer to the https://github.com/coreos/kube-prometheus#kubernetes-compatibility-matrix[Kubernetes compatibility matrix].
+endif::Downloading[]

--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
@@ -10,7 +10,7 @@ To deploy the Prometheus Operator to your Kafka cluster, apply the YAML bundle r
 
 .Procedure
 
-. Download the `bundle.yaml` resources file from the repository and replace the example `namespace` with your own:
+. Download the `bundle.yaml` resources file from the repository.
 +
 On Linux, use:
 +
@@ -22,7 +22,14 @@ On MacOS, use:
 [source,shell,subs="+quotes,attributes+"]
 curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/{SupportedPrometheusVersion}/bundle.yaml | sed -e '' 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
 +
-Use the https://github.com/coreos/kube-prometheus#kubernetes-compatibility-matrix[Kubernetes compatibility matrix] to help you choose a release that is compatible with your version of Kubernetes. If using OpenShift, specify a release of the link:https://github.com/openshift/prometheus-operator[OpenShift fork^] of the Prometheus Operator repository.
+** Replace the example `namespace` with your own.
++
+ifdef::Downloading[]
+** Use the latest `master` release as shown, or choose a release that is compatible with your version of Kubernetes (see the https://github.com/coreos/kube-prometheus#kubernetes-compatibility-matrix[Kubernetes compatibility matrix]). 
+The Prometheus Operator installation works with Kubernetes 1.18+.
+endif::Downloading[]
++
+NOTE: If using OpenShift, specify a release of the link:https://github.com/openshift/prometheus-operator[OpenShift fork^] of the Prometheus Operator repository.
 
 . (Optional) If it is not required, you can manually remove the `spec.template.spec.securityContext` property from the `prometheus-operator-deployment.yaml` file.
 
@@ -30,7 +37,3 @@ Use the https://github.com/coreos/kube-prometheus#kubernetes-compatibility-matri
 +
 [source,shell,subs="+attributes"]
 kubectl apply -f prometheus-operator-deployment.yaml
-+
-ifdef::Downloading[]
-NOTE: The Prometheus Operator installation works with Kubernetes 1.18+. To check which version to use with a different Kubernetes version, refer to the https://github.com/coreos/kube-prometheus#kubernetes-compatibility-matrix[Kubernetes compatibility matrix].
-endif::Downloading[]

--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
@@ -15,18 +15,18 @@ To deploy the Prometheus Operator to your Kafka cluster, apply the YAML bundle r
 On Linux, use:
 +
 [source,shell,subs="+quotes,attributes+"]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/{SupportedPrometheusVersion}/bundle.yaml | sed -e 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
+curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml | sed -e 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
 +
 On MacOS, use:
 +
 [source,shell,subs="+quotes,attributes+"]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/{SupportedPrometheusVersion}/bundle.yaml | sed -e '' 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
+curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml | sed -e '' 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
 +
 ** Replace the example `namespace` with your own.
 +
 ifdef::Downloading[]
 ** Use the latest `master` release as shown, or choose a release that is compatible with your version of Kubernetes (see the https://github.com/coreos/kube-prometheus#kubernetes-compatibility-matrix[Kubernetes compatibility matrix]). 
-The Prometheus Operator installation works with Kubernetes 1.18+.
+The `master` release of the Prometheus Operator works with Kubernetes 1.18+.
 endif::Downloading[]
 +
 NOTE: If using OpenShift, specify a release of the link:https://github.com/openshift/prometheus-operator[OpenShift fork^] of the Prometheus Operator repository.

--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
@@ -22,7 +22,7 @@ On MacOS, use:
 [source,shell,subs="+quotes,attributes+"]
 curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/{SupportedPrometheusVersion}/bundle.yaml | sed -e '' 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
 +
-Choose a release that is compatible with your version of Kubernetes.
+Use the https://github.com/coreos/kube-prometheus#kubernetes-compatibility-matrix[Kubernetes compatibility matrix] to help you choose a release that is compatible with your version of Kubernetes. If using OpenShift, specify a release of the link:https://github.com/openshift/prometheus-operator[OpenShift fork^] of the Prometheus Operator repository.
 
 . (Optional) If it is not required, you can manually remove the `spec.template.spec.securityContext` property from the `prometheus-operator-deployment.yaml` file.
 

--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
@@ -15,12 +15,12 @@ To deploy the Prometheus Operator to your Kafka cluster, apply the YAML bundle r
 On Linux, use:
 +
 [source,shell,subs="+quotes,attributes+"]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/{PrometheusSupport}/bundle.yaml | sed -e 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
+curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/{SupportedPrometheusVersion}/bundle.yaml | sed -e 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
 +
 On MacOS, use:
 +
 [source,shell,subs="+quotes,attributes+"]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/{PrometheusSupport}/bundle.yaml | sed -e '' 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
+curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/{SupportedPrometheusVersion}/bundle.yaml | sed -e '' 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
 +
 Choose a release that is compatible with your version of Kubernetes.
 

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -33,7 +33,7 @@
 :JMXExporter: link:https://github.com/prometheus/jmx_exporter[JMX Exporter documentation^]
 :PrometheusHome: link:https://github.com/prometheus[Prometheus^]
 :PrometheusConfig: link:https://prometheus.io/docs/prometheus/latest/configuration/configuration[Configuration^]
-:PrometheusSupport: master
+:SupportedPrometheusVersion: master
 :kafka-exporter-project: link:https://github.com/danielqsj/kafka_exporter[Kafka Exporter^]
 
 //OAuth attributes and links

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -33,6 +33,7 @@
 :JMXExporter: link:https://github.com/prometheus/jmx_exporter[JMX Exporter documentation^]
 :PrometheusHome: link:https://github.com/prometheus[Prometheus^]
 :PrometheusConfig: link:https://prometheus.io/docs/prometheus/latest/configuration/configuration[Configuration^]
+:PrometheusSupport: master
 :kafka-exporter-project: link:https://github.com/danielqsj/kafka_exporter[Kafka Exporter^]
 
 //OAuth attributes and links

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -33,7 +33,6 @@
 :JMXExporter: link:https://github.com/prometheus/jmx_exporter[JMX Exporter documentation^]
 :PrometheusHome: link:https://github.com/prometheus[Prometheus^]
 :PrometheusConfig: link:https://prometheus.io/docs/prometheus/latest/configuration/configuration[Configuration^]
-:SupportedPrometheusVersion: master
 :kafka-exporter-project: link:https://github.com/danielqsj/kafka_exporter[Kafka Exporter^]
 
 //OAuth attributes and links


### PR DESCRIPTION
Signed-off-by: Daniel Laing <dlaing@redhat.com>

### Type of change

- Documentation

### Description

Made a couple of improvements to the "Deploying the CoreOS Prometheus Operator" procedure.

* Added a statement: "Choose a release that is compatible with your version of Kubernetes".
* Added an attribute for the version of the Prometheus Operator (set to `master`).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

