### PR TITLE
Fix tracing in Kafka Mirror Maker 2

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -676,4 +676,13 @@ public class KafkaConnectCluster extends AbstractModel {
             return null;
         }
     }
+
+    /**
+     * Returns the Tracing object with tracing configuration or null if tracing was not enabled.
+     *
+     * @return  Tracing object with tracing configuration
+     */
+    public Tracing getTracing() {
+        return tracing;
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -280,6 +280,12 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
         if (mirror.getGroupsBlacklistPattern() != null) {
             config.put("groups.blacklist", mirror.getGroupsBlacklistPattern());
         }
+
+        if (mirrorMaker2Cluster.getTracing() != null)   {
+            config.put("consumer.interceptor.classes", "io.opentracing.contrib.kafka.TracingConsumerInterceptor");
+            config.put("producer.interceptor.classes", "io.opentracing.contrib.kafka.TracingProducerInterceptor");
+        }
+
         config.putAll(mirror.getAdditionalProperties());
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaClientsResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaClientsResource.java
@@ -222,6 +222,10 @@ public class KafkaClientsResource {
     }
 
     public static DoneableDeployment consumerWithTracing(String bootstrapServer) {
+        return consumerWithTracing(bootstrapServer, "my-topic");
+    }
+
+    public static DoneableDeployment consumerWithTracing(String bootstrapServer, String topic) {
         String consumerName = "hello-world-consumer";
 
         Map<String, String> consumerLabels = new HashMap<>();
@@ -253,7 +257,7 @@ public class KafkaClientsResource {
                                       .endEnv()
                                     .addNewEnv()
                                         .withName("TOPIC")
-                                        .withValue("my-topic")
+                                        .withValue(topic)
                                     .endEnv()
                                     .addNewEnv()
                                         .withName("GROUP_ID")

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/TracingUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/TracingUtils.java
@@ -20,29 +20,47 @@ public class TracingUtils {
 
     private static final String JAEGER_QUERY_SERVICE = "my-jaeger-query";
     private static final String JAEGER_QUERY_SERVICE_ENDPOINT = "/jaeger/api/services";
-    private static final String JAEGER_QUERY_SERVICE_TRACES_ENDPOINT = "/jaeger/api/traces?service=";
+    private static final String JAEGER_QUERY_SERVICE_TRACES_ENDPOINT = "/jaeger/api/traces";
+    private static final String JAEGER_QUERY_SERVICE_PARAM_SERVICE = "?service=";
+    private static final String JAEGER_QUERY_SERVICE_PARAM_OPERATION = "&operation=";
     private static final int JAEGER_QUERY_PORT = 16686;
 
     private TracingUtils() {}
 
     public static void verify(String jaegerServiceName, String clientPodName) {
+        verify(jaegerServiceName, clientPodName, null);
+    }
+
+    public static void verify(String jaegerServiceName, String clientPodName, String operation) {
         verifyThatServiceIsPresent(jaegerServiceName, clientPodName);
-        verifyThatServiceTracesArePresent(jaegerServiceName, clientPodName);
+        verifyThatServiceTracesArePresent(jaegerServiceName, clientPodName, operation);
     }
 
     private static void verifyThatServiceIsPresent(String jaegerServiceName, String clientPodName) {
         TestUtils.waitFor("Service" + jaegerServiceName + " is present", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT, () -> {
             JsonObject jaegerServices = new JsonObject(cmdKubeClient().execInPod(clientPodName, "/bin/bash", "-c", "curl " + JAEGER_QUERY_SERVICE + ":" + JAEGER_QUERY_PORT + JAEGER_QUERY_SERVICE_ENDPOINT).out());
 
-            LOGGER.info("Jaeger services {}", jaegerServices.getJsonArray("data").contains(jaegerServiceName));
-            return jaegerServices.getJsonArray("data").contains(jaegerServiceName);
+            if (jaegerServices.getJsonArray("data").contains(jaegerServiceName)) {
+                LOGGER.info("Jaeger service {} is present", jaegerServiceName);
+                return true;
+            } else {
+                LOGGER.info("Jaeger service {} is not present. Present services are {}.", jaegerServiceName, jaegerServices.getJsonArray("data"));
+                return false;
+            }
         });
     }
 
-    private static void verifyThatServiceTracesArePresent(String jaegerServiceName, String clientPodName) {
-        TestUtils.waitFor("Service" + jaegerServiceName + " has some traces", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT, () -> {
+    private static void verifyThatServiceTracesArePresent(String jaegerServiceName, String clientPodName, String operation) {
+        TestUtils.waitFor("Service " + jaegerServiceName + " has some traces", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT, () -> {
+            String query;
+            if (operation == null)  {
+                query = JAEGER_QUERY_SERVICE + ":" + JAEGER_QUERY_PORT + JAEGER_QUERY_SERVICE_TRACES_ENDPOINT + JAEGER_QUERY_SERVICE_PARAM_SERVICE + jaegerServiceName;
+            } else {
+                query = JAEGER_QUERY_SERVICE + ":" + JAEGER_QUERY_PORT + JAEGER_QUERY_SERVICE_TRACES_ENDPOINT + JAEGER_QUERY_SERVICE_PARAM_SERVICE + jaegerServiceName + JAEGER_QUERY_SERVICE_PARAM_OPERATION + operation;
+            }
+
             JsonObject jaegerServicesTraces = new JsonObject(cmdKubeClient().execInPod(clientPodName,
-                "/bin/bash", "-c", "curl " + JAEGER_QUERY_SERVICE + ":" + JAEGER_QUERY_PORT + JAEGER_QUERY_SERVICE_TRACES_ENDPOINT + jaegerServiceName).out());
+                "/bin/bash", "-c", "curl " + query).out());
             JsonArray traces = jaegerServicesTraces.getJsonArray("data");
 
             if (!(jaegerServicesTraces.getJsonArray("data").size() > 0)) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -399,18 +399,12 @@ public class TracingST extends AbstractST {
     @Test
     @Tag(MIRROR_MAKER2)
     void testProducerConsumerMirrorMaker2Service() {
-        Map<String, Object> configOfKafka = new HashMap<>();
-        configOfKafka.put("offsets.topic.replication.factor", "1");
-        configOfKafka.put("transaction.state.log.replication.factor", "1");
-        configOfKafka.put("transaction.state.log.min.isr", "1");
-
         final String kafkaClusterSourceName = CLUSTER_NAME + "-source";
         final String kafkaClusterTargetName = CLUSTER_NAME + "-target";
 
         KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 3, 1)
                 .editSpec()
                     .editKafka()
-                        .withConfig(configOfKafka)
                         .withNewPersistentClaimStorage()
                             .withNewSize("10")
                             .withDeleteClaim(true)
@@ -428,7 +422,6 @@ public class TracingST extends AbstractST {
         KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 3, 1)
                 .editSpec()
                     .editKafka()
-                        .withConfig(configOfKafka)
                         .withNewPersistentClaimStorage()
                             .withNewSize("10")
                             .withDeleteClaim(true)
@@ -498,31 +491,17 @@ public class TracingST extends AbstractST {
         TracingUtils.verify(JAEGER_CONSUMER_SERVICE, kafkaClientsPodName, "From_" + kafkaClusterSourceName + "." + TOPIC_NAME);
         TracingUtils.verify(JAEGER_MIRROR_MAKER2_SERVICE, kafkaClientsPodName, "From_" + TOPIC_NAME);
         TracingUtils.verify(JAEGER_MIRROR_MAKER2_SERVICE, kafkaClientsPodName, "To_" + kafkaClusterSourceName + "." + TOPIC_NAME);
-
-        LOGGER.info("Deleting topic {} from CR", TOPIC_NAME);
-        cmdKubeClient().deleteByName("kafkatopic", TOPIC_NAME);
-        KafkaTopicUtils.waitForKafkaTopicDeletion(TOPIC_NAME);
-
-        LOGGER.info("Deleting topic {} from CR", kafkaClusterSourceName + "." + TOPIC_NAME);
-        cmdKubeClient().deleteByName("kafkatopic", kafkaClusterSourceName + "." + TOPIC_NAME);
-        KafkaTopicUtils.waitForKafkaTopicDeletion(kafkaClusterSourceName + "." + TOPIC_NAME);
     }
 
     @Test
     @Tag(MIRROR_MAKER)
     void testProducerConsumerMirrorMakerService() {
-        Map<String, Object> configOfKafka = new HashMap<>();
-        configOfKafka.put("offsets.topic.replication.factor", "1");
-        configOfKafka.put("transaction.state.log.replication.factor", "1");
-        configOfKafka.put("transaction.state.log.min.isr", "1");
-
         final String kafkaClusterSourceName = CLUSTER_NAME + "-source";
         final String kafkaClusterTargetName = CLUSTER_NAME + "-target";
 
         KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 3, 1)
                 .editSpec()
                     .editKafka()
-                        .withConfig(configOfKafka)
                         .withNewPersistentClaimStorage()
                             .withNewSize("10")
                             .withDeleteClaim(true)
@@ -540,7 +519,6 @@ public class TracingST extends AbstractST {
         KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 3, 1)
                 .editSpec()
                     .editKafka()
-                        .withConfig(configOfKafka)
                         .withNewPersistentClaimStorage()
                             .withNewSize("10")
                             .withDeleteClaim(true)
@@ -612,14 +590,6 @@ public class TracingST extends AbstractST {
         TracingUtils.verify(JAEGER_CONSUMER_SERVICE, kafkaClientsPodName, "From_" + TOPIC_NAME);
         TracingUtils.verify(JAEGER_MIRROR_MAKER_SERVICE, kafkaClientsPodName, "From_" + TOPIC_NAME);
         TracingUtils.verify(JAEGER_MIRROR_MAKER_SERVICE, kafkaClientsPodName, "To_" + TOPIC_NAME);
-
-        LOGGER.info("Deleting topic {} from CR", TOPIC_NAME);
-        cmdKubeClient().deleteByName("kafkatopic", TOPIC_NAME);
-        KafkaTopicUtils.waitForKafkaTopicDeletion(TOPIC_NAME);
-
-        LOGGER.info("Deleting topic {} from CR", TOPIC_NAME + "-target");
-        cmdKubeClient().deleteByName("kafkatopic", TOPIC_NAME + "-target");
-        KafkaTopicUtils.waitForKafkaTopicDeletion(TOPIC_NAME + "-target");
     }
 
     @Test
@@ -628,11 +598,6 @@ public class TracingST extends AbstractST {
     @Tag(CONNECT_COMPONENTS)
     @SuppressWarnings({"checkstyle:MethodLength"})
     void testProducerConsumerMirrorMakerConnectStreamsService() {
-        Map<String, Object> configOfKafka = new HashMap<>();
-        configOfKafka.put("offsets.topic.replication.factor", "1");
-        configOfKafka.put("transaction.state.log.replication.factor", "1");
-        configOfKafka.put("transaction.state.log.min.isr", "1");
-
         final String kafkaClusterSourceName = CLUSTER_NAME + "-source";
         final String kafkaClusterTargetName = CLUSTER_NAME + "-target";
 
@@ -775,26 +740,6 @@ public class TracingST extends AbstractST {
         TracingUtils.verify(JAEGER_MIRROR_MAKER_SERVICE, kafkaClientsPodName, "To_" + TOPIC_NAME);
         TracingUtils.verify(JAEGER_MIRROR_MAKER_SERVICE, kafkaClientsPodName, "From_" + TOPIC_TARGET_NAME);
         TracingUtils.verify(JAEGER_MIRROR_MAKER_SERVICE, kafkaClientsPodName, "To_" + TOPIC_TARGET_NAME);
-
-        LOGGER.info("Deleting topic {} from CR", TEST_TOPIC_NAME);
-        cmdKubeClient().deleteByName("kafkatopic", TEST_TOPIC_NAME);
-        KafkaTopicUtils.waitForKafkaTopicDeletion(TEST_TOPIC_NAME);
-
-        LOGGER.info("Deleting topic {} from CR", TOPIC_NAME);
-        cmdKubeClient().deleteByName("kafkatopic", TOPIC_NAME);
-        KafkaTopicUtils.waitForKafkaTopicDeletion(TOPIC_NAME);
-
-        LOGGER.info("Deleting topic {} from CR", TOPIC_TARGET_NAME);
-        cmdKubeClient().deleteByName("kafkatopic", TOPIC_TARGET_NAME);
-        KafkaTopicUtils.waitForKafkaTopicDeletion(TOPIC_TARGET_NAME);
-
-        LOGGER.info("Deleting topic {} from CR", TOPIC_NAME + "-target");
-        cmdKubeClient().deleteByName("kafkatopic", TOPIC_NAME + "-target");
-        KafkaTopicUtils.waitForKafkaTopicDeletion(TOPIC_NAME + "-target");
-
-        LOGGER.info("Deleting topic {} from CR", TOPIC_TARGET_NAME + "-target");
-        cmdKubeClient().deleteByName("kafkatopic", TOPIC_TARGET_NAME + "-target");
-        KafkaTopicUtils.waitForKafkaTopicDeletion(TOPIC_TARGET_NAME + "-target");
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently, the Mirror Maker 2 doesn't properly implement tracing. When tracing is enabled, it is enabled in the underlying Connect cluster but not in the connector. Therefore the traces do not include the point when the message is consumed from the source cluster by MM2 but only the point when it is produced into the target cluster by MM2.

This PR injects the interceptors also to the connectors and makes sure the tracing is included also in them. That makes sure that the MM2 leaves always two traces - one when the message is consumed and one when the message is produced.

This PR also adds a new system test into TracingST to test tracing with Mirror Maker 2. Additionally it improves also the Mirror Maker 1 tracing tests:
* Fixes the oder to make things execute faster
* Improves the check to not just verify the service existence in Jaeger but also that it has the right operations  reading from and writing to a topic.

Documentation update is handled in #3314.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally