### PR TITLE
Remove env recreate in case of test failure

### DIFF
--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -128,18 +128,6 @@ For delete all resources from specific `Resources` instance you can do it like:
     ResourceManager.deleteClassResources();
 ```
 
-
-Another important thing is environment recreation in the case of failure. The `recreateTestEnv()` method in `BaseST`  is called in the case of an exception during test execution. 
-This is useful for these tests, which can break the cluster operator for subsequent test cases.
-
-Example of skip recreate environment in the case of failures. You must override the method from `BaseST` in your test class:
-```
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
-        LOGGER.info("Skip env recreation after failed tests!");
-    }
-```
-
 #### Cluster Operator log check
 
 After each test there is a check for cluster operator logs which looks for unexpected errors or unexpected exceptions.

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -189,52 +189,6 @@ public abstract class AbstractST implements TestSeparator {
     }
 
     /**
-     * Recreate namespace and CO after test failure
-     * @param coNamespace namespace where CO will be deployed to
-     * @param operationTimeout timeout for CO operations
-     * @param reconciliationInterval CO reconciliation interval
-     */
-    protected void recreateTestEnv(String coNamespace, long operationTimeout, long reconciliationInterval) throws Exception {
-        recreateTestEnv(coNamespace, Collections.singletonList(coNamespace), operationTimeout, reconciliationInterval);
-    }
-
-    /**
-     * Recreate namespace and CO after test failure
-     * @param coNamespace namespace where CO will be deployed to
-     * @param bindingsNamespaces array of namespaces where Bindings should be deployed to.
-     */
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
-        recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Constants.RECONCILIATION_INTERVAL);
-    }
-
-    /**
-     * Recreate namespace and CO after test failure
-     * @param coNamespace namespace where CO will be deployed to
-     * @param bindingsNamespaces array of namespaces where Bindings should be deployed to.
-     * @param operationTimeout timeout for CO operations
-     */
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces, long operationTimeout) throws Exception {
-        recreateTestEnv(coNamespace, bindingsNamespaces, operationTimeout, Constants.RECONCILIATION_INTERVAL);
-    }
-
-    /**
-     * Recreate namespace and CO after test failure
-     * @param coNamespace namespace where CO will be deployed to
-     * @param bindingsNamespaces array of namespaces where Bindings should be deployed to.
-     * @param operationTimeout timeout for CO operations
-     * @param reconciliationInterval CO reconciliation interval
-     */
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces, long operationTimeout, long reconciliationInterval) throws Exception {
-        ResourceManager.deleteMethodResources();
-        ResourceManager.deleteClassResources();
-
-        KubeClusterResource.getInstance().deleteClusterOperatorInstallFiles();
-        KubeClusterResource.getInstance().deleteNamespaces();
-
-        installClusterOperator(coNamespace, bindingsNamespaces, operationTimeout, reconciliationInterval);
-    }
-
-    /**
      * Method for apply Strimzi cluster operator specific Role and ClusterRole bindings for specific namespaces.
      * @param namespace namespace where CO will be deployed to
      * @param bindingsNamespaces list of namespaces where Bindings should be deployed to
@@ -699,12 +653,6 @@ public abstract class AbstractST implements TestSeparator {
         }
 
         if (Environment.SKIP_TEARDOWN == null) {
-            if (context.getExecutionException().isPresent() || assertionError != null) {
-                LOGGER.info("Test execution contains exception, going to recreate test environment");
-                recreateTestEnv(cluster.getTestNamespace(), cluster.getBindingsNamespaces());
-                KubernetesResource.applyDefaultNetworkPolicySettings(cluster.getBindingsNamespaces());
-                LOGGER.info("Env recreated.");
-            }
             tearDownEnvironmentAfterEach();
         }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeAbstractST.java
@@ -27,7 +27,6 @@ import io.strimzi.systemtest.resources.ResourceManager;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -137,11 +136,6 @@ public class HttpBridgeAbstractST extends AbstractST {
                 .build();
 
         assertThat(internalKafkaClient.receiveMessagesPlain(), is(MESSAGE_COUNT));
-    }
-
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
-        LOGGER.info("Skipping env recreation after each test - deployment should be same for whole test class!");
     }
 
     public String getBridgeNamespace() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeAbstractST.java
@@ -6,20 +6,11 @@ package io.strimzi.systemtest.bridge;
 
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
-import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaBridgeUtils;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
-import io.strimzi.systemtest.utils.specific.BridgeUtils;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.junit5.VertxExtension;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -27,7 +18,6 @@ import io.strimzi.systemtest.resources.ResourceManager;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -37,8 +27,6 @@ import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Base for test classes where HTTP Bridge is used.
@@ -70,72 +58,6 @@ public class HttpBridgeAbstractST extends AbstractST {
                     }
                 });
         return future.get(1, TimeUnit.MINUTES);
-    }
-
-    protected void doSimpleReceiveMessages(String clusterName, String bridgeHost, int bridgePort, String namespace, String clientsPodName) throws Exception {
-        String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
-        // Create topic
-        KafkaTopicResource.topic(clusterName, topicName).done();
-
-        String name = KafkaUserUtils.generateRandomNameOfKafkaUser();
-        String groupId = "my-group-" + new Random().nextInt(Integer.MAX_VALUE);
-
-        JsonObject config = new JsonObject();
-        config.put("name", name);
-        config.put("format", "json");
-        config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        // Create consumer
-        JsonObject response = BridgeUtils.createBridgeConsumer(config, bridgeHost, bridgePort, groupId, client);
-        assertThat("Consumer wasn't created correctly", response.getString("instance_id"), is(name));
-        // Create topics json
-        JsonArray topic = new JsonArray();
-        topic.add(topicName);
-        JsonObject topics = new JsonObject();
-        topics.put("topics", topic);
-        // Subscribe
-        assertThat(BridgeUtils.subscribeHttpConsumer(topics, bridgeHost, bridgePort, groupId, name, client), is(true));
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-                .withUsingPodName(clientsPodName)
-                .withTopicName(topicName)
-                .withNamespaceName(namespace)
-                .withClusterName(clusterName)
-                .withMessageCount(MESSAGE_COUNT)
-                .build();
-
-        // Send messages to Kafka
-        assertThat(internalKafkaClient.sendMessagesPlain(), is(MESSAGE_COUNT));
-
-        // Try to consume messages
-        JsonArray bridgeResponse = BridgeUtils.receiveMessagesHttpRequest(bridgeHost, bridgePort, groupId, name, client);
-        if (bridgeResponse.size() == 0) {
-            // Real consuming
-            bridgeResponse = BridgeUtils.receiveMessagesHttpRequest(bridgeHost, bridgePort, groupId, name, client);
-        }
-        assertThat("Sent message count is not equal with received message count", bridgeResponse.size(), is(MESSAGE_COUNT));
-        // Delete consumer
-        assertThat(deleteConsumer(bridgeHost, bridgePort, groupId, name), is(true));
-    }
-
-    protected void doSimpleSendMessages(String clusterName, String bridgeHost, int bridgePort,
-                                        String namespace, String clientsPodName) throws InterruptedException, ExecutionException, TimeoutException {
-        String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
-        // Create topic
-        KafkaTopicResource.topic(clusterName, topicName).done();
-
-        JsonObject records = BridgeUtils.generateHttpMessages(MESSAGE_COUNT);
-        JsonObject response = BridgeUtils.sendMessagesHttpRequest(records, bridgeHost, bridgePort, topicName, client);
-        KafkaBridgeUtils.checkSendResponse(response, MESSAGE_COUNT);
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-                .withUsingPodName(clientsPodName)
-                .withTopicName(topicName)
-                .withNamespaceName(namespace)
-                .withClusterName(clusterName)
-                .withMessageCount(MESSAGE_COUNT)
-                .build();
-
-        assertThat(internalKafkaClient.receiveMessagesPlain(), is(MESSAGE_COUNT));
     }
 
     public String getBridgeNamespace() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
@@ -773,12 +773,6 @@ class ConnectS2IST extends AbstractST {
         deployKafkaClients();
     }
 
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
-        super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_SHORT);
-        deployKafkaClients();
-    }
-
     private void deployKafkaClients() {
         KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).done();
         kafkaClientsPodName = kubeClient().listPodsByPrefixInName(KAFKA_CLIENTS_NAME).get(0).getMetadata().getName();

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -1008,12 +1008,6 @@ class ConnectST extends AbstractST {
         }
     }
 
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
-        super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_SHORT);
-        deployKafkaClients();
-    }
-
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -19,8 +19,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import java.util.List;
-
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -129,12 +127,6 @@ public class CruiseControlApiST extends AbstractST {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
 
-        deployTestResources();
-    }
-
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
-        super.recreateTestEnv(coNamespace, bindingsNamespaces);
         deployTestResources();
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -33,7 +33,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -232,12 +231,6 @@ public class CruiseControlConfigurationST extends AbstractST {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
 
-        deployTestResources();
-    }
-
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
-        super.recreateTestEnv(coNamespace, bindingsNamespaces);
         deployTestResources();
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
@@ -552,11 +552,6 @@ class LogSettingST extends AbstractST {
     }
 
     @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
-        LOGGER.info("Skip env recreation after failed tests!");
-    }
-
-    @Override
     protected void tearDownEnvironmentAfterAll() {
         teardownEnvForOperator();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.LOGGING_RELOADING_INTERVAL;
@@ -461,11 +460,6 @@ class LoggingChangeST extends AbstractST {
     void setup() throws Exception {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
-    }
-
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
-        LOGGER.info("Skip env recreation after failed tests!");
     }
 
     @Override

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -355,10 +355,6 @@ public class MetricsST extends AbstractST {
         assertThat(values.stream().mapToDouble(i -> i).count(), notNullValue());
     }
 
-    // No need to recreate environment after failed test. Only values from collected metrics are checked
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) { }
-
     @BeforeAll
     void setupEnvironment() throws Exception {
         ResourceManager.setClassResources();

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/PrometheusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/PrometheusST.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.List;
 
 import static io.strimzi.systemtest.Constants.METRICS;
 import static io.strimzi.systemtest.Constants.PROMETHEUS;
@@ -65,10 +64,6 @@ public class PrometheusST extends AbstractST {
         assertThat("alertmanager-alertmanager secret", kubeClient().getSecret("alertmanager-alertmanager") != null);
         assertThat("alertmanager-alertmanager secret does not contain key alertmanager.yaml", kubeClient().getSecret("alertmanager-alertmanager").getData().get("alertmanager.yaml") != null);
     }
-
-    // No need to recreate environment after failed test. Only values from collected metrics are checked
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) { }
 
     @BeforeAll
     void setup() throws IOException {

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAbstractST.java
@@ -27,7 +27,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 
-import java.util.List;
 import java.util.Map;
 
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -102,9 +101,5 @@ public class OlmAbstractST extends AbstractST {
         cmdKubeClient().deleteContent(OlmResource.getExampleResources().get(KafkaTopic.RESOURCE_KIND).toString());
         cmdKubeClient().deleteContent(OlmResource.getExampleResources().get(KafkaUser.RESOURCE_KIND).toString());
         cmdKubeClient().deleteContent(OlmResource.getExampleResources().get(Kafka.RESOURCE_KIND).toString());
-    }
-
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
@@ -27,7 +27,6 @@ import io.strimzi.api.kafka.model.status.ListenerStatus;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
-import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -409,12 +408,6 @@ class CustomResourceStatusST extends AbstractST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-        deployTestSpecificResources();
-    }
-
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
-        super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_SHORT);
         deployTestSpecificResources();
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
@@ -249,9 +249,6 @@ class NamespaceDeletionRecoveryST extends AbstractST {
         cluster.createNamespace(NAMESPACE);
     }
 
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) { }
-
     @BeforeAll
     void createStorageClass() {
         kubeClient().getClient().storage().storageClasses().inNamespace(NAMESPACE).withName(storageClassName).delete();

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
@@ -21,8 +21,6 @@ import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaBridgeResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 
-import java.util.List;
-
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -236,11 +234,5 @@ class RecoveryST extends AbstractST {
     void deployTestSpecificResources() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1).done();
         KafkaBridgeResource.kafkaBridge(CLUSTER_NAME, KafkaResources.plainBootstrapAddress(CLUSTER_NAME), 1).done();
-    }
-
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
-        super.recreateTestEnv(coNamespace, bindingsNamespaces);
-        deployTestSpecificResources();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -314,12 +314,6 @@ public class TopicST extends AbstractST {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1).done();
     }
 
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
-        super.recreateTestEnv(coNamespace, bindingsNamespaces);
-        deployTestSpecificResources();
-    }
-
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicScalabilityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicScalabilityST.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static io.strimzi.systemtest.Constants.SCALABILITY;
 
 @Tag(SCALABILITY)
@@ -54,12 +52,6 @@ public class TopicScalabilityST extends AbstractST {
     void deployTestSpecificResources() {
         LOGGER.info("Deploying shared kafka across all test cases in {} namespace", NAMESPACE);
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1).done();
-    }
-
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
-        super.recreateTestEnv(coNamespace, bindingsNamespaces);
-        deployTestSpecificResources();
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -26,7 +26,6 @@ import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.util.List;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -251,12 +250,6 @@ class UserST extends AbstractST {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
 
-        deployTestSpecificResources();
-    }
-
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
-        super.recreateTestEnv(coNamespace, bindingsNamespaces);
         deployTestSpecificResources();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
@@ -215,11 +214,6 @@ class AlternativeReconcileTriggersST extends AbstractST {
 
         int sentAfter = internalKafkaClient.sendMessagesTls();
         assertThat(sentAfter, is(MESSAGE_COUNT));
-    }
-
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
-        super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -118,11 +118,6 @@ class KafkaRollerST extends AbstractST {
         assertThat(StatefulSetUtils.ssSnapshot(kafkaName), is(not(kafkaPods)));
     }
 
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
-        super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
-    }
-
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -720,11 +720,6 @@ class RollingUpdateST extends AbstractST {
         zkMetricsOutput.values().forEach(value -> assertThat(value, is("")));
     }
 
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
-        super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_SHORT);
-    }
-
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/OpaIntegrationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/OpaIntegrationST.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.List;
 
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -134,12 +133,6 @@ public class OpaIntegrationST extends AbstractST {
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
         KafkaClientsResource.deployKafkaClients(true, kafkaClientsDeploymentName, false, goodUser, badUser, superuser).done();
         clientsPodName = kubeClient().listPodsByPrefixInName(kafkaClientsDeploymentName).get(0).getMetadata().getName();
-    }
-
-    // We don't need to recreate environment, because same resources are used accross whole class
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
-        LOGGER.info("Skip env recreation after failed tests!");
     }
 
     @AfterAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -28,7 +28,6 @@ import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.List;
 
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.OAUTH;
@@ -176,14 +175,6 @@ public class OauthAbstractST extends AbstractST {
         SecretUtils.createSecret(MIRROR_MAKER_OAUTH_SECRET, OAUTH_KEY, "a2Fma2EtbWlycm9yLW1ha2VyLXNlY3JldA==");
         SecretUtils.createSecret(MIRROR_MAKER_2_OAUTH_SECRET, OAUTH_KEY, "a2Fma2EtbWlycm9yLW1ha2VyLTItc2VjcmV0");
         SecretUtils.createSecret(BRIDGE_OAUTH_SECRET, OAUTH_KEY, "a2Fma2EtYnJpZGdlLXNlY3JldA==");
-    }
-
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) throws Exception {
-        super.recreateTestEnv(coNamespace, bindingsNamespaces);
-
-        createSecretsForDeployments();
-        deployTestSpecificResources();
     }
 }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/HelmChartST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/HelmChartST.java
@@ -16,8 +16,6 @@ import org.junit.jupiter.api.Test;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 
-import java.util.List;
-
 import static io.strimzi.systemtest.Constants.HELM;
 
 @Tag(HELM)
@@ -46,12 +44,5 @@ class HelmChartST extends AbstractST {
     @Override
     protected void tearDownEnvironmentAfterAll() {
         cluster.deleteNamespaces();
-    }
-
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
-        HelmResource.clusterOperator();
-        cluster.deleteNamespaces();
-        cluster.createNamespace(NAMESPACE);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/OpenShiftTemplatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/OpenShiftTemplatesST.java
@@ -24,8 +24,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.TestUtils.map;
@@ -209,10 +207,5 @@ public class OpenShiftTemplatesST extends AbstractST {
     protected void tearDownEnvironmentAfterAll() {
         cluster.deleteCustomResources();
         cluster.deleteNamespaces();
-    }
-
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
-        LOGGER.info("Skipping env recreation after each test - resources should be same for whole test class!");
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -528,10 +528,4 @@ public class StrimziUpgradeST extends AbstractST {
     @Override
     protected void tearDownEnvironmentAfterAll() {
     }
-
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
-        cluster.deleteNamespaces();
-        cluster.createNamespace(NAMESPACE);
-    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
@@ -231,12 +231,4 @@ class AllNamespaceST extends AbstractNamespaceST {
     void setupEnvironment() {
         deployTestSpecificResources();
     }
-
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
-        teardownEnvForOperator();
-        ResourceManager.setClassResources();
-        deployTestSpecificResources();
-        ResourceManager.setMethodResources();
-    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
@@ -87,9 +87,4 @@ class MultipleNamespaceST extends AbstractNamespaceST {
 
         cluster.setNamespace(CO_NAMESPACE);
     }
-
-    @Override
-    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
-        deployTestSpecificResources();
-    }
 }


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Refactoring

### Description

Strimzi should be fault-tolerant system, so in case of test failure, Strimzi should deal with it and should be operational for the following tests/operations. Based on that, we don't need to recreate test environment when some test fail.

### Checklist

- [x] Make sure all tests pass

