### PR TITLE
Set the default header.converter in Mirror Maker 2 configuration to ByteArrayConverter

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Configuration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Configuration.java
@@ -23,13 +23,14 @@ public class KafkaMirrorMaker2Configuration extends AbstractConfiguration {
         FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(KafkaMirrorMaker2ClusterSpec.FORBIDDEN_PREFIXES);
         FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(KafkaMirrorMaker2ClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
 
-        DEFAULTS = new HashMap<>(8);
+        DEFAULTS = new HashMap<>(9);
         DEFAULTS.put("group.id", "mirrormaker2-cluster");
         DEFAULTS.put("offset.storage.topic", "mirrormaker2-cluster-offsets");
         DEFAULTS.put("config.storage.topic", "mirrormaker2-cluster-configs");
         DEFAULTS.put("status.storage.topic", "mirrormaker2-cluster-status");
         DEFAULTS.put("key.converter", "org.apache.kafka.connect.converters.ByteArrayConverter");
         DEFAULTS.put("value.converter", "org.apache.kafka.connect.converters.ByteArrayConverter");
+        DEFAULTS.put("header.converter", "org.apache.kafka.connect.converters.ByteArrayConverter");
         DEFAULTS.put("config.providers", "file");
         DEFAULTS.put("config.providers.file.class", "org.apache.kafka.common.config.provider.FileConfigProvider");
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -89,7 +89,8 @@ public class KafkaMirrorMaker2ClusterTest {
             .addPair("offset.storage.topic", "mirrormaker2-cluster-offsets")
             .addPair("config.providers", "file")
             .addPair("value.converter", "org.apache.kafka.connect.converters.ByteArrayConverter")
-            .addPair("key.converter", "org.apache.kafka.connect.converters.ByteArrayConverter");
+            .addPair("key.converter", "org.apache.kafka.connect.converters.ByteArrayConverter")
+            .addPair("header.converter", "org.apache.kafka.connect.converters.ByteArrayConverter");
     private final OrderedProperties expectedConfiguration = new OrderedProperties()
             .addMapPairs(defaultConfiguration.asMap())
             .addPair("foo", "bar");

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -133,7 +133,15 @@ class MirrorMaker2ST extends AbstractST {
             internalKafkaClient.receiveMessagesPlain()
         );
         
-        KafkaMirrorMaker2Resource.kafkaMirrorMaker2(CLUSTER_NAME, kafkaClusterTargetName, kafkaClusterSourceName, 1, false).done();
+        KafkaMirrorMaker2Resource.kafkaMirrorMaker2(CLUSTER_NAME, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
+                .editSpec()
+                    .editFirstMirror()
+                        .editSourceConnector()
+                            .addToConfig("refresh.topics.interval.seconds", "60")
+                        .endSourceConnector()
+                    .endMirror()
+                .endSpec()
+                .done();
         LOGGER.info("Looks like the mirrormaker2 cluster my-cluster deployed OK");
 
         String podName = PodUtils.getPodNameByPrefix(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME));

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -78,6 +78,7 @@ class MirrorMaker2ST extends AbstractST {
         Map<String, Object> expectedConfig = StUtils.loadProperties("group.id=mirrormaker2-cluster\n" +
                 "key.converter=org.apache.kafka.connect.converters.ByteArrayConverter\n" +
                 "value.converter=org.apache.kafka.connect.converters.ByteArrayConverter\n" +
+                "header.converter=org.apache.kafka.connect.converters.ByteArrayConverter\n" +
                 "config.storage.topic=mirrormaker2-cluster-configs\n" +
                 "status.storage.topic=mirrormaker2-cluster-status\n" +
                 "offset.storage.topic=mirrormaker2-cluster-offsets\n" +


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently, when Mirror Maker 2 mirrors messages with headers, it will convert all headers from the original format into Base64 encoding using the default `org.apache.kafka.connect.storage.SimpleHeaderConverter`. This is not intended since it changes the mirrored messages.

This PR sets instead the default `header.converter` to `org.apache.kafka.connect.converters.ByteArrayConverter` which keeps the headers intact. The same converter is already set as default for keys and values.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally