### PR TITLE
Fixes VSCode compiler error related to Scala code

### DIFF
--- a/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
+++ b/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
@@ -84,7 +84,7 @@ public class KafkaConfigModelGenerator {
             } else if (key.validator instanceof ConfigDef.ValidList) {
                 descriptor.setItems(validList(key));
             } else if (key.validator instanceof ApiVersionValidator$) {
-                Iterator<ApiVersion> iterator = ApiVersion$.MODULE$.allVersions().iterator();
+                Iterator<ApiVersion> iterator = ((scala.collection.GenIterableLike<ApiVersion, ?>) ApiVersion$.MODULE$.allVersions()).iterator();
                 LinkedHashSet<String> versions = new LinkedHashSet<>();
                 while (iterator.hasNext()) {
                     ApiVersion next = iterator.next();


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Refactoring

### Description

The VSCode compiler, using the Eclipse JDT Language Server, raises the following error when we get an iterator for the `ApiVersion$.MODULE$.allVersions()` collection in the `KafkaConfigModelGenerator`:

```
The method iterator() is ambiguous for the type Seq<ApiVersion>
```

This PR fixes such an error with an explicit cast as it was already fixed in other places with #2722 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

