### PR TITLE
[DOC] Updates for config exceptions

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpec.adoc
@@ -7,3 +7,4 @@ Use the `config` properties to configure Kafka options.
 Standard Apache Kafka configuration may be provided, xref:assembly-kafka-connect-configuration-deployment-configuration-kafka-connect[restricted to those properties not managed directly by Strimzi].
 
 For client connection using a specific _cipher suite_ for a TLS version, you can xref:con-common-configuration-ssl-reference[configure allowed `ssl` properties].
+You can also xref:con-common-configuration-ssl-reference[configure the `ssl.endpoint.identification.algorithm` property] to enable or disable hostname verification.

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec.adoc
@@ -28,7 +28,8 @@ The `config` property contains the Kafka MirrorMaker consumer configuration opti
 * Number
 * Boolean
 
-For client connection using  a specific _cipher suite_ for a TLS version, you can xref:con-common-configuration-ssl-reference[configure allowed `ssl` properties].
+For client connection using a specific _cipher suite_ for a TLS version, you can xref:con-common-configuration-ssl-reference[configure allowed `ssl` properties].
+You can also xref:con-common-configuration-ssl-reference[configure the `ssl.endpoint.identification.algorithm` property] to enable or disable hostname verification.
 
 *Exceptions*
 
@@ -46,7 +47,7 @@ Specifically, all configuration options with keys equal to or starting with one 
 * `bootstrap.servers`
 * `group.id`
 * `interceptor.classes`
-* `ssl.` (with the exception of xref:con-common-configuration-ssl-reference[cipher suites])
+* `ssl.` (xref:con-common-configuration-ssl-reference[not including specific exceptions])
 * `sasl.`
 * `security.`
 

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec.adoc
@@ -24,6 +24,7 @@ The `config` property contains the Kafka MirrorMaker producer configuration opti
 * Boolean
 
 For client connection using a specific _cipher suite_ for a TLS version, you can xref:con-common-configuration-ssl-reference[configure allowed `ssl` properties].
+You can also xref:con-common-configuration-ssl-reference[configure the `ssl.endpoint.identification.algorithm` property] to enable or disable hostname verification.
 
 *Exceptions*
 
@@ -39,7 +40,7 @@ Specifically, all configuration options with keys equal to or starting with one 
 
 * `bootstrap.servers`
 * `interceptor.classes`
-* `ssl.` (with the exception of xref:con-common-configuration-ssl-reference[cipher suites])
+* `ssl.` (xref:con-common-configuration-ssl-reference[not including specific exceptions])
 * `sasl.`
 * `security.`
 

--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -38,7 +38,7 @@ When using Kafka with a Kafka cluster not managed by Strimzi, you can specify th
 .`ssl`
 
 Use the three allowed `ssl` configuration options for client connection using a specific _cipher suite_ for a TLS version.
-A _cipher suite_ combines algorithms for secure connection and data transfer.
+A cipher suite combines algorithms for secure connection and data transfer.
 
 You can also configure the `ssl.endpoint.identification.algorithm` property to enable or disable hostname verification.
 

--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -40,6 +40,8 @@ When using Kafka with a Kafka cluster not managed by Strimzi, you can specify th
 Use the three allowed `ssl` configuration options for client connection using a specific _cipher suite_ for a TLS version.
 A _cipher suite_ combines algorithms for secure connection and data transfer.
 
+You can also configure the `ssl.endpoint.identification.algorithm` property to enable or disable hostname verification.
+
 .Example SSL configuration
 [source,yaml,subs="attributes+"]
 ----
@@ -49,6 +51,7 @@ spec:
     ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <1>
     ssl.enabled.protocols: "TLSv1.2" <2>
     ssl.protocol: "TLSv1.2" <3>
+    ssl.endpoint.identification.algorithm: HTTPS <4>
 # ...
 ----
 <1> The cipher suite for TLS using a combination of `ECDHE` key exchange mechanism, `RSA` authentication algorithm,
@@ -56,6 +59,7 @@ spec:
 <2> The SSl protocol `TLSv1.2` is enabled.
 <3> Specifies the `TLSv1.2` protocol to generate the SSL context.
 Allowed values are `TLSv1.1` and `TLSv1.2`.
+<4> Hostname verification is enabled by setting to `HTTPS`. An empty string disables the verification.
 
 [id='con-common-configuration-resources-{context}']
 .`resources`

--- a/documentation/modules/mirrormaker2/proc-mirrormaker-replication.adoc
+++ b/documentation/modules/mirrormaker2/proc-mirrormaker-replication.adoc
@@ -98,48 +98,49 @@ spec:
       ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <13>
       ssl.enabled.protocols: "TLSv1.2"
       ssl.protocol: "TLSv1.2"
-    tls: <14>
+      ssl.endpoint.identification.algorithm: HTTPS <14>
+    tls: <15>
       trustedCertificates:
       - certificate: ca.crt
         secretName: my-cluster-target-cluster-ca-cert
-  mirrors: <15>
-  - sourceCluster: "my-cluster-source" <16>
-    targetCluster: "my-cluster-target" <17>
-    sourceConnector: <18>
+  mirrors: <16>
+  - sourceCluster: "my-cluster-source" <17>
+    targetCluster: "my-cluster-target" <18>
+    sourceConnector: <19>
       config:
-        replication.factor: 1 <19>
-        offset-syncs.topic.replication.factor: 1 <20>
-        sync.topic.acls.enabled: "false" <21>
-    heartbeatConnector: <22>
+        replication.factor: 1 <20>
+        offset-syncs.topic.replication.factor: 1 <21>
+        sync.topic.acls.enabled: "false" <22>
+    heartbeatConnector: <23>
       config:
-        heartbeats.topic.replication.factor: 1 <23>
-    checkpointConnector: <24>
+        heartbeats.topic.replication.factor: 1 <24>
+    checkpointConnector: <25>
       config:
-        checkpoints.topic.replication.factor: 1 <25>
-    topicsPattern: ".*" <26>
-    groupsPattern: "group1|group2|group3" <27>
-  resources: <28>
+        checkpoints.topic.replication.factor: 1 <26>
+    topicsPattern: ".*" <27>
+    groupsPattern: "group1|group2|group3" <28>
+  resources: <29>
     requests:
       cpu: "1"
       memory: 2Gi
     limits:
       cpu: "2"
       memory: 2Gi
-  logging: <29>
+  logging: <30>
     type: inline
     loggers:
       connect.root.logger.level: "INFO"
-  readinessProbe: <30>
+  readinessProbe: <31>
     initialDelaySeconds: 15
     timeoutSeconds: 5
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5
-  jvmOptions: <31>
+  jvmOptions: <32>
     "-Xmx": "1g"
     "-Xms": "1g"
-  image: my-org/my-image:latest <32>
-  template: <33>
+  image: my-org/my-image:latest <33>
+  template: <34>
     pod:
       affinity:
         podAntiAffinity:
@@ -152,7 +153,7 @@ spec:
                       - postgresql
                       - mongodb
               topologyKey: "kubernetes.io/hostname"
-    connectContainer: <34>
+    connectContainer: <35>
       env:
         - name: JAEGER_SERVICE_NAME
           value: my-jaeger-service
@@ -161,8 +162,8 @@ spec:
         - name: JAEGER_AGENT_PORT
           value: "6831"
   tracing:
-    type: jaeger <35>
-  externalConfiguration: <36>
+    type: jaeger <36>
+  externalConfiguration: <37>
     env:
       - name: AWS_ACCESS_KEY_ID
         valueFrom:
@@ -189,30 +190,31 @@ spec:
 <12> xref:assembly-kafka-connect-configuration-deployment-configuration-kafka-connect[Kafka Connect configuration].
 Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi.
 <13> xref:con-common-configuration-ssl-reference[SSL properties] for external listeners to run with a specific _cipher suite_ for a TLS version.
-<14> TLS encryption for the target Kafka cluster is configured in the same way as for the source Kafka cluster.
-<15> xref:type-KafkaMirrorMaker2MirrorSpec-reference[MirrorMaker 2.0 connectors].
-<16> xref:type-KafkaMirrorMaker2MirrorSpec-reference[Cluster alias] for the source cluster used by the MirrorMaker 2.0 connectors.
-<17> xref:type-KafkaMirrorMaker2MirrorSpec-reference[Cluster alias] for the target cluster used by the MirrorMaker 2.0 connectors.
-<18> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorSourceConnector`] that creates remote topics. The `config` overrides the default configuration options.
-<19> Replication factor for mirrored topics created at the target cluster.
-<20> Replication factor for the `MirrorSourceConnector` `offset-syncs` internal topic that maps the offsets of the source and target clusters.
-<21> When xref:con-mirrormaker-acls-{context}[ACL rules synchronization] is enabled, ACLs are applied to synchronized topics. The default is `true`.
-<22> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorHeartbeatConnector`] that performs connectivity checks. The `config` overrides the default configuration options.
-<23> Replication factor for the heartbeat topic created at the target cluster.
-<24> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorCheckpointConnector`] that tracks offsets. The `config` overrides the default configuration options.
-<25> Replication factor for the checkpoints topic created at the target cluster.
-<26> Topic replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request all topics.
-<27> Consumer group replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request three consumer groups by name.
+<14> xref:type-KafkaMirrorMaker2ClusterSpec-reference[Hostname verification is enabled] by setting to `HTTPS`. An empty string disables the verification.
+<15> TLS encryption for the target Kafka cluster is configured in the same way as for the source Kafka cluster.
+<16> xref:type-KafkaMirrorMaker2MirrorSpec-reference[MirrorMaker 2.0 connectors].
+<17> xref:type-KafkaMirrorMaker2MirrorSpec-reference[Cluster alias] for the source cluster used by the MirrorMaker 2.0 connectors.
+<18> xref:type-KafkaMirrorMaker2MirrorSpec-reference[Cluster alias] for the target cluster used by the MirrorMaker 2.0 connectors.
+<19> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorSourceConnector`] that creates remote topics. The `config` overrides the default configuration options.
+<20> Replication factor for mirrored topics created at the target cluster.
+<21> Replication factor for the `MirrorSourceConnector` `offset-syncs` internal topic that maps the offsets of the source and target clusters.
+<22> When xref:con-mirrormaker-acls-{context}[ACL rules synchronization] is enabled, ACLs are applied to synchronized topics. The default is `true`.
+<23> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorHeartbeatConnector`] that performs connectivity checks. The `config` overrides the default configuration options.
+<24> Replication factor for the heartbeat topic created at the target cluster.
+<25> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorCheckpointConnector`] that tracks offsets. The `config` overrides the default configuration options.
+<26> Replication factor for the checkpoints topic created at the target cluster.
+<27> Topic replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request all topics.
+<28> Consumer group replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request three consumer groups by name.
 You can use comma-separated lists.
-<28> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
-<29> Specified xref:property-kafka-connect-logging-reference[Kafka Connect loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. Kafka Connect has a single logger called `connect.root.logger.level`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
-<30> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
-<31> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
-<32> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
-<33> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<34> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
-<35> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
-<36> xref:type-ExternalConfiguration-reference[External configuration] for a Kubernetes Secret mounted to Kafka MirrorMaker as an environment variable.
+<29> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
+<30> Specified xref:property-kafka-connect-logging-reference[Kafka Connect loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. Kafka Connect has a single logger called `connect.root.logger.level`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<31> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
+<32> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
+<33> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
+<34> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
+<35> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
+<36> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
+<37> xref:type-ExternalConfiguration-reference[External configuration] for a Kubernetes Secret mounted to Kafka MirrorMaker as an environment variable.
 
 . Create or update the resource:
 +

--- a/documentation/modules/proc-configuring-mirror-maker.adoc
+++ b/documentation/modules/proc-configuring-mirror-maker.adoc
@@ -52,9 +52,10 @@ spec:
       ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <9>
       ssl.enabled.protocols: "TLSv1.2"
       ssl.protocol: "TLSv1.2"
+      ssl.endpoint.identification.algorithm: HTTPS <10>
   producer:
     bootstrapServers: my-target-cluster-kafka-bootstrap:9092
-    abortOnSendFailure: false <10>
+    abortOnSendFailure: false <11>
     tls:
       trustedCertificates:
       - secretName: my-target-cluster-ca-cert
@@ -68,28 +69,29 @@ spec:
     config:
       compression.type: gzip
       batch.size: 8192
-      ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <11>
+      ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <12>
       ssl.enabled.protocols: "TLSv1.2"
       ssl.protocol: "TLSv1.2"
-  whitelist: "my-topic|other-topic" <12>
-  resources: <13>
+      ssl.endpoint.identification.algorithm: HTTPS <13>
+  whitelist: "my-topic|other-topic" <14>
+  resources: <15>
     requests:
       cpu: "1"
       memory: 2Gi
     limits:
       cpu: "2"
       memory: 2Gi
-  logging: <14>
+  logging: <16>
     type: inline
     loggers:
       mirrormaker.root.logger: "INFO"
-  readinessProbe: <15>
+  readinessProbe: <17>
     initialDelaySeconds: 15
     timeoutSeconds: 5
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5
-  metrics: <16>
+  metrics: <18>
     lowercaseOutputName: true
     rules:
       - pattern: "kafka.server<type=(.+), name=(.+)PerSec\\w*><>Count"
@@ -99,11 +101,11 @@ spec:
         name: "kafka_server_$1_$2_total"
         labels:
           topic: "$3"
-  jvmOptions: <17>
+  jvmOptions: <19>
     "-Xmx": "1g"
     "-Xms": "1g"
-  image: my-org/my-image:latest <18>
-  template: <19>
+  image: my-org/my-image:latest <20>
+  template: <21>
     pod:
       affinity:
         podAntiAffinity:
@@ -116,7 +118,7 @@ spec:
                       - postgresql
                       - mongodb
               topologyKey: "kubernetes.io/hostname"
-    connectContainer: <20>
+    connectContainer: <22>
       env:
         - name: JAEGER_SERVICE_NAME
           value: my-jaeger-service
@@ -124,7 +126,7 @@ spec:
           value: jaeger-agent-name
         - name: JAEGER_AGENT_PORT
           value: "6831"
-  tracing: <21>
+  tracing: <23>
     type: jaeger
 ----
 <1> xref:con-common-configuration-replicas-reference[The number of replica nodes].
@@ -136,18 +138,20 @@ spec:
 <7> Authentication for consumer or producer, using the xref:type-KafkaClientAuthenticationTls-reference[TLS mechanism], as shown here, using xref:type-KafkaClientAuthenticationOAuth-reference[OAuth bearer tokens], or a SASL-based xref:type-KafkaClientAuthenticationScramSha512-reference[SCRAM-SHA-512] or xref:type-KafkaClientAuthenticationPlain-reference[PLAIN] mechanism.
 <8> Kafka configuration options for xref:property-consumer-config-reference[consumer] and xref:property-producer-config-reference[producer].
 <9> xref:con-common-configuration-ssl-reference[SSL properties] for external listeners to run with a specific _cipher suite_ for a TLS version.
-<10> If the xref:property-producer-abort-on-send-reference[`abortOnSendFailure` property] is set to `true`, Kafka MirrorMaker will exit and the container will restart following a send failure for a message.
-<11> xref:con-common-configuration-ssl-reference[SSL properties] for external listeners to run with a specific _cipher suite_ for a TLS version.
-<12> A xref:property-mm-whitelist-reference[_whitelist_ of topics] mirrored from source to target Kafka cluster.
-<13> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
-<14> Specified xref:property-mm-loggers-reference[loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. MirrorMaker has a single logger called `mirrormaker.root.logger`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
-<15> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
-<16> xref:con-common-configuration-prometheus-reference[Prometheus metrics], which are enabled with configuration for the Prometheus JMX exporter in this example. You can enable metrics without further configuration using `metrics: {}`.
-<17> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
-<18> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
-<19> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<20> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
-<21> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
+<10> xref:type-KafkaMirrorMakerConsumerSpec-reference[Hostname verification is enabled] by setting to `HTTPS`. An empty string disables the verification.
+<11> If the xref:property-producer-abort-on-send-reference[`abortOnSendFailure` property] is set to `true`, Kafka MirrorMaker will exit and the container will restart following a send failure for a message.
+<12> xref:con-common-configuration-ssl-reference[SSL properties] for external listeners to run with a specific _cipher suite_ for a TLS version.
+<13> xref:type-KafkaMirrorMakerProducerSpec-reference[Hostname verification is enabled] by setting to `HTTPS`. An empty string disables the verification.
+<14> A xref:property-mm-whitelist-reference[_whitelist_ of topics] mirrored from source to target Kafka cluster.
+<15> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
+<16> Specified xref:property-mm-loggers-reference[loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. MirrorMaker has a single logger called `mirrormaker.root.logger`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<17> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
+<18> xref:con-common-configuration-prometheus-reference[Prometheus metrics], which are enabled with configuration for the Prometheus JMX exporter in this example. You can enable metrics without further configuration using `metrics: {}`.
+<19> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
+<20> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
+<21> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
+<22> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
+<23> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
 +
 WARNING: With the `abortOnSendFailure` property set to `false`, the producer attempts to send the next message in a topic. The original message might be lost, as there is no attempt to resend a failed message.
 

--- a/documentation/modules/ref-kafka-bridge-consumer-configuration.adoc
+++ b/documentation/modules/ref-kafka-bridge-consumer-configuration.adoc
@@ -29,8 +29,10 @@ IMPORTANT: The Cluster Operator does not validate keys or values in the `config`
 When an invalid configuration is provided, the Kafka Bridge cluster might not start or might become unstable.
 In this circumstance, fix the configuration in the `KafkaBridge.spec.consumer.config` object, then the Cluster Operator can roll out the new configuration to all Kafka Bridge nodes.
 
-Use the three allowed `ssl` configuration options for client connection using a specific _cipher suite_ for a TLS version.
+There are exceptions to the restrictions imposed on the configuration.
+You can use three allowed `ssl` configuration options for client connection using a specific _cipher suite_ for a TLS version.
 A _cipher suite_ combines algorithms for secure connection and data transfer.
+You can also configure the `ssl.endpoint.identification.algorithm` property to enable or disable hostname verification.
 
 .Example Kafka Bridge consumer configuration
 [source,yaml,subs="attributes+"]
@@ -48,6 +50,7 @@ spec:
       ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <1>
       ssl.enabled.protocols: "TLSv1.2" <2>
       ssl.protocol: "TLSv1.2" <3>
+      ssl.endpoint.identification.algorithm: HTTPS <4>
     # ...
 ----
 <1> The cipher suite for TLS using a combination of `ECDHE` key exchange mechanism, `RSA` authentication algorithm,
@@ -55,3 +58,4 @@ spec:
 <2> The SSl protocol `TLSv1.2` is enabled.
 <3> Specifies the `TLSv1.2` protocol to generate the SSL context.
 Allowed values are `TLSv1.1` and `TLSv1.2`.
+<4> Hostname verification is enabled by setting to `HTTPS`. An empty string disables the verification.

--- a/documentation/modules/ref-kafka-bridge-consumer-configuration.adoc
+++ b/documentation/modules/ref-kafka-bridge-consumer-configuration.adoc
@@ -29,9 +29,9 @@ IMPORTANT: The Cluster Operator does not validate keys or values in the `config`
 When an invalid configuration is provided, the Kafka Bridge cluster might not start or might become unstable.
 In this circumstance, fix the configuration in the `KafkaBridge.spec.consumer.config` object, then the Cluster Operator can roll out the new configuration to all Kafka Bridge nodes.
 
-There are exceptions to the restrictions imposed on the configuration.
+There are exceptions to the forbidden options.
 You can use three allowed `ssl` configuration options for client connection using a specific _cipher suite_ for a TLS version.
-A _cipher suite_ combines algorithms for secure connection and data transfer.
+A cipher suite combines algorithms for secure connection and data transfer.
 You can also configure the `ssl.endpoint.identification.algorithm` property to enable or disable hostname verification.
 
 .Example Kafka Bridge consumer configuration

--- a/documentation/modules/ref-kafka-bridge-producer-configuration.adoc
+++ b/documentation/modules/ref-kafka-bridge-producer-configuration.adoc
@@ -25,8 +25,10 @@ IMPORTANT: The Cluster Operator does not validate keys or values in the `config`
 When an invalid configuration is provided, the Kafka Bridge cluster might not start or might become unstable.
 In this circumstance, fix the configuration in the `KafkaBridge.spec.producer.config` object, then the Cluster Operator can roll out the new configuration to all Kafka Bridge nodes.
 
-Use the three allowed `ssl` configuration options for client connection using a specific _cipher suite_ for a TLS version.
+There are exceptions to the restrictions imposed on the configuration.
+You can use three allowed `ssl` configuration options for client connection using a specific _cipher suite_ for a TLS version.
 A _cipher suite_ combines algorithms for secure connection and data transfer.
+You can also configure the `ssl.endpoint.identification.algorithm` property to enable or disable hostname verification.
 
 .Example Kafka Bridge producer configuration
 [source,yaml,subs="attributes+"]
@@ -44,6 +46,7 @@ spec:
       ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <1>
       ssl.enabled.protocols: "TLSv1.2" <2>
       ssl.protocol: "TLSv1.2" <3>
+      ssl.endpoint.identification.algorithm: HTTPS <4>
     # ...
 ----
 <1> The cipher suite for TLS using a combination of `ECDHE` key exchange mechanism, `RSA` authentication algorithm,
@@ -51,3 +54,4 @@ spec:
 <2> The SSl protocol `TLSv1.2` is enabled.
 <3> Specifies the `TLSv1.2` protocol to generate the SSL context.
 Allowed values are `TLSv1.1` and `TLSv1.2`.
+<4> Hostname verification is enabled by setting to `HTTPS`. An empty string disables the verification.

--- a/documentation/modules/ref-kafka-bridge-producer-configuration.adoc
+++ b/documentation/modules/ref-kafka-bridge-producer-configuration.adoc
@@ -25,9 +25,9 @@ IMPORTANT: The Cluster Operator does not validate keys or values in the `config`
 When an invalid configuration is provided, the Kafka Bridge cluster might not start or might become unstable.
 In this circumstance, fix the configuration in the `KafkaBridge.spec.producer.config` object, then the Cluster Operator can roll out the new configuration to all Kafka Bridge nodes.
 
-There are exceptions to the restrictions imposed on the configuration.
+There are exceptions to the forbidden options.
 You can use three allowed `ssl` configuration options for client connection using a specific _cipher suite_ for a TLS version.
-A _cipher suite_ combines algorithms for secure connection and data transfer.
+A cipher suite combines algorithms for secure connection and data transfer.
 You can also configure the `ssl.endpoint.identification.algorithm` property to enable or disable hostname verification.
 
 .Example Kafka Bridge producer configuration

--- a/documentation/modules/ref-kafka-broker-configuration.adoc
+++ b/documentation/modules/ref-kafka-broker-configuration.adoc
@@ -12,7 +12,7 @@ The `config` property in `Kafka.spec.kafka` contains Kafka broker configuration 
 * Boolean
 
 You can specify and configure all of the options in the "Broker Configs" section of the {ApacheKafkaBrokerConfig} apart from those managed directly by Strimzi.
-Specifically, you are prevented from modifying all configuration options with keys equal to or starting with one of the following strings:
+Specifically, all configuration options with keys equal to or starting with one of the following strings are forbidden:
 
 * `listeners`
 * `advertised.`
@@ -32,13 +32,13 @@ Specifically, you are prevented from modifying all configuration options with ke
 * `authorizer.`
 * `super.user`
 
-If the `config` property specifies a restricted option, it is ignored and a warning message is printed to the Cluster Operator log file.
+When a forbidden option is present in the `config` property, it is ignored and a warning message is printed to the Cluster Operator log file.
 All other supported options are passed to Kafka.
 
-There are exceptions to the restrictions imposed on the configuration.
+There are exceptions to the forbidden options.
 You can use three allowed `ssl` configuration options for client connection using a specific _cipher suite_ for a TLS version.
-A _cipher suite_ combines algorithms for secure connection and data transfer.
-You can also configure the `zookeeper.connection.timeout.ms` property to set maximum time allowed for establishing a ZooKeeper connection.
+A cipher suite combines algorithms for secure connection and data transfer.
+You can also configure the `zookeeper.connection.timeout.ms` property to set the maximum time allowed for establishing a ZooKeeper connection.
 
 .Example Kafka broker configuration
 [source,yaml,subs="attributes+"]

--- a/documentation/modules/ref-kafka-broker-configuration.adoc
+++ b/documentation/modules/ref-kafka-broker-configuration.adoc
@@ -35,8 +35,10 @@ Specifically, you are prevented from modifying all configuration options with ke
 If the `config` property specifies a restricted option, it is ignored and a warning message is printed to the Cluster Operator log file.
 All other supported options are passed to Kafka.
 
-Use the three allowed `ssl` configuration options for client connection using a specific _cipher suite_ for a TLS version.
+There are exceptions to the restrictions imposed on the configuration.
+You can use three allowed `ssl` configuration options for client connection using a specific _cipher suite_ for a TLS version.
 A _cipher suite_ combines algorithms for secure connection and data transfer.
+You can also configure the `zookeeper.connection.timeout.ms` property to set maximum time allowed for establishing a ZooKeeper connection.
 
 .Example Kafka broker configuration
 [source,yaml,subs="attributes+"]
@@ -67,6 +69,7 @@ spec:
       ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <1>
       ssl.enabled.protocols: "TLSv1.2" <2>
       ssl.protocol: "TLSv1.2" <3>
+      zookeeper.connection.timeout.ms: 6000 <4>
     # ...
 ----
 <1> The cipher suite for TLS using a combination of `ECDHE` key exchange mechanism, `RSA` authentication algorithm,
@@ -74,3 +77,4 @@ spec:
 <2> The SSl protocol `TLSv1.2` is enabled.
 <3> Specifies the `TLSv1.2` protocol to generate the SSL context.
 Allowed values are `TLSv1.1` and `TLSv1.2`.
+<4> Maximum time in milliseconds to establish a ZooKeeper connection.

--- a/documentation/modules/ref-kafka-connect-configuration.adoc
+++ b/documentation/modules/ref-kafka-connect-configuration.adoc
@@ -42,8 +42,10 @@ Certain options have default values:
 
 These options are automatically configured in case they are not present in the `KafkaConnect.spec.config` or `KafkaConnectS2I.spec.config` properties.
 
-Use the three allowed `ssl` configuration options for client connection using a specific _cipher suite_ for a TLS version.
+There are exceptions to the restrictions imposed on the configuration.
+You can use three allowed `ssl` configuration options for client connection using a specific _cipher suite_ for a TLS version.
 A _cipher suite_ combines algorithms for secure connection and data transfer.
+You can also configure the `ssl.endpoint.identification.algorithm` property to enable or disable hostname verification.
 
 .Example Kafka Connect configuration
 [source,yaml,subs="attributes+"]
@@ -69,6 +71,7 @@ spec:
     ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <1>
     ssl.enabled.protocols: "TLSv1.2" <2>
     ssl.protocol: "TLSv1.2" <3>
+    ssl.endpoint.identification.algorithm: HTTPS <4>
   # ...
 ----
 <1> The cipher suite for TLS using a combination of `ECDHE` key exchange mechanism, `RSA` authentication algorithm,
@@ -76,3 +79,4 @@ spec:
 <2> The SSl protocol `TLSv1.2` is enabled.
 <3> Specifies the `TLSv1.2` protocol to generate the SSL context.
 Allowed values are `TLSv1.1` and `TLSv1.2`.
+<4> Hostname verification is enabled by setting to `HTTPS`. An empty string disables the verification.

--- a/documentation/modules/ref-kafka-connect-configuration.adoc
+++ b/documentation/modules/ref-kafka-connect-configuration.adoc
@@ -42,9 +42,9 @@ Certain options have default values:
 
 These options are automatically configured in case they are not present in the `KafkaConnect.spec.config` or `KafkaConnectS2I.spec.config` properties.
 
-There are exceptions to the restrictions imposed on the configuration.
+There are exceptions to the forbidden options.
 You can use three allowed `ssl` configuration options for client connection using a specific _cipher suite_ for a TLS version.
-A _cipher suite_ combines algorithms for secure connection and data transfer.
+A cipher suite combines algorithms for secure connection and data transfer.
 You can also configure the `ssl.endpoint.identification.algorithm` property to enable or disable hostname verification.
 
 .Example Kafka Connect configuration

--- a/documentation/modules/ref-zookeeper-node-configuration.adoc
+++ b/documentation/modules/ref-zookeeper-node-configuration.adoc
@@ -41,7 +41,7 @@ Selected options have default values:
 These options will be automatically configured when they are not present in the `Kafka.spec.zookeeper.config` property.
 
 Use the three allowed `ssl` configuration options for client connection using a specific _cipher suite_ for a TLS version.
-A _cipher suite_ combines algorithms for secure connection and data transfer.
+A cipher suite combines algorithms for secure connection and data transfer.
 
 .Example ZooKeeper configuration
 [source,yaml,subs="attributes+"]


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

- Added a description of `zookeeper.connection.timeout.ms` for Kafka broker config
- Added a description of `ssl.endpoint.identification.algorithm` for:
    - KafkaConnect
    - KafkaConnectS2I
    - MirrorMaker consumer and producer
    - MirrorMaker2
    - Kafka bridge consumer and producer

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

