### PR TITLE
[systemtest][kr] Change wait for KafkaRebalance state

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
@@ -4,13 +4,11 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
+import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.operator.assembly.KafkaRebalanceState;
-import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
-import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
-import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -45,16 +43,9 @@ public class KafkaRebalanceUtils {
         }
     }
 
-    // TODO: after revert of changes related to status we should use --> ResourceManager.waitForResourceStatus()
     public static void waitForKafkaRebalanceCustomResourceState(String resourceName, KafkaRebalanceState state) {
-        LOGGER.info("Waiting for KafkaRebalance to be in the {} state", state);
-
-        TestUtils.waitFor("KafkaRebalance to be in the " + state.name(), Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,
-            ResourceOperation.getTimeoutForKafkaRebalanceState(state),
-            () -> rebalanceStateCondition(resourceName).getType().equals(state.toString()),
-            () -> ResourceManager.logCurrentResourceStatus(KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(kubeClient().getNamespace())
-                .withName(resourceName).get())
-        );
+        KafkaRebalance kafkaRebalance = KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get();
+        ResourceManager.waitForResourceStatus(KafkaRebalanceResource.kafkaRebalanceClient(), kafkaRebalance, state.toString());
     }
 
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
-import static io.strimzi.systemtest.Constants.FLAKY;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.resources.ResourceManager.cmdKubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -70,7 +69,6 @@ public class CruiseControlIsolatedST extends AbstractST {
 
     @Test
     @Tag(ACCEPTANCE)
-    @Tag(FLAKY)
     void testCruiseControlWithRebalanceResource() {
         KafkaResource.kafkaWithCruiseControl(CLUSTER_NAME, 3, 3).done();
         KafkaRebalanceResource.kafkaRebalance(CLUSTER_NAME).done();


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR gonna fix waits for `KafkaRebalance` state - I realized that we didn't changed it after #3190 and that's maybe the problem why `testCruiseControlWithRebalanceResource` was failing. 

### Checklist

- [x] Make sure all tests pass


