### PR TITLE
Deprecation of log level environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,7 @@ Together with it we will also remove the Prometheus annotation from the service.
 
 #### Removal warning of Cluster Operator log level
 
-Because of the new Cluster Operator dynamic logging configuration via [PR#3328](https://github.com/strimzi/strimzi-kafka-operator/pull/3328) we are going to remove the `STRIMZI_LOG_LEVEL` environment variable from the Cluster Operator deployment YAML file in the next release.
-If you are using this environment variable in your current Cluster Operator installation, please takes this into account when updating to the next release.
+Because of the new Cluster Operator dynamic logging configuration via [PR#3328](https://github.com/strimzi/strimzi-kafka-operator/pull/3328) we are going to remove the `STRIMZI_LOG_LEVEL` environment variable from the Cluster Operator deployment YAML file in the 0.20.0 release.
 
 ## 0.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ For this reason, we are deprecating the monitoring port `tcp-prometheus` (9404) 
 This port will be removed in the next release.
 Together with it we will also remove the Prometheus annotation from the service.
 
+#### Deprecation of Cluster Operator log level
+
+Because of the new Cluster Operator dynamic logging configuration coming in the next release via [PR#3328](https://github.com/strimzi/strimzi-kafka-operator/pull/3328) we are deprecating the usage of the `STRIMZI_LOG_LEVEL` environment variable in the Cluster Operator deployment YAML file. 
+This environment variable will be removed in the next release.
+
 ## 0.18.0
 
 * Add possibility to set Java System Properties for User Operator and Topic Operator via `Kafka` CR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,10 +62,10 @@ For this reason, we are deprecating the monitoring port `tcp-prometheus` (9404) 
 This port will be removed in the next release.
 Together with it we will also remove the Prometheus annotation from the service.
 
-#### Deprecation of Cluster Operator log level
+#### Removal warning of Cluster Operator log level
 
-Because of the new Cluster Operator dynamic logging configuration coming in the next release via [PR#3328](https://github.com/strimzi/strimzi-kafka-operator/pull/3328) we are deprecating the usage of the `STRIMZI_LOG_LEVEL` environment variable in the Cluster Operator deployment YAML file. 
-This environment variable will be removed in the next release.
+Because of the new Cluster Operator dynamic logging configuration via [PR#3328](https://github.com/strimzi/strimzi-kafka-operator/pull/3328) we are going to remove the `STRIMZI_LOG_LEVEL` environment variable from the Cluster Operator deployment YAML file in the next release.
+If you are using this environment variable in your current Cluster Operator installation, please takes this into account when updating to the next release.
 
 ## 0.18.0
 


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Documentation

### Description

This PR updates the CHANGELOG about deprecating usage of `STRIMZI_LOG_LEVEL` that will be removed in the future release due to the coming dynamic logging configuration.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

