### PR TITLE
Fixed NPEs related to dynamic configuration

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -265,6 +265,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         reconcileState.initialStatus()
                 .compose(state -> state.reconcileCas(this::dateSupplier))
                 .compose(state -> state.clusterOperatorSecret(this::dateSupplier))
+                .compose(state -> state.getKafkaClusterDescription())
                 // Roll everything if a new CA is added to the trust store.
                 .compose(state -> state.rollingUpdateForNewCaKey())
                 .compose(state -> state.getZookeeperDescription())
@@ -290,7 +291,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(state -> state.zkHeadlessServiceEndpointReadiness())
                 .compose(state -> state.zkPersistentClaimDeletion())
 
-                .compose(state -> state.getKafkaClusterDescription())
                 .compose(state -> state.checkKafkaSpec())
                 .compose(state -> state.kafkaModelWarnings())
                 .compose(state -> state.kafkaManualPodCleaning())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
@@ -139,7 +139,7 @@ public class KafkaBrokerConfigurationDiff extends AbstractResourceDiff {
     private static Collection<AlterConfigOp> diff(int brokerId, String desired,
                                                   Config brokerConfigs,
                                                   Map<String, ConfigModel> configModel) {
-        if (brokerConfigs == null) {
+        if (brokerConfigs == null || desired == null) {
             return Collections.emptyList();
         }
         Map<String, String> currentMap;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
@@ -131,7 +131,7 @@ public class KafkaBrokerConfigurationDiff extends AbstractResourceDiff {
     /**
      * Computes diff between two maps. Entries in IGNORABLE_PROPERTIES are skipped
      * @param brokerId id of compared broker
-     * @param desired desired configuration
+     * @param desired desired configuration, may be null if the related ConfigMap does not exist yet or no changes are required
      * @param brokerConfigs current configuration
      * @param configModel default configuration for {@code kafkaVersion} of broker
      * @return KafkaConfiguration containing all entries which were changed from current in desired configuration


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
After the Kafka dynamic broker configuration has been merged, few NPEs emerged.

First of them was related to null string configuration fetched from starting broker.

Second NPE was about wrong composition (we dereferenced `io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator.ReconciliationState#kafkaCluster` in `io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator.ReconciliationState#rollingUpdateForNewCaKey` before it was defined (in `io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator.ReconciliationState#getKafkaClusterDescription`)).

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

