### PR TITLE
Add option to select replica movement strategy for rebalances

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalanceSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalanceSpec.java
@@ -23,7 +23,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "goals", "skipHardGoalCheck", "excludedTopics", "concurrentPartitionMovementsPerBroker",
-                     "concurrentIntraBrokerPartitionMovements", "concurrentLeaderMovements", "replicationThrottle" })
+                     "concurrentIntraBrokerPartitionMovements", "concurrentLeaderMovements", "replicationThrottle", "replicaMovementStrategies" })
 @EqualsAndHashCode
 public class KafkaRebalanceSpec implements UnknownPropertyPreserving, Serializable {
 
@@ -41,6 +41,7 @@ public class KafkaRebalanceSpec implements UnknownPropertyPreserving, Serializab
     private int concurrentIntraBrokerPartitionMovements;
     private int concurrentLeaderMovements;
     private long replicationThrottle;
+    private List<String> replicaMovementStrategies;
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -116,6 +117,16 @@ public class KafkaRebalanceSpec implements UnknownPropertyPreserving, Serializab
 
     public void setReplicationThrottle(long bandwidth) {
         this.replicationThrottle = bandwidth;
+    }
+
+    @Description("A list of strategy class names used to determine the execution order for the replica movements in the generated optimization proposal. " +
+        "By default BaseReplicaMovementStrategy is used, which will execute the replica movements in the order that they were generated.")
+    public List<String> getReplicaMovementStrategies() {
+        return replicaMovementStrategies;
+    }
+
+    public void setReplicaMovementStrategies(List<String> replicaMovementStrategies) {
+        this.replicaMovementStrategies = replicaMovementStrategies;
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -297,6 +297,9 @@ public class KafkaRebalanceAssemblyOperator
         if (kafkaRebalanceSpec.getReplicationThrottle() > 0) {
             rebalanceOptionsBuilder.withReplicationThrottle(kafkaRebalanceSpec.getReplicationThrottle());
         }
+        if (kafkaRebalanceSpec.getReplicaMovementStrategies() != null) {
+            rebalanceOptionsBuilder.withReplicaMovementStrategies(kafkaRebalanceSpec.getReplicaMovementStrategies());
+        }
 
         return rebalanceOptionsBuilder;
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/PathBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/PathBuilder.java
@@ -76,6 +76,9 @@ public class PathBuilder {
             if (options.getExcludedTopics() != null) {
                 builder.addParameter(CruiseControlParameters.EXCLUDED_TOPICS, options.getExcludedTopics());
             }
+            if (options.getReplicaMovementStrategies() != null) {
+                builder.addParameter(CruiseControlParameters.REPLICA_MOVEMENT_STRATEGIES, options.getReplicaMovementStrategies());
+            }
 
             addIfNotZero(builder, CruiseControlParameters.CONCURRENT_PARTITION_MOVEMENTS, options.getConcurrentPartitionMovementsPerBroker());
             addIfNotZero(builder, CruiseControlParameters.CONCURRENT_INTRA_PARTITION_MOVEMENTS, options.getConcurrentIntraBrokerPartitionMovements());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/RebalanceOptions.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/RebalanceOptions.java
@@ -28,6 +28,8 @@ public class RebalanceOptions {
     private int concurrentLeaderMovements;
     /** The upper bound, in bytes per second, on the bandwidth used to move replicas */
     private long replicationThrottle;
+    /** A list of strategy class names used to determine the execution order for the replica movements in the generated optimization proposal. */
+    private List<String> replicaMovementStrategies;
 
     public boolean isDryRun() {
         return isDryRun;
@@ -69,6 +71,10 @@ public class RebalanceOptions {
         return replicationThrottle;
     }
 
+    public List<String> getReplicaMovementStrategies() {
+        return replicaMovementStrategies;
+    }
+
     private RebalanceOptions(RebalanceOptionsBuilder builder) {
         this.isDryRun = builder.isDryRun;
         this.verbose = builder.verbose;
@@ -80,6 +86,7 @@ public class RebalanceOptions {
         this.concurrentIntraBrokerPartitionMovements = builder.concurrentIntraPartitionMovements;
         this.concurrentLeaderMovements = builder.concurrentLeaderMovements;
         this.replicationThrottle = builder.replicationThrottle;
+        this.replicaMovementStrategies = builder.replicaMovementStrategies;
     }
 
     public static class RebalanceOptionsBuilder {
@@ -93,6 +100,7 @@ public class RebalanceOptions {
         private int concurrentIntraPartitionMovements;
         private int concurrentLeaderMovements;
         private long replicationThrottle;
+        private List<String> replicaMovementStrategies;
 
         public RebalanceOptionsBuilder() {
             isDryRun = true;
@@ -104,6 +112,7 @@ public class RebalanceOptions {
             concurrentIntraPartitionMovements = 0;
             concurrentLeaderMovements = 0;
             replicationThrottle = 0;
+            replicaMovementStrategies = null;
         }
 
         public RebalanceOptionsBuilder withFullRun() {
@@ -160,6 +169,11 @@ public class RebalanceOptions {
                 throw new IllegalArgumentException("The max replication bandwidth should be greater than zero");
             }
             this.replicationThrottle = bandwidth;
+            return this;
+        }
+
+        public RebalanceOptionsBuilder withReplicaMovementStrategies(List<String> replicaMovementStrategies) {
+            this.replicaMovementStrategies = replicaMovementStrategies;
             return this;
         }
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2959,6 +2959,8 @@ Used in: xref:type-KafkaRebalance-{context}[`KafkaRebalance`]
 |integer
 |replicationThrottle                      1.2+<.<|The upper bound, in bytes per second, on the bandwidth used to move replicas. There is no limit by default.
 |integer
+|replicaMovementStrategies                1.2+<.<|A list of strategy class names used to determine the execution order for the replica movements in the generated optimization proposal. By default BaseReplicaMovementStrategy is used, which will execute the replica movements in the order that they were generated.
+|string array
 |====
 
 [id='type-KafkaRebalanceStatus-{context}']

--- a/documentation/modules/cruise-control/con-rebalance-performance.adoc
+++ b/documentation/modules/cruise-control/con-rebalance-performance.adoc
@@ -6,8 +6,16 @@
 
 = Rebalance performance tuning overview 
 
-When an xref:con-optimization-proposals-{context}[optimization proposal] is xref:proc-approving-optimization-proposal-{context}[approved], the partition reassignment commands that comprise the proposal are applied to the Kafka cluster by the Cruise Control server. 
-These commands consist of two types of operations:
+You can adjust several performance tuning options for cluster rebalances. 
+These options control how partition replica and leadership movements in a rebalance are executed, as well as the bandwidth that is allocated to a rebalance operation.
+
+[discrete]
+== Partition reassignment commands
+
+xref:con-optimization-proposals-{context}[Optimization proposals] are comprised of separate partition reassignment commands. 
+When you xref:proc-approving-optimization-proposal-{context}[approve] a proposal, the Cruise Control server applies these commands to the Kafka cluster.
+
+A partition reassignment command consists of either of the following types of operations:
 
 * Partition movement: Involves transferring the partition replica and its data to a new location. Partition movements can take one of two forms:
     ** Inter-broker movement: The partition replica is moved to a log directory on a different broker.
@@ -15,34 +23,62 @@ These commands consist of two types of operations:
 
 * Leadership movement: This involves switching the leader of the partition's replicas.
 
-Cruise Control batches up these reassignment commands and issues them to the Kafka cluster. 
+Cruise Control issues partition reassignment commands to the Kafka cluster in batches.
 The performance of the cluster during the rebalance is affected by the number of each type of movement contained in each batch.
-Cruise Control provides several configuration options for tuning a cluster rebalance for optimal performance. 
 
-You can set these _tuning_ options at either the xref:ref-cruise-control-configuration-{context}[Cruise Control server] or xref:proc-generating-optimization-proposals-{context}[optimization proposal] levels:
+[discrete]
+== Replica movement strategies
+
+Cluster rebalance performance is also influenced by the _replica movement strategy_ that is applied to the batches of partition reassignment commands. 
+By default, Cruise Control uses the `BaseReplicaMovementStrategy`, which simply applies the commands in the order they were generated.
+However, if there are some very large partition reassignments early in the proposal, this strategy can slow down the application of the other reassignments.
+
+Cruise Control provides three alternative replica movement strategies that can be applied to optimization proposals:
+
+* `PrioritizeSmallReplicaMovementStrategy`: Order reassignments in order of ascending size.
+* `PrioritizeLargeReplicaMovementStrategy`: Order reassignments in order of descending size. 
+* `PostponeUrpReplicaMovementStrategy`: Prioritize reassignments for replicas of partitions which have no out-of-sync replicas.
+
+These strategies can be configured as a sequence.
+The first strategy attempts to compare two partition reassignments using its internal logic. 
+If the reassignments are equivalent, then it passes them to the next strategy in the sequence to decide the order, and so on.
+
+[discrete]
+== Rebalance tuning options
+
+Cruise Control provides several configuration options for tuning the rebalance parameters discussed above.
+You can set these tuning options at either the xref:ref-cruise-control-configuration-{context}[Cruise Control server] or xref:proc-generating-optimization-proposals-{context}[optimization proposal] levels:
 
 * The Cruise Control server setting can be set in the Kafka custom resource under `Kafka.spec.kafka.spec.cruiseControl.spec`. 
 * The individual rebalance performance configurations can be set under `KafkaRebalance.spec`. 
 
 The relevant configurations are summarised below:
 
-|==========================================================================================================================
-| Server Configuration                              | KafkaRebalance Configuration            | Description | Default Value 
+|============================================================================================================================
+| Server / KafkaRebalance Configuration                | Description                                          | Default Value
 
-| `num.concurrent.partition.movements.per.broker`   | `concurrentPartitionMovementsPerBroker` | 
-  The maximum number of inter-broker partition movements in each partition reassignment batch | 5
+| `num.concurrent.partition.movements.per.broker`   .2+| 
+  The maximum number of inter-broker partition movements in each partition reassignment batch              .2+| 5 
+| `concurrentPartitionMovementsPerBroker` 
 
-| `num.concurrent.intra.broker.partition.movements` | `concurrentIntraBrokerPartitionMovements`     | 
-  The maximum number of intra-broker partition movements in each partition reassignment batch | 2
+| `num.concurrent.intra.broker.partition.movements` .2+| 
+  The maximum number of intra-broker partition movements in each partition reassignment batch              .2+| 2
+| `concurrentIntraBrokerPartitionMovements`
 
+| `num.concurrent.leader.movements`                 .2+| 
+  The maximum number of partition leadership changes in each partition reassignment batch                  .2+| 1000        
+| `concurrentLeaderMovements`              
 
-| `num.concurrent.leader.movements`                 | `concurrentLeaderMovements`             | 
-  The maximum number of partition leadership changes in each partition reassignment batch     | 1000        
+| `default.replication.throttle`                    .2+|
+  The bandwidth (in bytes per second) to be assigned to the reassigning of partitions                      .2+| No Limit    
+| `replicationThrottle`
 
+| `default.replica.movement.strategies`             .2+| 
+  The list of strategies (in priority order) used to determine the order in which partition reassignment commands are executed for generated proposals. Use a comma separated string for server and a YAML array for `KafkaRebalance` resources.
+.2+| `BaseReplicaMovementStrategy`
+| `replicaMovementStrategies`
 
-| `default.replication.throttle`                    | `replicationThrottle`                   |
-  The bandwidth (in bytes per second) to be assigned to the reassigning of partitions         | No Limit    
-|==========================================================================================================================
+|============================================================================================================================
 
 Changing the default settings affects the length of time that the rebalance takes to complete, as well as the load placed on the Kafka cluster during the rebalance. 
 Using lower values reduces the load but increases the amount of time taken, and vice versa.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/049-Crd-kafkarebalance.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/049-Crd-kafkarebalance.yaml
@@ -62,6 +62,11 @@ spec:
               type: integer
               minimum: 0
               description: The upper bound, in bytes per second, on the bandwidth used to move replicas. There is no limit by default.
+            replicaMovementStrategies:
+              type: array
+              items:
+                type: string
+              description: A list of strategy class names used to determine the execution order for the replica movements in the generated optimization proposal. By default BaseReplicaMovementStrategy is used, which will execute the replica movements in the order that they were generated.
           description: The specification of the Kafka rebalance.
         status:
           type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
@@ -58,6 +58,11 @@ spec:
               type: integer
               minimum: 0
               description: The upper bound, in bytes per second, on the bandwidth used to move replicas. There is no limit by default.
+            replicaMovementStrategies:
+              type: array
+              items:
+                type: string
+              description: A list of strategy class names used to determine the execution order for the replica movements in the generated optimization proposal. By default BaseReplicaMovementStrategy is used, which will execute the replica movements in the order that they were generated.
           description: The specification of the Kafka rebalance.
         status:
           type: object

--- a/install/cluster-operator/049-Crd-kafkarebalance.yaml
+++ b/install/cluster-operator/049-Crd-kafkarebalance.yaml
@@ -71,6 +71,14 @@ spec:
               minimum: 0
               description: The upper bound, in bytes per second, on the bandwidth
                 used to move replicas. There is no limit by default.
+            replicaMovementStrategies:
+              type: array
+              items:
+                type: string
+              description: A list of strategy class names used to determine the execution
+                order for the replica movements in the generated optimization proposal.
+                By default BaseReplicaMovementStrategy is used, which will execute
+                the replica movements in the order that they were generated.
           description: The specification of the Kafka rebalance.
         status:
           type: object

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlParameters.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlParameters.java
@@ -21,7 +21,8 @@ public enum CruiseControlParameters {
     CONCURRENT_PARTITION_MOVEMENTS("concurrent_partition_movements_per_broker"),
     CONCURRENT_INTRA_PARTITION_MOVEMENTS("concurrent_intra_broker_partition_movements"),
     CONCURRENT_LEADER_MOVEMENTS("concurrent_leader_movements"),
-    REPLICATION_THROTTLE("replication_throttle");
+    REPLICATION_THROTTLE("replication_throttle"),
+    REPLICA_MOVEMENT_STRATEGIES("replica_movement_strategies");
 
     String key;
 


### PR DESCRIPTION
### Type of change

Enhancement 

### Description

This adds the option to specify the `replicaMovementStrategies` for a cluster rebalance. By default `BaseReplicaMovementStrategy` is used, which randomly sorts the replica movements but other strategies [are available](https://github.com/linkedin/cruise-control/wiki/Pluggable-Components#replica-movement-strategy). The strategies can be specified in a comma separated list to form a priority chain. If a strategy earlier in the list finds two replica movements equivalent then these can be passed to the next strategy down to determine an order.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Update CHANGELOG.md

