### PR TITLE
[systemtest][subresources] Add deletion of subresource pods to the tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
@@ -286,6 +286,14 @@ class HttpBridgeST extends HttpBridgeAbstractST {
         for (String pod : bridgePods) {
             assertThat(pod.contains(bridgeGenName), is(true));
         }
+
+        LOGGER.info("Deleting created pods, should be recreated back to {}", scaleTo);
+        for (String pod : bridgePods) {
+            kubeClient().deletePod(kubeClient().getPod(pod));
+        }
+        DeploymentUtils.waitForDeploymentAndPodsReady(KafkaBridgeResources.deploymentName(bridgeName), scaleTo);
+        assertThat(kubeClient().listPodNames("type", "kafka-bridge").size(), is(scaleTo));
+        assertThat(kubeClient().listPodNames("type", "kafka-bridge"), is(not(bridgePods)));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
@@ -723,6 +723,14 @@ class ConnectS2IST extends AbstractST {
         for (String pod : connectS2IPods) {
             assertThat(pod.contains(connectS2IGenName), is(true));
         }
+
+        LOGGER.info("Deleting created pods, should be recreated back to {}", scaleTo);
+        for (String pod : connectS2IPods) {
+            kubeClient().deletePod(kubeClient().getPod(pod));
+        }
+        DeploymentConfigUtils.waitForDeploymentConfigAndPodsReady(KafkaConnectS2IResources.deploymentName(CLUSTER_NAME), scaleTo);
+        assertThat(kubeClient().listPodNames("type", "kafka-connect-s2i").size(), is(scaleTo));
+        assertThat(kubeClient().listPodNames("type", "kafka-connect-s2i"), is(not(connectS2IPods)));
     }
 
     private void deployConnectS2IWithMongoDb(String kafkaConnectS2IName, boolean useConnectorOperator) throws IOException {

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -48,6 +48,7 @@ import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
@@ -598,6 +599,14 @@ class MirrorMaker2ST extends AbstractST {
         for (String pod : mm2Pods) {
             assertThat(pod.contains(mm2GenName), is(true));
         }
+
+        LOGGER.info("Deleting created pods, should be recreated back to {}", scaleTo);
+        for (String pod : mm2Pods) {
+            kubeClient().deletePod(kubeClient().getPod(pod));
+        }
+        DeploymentUtils.waitForDeploymentAndPodsReady(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME), scaleTo);
+        assertThat(kubeClient().listPodNames("type", "kafka-mirror-maker-2").size(), is(scaleTo));
+        assertThat(kubeClient().listPodNames("type", "kafka-mirror-maker-2"), is(not(mm2Pods)));
     }
 
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
@@ -662,6 +662,14 @@ public class MirrorMakerST extends AbstractST {
         for (String pod : mmPods) {
             assertThat(pod.contains(mmGenName), is(true));
         }
+
+        LOGGER.info("Deleting created pods, should be recreated back to {}", scaleTo);
+        for (String pod : mmPods) {
+            kubeClient().deletePod(kubeClient().getPod(pod));
+        }
+        DeploymentUtils.waitForDeploymentAndPodsReady(KafkaMirrorMakerResources.deploymentName(CLUSTER_NAME), scaleTo);
+        assertThat(kubeClient().listPodNames("type", "kafka-mirror-maker").size(), is(scaleTo));
+        assertThat(kubeClient().listPodNames("type", "kafka-mirror-maker"), is(not(mmPods)));
     }
     
     @BeforeAll


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

In this PR I'm gonna add deletion of sub-resources to the tests -> the idea is that if we delete the created sub-resources (pods), it should be recreated with different names, but to the original value. For KafkaConnector there is a difference -> the `taskMax` will stay on it's value, the value that we want to set will be ignored.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
