### PR TITLE
Fixed metrics path and deprecated labels for the cadvisor job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Please follow the guide for upgrading the resources: https://strimzi.io/docs/ope
 The `pod_name` and `container_name` labels provided on the cadvisor metrics are now just `pod` and `container` starting from Kubernetes 1.16.
 We removed the old ones from the Prometheus scraping configuration/alerts and on the Kafka and ZooKeeper dashboard as well.
 It means that the charts related to memory and CPU usage are not going to work on Kuvbernetes version previous 1.14.
-For more information see this Kubernetes PR https://github.com/kubernetes/kubernetes/pull/80376
+For more information on what is changed: https://github.com/strimzi/strimzi-kafka-operator/pull/3312
 
 ## 0.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ In Strimzi 0.12.0, the `v1alpha1` versions of the following resources have been 
 In the next release, the `v1alpha1` versions of these resources will be removed. 
 Please follow the guide for upgrading the resources: https://strimzi.io/docs/operators/latest/full/deploying.html#assembly-upgrade-resources-str.
 
+#### Removal deprecated cadvisor metric labels
+
+The `pod_name` and `container_name` labels provided on the cadvisor metrics are now just `pod` and `container` starting from Kubernetes 1.16.
+We removed the old ones from the Prometheus scraping configuration/alerts and on the Kafka and ZooKeeper dashboard as well.
+It means that the charts related to memory and CPU usage are not going to work on Kuvbernetes version previous 1.14.
+For more information see this Kubernetes PR https://github.com/kubernetes/kubernetes/pull/80376
+
 ## 0.18.0
 
 * Add possibility to set Java System Properties for User Operator and Topic Operator via `Kafka` CR.

--- a/examples/metrics/grafana-dashboards/strimzi-kafka.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kafka.json
@@ -764,7 +764,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(container_memory_usage_bytes{namespace=\"$kubernetes_namespace\",kubernetes_pod_name=~\"$strimzi_cluster_name-$kafka_broker\",container_name=\"kafka\"}) by (kubernetes_pod_name)",
+          "expr": "sum(container_memory_usage_bytes{namespace=\"$kubernetes_namespace\",kubernetes_pod_name=~\"$strimzi_cluster_name-$kafka_broker\",container=\"kafka\"}) by (kubernetes_pod_name)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -852,7 +852,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_user_seconds_total{namespace=\"$kubernetes_namespace\",kubernetes_pod_name=~\"$strimzi_cluster_name-$kafka_broker\",container_name=\"kafka\"}[5m])) by (kubernetes_pod_name)",
+          "expr": "sum(rate(container_cpu_user_seconds_total{namespace=\"$kubernetes_namespace\",kubernetes_pod_name=~\"$strimzi_cluster_name-$kafka_broker\",container=\"kafka\"}[5m])) by (kubernetes_pod_name)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,

--- a/examples/metrics/grafana-dashboards/strimzi-zookeeper.json
+++ b/examples/metrics/grafana-dashboards/strimzi-zookeeper.json
@@ -517,7 +517,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(container_memory_usage_bytes{namespace=\"$kubernetes_namespace\",container_name=\"zookeeper\",kubernetes_pod_name=~\"$strimzi_cluster_name-$zk_node\"}) by (kubernetes_pod_name)",
+          "expr": "sum(container_memory_usage_bytes{namespace=\"$kubernetes_namespace\",container=\"zookeeper\",kubernetes_pod_name=~\"$strimzi_cluster_name-$zk_node\"}) by (kubernetes_pod_name)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{kubernetes_pod_name}}",
@@ -602,7 +602,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_user_seconds_total{namespace=\"$kubernetes_namespace\",container_name=\"zookeeper\",kubernetes_pod_name=~\"$strimzi_cluster_name-$zk_node\"}[5m])) by (kubernetes_pod_name)",
+          "expr": "sum(rate(container_cpu_user_seconds_total{namespace=\"$kubernetes_namespace\",container=\"zookeeper\",kubernetes_pod_name=~\"$strimzi_cluster_name-$zk_node\"}[5m])) by (kubernetes_pod_name)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{kubernetes_pod_name}}",

--- a/examples/metrics/prometheus-additional-properties/prometheus-additional.yaml
+++ b/examples/metrics/prometheus-additional-properties/prometheus-additional.yaml
@@ -4,7 +4,7 @@
   honor_labels: true
   scrape_interval: 10s
   scrape_timeout: 10s
-  metrics_path: /metrics
+  metrics_path: /metrics/cadvisor
   scheme: https
   kubernetes_sd_configs:
   - role: node
@@ -43,28 +43,28 @@
     replacement: $1
     action: replace
   metric_relabel_configs:
-  - source_labels: [pod_name]
+  - source_labels: [pod]
     separator: ;
     regex: (.*)
     target_label: kubernetes_pod_name
     replacement: $1
     action: replace
   - separator: ;
-    regex: pod_name
+    regex: pod
     replacement: $1
     action: labeldrop
-  - source_labels: [container_name, __name__]
+  - source_labels: [container, __name__]
     separator: ;
     regex: POD;container_(network).*
-    target_label: container_name
+    target_label: container
     replacement: $1
     action: replace
-  - source_labels: [container_name]
+  - source_labels: [container]
     separator: ;
     regex: POD
     replacement: $1
     action: drop
-  - source_labels: [container_name]
+  - source_labels: [container]
     separator: ;
     regex: ^$
     replacement: $1

--- a/examples/metrics/prometheus-install/prometheus-rules.yaml
+++ b/examples/metrics/prometheus-install/prometheus-rules.yaml
@@ -66,7 +66,7 @@ spec:
         summary: 'Prometheus unable to scrape metrics from {{ $labels.kubernetes_pod_name }}/{{ $labels.instance }}'
         description: 'Prometheus was unable to scrape metrics from {{ $labels.kubernetes_pod_name }}/{{ $labels.instance }} for more than 3 minutes'
     - alert: ClusterOperatorContainerDown
-      expr: count((container_last_seen{container_name="strimzi-cluster-operator"} > (time() - 90))) < 1 or absent(container_last_seen{container_name="strimzi-cluster-operator"})
+      expr: count((container_last_seen{container="strimzi-cluster-operator"} > (time() - 90))) < 1 or absent(container_last_seen{container="strimzi-cluster-operator"})
       for: 1m
       labels:
         severity: major
@@ -74,7 +74,7 @@ spec:
         summary: 'Cluster Operator down'
         description: 'The Cluster Operator has been down for longer than 90 seconds'
     - alert: KafkaBrokerContainersDown
-      expr: absent(container_last_seen{container_name="kafka",kubernetes_pod_name=~".+-kafka-[0-9]+"})
+      expr: absent(container_last_seen{container="kafka",kubernetes_pod_name=~".+-kafka-[0-9]+"})
       for: 3m
       labels:
         severity: major
@@ -82,7 +82,7 @@ spec:
         summary: 'All `kafka` containers down or in CrashLookBackOff status'
         description: 'All `kafka` containers have been down or in CrashLookBackOff status for 3 minutes'
     - alert: KafkaTlsSidecarContainersDown
-      expr: absent(container_last_seen{container_name="tls-sidecar",kubernetes_pod_name=~".+-kafka-[0-9]+"})
+      expr: absent(container_last_seen{container="tls-sidecar",kubernetes_pod_name=~".+-kafka-[0-9]+"})
       for: 3m
       labels:
         severity: major
@@ -90,7 +90,7 @@ spec:
         summary: 'All `tls-sidecar` containers in the Kafka pods are down or in CrashLookBackOff status'
         description: 'All `tls-sidecar` containers in the Kafka pods are down or in CrashLookBackOff status for 3 minutes'
     - alert: KafkaContainerRestartedInTheLast5Minutes
-      expr: count(count_over_time(container_last_seen{container_name="kafka"}[5m])) > 2 * count(container_last_seen{container_name="kafka",kubernetes_pod_name=~".+-kafka-[0-9]+"})
+      expr: count(count_over_time(container_last_seen{container="kafka"}[5m])) > 2 * count(container_last_seen{container="kafka",kubernetes_pod_name=~".+-kafka-[0-9]+"})
       for: 5m
       labels:
         severity: warning
@@ -124,7 +124,7 @@ spec:
         summary: 'Zookeeper is running out of free disk space'
         description: 'There are only {{ $value }} bytes available at {{ $labels.persistentvolumeclaim }} PVC'
     - alert: ZookeeperContainerRestartedInTheLast5Minutes
-      expr: count(count_over_time(container_last_seen{container_name="zookeeper"}[5m])) > 2 * count(container_last_seen{container_name="zookeeper",kubernetes_pod_name=~".+-zookeeper-[0-9]+"})
+      expr: count(count_over_time(container_last_seen{container="zookeeper"}[5m])) > 2 * count(container_last_seen{container="zookeeper",kubernetes_pod_name=~".+-zookeeper-[0-9]+"})
       for: 5m
       labels:
         severity: warning
@@ -132,7 +132,7 @@ spec:
         summary: 'One or more Zookeeper containers were restarted too often'
         description: 'One or more Zookeeper containers were restarted too often within the last 5 minutes. This alert can be ignored when the Zookeeper cluster is scaling up'
     - alert: ZookeeperContainersDown
-      expr: absent(container_last_seen{container_name="zookeeper",kubernetes_pod_name=~".+-zookeeper-[0-9]+"})
+      expr: absent(container_last_seen{container="zookeeper",kubernetes_pod_name=~".+-zookeeper-[0-9]+"})
       for: 3m
       labels:
         severity: major
@@ -142,7 +142,7 @@ spec:
   - name: entityOperator
     rules:
     - alert: TopicOperatorContainerDown
-      expr: absent(container_last_seen{container_name="topic-operator",kubernetes_pod_name=~".+-entity-operator-.+"})
+      expr: absent(container_last_seen{container="topic-operator",kubernetes_pod_name=~".+-entity-operator-.+"})
       for: 3m
       labels:
         severity: major
@@ -150,7 +150,7 @@ spec:
         summary: 'Container topic-operator in Entity Operator pod down or in CrashLookBackOff status'
         description: 'Container topic-operator in Entity Operator pod has been or in CrashLookBackOff status for 3 minutes'
     - alert: UserOperatorContainerDown
-      expr: absent(container_last_seen{container_name="user-operator",kubernetes_pod_name=~".+-entity-operator-.+"})
+      expr: absent(container_last_seen{container="user-operator",kubernetes_pod_name=~".+-entity-operator-.+"})
       for: 3m
       labels:
         severity: major
@@ -158,7 +158,7 @@ spec:
         summary: 'Container user-operator in Entity Operator pod down or in CrashLookBackOff status'
         description: 'Container user-operator in Entity Operator pod have been down or in CrashLookBackOff status for 3 minutes'
     - alert: EntityOperatorTlsSidecarContainerDown
-      expr: absent(container_last_seen{container_name="tls-sidecar",kubernetes_pod_name=~".+-entity-operator-.+"})
+      expr: absent(container_last_seen{container="tls-sidecar",kubernetes_pod_name=~".+-entity-operator-.+"})
       for: 3m
       labels:
         severity: major
@@ -168,7 +168,7 @@ spec:
   - name: connect
     rules:
     - alert: ConnectContainersDown
-      expr: absent(container_last_seen{container_name=~".+-connect",kubernetes_pod_name=~".+-connect-.+"})
+      expr: absent(container_last_seen{container=~".+-connect",kubernetes_pod_name=~".+-connect-.+"})
       for: 3m
       labels:
         severity: major
@@ -178,7 +178,7 @@ spec:
   - name: bridge
     rules:
     - alert: BridgeContainersDown
-      expr: absent(container_last_seen{container_name=~".+-bridge",kubernetes_pod_name=~".+-bridge-.+"})
+      expr: absent(container_last_seen{container=~".+-bridge",kubernetes_pod_name=~".+-bridge-.+"})
       for: 3m
       labels:
         severity: major
@@ -188,7 +188,7 @@ spec:
   - name: mirrorMaker
     rules:
     - alert: MirrorMakerContainerDown
-      expr: absent(container_last_seen{container_name=~".+-mirror-maker",kubernetes_pod_name=~".+-mirror-maker-.+"})
+      expr: absent(container_last_seen{container=~".+-mirror-maker",kubernetes_pod_name=~".+-mirror-maker-.+"})
       for: 3m
       labels:
         severity: major


### PR DESCRIPTION
Fixed dashboards using the right label

Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

_Select the type of your PR_

- Bugfix

### Description

This PR fixes #3308.
Memory and CPU usage metrics are not working anymore on Kafka and ZooKeeper dashboards due to change on the path where cadvisor exposes the metrics and some deprecated and dropped labels on the related metrics.
Following the current not working metrics for Kafka and ZooKeeper dashboards.

![without_metrics](https://user-images.githubusercontent.com/5842311/87312318-aff64880-c520-11ea-8e60-2dcb9967ac35.png)

and here the working ones using this PR.

![with_metrics](https://user-images.githubusercontent.com/5842311/87312347-b84e8380-c520-11ea-94e0-809f395ecfdb.png)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
