### PR TITLE
ST: fix testSendMessagesTlsScramSha by correct configuration for Kafka listeners

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
@@ -248,7 +248,7 @@ public class ListenersST extends AbstractST {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3)
                 .editSpec()
                     .editKafka()
-                        .editListeners()
+                        .withNewListeners()
                             .editOrNewTls()
                                 .withNewKafkaListenerAuthenticationScramSha512Auth()
                                 .endKafkaListenerAuthenticationScramSha512Auth()


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

_Select the type of your PR_

- Bugfix

### Description

This PR fix test `testSendMessagesTlsScramSha` where we just edit the listeners which caused different value in strimzi discovery annotation. 

### Checklist

- [x] Make sure all tests pass
