### PR TITLE
[systemtest][enhancement] Variable timeout part 3 - resource deletion

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -104,6 +104,7 @@ public interface Constants {
     String KAFKA_EXPORTER_DEPLOYMENT = "KafkaWithExporter";
     String KAFKA_CRUISE_CONTROL_DEPLOYMENT = "KafkaWithCruiseControl";
     String STATEFUL_SET = "StatefulSet";
+    String POD = "Pod";
 
     /**
      * Kafka Bridge JSON encoding with JSON embedded format

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -14,8 +14,6 @@ public interface Constants {
     long TIMEOUT_FOR_RESOURCE_CREATION = Duration.ofMinutes(5).toMillis();
     long TIMEOUT_FOR_SECRET_CREATION = Duration.ofMinutes(2).toMillis();
     long TIMEOUT_FOR_RESOURCE_READINESS = Duration.ofMinutes(14).toMillis();
-    long TIMEOUT_FOR_RESOURCE_DELETION = Duration.ofMinutes(1).toMillis();
-    long TIMEOUT_FOR_POD_DELETION = Duration.ofMinutes(5).toMillis();
     long TIMEOUT_FOR_CR_CREATION = Duration.ofMinutes(3).toMillis();
     long TIMEOUT_FOR_MIRROR_MAKER_COPY_MESSAGES_BETWEEN_BROKERS = Duration.ofMinutes(7).toMillis();
     long TIMEOUT_FOR_MIRROR_JOIN_TO_GROUP = Duration.ofMinutes(2).toMillis();

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
@@ -64,10 +64,18 @@ public class ResourceOperation {
     }
 
     /**
-     * timeoutForPodsOperation returns a reasonable timeout in milliseconds for a number of pods in a quorum to roll on update,
+     * getTimeoutForPodsOperation returns a reasonable timeout in milliseconds for a number of pods in a quorum to roll on update,
      *  scale up or create
      */
-    public static long timeoutForPodsOperation(int numberOfPods) {
+    public static long getTimeoutForPodsOperation(int numberOfPods) {
         return Duration.ofMinutes(5).toMillis() * Math.max(1, numberOfPods);
+    }
+
+    public static long getTimeoutForResourceDeletion(boolean hasPods) {
+        if (hasPods) {
+            return Duration.ofMinutes(5).toMillis();
+        } else {
+            return Duration.ofMinutes(2).toMillis();
+        }
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
@@ -71,11 +71,28 @@ public class ResourceOperation {
         return Duration.ofMinutes(5).toMillis() * Math.max(1, numberOfPods);
     }
 
-    public static long getTimeoutForResourceDeletion(boolean hasPods) {
-        if (hasPods) {
-            return Duration.ofMinutes(5).toMillis();
-        } else {
-            return Duration.ofMinutes(2).toMillis();
+    public static long getTimeoutForResourceDeletion() {
+        return getTimeoutForResourceDeletion("default");
+    }
+
+    public static long getTimeoutForResourceDeletion(String kind) {
+        long timeout;
+
+        switch (kind) {
+            case Kafka.RESOURCE_KIND:
+            case KafkaConnect.RESOURCE_KIND:
+            case KafkaConnectS2I.RESOURCE_KIND:
+            case KafkaMirrorMaker2.RESOURCE_KIND:
+            case KafkaMirrorMaker.RESOURCE_KIND:
+            case KafkaBridge.RESOURCE_KIND:
+            case Constants.STATEFUL_SET:
+            case Constants.POD:
+                timeout = Duration.ofMinutes(5).toMillis();
+                break;
+            default:
+                timeout = Duration.ofMinutes(2).toMillis();
         }
+
+        return timeout;
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
@@ -64,10 +64,10 @@ public class ResourceOperation {
     }
 
     /**
-     * getTimeoutForPodsOperation returns a reasonable timeout in milliseconds for a number of pods in a quorum to roll on update,
+     * timeoutForPodsOperation returns a reasonable timeout in milliseconds for a number of pods in a quorum to roll on update,
      *  scale up or create
      */
-    public static long getTimeoutForPodsOperation(int numberOfPods) {
+    public static long timeoutForPodsOperation(int numberOfPods) {
         return Duration.ofMinutes(5).toMillis() * Math.max(1, numberOfPods);
     }
 
@@ -90,7 +90,7 @@ public class ResourceOperation {
                 timeout = Duration.ofMinutes(5).toMillis();
                 break;
             default:
-                timeout = Duration.ofMinutes(2).toMillis();
+                timeout = Duration.ofMinutes(3).toMillis();
         }
 
         return timeout;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -23,6 +23,7 @@ public class KafkaTopicUtils {
     private static final Logger LOGGER = LogManager.getLogger(KafkaTopicUtils.class);
     private static final String TOPIC_NAME_PREFIX = "my-topic-";
     private static final long READINESS_TIMEOUT = ResourceOperation.getTimeoutForResourceReadiness(KafkaTopic.RESOURCE_KIND);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
 
     private KafkaTopicUtils() {}
 
@@ -77,7 +78,7 @@ public class KafkaTopicUtils {
 
     public static void waitForKafkaTopicDeletion(String topicName) {
         LOGGER.info("Waiting for KafkaTopic {} deletion", topicName);
-        TestUtils.waitFor("KafkaTopic deletion " + topicName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+        TestUtils.waitFor("KafkaTopic deletion " + topicName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, DELETION_TIMEOUT,
             () -> KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(topicName).get() == null,
             () -> LOGGER.info(KafkaTopicResource.kafkaTopicClient().inNamespace(kubeClient().getNamespace()).withName(topicName).get())
         );

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -23,7 +23,7 @@ public class KafkaTopicUtils {
     private static final Logger LOGGER = LogManager.getLogger(KafkaTopicUtils.class);
     private static final String TOPIC_NAME_PREFIX = "my-topic-";
     private static final long READINESS_TIMEOUT = ResourceOperation.getTimeoutForResourceReadiness(KafkaTopic.RESOURCE_KIND);
-    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion();
 
     private KafkaTopicUtils() {}
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
@@ -22,7 +22,7 @@ public class KafkaUserUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(KafkaUserUtils.class);
     private static final String KAFKA_USER_NAME_PREFIX = "my-user-";
-    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion();
 
     private KafkaUserUtils() {}
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.utils.kafkaUtils;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.test.TestUtils;
@@ -21,6 +22,7 @@ public class KafkaUserUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(KafkaUserUtils.class);
     private static final String KAFKA_USER_NAME_PREFIX = "my-user-";
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
 
     private KafkaUserUtils() {}
 
@@ -45,7 +47,7 @@ public class KafkaUserUtils {
 
     public static void waitForKafkaUserDeletion(String userName) {
         LOGGER.info("Waiting for KafkaUser deletion {}", userName);
-        TestUtils.waitFor("KafkaUser deletion " + userName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+        TestUtils.waitFor("KafkaUser deletion " + userName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, DELETION_TIMEOUT,
             () -> KafkaUserResource.kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName).get() == null,
             () -> LOGGER.info(KafkaUserResource.kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName).get())
         );

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/ConfigMapUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/ConfigMapUtils.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -22,6 +23,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 public class ConfigMapUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(ConfigMapUtils.class);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
 
     private ConfigMapUtils() { }
 
@@ -55,7 +57,7 @@ public class ConfigMapUtils {
         for (final String labelKey : labelKeys) {
             LOGGER.info("Waiting for ConfigMap {} label {} change to {}", configMapName, labelKey, null);
             TestUtils.waitFor("Kafka configMap label" + labelKey + " change to " + null, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,
-                Constants.TIMEOUT_FOR_RESOURCE_READINESS, () ->
+                DELETION_TIMEOUT, () ->
                     kubeClient().getConfigMap(configMapName).getMetadata().getLabels().get(labelKey) == null
             );
             LOGGER.info("ConfigMap {} label {} change to {}", configMapName, labelKey, null);
@@ -64,7 +66,7 @@ public class ConfigMapUtils {
 
     public static void waitUntilConfigMapDeletion(String clusterName) {
         LOGGER.info("Waiting for all ConfigMaps of cluster {} deletion", clusterName);
-        TestUtils.waitFor("ConfigMaps will be deleted {}", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT,
+        TestUtils.waitFor("ConfigMaps will be deleted {}", Constants.GLOBAL_POLL_INTERVAL, DELETION_TIMEOUT,
             () -> {
                 List<ConfigMap> cmList = kubeClient().listConfigMaps().stream().filter(cm -> cm.getMetadata().getName().contains(clusterName)).collect(Collectors.toList());
                 if (cmList.isEmpty()) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/ConfigMapUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/ConfigMapUtils.java
@@ -23,7 +23,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 public class ConfigMapUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(ConfigMapUtils.class);
-    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion();
 
     private ConfigMapUtils() { }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentConfigUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentConfigUtils.java
@@ -23,6 +23,7 @@ public class DeploymentConfigUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(DeploymentConfigUtils.class);
     private static final long READINESS_TIMEOUT = ResourceOperation.getTimeoutForResourceReadiness(Constants.DEPLOYMENT_CONFIG);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
 
     /**
      * Returns a map of pod name to resource version for the pods currently in the given DeploymentConfig.
@@ -65,7 +66,7 @@ public class DeploymentConfigUtils {
     public static Map<String, String> waitTillDepConfigHasRolled(String depConfigName, Map<String, String> snapshot) {
         LOGGER.info("Waiting for DeploymentConfig {} rolling update", depConfigName);
         TestUtils.waitFor("DeploymentConfig roll of " + depConfigName,
-            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.timeoutForPodsOperation(snapshot.size()), () -> depConfigHasRolled(depConfigName, snapshot));
+            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.getTimeoutForPodsOperation(snapshot.size()), () -> depConfigHasRolled(depConfigName, snapshot));
         waitForDeploymentConfigReady(depConfigName);
         LOGGER.info("DeploymentConfig {} rolling update finished", depConfigName);
         return depConfigSnapshot(depConfigName);
@@ -77,7 +78,7 @@ public class DeploymentConfigUtils {
      */
     public static void waitForDeploymentConfigDeletion(String name) {
         LOGGER.debug("Waiting for DeploymentConfig {} deletion", name);
-        TestUtils.waitFor("DeploymentConfig " + name + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.TIMEOUT_FOR_RESOURCE_DELETION,
+        TestUtils.waitFor("DeploymentConfig " + name + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, DELETION_TIMEOUT,
             () -> {
                 if (kubeClient().getDeploymentConfig(name) == null) {
                     return true;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentConfigUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentConfigUtils.java
@@ -66,7 +66,7 @@ public class DeploymentConfigUtils {
     public static Map<String, String> waitTillDepConfigHasRolled(String depConfigName, Map<String, String> snapshot) {
         LOGGER.info("Waiting for DeploymentConfig {} rolling update", depConfigName);
         TestUtils.waitFor("DeploymentConfig roll of " + depConfigName,
-            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.getTimeoutForPodsOperation(snapshot.size()), () -> depConfigHasRolled(depConfigName, snapshot));
+            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.timeoutForPodsOperation(snapshot.size()), () -> depConfigHasRolled(depConfigName, snapshot));
         waitForDeploymentConfigReady(depConfigName);
         LOGGER.info("DeploymentConfig {} rolling update finished", depConfigName);
         return depConfigSnapshot(depConfigName);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentConfigUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentConfigUtils.java
@@ -23,7 +23,7 @@ public class DeploymentConfigUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(DeploymentConfigUtils.class);
     private static final long READINESS_TIMEOUT = ResourceOperation.getTimeoutForResourceReadiness(Constants.DEPLOYMENT_CONFIG);
-    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion();
 
     /**
      * Returns a map of pod name to resource version for the pods currently in the given DeploymentConfig.

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
@@ -129,7 +129,7 @@ public class DeploymentUtils {
     public static Map<String, String> waitTillDepHasRolled(String name, int expectedPods, Map<String, String> snapshot) {
         LOGGER.info("Waiting for Deployment {} rolling update", name);
         TestUtils.waitFor("Deployment " + name + " rolling update",
-            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.getTimeoutForPodsOperation(expectedPods), () -> depHasRolled(name, snapshot));
+            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.timeoutForPodsOperation(expectedPods), () -> depHasRolled(name, snapshot));
         waitForDeploymentReady(name);
         PodUtils.waitForPodsReady(kubeClient().getDeployment(name).getSpec().getSelector(), expectedPods, true);
         LOGGER.info("Deployment {} rolling update finished", name);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
@@ -29,6 +29,7 @@ public class DeploymentUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(DeploymentUtils.class);
     private static final long READINESS_TIMEOUT = ResourceOperation.getTimeoutForResourceReadiness(Constants.DEPLOYMENT);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
 
     private DeploymentUtils() { }
 
@@ -128,7 +129,7 @@ public class DeploymentUtils {
     public static Map<String, String> waitTillDepHasRolled(String name, int expectedPods, Map<String, String> snapshot) {
         LOGGER.info("Waiting for Deployment {} rolling update", name);
         TestUtils.waitFor("Deployment " + name + " rolling update",
-            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.timeoutForPodsOperation(expectedPods), () -> depHasRolled(name, snapshot));
+            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.getTimeoutForPodsOperation(expectedPods), () -> depHasRolled(name, snapshot));
         waitForDeploymentReady(name);
         PodUtils.waitForPodsReady(kubeClient().getDeployment(name).getSpec().getSelector(), expectedPods, true);
         LOGGER.info("Deployment {} rolling update finished", name);
@@ -177,7 +178,7 @@ public class DeploymentUtils {
      */
     public static void waitForDeploymentDeletion(String name) {
         LOGGER.debug("Waiting for Deployment {} deletion", name);
-        TestUtils.waitFor("Deployment " + name + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.TIMEOUT_FOR_RESOURCE_DELETION,
+        TestUtils.waitFor("Deployment " + name + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, DELETION_TIMEOUT,
             () -> {
                 if (kubeClient().getDeployment(name) == null) {
                     return true;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
@@ -29,7 +29,7 @@ public class DeploymentUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(DeploymentUtils.class);
     private static final long READINESS_TIMEOUT = ResourceOperation.getTimeoutForResourceReadiness(Constants.DEPLOYMENT);
-    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion();
 
     private DeploymentUtils() { }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/ReplicaSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/ReplicaSetUtils.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.utils.kubeUtils.controllers;
 
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -15,6 +16,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 public class ReplicaSetUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(ReplicaSetUtils.class);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
 
     private ReplicaSetUtils() { }
 
@@ -24,7 +26,7 @@ public class ReplicaSetUtils {
      */
     public static void waitForReplicaSetDeletion(String name) {
         LOGGER.debug("Waiting for ReplicaSet of Deployment {} deletion", name);
-        TestUtils.waitFor("ReplicaSet " + name + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.TIMEOUT_FOR_RESOURCE_DELETION,
+        TestUtils.waitFor("ReplicaSet " + name + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, DELETION_TIMEOUT,
             () -> {
                 if (!kubeClient().replicaSetExists(name)) {
                     return true;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/ReplicaSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/ReplicaSetUtils.java
@@ -16,7 +16,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 public class ReplicaSetUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(ReplicaSetUtils.class);
-    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion();
 
     private ReplicaSetUtils() { }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
@@ -103,7 +103,7 @@ public class StatefulSetUtils {
     public static Map<String, String> waitTillSsHasRolled(String name, Map<String, String> snapshot) {
         LOGGER.info("Waiting for StatefulSet {} rolling update", name);
         TestUtils.waitFor("StatefulSet " + name + " rolling update",
-            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.getTimeoutForPodsOperation(snapshot.size()), () -> {
+            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.timeoutForPodsOperation(snapshot.size()), () -> {
                 try {
                     return ssHasRolled(name, snapshot);
                 } catch (Exception e) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
@@ -26,7 +26,7 @@ public class StatefulSetUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(StatefulSetUtils.class);
     private static final long READINESS_TIMEOUT = ResourceOperation.getTimeoutForResourceReadiness(Constants.STATEFUL_SET);
-    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(Constants.STATEFUL_SET);
 
     private StatefulSetUtils() { }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
@@ -26,6 +26,7 @@ public class StatefulSetUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(StatefulSetUtils.class);
     private static final long READINESS_TIMEOUT = ResourceOperation.getTimeoutForResourceReadiness(Constants.STATEFUL_SET);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
 
     private StatefulSetUtils() { }
 
@@ -102,7 +103,7 @@ public class StatefulSetUtils {
     public static Map<String, String> waitTillSsHasRolled(String name, Map<String, String> snapshot) {
         LOGGER.info("Waiting for StatefulSet {} rolling update", name);
         TestUtils.waitFor("StatefulSet " + name + " rolling update",
-            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.timeoutForPodsOperation(snapshot.size()), () -> {
+            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.getTimeoutForPodsOperation(snapshot.size()), () -> {
                 try {
                     return ssHasRolled(name, snapshot);
                 } catch (Exception e) {
@@ -153,7 +154,7 @@ public class StatefulSetUtils {
      */
     public static void waitForStatefulSetDeletion(String name) {
         LOGGER.debug("Waiting for StatefulSet {} deletion", name);
-        TestUtils.waitFor("StatefulSet " + name + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.TIMEOUT_FOR_RESOURCE_DELETION,
+        TestUtils.waitFor("StatefulSet " + name + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, DELETION_TIMEOUT,
             () -> {
                 if (kubeClient().getStatefulSet(name) == null) {
                     return true;
@@ -196,7 +197,7 @@ public class StatefulSetUtils {
         for (final String labelKey : labelKeys) {
             LOGGER.info("Waiting for StatefulSet label {} change to {}", labelKey, null);
             TestUtils.waitFor("Waiting for StatefulSet label" + labelKey + " change to " + null, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,
-                Constants.TIMEOUT_FOR_RESOURCE_READINESS, () ->
+                DELETION_TIMEOUT, () ->
                     kubeClient().getStatefulSet(statefulSetName).getMetadata().getLabels().get(labelKey) == null
             );
             LOGGER.info("StatefulSet label {} change to {}", labelKey, null);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/NamespaceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/NamespaceUtils.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.utils.kubeUtils.objects;
 
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -14,13 +15,14 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 public class NamespaceUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(NamespaceUtils.class);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
 
     private NamespaceUtils() { }
 
     public static void waitForNamespaceDeletion(String name) {
         LOGGER.info("Waiting for Namespace {} deletion", name);
 
-        TestUtils.waitFor("namespace " + name, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+        TestUtils.waitFor("namespace " + name, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, DELETION_TIMEOUT,
             () -> kubeClient().getNamespace(name) == null);
         LOGGER.info("Namespace {} was deleted", name);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/NamespaceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/NamespaceUtils.java
@@ -15,7 +15,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 public class NamespaceUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(NamespaceUtils.class);
-    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion();
 
     private NamespaceUtils() { }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
@@ -24,7 +24,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 public class PersistentVolumeClaimUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(PersistentVolumeClaimUtils.class);
-    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion();
 
     private PersistentVolumeClaimUtils() { }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
@@ -9,6 +9,7 @@ import io.strimzi.api.kafka.model.storage.JbodStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -23,6 +24,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 public class PersistentVolumeClaimUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(PersistentVolumeClaimUtils.class);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
 
     private PersistentVolumeClaimUtils() { }
 
@@ -56,7 +58,7 @@ public class PersistentVolumeClaimUtils {
 
     public static void waitUntilPVCDeletion(String clusterName) {
         LOGGER.info("Wait until PVC deletion for cluster {}", clusterName);
-        TestUtils.waitFor("PVC will be deleted {}", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT,
+        TestUtils.waitFor("PVC will be deleted {}", Constants.GLOBAL_POLL_INTERVAL, DELETION_TIMEOUT,
             () -> {
                 List<PersistentVolumeClaim> pvcList = kubeClient().listPersistentVolumeClaims().stream().filter(pvc -> pvc.getMetadata().getName().contains(clusterName)).collect(Collectors.toList());
                 if (pvcList.isEmpty()) {
@@ -73,7 +75,7 @@ public class PersistentVolumeClaimUtils {
     }
 
     public static void waitForPVCDeletion(int kafkaReplicas, JbodStorage jbodStorage, String clusterName) {
-        TestUtils.waitFor("Wait for PVC deletion", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.TIMEOUT_FOR_RESOURCE_CREATION, () -> {
+        TestUtils.waitFor("Wait for PVC deletion", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, DELETION_TIMEOUT, () -> {
             List<String> pvcs = kubeClient().listPersistentVolumeClaims().stream()
                     .map(pvc -> pvc.getMetadata().getName())
                     .collect(Collectors.toList());

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -26,6 +26,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 public class PodUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(PodUtils.class);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(true);
 
     private PodUtils() { }
 
@@ -63,7 +64,7 @@ public class PodUtils {
         int[] counter = {0};
 
         TestUtils.waitFor("All pods matching " + selector + "to be ready",
-            Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, ResourceOperation.timeoutForPodsOperation(expectPods),
+            Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, ResourceOperation.getTimeoutForPodsOperation(expectPods),
             () -> {
                 List<Pod> pods = kubeClient().listPods(selector);
                 if (pods.isEmpty() && expectPods == 0) {
@@ -132,7 +133,7 @@ public class PodUtils {
     public static void waitForPod(String name) {
         LOGGER.info("Waiting when Pod {} will be ready", name);
 
-        TestUtils.waitFor("pod " + name + " to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, ResourceOperation.timeoutForPodsOperation(1),
+        TestUtils.waitFor("pod " + name + " to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, ResourceOperation.getTimeoutForPodsOperation(1),
             () -> {
                 List<ContainerStatus> statuses =  kubeClient().getPod(name).getStatus().getContainerStatuses();
                 for (ContainerStatus containerStatus : statuses) {
@@ -148,7 +149,7 @@ public class PodUtils {
     public static void deletePodWithWait(String name) {
         LOGGER.info("Waiting when Pod {} will be deleted", name);
 
-        TestUtils.waitFor("Pod " + name + " could not be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.TIMEOUT_FOR_POD_DELETION,
+        TestUtils.waitFor("Pod " + name + " could not be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, DELETION_TIMEOUT,
             () -> {
                 List<Pod> pods = kubeClient().listPodsByPrefixInName(name);
                 if (pods.size() != 0) {
@@ -247,7 +248,7 @@ public class PodUtils {
         for (final String labelKey : labelKeys) {
             LOGGER.info("Waiting for Pod label {} change to {}", labelKey, null);
             TestUtils.waitFor("Pod label" + labelKey + " change to " + null, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,
-                Constants.TIMEOUT_FOR_RESOURCE_READINESS, () ->
+                DELETION_TIMEOUT, () ->
                     kubeClient().getPod(podName).getMetadata().getLabels().get(labelKey) == null
             );
             LOGGER.info("Pod label {} changed to {}", labelKey, null);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -64,7 +64,7 @@ public class PodUtils {
         int[] counter = {0};
 
         TestUtils.waitFor("All pods matching " + selector + "to be ready",
-            Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, ResourceOperation.getTimeoutForPodsOperation(expectPods),
+            Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, ResourceOperation.timeoutForPodsOperation(expectPods),
             () -> {
                 List<Pod> pods = kubeClient().listPods(selector);
                 if (pods.isEmpty() && expectPods == 0) {
@@ -133,7 +133,7 @@ public class PodUtils {
     public static void waitForPod(String name) {
         LOGGER.info("Waiting when Pod {} will be ready", name);
 
-        TestUtils.waitFor("pod " + name + " to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, ResourceOperation.getTimeoutForPodsOperation(1),
+        TestUtils.waitFor("pod " + name + " to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, ResourceOperation.timeoutForPodsOperation(1),
             () -> {
                 List<ContainerStatus> statuses =  kubeClient().getPod(name).getStatus().getContainerStatuses();
                 for (ContainerStatus containerStatus : statuses) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -26,7 +26,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 public class PodUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(PodUtils.class);
-    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(true);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(Constants.POD);
 
     private PodUtils() { }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -30,7 +30,7 @@ public class SecretUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(SecretUtils.class);
     private static final long READINESS_TIMEOUT = ResourceOperation.getTimeoutForResourceReadiness(Constants.SECRET);
-    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion();
 
     private SecretUtils() { }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -30,6 +30,7 @@ public class SecretUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(SecretUtils.class);
     private static final long READINESS_TIMEOUT = ResourceOperation.getTimeoutForResourceReadiness(Constants.SECRET);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
 
     private SecretUtils() { }
 
@@ -94,7 +95,7 @@ public class SecretUtils {
 
     public static void waitForClusterSecretsDeletion(String clusterName) {
         LOGGER.info("Waiting for Secret {} deletion", clusterName);
-        TestUtils.waitFor("Secret " + clusterName + " deletion", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_SECRET_CREATION,
+        TestUtils.waitFor("Secret " + clusterName + " deletion", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, DELETION_TIMEOUT,
             () -> {
                 List<Secret> secretList = kubeClient().listSecrets(Labels.STRIMZI_CLUSTER_LABEL, clusterName);
                 if (secretList.isEmpty()) {
@@ -144,7 +145,7 @@ public class SecretUtils {
         kubeClient().getClient().secrets().inNamespace(namespace).withName(secretName).delete();
 
         LOGGER.info("Waiting for Secret: {} to be deleted", secretName);
-        TestUtils.waitFor(String.format("Deletion of secret: {}", secretName), Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_RESOURCE_DELETION,
+        TestUtils.waitFor(String.format("Deletion of secret: {}", secretName), Constants.GLOBAL_POLL_INTERVAL, DELETION_TIMEOUT,
             () -> kubeClient().getSecret(secretName) == null);
 
         LOGGER.info("Secret: {} successfully deleted", secretName);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/ServiceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/ServiceUtils.java
@@ -21,7 +21,7 @@ public class ServiceUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(ServiceUtils.class);
     private static final long READINESS_TIMEOUT = ResourceOperation.getTimeoutForResourceReadiness(Constants.SERVICE);
-    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion();
 
     private ServiceUtils() { }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/ServiceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/ServiceUtils.java
@@ -21,6 +21,7 @@ public class ServiceUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(ServiceUtils.class);
     private static final long READINESS_TIMEOUT = ResourceOperation.getTimeoutForResourceReadiness(Constants.SERVICE);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(false);
 
     private ServiceUtils() { }
 
@@ -43,7 +44,7 @@ public class ServiceUtils {
         for (final String labelKey : labelKeys) {
             LOGGER.info("Service label {} change to {}", labelKey, null);
             TestUtils.waitFor("Service label" + labelKey + " change to " + null, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,
-                Constants.TIMEOUT_FOR_RESOURCE_READINESS, () ->
+                DELETION_TIMEOUT, () ->
                     kubeClient().getService(serviceName).getMetadata().getLabels().get(labelKey) == null
             );
         }
@@ -74,7 +75,7 @@ public class ServiceUtils {
     public static void waitForServiceDeletion(String serviceName) {
         LOGGER.info("Waiting for Service {} deletion in namespace {}", serviceName, kubeClient().getNamespace());
 
-        TestUtils.waitFor("Service " + serviceName + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+        TestUtils.waitFor("Service " + serviceName + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, DELETION_TIMEOUT,
             () -> kubeClient().getService(serviceName) == null);
         LOGGER.info("Service {} in namespace {} was deleted", serviceName, kubeClient().getNamespace());
     }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement / new feature

### Description

In this PR I'm gonna add method for resource deletion, as the last part of variable timeouts for resource operations. I changed it in utils classes and removed constants that we had for deletion.

Also changed the method `timeoutForPodOperation` to `getTimeoutForPodsOperation` -> to match the pattern.

### Checklist

- [ ] Make sure all tests pass

