### PR TITLE
Add KafkaConnect to the Prometheus ServiceMonitor example.

### DIFF
--- a/examples/metrics/prometheus-install/strimzi-service-monitor.yaml
+++ b/examples/metrics/prometheus-install/strimzi-service-monitor.yaml
@@ -6,8 +6,8 @@ metadata:
     app: strimzi
 spec:
   selector:
-    matchLabels:
-      strimzi.io/kind: Kafka
+    matchExpressions:
+      - {key: "strimzi.io/kind", operator: In, values: ["Kafka", "KafkaConnect"]}
   namespaceSelector:
     matchNames:
       - myproject

--- a/examples/metrics/prometheus-install/strimzi-service-monitor.yaml
+++ b/examples/metrics/prometheus-install/strimzi-service-monitor.yaml
@@ -7,7 +7,9 @@ metadata:
 spec:
   selector:
     matchExpressions:
-      - {key: "strimzi.io/kind", operator: In, values: ["Kafka", "KafkaConnect"]}
+      - key: "strimzi.io/kind"
+        operator: In
+        values: ["Kafka", "KafkaConnect"]
   namespaceSelector:
     matchNames:
       - myproject


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description
We've found that the ServiceMonitor configuration did not include Kafka Connect metrics.  The changes in this pull request allows Prometheus to scrape Kafka Connect metrics as well.

### Checklist
_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

