### PR TITLE
Updated Grafana version

### DIFF
--- a/examples/metrics/grafana-install/grafana.yaml
+++ b/examples/metrics/grafana-install/grafana.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: grafana/grafana:6.2.5
+        image: grafana/grafana:6.3.0
         ports:
         - name: grafana
           containerPort: 3000


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Enhancement / new feature

### Description

This PR upgrades the Grafana version to 6.3.0. It's not the last release of course but it seems to be the minimum version that supports authenticate to a Prometheus server with OAuth and providing bearer token.
It's needed when a Prometheus (or Thanos) instance runs with an oauth-proxy sidecar, for example, handling this kind of authentication. It happens in the OpenShift monitoring stack.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

