### PR TITLE
[DOC] Updates to external listener config procedures

### DIFF
--- a/documentation/modules/proc-accessing-kafka-using-ingress.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-ingress.adoc
@@ -64,6 +64,8 @@ These services are used by the Ingress controller to route traffic to the Kafka 
 An `Ingress` resource is also created for each service to expose them using the Ingress controller.
 The Ingress hosts are propagated to the `status` of each service.
 +
+The cluster CA certificate to verify the identity of the kafka brokers is also created with the same name as the `Kafka` resource.
++
 Use the address for the bootstrap host you specified in the `configuration` and port 443 (_BOOTSTRAP-HOST:443_) in your Kafka client as the _bootstrap address_ to connect to the Kafka cluster.
 
 . Extract the public certificate of the broker certificate authority.

--- a/documentation/modules/proc-accessing-kafka-using-ingress.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-ingress.adoc
@@ -20,7 +20,7 @@ Ingress is used for HTTP access, so the port used to connect is always 443.
 
 .Procedure
 
-. Configure a `Kafka` resource with an external listener enabled and configured to the type `ingress`.
+. Configure a `Kafka` resource with an external listener set to the `ingress` type.
 +
 Specify the Ingress hosts for the bootstrap service and kafka brokers.
 +

--- a/documentation/modules/proc-accessing-kafka-using-ingress.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-ingress.adoc
@@ -5,12 +5,12 @@
 [id='proc-accessing-kafka-using-ingress-{context}']
 = Accessing Kafka using ingress
 
-This procedure shows how to access a Strimzi Kafka cluster from an external client outside of Kubernetes using Ingress.
+This procedure shows how to access a Strimzi Kafka cluster from an external client outside of Kubernetes using Nginx Ingress.
 
 To connect to a broker, you need a hostname (advertised address) for the Ingress _bootstrap address_,
 as well as the certificate used for authentication.
 
-Ingress is used for HTTP access, so the port used to connect is always 443.
+For access using Ingress, the port is always 443.
 
 .Prerequisites
 
@@ -22,7 +22,7 @@ Ingress is used for HTTP access, so the port used to connect is always 443.
 
 . Configure a `Kafka` resource with an external listener set to the `ingress` type.
 +
-Specify the Ingress hosts for the bootstrap service and kafka brokers.
+Specify the Ingress hosts for the bootstrap service and Kafka brokers.
 +
 For example:
 +
@@ -52,21 +52,15 @@ spec:
   zookeeper:
     # ...
 ----
-<1> Ingress hosts for the bootstrap service and kafka brokers.
-
-. Make sure the hosts in the `configuration` resolve to the Ingress endpoints.
-+
-[source,shell,subs=+quotes]
-kubectl get services
-kubectl describe service _INGRESS-NAME_
+<1> Ingress hosts for the bootstrap service and Kafka brokers.
 
 . Create or update the resource.
 +
 [source,shell,subs=+quotes]
 kubectl apply -f _KAFKA-CONFIG-FILE_
 +
-`ingress` type services are created for each Kafka broker, as well as an external _bootstrap service_.
-The bootstrap service routes external traffic to the Kafka brokers.
+`ClusterIP` type services are created for each Kafka broker, as well as an additional _bootstrap service_.
+These services are used by the Ingress controller to route traffic to the Kafka brokers.
 An `Ingress` resource is also created for each service to expose them using the Ingress controller.
 The Ingress hosts are propagated to the `status` of each service.
 +

--- a/documentation/modules/proc-accessing-kafka-using-ingress.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-ingress.adoc
@@ -5,19 +5,26 @@
 [id='proc-accessing-kafka-using-ingress-{context}']
 = Accessing Kafka using ingress
 
-This procedure shows how to access Strimzi Kafka clusters from outside of Kubernetes using Ingress.
+This procedure shows how to access a Strimzi Kafka cluster from an external client outside of Kubernetes using Ingress.
+
+To connect to a broker, you need a hostname (advertised address) for the Ingress _bootstrap address_,
+as well as the certificate used for authentication.
+
+Ingress is used for HTTP access, so the port used to connect is always 443.
 
 .Prerequisites
 
-* An Kubernetes cluster
+* Kubernetes cluster
 * Deployed {NginxIngressController} with TLS passthrough enabled
 * A running Cluster Operator
 
 .Procedure
 
-. Deploy Kafka cluster with an external listener enabled and configured to the type `ingress`.
+. Configure a `Kafka` resource with an external listener enabled and configured to the type `ingress`.
 +
-An example configuration with an external listener configured to use `Ingress`:
+Specify the Ingress hosts for the bootstrap service and kafka brokers.
++
+For example:
 +
 [source,yaml,subs=attributes+]
 ----
@@ -31,7 +38,7 @@ spec:
         type: ingress
         authentication:
           type: tls
-        configuration:
+        configuration: <1>
           bootstrap:
             host: bootstrap.myingress.com
           brokers:
@@ -45,22 +52,33 @@ spec:
   zookeeper:
     # ...
 ----
+<1> Ingress hosts for the bootstrap service and kafka brokers.
 
-. Make sure the hosts in the `configuration` section properly resolve to the Ingress endpoints.
+. Make sure the hosts in the `configuration` resolve to the Ingress endpoints.
++
+[source,shell,subs=+quotes]
+kubectl get services
+kubectl describe service _INGRESS-NAME_
 
 . Create or update the resource.
 +
 [source,shell,subs=+quotes]
 kubectl apply -f _KAFKA-CONFIG-FILE_
++
+`ingress` type services are created for each Kafka broker, as well as an external _bootstrap service_.
+The bootstrap service routes external traffic to the Kafka brokers.
+An `Ingress` resource is also created for each service to expose them using the Ingress controller.
+The Ingress hosts are propagated to the `status` of each service.
++
+Use the address for the bootstrap host you specified in the `configuration` and port 443 (_BOOTSTRAP-HOST:443_) in your Kafka client as the _bootstrap address_ to connect to the Kafka cluster.
 
-. Extract the public certificate of the broker certificate authority
+. Extract the public certificate of the broker certificate authority.
 +
 [source,shell,subs=+quotes]
 kubectl get secret _KAFKA-CLUSTER-NAME_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
 +
-. Use the extracted certificate in your Kafka client to configure the TLS connection.
+Use the extracted certificate in your Kafka client to configure the TLS connection.
 If you enabled any authentication, you will also need to configure SASL or TLS authentication.
-Connect with your client to the host you specified in the configuration on port 443.
 
 .Additional resources
 * For more information about the schema, see xref:type-KafkaListeners-reference[`KafkaListeners` schema reference].

--- a/documentation/modules/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-loadbalancers.adoc
@@ -5,6 +5,13 @@
 [id='proc-accessing-kafka-using-loadbalancers-{context}']
 = Accessing Kafka using loadbalancers
 
+This procedure describes how to access a Strimzi Kafka cluster from an external client using loadbalancers.
+
+To connect to a broker, you need a hostname (advertised address) for the loadbalancer _bootstrap address_,
+as well as the certificate used for authentication.
+
+The port used to connect is always 9094.
+
 .Prerequisites
 
 * A Kubernetes cluster
@@ -12,9 +19,9 @@
 
 .Procedure
 
-. Deploy Kafka cluster with an external listener enabled and configured to the type `loadbalancer`.
+. Configure a `Kafka` resource with an external listener enabled and configured to the `loadbalancer` type.
 +
-An example configuration with an external listener configured to use loadbalancers:
+For example:
 +
 [source,yaml,subs=attributes+]
 ----
@@ -36,27 +43,28 @@ spec:
 
 . Create or update the resource.
 +
-This can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
 kubectl apply -f _KAFKA-CONFIG-FILE_
-
-. Find the hostname of the bootstrap loadbalancer.
 +
-This can be done using `kubectl get`:
+`loadbalancer` type services and loadbalancers are created for each Kafka broker, as well as an external _bootstrap service_.
+The bootstrap service routes external traffic to the Kafka brokers.
+DNS names and IP addresses used for connection are propagated to the `status` of each service.
+
+. Retrieve the address of the bootstrap service to access the Kafka cluster.
++
 [source,shell,subs=+quotes]
 kubectl get service _KAFKA-CLUSTER-NAME_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}{"\n"}'
 +
-If no hostname was found (nothing was returned by the command), use the loadbalancer IP address.
+You need the address of the loadbalancer bootstrap service (`_KAFKA-CLUSTER-NAME_-kafka-external-bootstrap`).
 +
-This can be done using `kubectl get`:
+If a hostname is not found, use the loadbalancer IP address.
++
 [source,shell,subs=+quotes]
 kubectl get service _KAFKA-CLUSTER-NAME_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].ip}{"\n"}'
 +
-Use the hostname or IP address together with port 9094 in your Kafka client as the _bootstrap_ address.
+Use the loadbalancer service address and port 9094 (_LOADBALANCER-ADDRESS:9094_) in your Kafka client as the _bootstrap address_ to connect to the Kafka cluster.
 
-. Unless TLS encryption was disabled, extract the public certificate of the broker certification authority.
-+
-This can be done using `kubectl get`:
+. If TLS encryption is enabled, extract the public certificate of the broker certification authority.
 +
 [source,shell,subs=+quotes]
 kubectl get secret _KAFKA-CLUSTER-NAME_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt

--- a/documentation/modules/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-loadbalancers.adoc
@@ -7,10 +7,10 @@
 
 This procedure describes how to access a Strimzi Kafka cluster from an external client using loadbalancers.
 
-To connect to a broker, you need a hostname (advertised address) for the loadbalancer _bootstrap address_,
-as well as the certificate used for authentication.
+To connect to a broker, you need the address of the _bootstrap loadbalancer_,
+as well as the certificate used for TLS encryption.
 
-The port used to connect is always 9094.
+For access using loadbalancers, the port is always 9094.
 
 .Prerequisites
 
@@ -47,7 +47,7 @@ spec:
 kubectl apply -f _KAFKA-CONFIG-FILE_
 +
 `loadbalancer` type services and loadbalancers are created for each Kafka broker, as well as an external _bootstrap service_.
-The bootstrap service routes external traffic to the Kafka brokers.
+The bootstrap service routes external traffic to all Kafka brokers.
 DNS names and IP addresses used for connection are propagated to the `status` of each service.
 
 . Retrieve the address of the bootstrap service you can use to access the Kafka cluster.

--- a/documentation/modules/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-loadbalancers.adoc
@@ -50,19 +50,10 @@ kubectl apply -f _KAFKA-CONFIG-FILE_
 The bootstrap service routes external traffic to the Kafka brokers.
 DNS names and IP addresses used for connection are propagated to the `status` of each service.
 
-. Retrieve the address of the bootstrap service to access the Kafka cluster.
+. Retrieve the address of the bootstrap service you can use to access the Kafka cluster.
 +
 [source,shell,subs=+quotes]
-kubectl get service _KAFKA-CLUSTER-NAME_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}{"\n"}'
-+
-You need the address of the loadbalancer bootstrap service (`_KAFKA-CLUSTER-NAME_-kafka-external-bootstrap`).
-+
-If a hostname is not found, use the loadbalancer IP address.
-+
-[source,shell,subs=+quotes]
-kubectl get service _KAFKA-CLUSTER-NAME_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].ip}{"\n"}'
-+
-Use the loadbalancer service address and port 9094 (_LOADBALANCER-ADDRESS:9094_) in your Kafka client as the _bootstrap address_ to connect to the Kafka cluster.
+kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.type=="external")].bootstrapServers}{"\n"}'
 
 . If TLS encryption is enabled, extract the public certificate of the broker certification authority.
 +

--- a/documentation/modules/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-loadbalancers.adoc
@@ -49,8 +49,10 @@ kubectl apply -f _KAFKA-CONFIG-FILE_
 `loadbalancer` type services and loadbalancers are created for each Kafka broker, as well as an external _bootstrap service_.
 The bootstrap service routes external traffic to all Kafka brokers.
 DNS names and IP addresses used for connection are propagated to the `status` of each service.
++
+The cluster CA certificate to verify the identity of the kafka brokers is also created with the same name as the `Kafka` resource.
 
-. Retrieve the address of the bootstrap service you can use to access the Kafka cluster.
+. Retrieve the address of the bootstrap service you can use to access the Kafka cluster from the status of the `Kafka` resource.
 +
 [source,shell,subs=+quotes]
 kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.type=="external")].bootstrapServers}{"\n"}'

--- a/documentation/modules/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-loadbalancers.adoc
@@ -19,7 +19,7 @@ The port used to connect is always 9094.
 
 .Procedure
 
-. Configure a `Kafka` resource with an external listener enabled and configured to the `loadbalancer` type.
+. Configure a `Kafka` resource with an external listener set to the `loadbalancer` type.
 +
 For example:
 +

--- a/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
@@ -7,7 +7,7 @@
 
 This procedure describes how to access a Strimzi Kafka cluster from an external client using node ports.
 
-To connect to a broker, you need a hostname (advertised address) and port number for the Kafka _bootstrap address_,
+To connect to a broker, you need a hostname and port number for the Kafka _bootstrap address_,
 as well as the certificate used for authentication.
 
 .Prerequisites
@@ -47,7 +47,7 @@ kubectl apply -f _KAFKA-CONFIG-FILE_
 +
 `NodePort` type services are created for each Kafka broker, as well as an external _bootstrap service_.
 The bootstrap service routes external traffic to the Kafka brokers.
-Node addresses used for connection are propagated to the `status` of each service.
+Node addresses used for connection are propagated to the `status` of the Kafka custom resource.
 
 . Retrieve the bootstrap address you can use to access the Kafka cluster.
 +

--- a/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
@@ -34,18 +34,11 @@ spec:
         tls: true
         authentication:
           type: tls
-        configuration:
-          brokerCertChainAndKey: <2>
-            secretName: my-secret
-            certificate: my-certificate.crt
-            key: my-key.key
-          preferredAddressType: InternalDNS <3>
+        # ...
     # ...
   zookeeper:
     # ...
 ----
-<2> Optional configuration for a xref:kafka-listener-certificates-str[Kafka listener certificate] managed by an external Certificate Authority. The `brokerCertChainAndKey` property specifies a `Secret` that holds a server certificate and a private key. Kafka listener certificates can also be configured for TLS listeners.
-<3> Optional configuration to xref:con-kafka-broker-external-listeners-nodeports-{context}[specify a preference for the first address type used by Strimzi as the node address].
 
 . Create or update the resource.
 +
@@ -56,27 +49,10 @@ kubectl apply -f _KAFKA-CONFIG-FILE_
 The bootstrap service routes external traffic to the Kafka brokers.
 Node addresses used for connection are propagated to the `status` of each service.
 
-. Retrieve the connection details to access the Kafka cluster.
+. Retrieve the bootstrap address you can use to access the Kafka cluster.
 +
 [source,shell,subs=+quotes]
 kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.type=="external")].bootstrapServers}{"\n"}'
-+
-You need:
-+
-* The port number of the `NodePort` bootstrap service (`_KAFKA-CLUSTER-NAME_-kafka-external-bootstrap`)
-* The address of one of the kafka broker nodes
-+
-If different node addresses are returned, select the address type you want based on the following order:
-+
---
-. ExternalDNS
-. ExternalIP
-. Hostname
-. InternalDNS
-. InternalIP
---
-+
-Use the node address and port number (_NODE-ADDRESS:NODE-PORT_) in your Kafka client as the _bootstrap address_ to connect to the Kafka cluster.
 
 . If TLS encryption is enabled, extract the public certificate of the broker certification authority.
 +

--- a/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
@@ -48,8 +48,10 @@ kubectl apply -f _KAFKA-CONFIG-FILE_
 `NodePort` type services are created for each Kafka broker, as well as an external _bootstrap service_.
 The bootstrap service routes external traffic to the Kafka brokers.
 Node addresses used for connection are propagated to the `status` of the Kafka custom resource.
++
+The cluster CA certificate to verify the identity of the kafka brokers is also created with the same name as the `Kafka` resource.
 
-. Retrieve the bootstrap address you can use to access the Kafka cluster.
+. Retrieve the bootstrap address you can use to access the Kafka cluster from the status of the `Kafka` resource.
 +
 [source,shell,subs=+quotes]
 kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.type=="external")].bootstrapServers}{"\n"}'

--- a/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
@@ -17,7 +17,7 @@ as well as the certificate used for authentication.
 
 .Procedure
 
-. Configure a `Kafka` resource with an external listener enabled and configured to the `nodeport` type.
+. Configure a `Kafka` resource with an external listener set to the `nodeport` type.
 +
 For example:
 +

--- a/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
@@ -7,7 +7,7 @@
 
 This procedure describes how to access a Strimzi Kafka cluster from an external client using node ports.
 
-To connect to a broker, you need the hostname (advertised address) and port number for the Kafka _bootstrap_ address,
+To connect to a broker, you need a hostname (advertised address) and port number for the Kafka _bootstrap address_,
 as well as the certificate used for authentication.
 
 .Prerequisites
@@ -17,7 +17,7 @@ as well as the certificate used for authentication.
 
 .Procedure
 
-. Deploy the Kafka cluster with an external listener enabled and configured to the type `nodeport`.
+. Configure a `Kafka` resource with an external listener enabled and configured to the `nodeport` type.
 +
 For example:
 +
@@ -35,36 +35,38 @@ spec:
         authentication:
           type: tls
         configuration:
-          brokerCertChainAndKey: <1>
+          brokerCertChainAndKey: <2>
             secretName: my-secret
             certificate: my-certificate.crt
             key: my-key.key
-          preferredAddressType: InternalDNS <2>
+          preferredAddressType: InternalDNS <3>
     # ...
   zookeeper:
     # ...
 ----
-<1> Optional configuration for a xref:kafka-listener-certificates-str[Kafka listener certificate] managed by an external Certificate Authority. The `brokerCertChainAndKey` property specifies a `Secret` that holds a server certificate and a private key. Kafka listener certificates can also be configured for TLS listeners.
-<2> Optional configuration to xref:con-kafka-broker-external-listeners-nodeports-{context}[specify a preference for the first address type used by Strimzi as the node address].
+<2> Optional configuration for a xref:kafka-listener-certificates-str[Kafka listener certificate] managed by an external Certificate Authority. The `brokerCertChainAndKey` property specifies a `Secret` that holds a server certificate and a private key. Kafka listener certificates can also be configured for TLS listeners.
+<3> Optional configuration to xref:con-kafka-broker-external-listeners-nodeports-{context}[specify a preference for the first address type used by Strimzi as the node address].
 
 . Create or update the resource.
 +
 [source,shell,subs=+quotes]
 kubectl apply -f _KAFKA-CONFIG-FILE_
++
+`NodePort` type services are created for each Kafka broker, as well as an external _bootstrap service_.
+The bootstrap service routes external traffic to the Kafka brokers.
+Node addresses used for connection are propagated to the `status` of each service.
 
-. Find the port number of the bootstrap service.
+. Retrieve the connection details to access the Kafka cluster.
 +
 [source,shell,subs=+quotes]
-kubectl get service _KAFKA-CLUSTER-NAME_-kafka-external-bootstrap -o=jsonpath='{.spec.ports[0].nodePort}{"\n"}'
+kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.type=="external")].bootstrapServers}{"\n"}'
 +
-The port is used in the Kafka _bootstrap_ address.
-
-. Find the address of the Kubernetes node.
+You need:
 +
-[source,shell,subs=+quotes]
-kubectl get node _KUBERNETES-NODE-NAME_ -o=jsonpath='{range .status.addresses[*]}{.type}{"\t"}{.address}{"\n"}'
+* The port number of the `NodePort` bootstrap service (`_KAFKA-CLUSTER-NAME_-kafka-external-bootstrap`)
+* The address of one of the kafka broker nodes
 +
-If several different addresses are returned, select the address type you want based on the following order:
+If different node addresses are returned, select the address type you want based on the following order:
 +
 --
 . ExternalDNS
@@ -74,9 +76,9 @@ If several different addresses are returned, select the address type you want ba
 . InternalIP
 --
 +
-Use the address with the port found in the previous step in the Kafka _bootstrap_ address.
+Use the node address and port number (_NODE-ADDRESS:NODE-PORT_) in your Kafka client as the _bootstrap address_ to connect to the Kafka cluster.
 
-. Unless TLS encryption was disabled, extract the public certificate of the broker certification authority.
+. If TLS encryption is enabled, extract the public certificate of the broker certification authority.
 +
 [source,shell,subs=+quotes]
 kubectl get secret _KAFKA-CLUSTER-NAME_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt

--- a/documentation/modules/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-routes.adoc
@@ -5,6 +5,13 @@
 [id='proc-accessing-kafka-using-routes-{context}']
 = Accessing Kafka using OpenShift routes
 
+This procedure describes how to access a Strimzi Kafka cluster from an external client outside of OpenShift using routes.
+
+To connect to a broker, you need a hostname (advertised address) for the route _bootstrap address_,
+as well as the certificate used for authentication.
+
+Routes are used for HTTP access, so the port used to connect is always 443.
+
 .Prerequisites
 
 * An OpenShift cluster
@@ -12,9 +19,9 @@
 
 .Procedure
 
-. Deploy a Kafka cluster with an external listener enabled and configured to the type `route`.
+. Configure a `Kafka` resource with an external listener enabled and configured to the `route` type.
 +
-An example configuration with an external listener configured to use `Routes`:
+For example:
 +
 [source,yaml,subs=attributes+]
 ----
@@ -36,13 +43,20 @@ spec:
 +
 [source,shell,subs=+quotes]
 oc apply -f _KAFKA-CONFIG-FILE_
++
+`ClusterIP` type services are created for each Kafka broker, as well as an external _bootstrap service_.
+The bootstrap service routes external traffic to the Kafka brokers.
+An OpenShift `Route` resource is also created for each service to expose them using the HAProxy load balancer.
+DNS addresses used for connection are propagated to the `status` of each service.
 
-. Find the address of the bootstrap `Route`.
+. Retrieve the address of the bootstrap service to access the Kafka cluster.
 +
 [source,shell,subs=+quotes]
 oc get routes _KAFKA-CLUSTER-NAME_-kafka-bootstrap -o=jsonpath='{.status.ingress[0].host}{"\n"}'
 +
-Use the address together with port 443 in your Kafka client as the _bootstrap_ address.
+You need the address of the `Route` bootstrap service (`_KAFKA-CLUSTER-NAME_-kafka-bootstrap`).
++
+Use the route service address and port 443 (_ROUTE-ADDRESS:443_) in your Kafka client as the _bootstrap address_ to connect to the Kafka cluster.
 
 . Extract the public certificate of the broker certification authority
 +

--- a/documentation/modules/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-routes.adoc
@@ -49,14 +49,10 @@ The bootstrap service routes external traffic to the Kafka brokers.
 An OpenShift `Route` resource is also created for each service to expose them using the HAProxy load balancer.
 DNS addresses used for connection are propagated to the `status` of each service.
 
-. Retrieve the address of the bootstrap service to access the Kafka cluster.
+. Retrieve the address of the bootstrap service you can use to access the Kafka cluster.
 +
 [source,shell,subs=+quotes]
-oc get routes _KAFKA-CLUSTER-NAME_-kafka-bootstrap -o=jsonpath='{.status.ingress[0].host}{"\n"}'
-+
-You need the address of the `Route` bootstrap service (`_KAFKA-CLUSTER-NAME_-kafka-bootstrap`).
-+
-Use the route service address and port 443 (_ROUTE-ADDRESS:443_) in your Kafka client as the _bootstrap address_ to connect to the Kafka cluster.
+kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.type=="external")].bootstrapServers}{"\n"}'
 
 . Extract the public certificate of the broker certification authority
 +

--- a/documentation/modules/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-routes.adoc
@@ -48,8 +48,10 @@ oc apply -f _KAFKA-CONFIG-FILE_
 The services route the traffic from the OpenShift Routes to the Kafka brokers.
 An OpenShift `Route` resource is also created for each service to expose them using the HAProxy load balancer.
 DNS addresses used for connection are propagated to the `status` of each service.
++
+The cluster CA certificate to verify the identity of the kafka brokers is also created with the same name as the `Kafka` resource.
 
-. Retrieve the address of the bootstrap service you can use to access the Kafka cluster.
+. Retrieve the address of the bootstrap service you can use to access the Kafka cluster from the status of the `Kafka` resource.
 +
 [source,shell,subs=+quotes]
 kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.type=="external")].bootstrapServers}{"\n"}'

--- a/documentation/modules/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-routes.adoc
@@ -19,7 +19,7 @@ Routes are used for HTTP access, so the port used to connect is always 443.
 
 .Procedure
 
-. Configure a `Kafka` resource with an external listener enabled and configured to the `route` type.
+. Configure a `Kafka` resource with an external listener set to the `route` type.
 +
 For example:
 +

--- a/documentation/modules/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-routes.adoc
@@ -7,10 +7,10 @@
 
 This procedure describes how to access a Strimzi Kafka cluster from an external client outside of OpenShift using routes.
 
-To connect to a broker, you need a hostname (advertised address) for the route _bootstrap address_,
-as well as the certificate used for authentication.
+To connect to a broker, you need a hostname for the route _bootstrap address_,
+as well as the certificate used for TLS encryption.
 
-Routes are used for HTTP access, so the port used to connect is always 443.
+For access using routes, the port is always 443.
 
 .Prerequisites
 
@@ -45,7 +45,7 @@ spec:
 oc apply -f _KAFKA-CONFIG-FILE_
 +
 `ClusterIP` type services are created for each Kafka broker, as well as an external _bootstrap service_.
-The bootstrap service routes external traffic to the Kafka brokers.
+The services route the traffic from the OpenShift Routes to the Kafka brokers.
 An OpenShift `Route` resource is also created for each service to expose them using the HAProxy load balancer.
 DNS addresses used for connection are propagated to the `status` of each service.
 


### PR DESCRIPTION
**Documentation**

Updates to the procedures describing how to connect to the Kafka cluster using an external listener.

- Node port procedure updated to use single step retrieval of addresses used in connection
- More context on what's created when each listener config is applied
- Made the procedures more consistent


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

