### PR TITLE
Deprecate the Helm v2 chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@
 
 ### Deprecations and removals
 
+#### Deprecation of Helm v2 chart
+
+The Helm v2 support will end soon. 
+Bug fixing should stop on August 13th 2020 and security fixes on November 13th.
+See https://helm.sh/blog/covid-19-extending-helm-v2-bug-fixes/ for more details.
+
+In sync with that, the Helm v2 chart of Strimzi Cluster Operator is now deprecated and will be removed in the future as Helm v2 support ends.
+Since Strimzi 0.19.0, we have a new chart for Helm v3 which can be used instead.
+
 #### Removal of v1alpha1 versions of several custom resources
 
 In Strimzi 0.12.0, the `v1alpha1` versions of the following resources have been deprecated and replaced by `v1beta1`:

--- a/helm-charts/helm2/strimzi-kafka-operator/README.md
+++ b/helm-charts/helm2/strimzi-kafka-operator/README.md
@@ -1,5 +1,7 @@
 # Strimzi: Kafka as a Service
 
+_**Warning:** This chart is now deprecated. Use the Helm v3 chart instead._
+
 Strimzi provides a way to run an [Apache Kafka®](https://kafka.apache.org) cluster on 
 [Kubernetes](https://kubernetes.io/) or [OpenShift](https://www.openshift.com/) in various deployment configurations.
 See our [website](https://strimzi.io) for more details about the project.

--- a/helm-charts/helm2/strimzi-kafka-operator/README.md
+++ b/helm-charts/helm2/strimzi-kafka-operator/README.md
@@ -1,6 +1,6 @@
 # Strimzi: Kafka as a Service
 
-_**Warning:** This chart is now deprecated. Use the Helm v3 chart instead._
+_**Warning:** This chart is now deprecated and will be removed in the future as Helm v2 support ends. Use the Helm v3 chart instead._
 
 Strimzi provides a way to run an [Apache Kafka®](https://kafka.apache.org) cluster on 
 [Kubernetes](https://kubernetes.io/) or [OpenShift](https://www.openshift.com/) in various deployment configurations.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Following the discussions on the Strimzi community meetings and the Twitter poll, we should deprecate the Helm v2 chart before we remove it in the future as Helm v2 stops being supported. This PR adds this information to the CHANGELOG.md and to the Helm v2 Chart README.md.