### PR TITLE
Bridge dynamic logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   * enable/disable metrics in the KafkaBridge custom resource
   * new Grafana dashboard for the bridge metrics
 * Support dynamically changeable logging in the Entity Operator 
+* Support dynamically changeable logging in the Kafka Bridge 
 
 ### Deprecations and removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@
 * Strimzi Kafka Bridge metrics integration:
   * enable/disable metrics in the KafkaBridge custom resource
   * new Grafana dashboard for the bridge metrics
-* Support dynamically changeable logging in the Entity Operator 
-* Support dynamically changeable logging in the Kafka Bridge 
+* Support dynamically changeable logging in the Entity Operator and Kafka Bridge 
 
 ### Deprecations and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -502,4 +502,17 @@ public class KafkaBridgeCluster extends AbstractModel {
     public KafkaBridgeHttpConfig getHttp() {
         return this.http;
     }
+
+    /**
+     * Transforms properties to log4j2 properties file format and adds property for reloading the config
+     * @param properties map with properties
+     * @return modified string with monitorInterval
+     */
+    @Override
+    public String createLog4jProperties(OrderedProperties properties) {
+        if (!properties.asMap().keySet().contains("monitorInterval")) {
+            properties.addPair("monitorInterval", "30");
+        }
+        return super.createLog4jProperties(properties);
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -23,7 +23,6 @@ import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaBridgeCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -166,9 +165,7 @@ public class KafkaBridgeAssemblyOperatorTest {
                 assertThat(capturedDc, hasSize(1));
                 Deployment dc = capturedDc.get(0);
                 assertThat(dc.getMetadata().getName(), is(bridge.getName()));
-                Map annotations = new HashMap();
-                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
-                assertThat(dc, is(bridge.generateDeployment(annotations, true, null, null)));
+                assertThat(dc, is(bridge.generateDeployment(Collections.emptyMap(), true, null, null)));
 
                 // Verify PodDisruptionBudget
                 List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
@@ -369,9 +366,7 @@ public class KafkaBridgeAssemblyOperatorTest {
                 assertThat(capturedDc, hasSize(1));
                 Deployment dc = capturedDc.get(0);
                 assertThat(dc.getMetadata().getName(), is(compareTo.getName()));
-                Map<String, String> annotations = new HashMap();
-                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, loggingCm.getData().get(compareTo.ANCILLARY_CM_KEY_LOG_CONFIG));
-                assertThat(dc, is(compareTo.generateDeployment(annotations, true, null, null)));
+                assertThat(dc, is(compareTo.generateDeployment(Collections.emptyMap(), true, null, null)));
 
                 // Verify PodDisruptionBudget
                 List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
@@ -178,7 +178,7 @@ class HttpBridgeST extends HttpBridgeAbstractST {
                 .endLivenessProbe()
             .endSpec().done();
 
-        Map<String, String> connectSnapshot = DeploymentUtils.depSnapshot(KafkaBridgeResources.deploymentName(bridgeName));
+        Map<String, String> bridgeSnapshot = DeploymentUtils.depSnapshot(KafkaBridgeResources.deploymentName(bridgeName));
 
         // Remove variable which is already in use
         envVarGeneral.remove(usedVariable);
@@ -208,7 +208,7 @@ class HttpBridgeST extends HttpBridgeAbstractST {
             kb.getSpec().getReadinessProbe().setFailureThreshold(updatedFailureThreshold);
         });
 
-        DeploymentUtils.waitTillDepHasRolled(KafkaBridgeResources.deploymentName(bridgeName), 1, connectSnapshot);
+        DeploymentUtils.waitTillDepHasRolled(KafkaBridgeResources.deploymentName(bridgeName), 1, bridgeSnapshot);
 
         LOGGER.info("Verify values after update");
         checkReadinessLivenessProbe(KafkaBridgeResources.deploymentName(bridgeName), KafkaBridgeResources.deploymentName(bridgeName), updatedInitialDelaySeconds, updatedTimeoutSeconds,

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -11,11 +11,13 @@ import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.strimzi.api.kafka.model.ExternalLogging;
 import io.strimzi.api.kafka.model.ExternalLoggingBuilder;
 import io.strimzi.api.kafka.model.InlineLogging;
+import io.strimzi.api.kafka.model.KafkaBridgeResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaBridgeResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
@@ -28,6 +30,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -347,6 +350,111 @@ class LoggingChangeST extends AbstractST {
         assertThat(StUtils.getLogFromPodByTime(eoPodName, "topic-operator", "30s"), is(not(emptyString())));
 
         assertThat("EO pod should not roll", DeploymentUtils.depSnapshot(eoDeploymentName), equalTo(eoPods));
+    }
+
+    @Test
+    void testDynamicallySetBridgeLoggingLevels() throws InterruptedException {
+        InlineLogging ilOff = new InlineLogging();
+        Map<String, String> loggers = new HashMap<>();
+        loggers.put("rootLogger.level", "OFF");
+        loggers.put("logger.bridge.level", "OFF");
+        loggers.put("logger.healthy.level", "OFF");
+        loggers.put("logger.ready.level", "OFF");
+        ilOff.setLoggers(loggers);
+
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 1, 1).done();
+        KafkaBridgeResource.kafkaBridge(CLUSTER_NAME, KafkaResources.tlsBootstrapAddress(CLUSTER_NAME), 1)
+                .editSpec()
+                    .withInlineLogging(ilOff)
+                .endSpec()
+                .done();
+
+        Map<String, String> bridgeSnapshot = DeploymentUtils.depSnapshot(KafkaBridgeResources.deploymentName(CLUSTER_NAME));
+
+        LOGGER.info("Changing rootLogger level to DEBUG with inline logging");
+        InlineLogging ilDebug = new InlineLogging();
+        loggers.put("rootLogger.level", "DEBUG");
+        loggers.put("logger.bridge.level", "OFF");
+        loggers.put("logger.healthy.level", "OFF");
+        loggers.put("logger.ready.level", "OFF");
+        ilDebug.setLoggers(loggers);
+
+        KafkaBridgeResource.replaceBridgeResource(CLUSTER_NAME, bridz -> {
+            bridz.getSpec().setLogging(ilDebug);
+        });
+
+        final String bridgePodName = bridgeSnapshot.keySet().iterator().next();
+        LOGGER.info("Waiting for log4j2.properties will contain desired settings");
+        TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> cmdKubeClient().execInPodContainer(bridgePodName, KafkaBridgeResources.deploymentName(CLUSTER_NAME), "cat", "/opt/strimzi/custom-config/log4j2.properties").out().contains("rootLogger.level=DEBUG")
+                && cmdKubeClient().execInPodContainer(bridgePodName, KafkaBridgeResources.deploymentName(CLUSTER_NAME), "cat", "/opt/strimzi/custom-config/log4j2.properties").out().contains("monitorInterval=30")
+        );
+
+        LOGGER.info("Waiting {} ms for DEBUG log will appear", LOGGING_RELOADING_INTERVAL * 2);
+        // wait some time and check whether logs after this time contain anything
+        Thread.sleep(LOGGING_RELOADING_INTERVAL * 2);
+
+        LOGGER.info("Asserting if log will contain some records");
+        assertThat(StUtils.getLogFromPodByTime(bridgePodName, KafkaBridgeResources.deploymentName(CLUSTER_NAME), "30s"), is(not(emptyString())));
+
+        ConfigMap configMapBridge = new ConfigMapBuilder()
+                .withNewMetadata()
+                .withName("external-configmap-bridge")
+                .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withData(Collections.singletonMap("log4j2.properties",
+                        "name = BridgeConfig\n" +
+                                "\n" +
+                                "appender.console.type = Console\n" +
+                                "appender.console.name = STDOUT\n" +
+                                "appender.console.layout.type = PatternLayout\n" +
+                                "appender.console.layout.pattern = [%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n\n" +
+                                "\n" +
+                                "rootLogger.level = OFF\n" +
+                                "rootLogger.appenderRefs = console\n" +
+                                "rootLogger.appenderRef.console.ref = STDOUT\n" +
+                                "rootLogger.additivity = false\n" +
+                                "\n" +
+                                "logger.bridge.name = io.strimzi.kafka.bridge\n" +
+                                "logger.bridge.level = OFF\n" +
+                                "logger.bridge.appenderRefs = console\n" +
+                                "logger.bridge.appenderRef.console.ref = STDOUT\n" +
+                                "logger.bridge.additivity = false\n" +
+                                "\n" +
+                                "# HTTP OpenAPI specific logging levels (default is INFO)\n" +
+                                "# Logging healthy and ready endpoints is very verbose because of Kubernetes health checking.\n" +
+                                "logger.healthy.name = http.openapi.operation.healthy\n" +
+                                "logger.healthy.level = OFF\n" +
+                                "logger.ready.name = http.openapi.operation.ready\n" +
+                                "logger.ready.level = OFF"))
+                .build();
+
+        kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMapBridge);
+
+        ExternalLogging bridgeXternalLogging = new ExternalLoggingBuilder()
+                .withName("external-configmap-bridge")
+                .build();
+
+        LOGGER.info("Setting log level of Bridge to OFF - records should not appear in the log");
+        // change to the external logging
+        KafkaBridgeResource.replaceBridgeResource(CLUSTER_NAME, bridz -> {
+            bridz.getSpec().setLogging(bridgeXternalLogging);
+        });
+
+        LOGGER.info("Waiting for log4j2.properties will contain desired settings");
+        TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> cmdKubeClient().execInPodContainer(bridgePodName, KafkaBridgeResources.deploymentName(CLUSTER_NAME), "cat", "/opt/strimzi/custom-config/log4j2.properties").out().contains("rootLogger.level = OFF")
+                && cmdKubeClient().execInPodContainer(bridgePodName, KafkaBridgeResources.deploymentName(CLUSTER_NAME), "cat", "/opt/strimzi/custom-config/log4j2.properties").out().contains("monitorInterval=30")
+        );
+
+        LOGGER.info("Waiting {} ms log to be empty", LOGGING_RELOADING_INTERVAL * 2);
+        // wait some time and check whether logs after this time are empty
+        Thread.sleep(LOGGING_RELOADING_INTERVAL * 2);
+
+        LOGGER.info("Asserting if log will contain no records");
+        assertThat(StUtils.getLogFromPodByTime(bridgePodName, KafkaBridgeResources.deploymentName(CLUSTER_NAME), "30s"), is(emptyString()));
+
+        assertThat("Bridge pod should not roll", DeploymentUtils.depSnapshot(KafkaBridgeResources.deploymentName(CLUSTER_NAME)), equalTo(bridgeSnapshot));
     }
 
     @BeforeAll


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement / new feature

### Description
Allow setting bridge logging configuration without RU (dynamically).

### Checklist
- [x] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

