### PR TITLE
[systemtest] Load ST variables from json config

### DIFF
--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -181,12 +181,12 @@ All available test groups are listed in [Constants](systemtest/src/main/java/io/
 ## Environment variables
 
 System tests can be configured by several environment variables, which are loaded before test execution.
-Variables can be defined via env or via configuration file, this file can be placed anywhere and path to this
-file is defined by env variable `CONFIG`, if `CONFIG` env variable is not defined, default config location is used `systemtest/config.json`.
 
-Loading of variables has following priority:
+Variables can be defined via environmental variables or a configuration file, this file can be located anywhere on the file system as long as a path is provided to this file.
+The path is defined by environmental variable `ST_CONFIG_PATH`, if the `ST_CONFIG_PATH` environmental variable is not defined, the default config file location is used `systemtest/config.json`.
+Loading of system configuration has the following priority order:
 1. Environment variable
-2. Variable defined in config
+2. Variable defined in configuration file
 3. Default value
 
 All environment variables are defined in [Environment](systemtest/src/main/java/io/strimzi/systemtest/Environment.java) class:

--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -181,6 +181,14 @@ All available test groups are listed in [Constants](systemtest/src/main/java/io/
 ## Environment variables
 
 System tests can be configured by several environment variables, which are loaded before test execution.
+Variables can be defined via env or via configuration file, this file can be placed anywhere and path to this
+file is defined by env variable `CONFIG`, if `CONFIG` env variable is not defined, default config location is used `systemtest/config.json`.
+
+Loading of variables has following priority:
+1. Environment variable
+2. Variable defined in config
+3. Default value
+
 All environment variables are defined in [Environment](systemtest/src/main/java/io/strimzi/systemtest/Environment.java) class:
 
 | Name                                   | Description                                                                              | Default                                          |

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -4,10 +4,18 @@
  */
 package io.strimzi.systemtest;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
 
 /**
  * Class which holds environment variables for system tests.
@@ -15,7 +23,13 @@ import java.util.Locale;
 public class Environment {
 
     private static final Logger LOGGER = LogManager.getLogger(Environment.class);
+    private static final Map<String, String> values = new HashMap<>();
+    private static final JsonNode jsonEnv = loadJsonEnv();
 
+    /**
+     * Specify config json/yaml path with env variables values
+     */
+    private static final String CONFIG_ENV = "CONFIG";
     /**
      * Specify organization which owns image used in system tests.
      */
@@ -99,55 +113,43 @@ public class Environment {
     private static final String DEFAULT_TO_DENY_NETWORK_POLICIES_DEFAULT = "true";
     private static final String CLUSTER_OPERATOR_INSTALL_TYPE_DEFAULT = "bundle";
 
-    public static final String STRIMZI_ORG = System.getenv().getOrDefault(STRIMZI_ORG_ENV, STRIMZI_ORG_DEFAULT);
-    public static final String STRIMZI_TAG = System.getenv().getOrDefault(STRIMZI_TAG_ENV, STRIMZI_TAG_DEFAULT);
-    public static final String STRIMZI_REGISTRY = System.getenv().getOrDefault(STRIMZI_REGISTRY_ENV, STRIMZI_REGISTRY_DEFAULT);
-    public static final String TEST_LOG_DIR = System.getenv().getOrDefault(TEST_LOG_DIR_ENV, TEST_LOG_DIR_DEFAULT);
-    public static final String ST_KAFKA_VERSION = System.getenv().getOrDefault(ST_KAFKA_VERSION_ENV, ST_KAFKA_VERSION_DEFAULT);
-    public static final String STRIMZI_LOG_LEVEL = System.getenv().getOrDefault(STRIMZI_LOG_LEVEL_ENV, STRIMZI_LOG_LEVEL_DEFAULT);
-    public static final String KUBERNETES_DOMAIN = System.getenv().getOrDefault(KUBERNETES_DOMAIN_ENV, KUBERNETES_DOMAIN_DEFAULT);
-    public static final String SKIP_TEARDOWN = System.getenv(SKIP_TEARDOWN_ENV);
+    private static String config;
+    public static final String STRIMZI_ORG = getOrDefault(STRIMZI_ORG_ENV, STRIMZI_ORG_DEFAULT);
+    public static final String STRIMZI_TAG = getOrDefault(STRIMZI_TAG_ENV, STRIMZI_TAG_DEFAULT);
+    public static final String STRIMZI_REGISTRY = getOrDefault(STRIMZI_REGISTRY_ENV, STRIMZI_REGISTRY_DEFAULT);
+    public static final String TEST_LOG_DIR = getOrDefault(TEST_LOG_DIR_ENV, TEST_LOG_DIR_DEFAULT);
+    public static final String ST_KAFKA_VERSION = getOrDefault(ST_KAFKA_VERSION_ENV, ST_KAFKA_VERSION_DEFAULT);
+    public static final String STRIMZI_LOG_LEVEL = getOrDefault(STRIMZI_LOG_LEVEL_ENV, STRIMZI_LOG_LEVEL_DEFAULT);
+    public static final String KUBERNETES_DOMAIN = getOrDefault(KUBERNETES_DOMAIN_ENV, KUBERNETES_DOMAIN_DEFAULT);
+    public static final boolean SKIP_TEARDOWN = getOrDefault(SKIP_TEARDOWN_ENV, Boolean::parseBoolean, false);
     // variables for test-client image
     private static final String TEST_CLIENT_IMAGE_DEFAULT = STRIMZI_REGISTRY + "/" + STRIMZI_ORG + "/test-client:" + STRIMZI_TAG + "-kafka-" + ST_KAFKA_VERSION;
-    public static final String TEST_CLIENT_IMAGE = System.getenv().getOrDefault(TEST_CLIENT_IMAGE_ENV, TEST_CLIENT_IMAGE_DEFAULT);
+    public static final String TEST_CLIENT_IMAGE = getOrDefault(TEST_CLIENT_IMAGE_ENV, TEST_CLIENT_IMAGE_DEFAULT);
     // variables for kafka bridge image
     private static final String BRIDGE_IMAGE_DEFAULT = "latest-released";
-    public static final String BRIDGE_IMAGE = System.getenv().getOrDefault(BRIDGE_IMAGE_ENV, BRIDGE_IMAGE_DEFAULT);
+    public static final String BRIDGE_IMAGE = getOrDefault(BRIDGE_IMAGE_ENV, BRIDGE_IMAGE_DEFAULT);
     // Image pull policy variables
-    public static final String COMPONENTS_IMAGE_PULL_POLICY = System.getenv().getOrDefault(COMPONENTS_IMAGE_PULL_POLICY_ENV, COMPONENTS_IMAGE_PULL_POLICY_ENV_DEFAULT);
-    public static final String OPERATOR_IMAGE_PULL_POLICY = System.getenv().getOrDefault(OPERATOR_IMAGE_PULL_POLICY_ENV, OPERATOR_IMAGE_PULL_POLICY_ENV_DEFAULT);
+    public static final String COMPONENTS_IMAGE_PULL_POLICY = getOrDefault(COMPONENTS_IMAGE_PULL_POLICY_ENV, COMPONENTS_IMAGE_PULL_POLICY_ENV_DEFAULT);
+    public static final String OPERATOR_IMAGE_PULL_POLICY = getOrDefault(OPERATOR_IMAGE_PULL_POLICY_ENV, OPERATOR_IMAGE_PULL_POLICY_ENV_DEFAULT);
     // OLM env variables
-    public static final String OLM_OPERATOR_NAME = System.getenv().getOrDefault(OLM_OPERATOR_NAME_ENV, OLM_OPERATOR_NAME_DEFAULT);
-    public static final String OLM_SOURCE_NAME = System.getenv().getOrDefault(OLM_SOURCE_NAME_ENV, OLM_SOURCE_NAME_DEFAULT);
-    public static final String OLM_APP_BUNDLE_PREFIX = System.getenv().getOrDefault(OLM_APP_BUNDLE_PREFIX_ENV, OLM_APP_BUNDLE_PREFIX_DEFAULT);
-    public static final String OLM_OPERATOR_VERSION = System.getenv().getOrDefault(OLM_OPERATOR_VERSION_ENV, OLM_OPERATOR_VERSION_DEFAULT);
+    public static final String OLM_OPERATOR_NAME = getOrDefault(OLM_OPERATOR_NAME_ENV, OLM_OPERATOR_NAME_DEFAULT);
+    public static final String OLM_SOURCE_NAME = getOrDefault(OLM_SOURCE_NAME_ENV, OLM_SOURCE_NAME_DEFAULT);
+    public static final String OLM_APP_BUNDLE_PREFIX = getOrDefault(OLM_APP_BUNDLE_PREFIX_ENV, OLM_APP_BUNDLE_PREFIX_DEFAULT);
+    public static final String OLM_OPERATOR_VERSION = getOrDefault(OLM_OPERATOR_VERSION_ENV, OLM_OPERATOR_VERSION_DEFAULT);
     // NetworkPolicy variable
-    public static final String DEFAULT_TO_DENY_NETWORK_POLICIES = System.getenv().getOrDefault(DEFAULT_TO_DENY_NETWORK_POLICIES_ENV, DEFAULT_TO_DENY_NETWORK_POLICIES_DEFAULT);
+    public static final String DEFAULT_TO_DENY_NETWORK_POLICIES = getOrDefault(DEFAULT_TO_DENY_NETWORK_POLICIES_ENV, DEFAULT_TO_DENY_NETWORK_POLICIES_DEFAULT);
     // ClusterOperator installation type variable
-    public static final String CLUSTER_OPERATOR_INSTALL_TYPE = System.getenv().getOrDefault(CLUSTER_OPERATOR_INSTALL_TYPE_ENV, CLUSTER_OPERATOR_INSTALL_TYPE_DEFAULT);
+    public static final String CLUSTER_OPERATOR_INSTALL_TYPE = getOrDefault(CLUSTER_OPERATOR_INSTALL_TYPE_ENV, CLUSTER_OPERATOR_INSTALL_TYPE_DEFAULT);
 
 
-    private Environment() { }
+    private Environment() {
+    }
 
     static {
         String debugFormat = "{}: {}";
         LOGGER.info("Used environment variables:");
-        LOGGER.info(debugFormat, STRIMZI_ORG_ENV, STRIMZI_ORG);
-        LOGGER.info(debugFormat, STRIMZI_TAG_ENV, STRIMZI_TAG);
-        LOGGER.info(debugFormat, STRIMZI_REGISTRY_ENV, STRIMZI_REGISTRY);
-        LOGGER.info(debugFormat, TEST_CLIENT_IMAGE_ENV, TEST_CLIENT_IMAGE);
-        LOGGER.info(debugFormat, BRIDGE_IMAGE_ENV, BRIDGE_IMAGE);
-        LOGGER.info(debugFormat, TEST_LOG_DIR_ENV, TEST_LOG_DIR);
-        LOGGER.info(debugFormat, ST_KAFKA_VERSION_ENV, ST_KAFKA_VERSION);
-        LOGGER.info(debugFormat, STRIMZI_LOG_LEVEL_ENV, STRIMZI_LOG_LEVEL);
-        LOGGER.info(debugFormat, KUBERNETES_DOMAIN_ENV, KUBERNETES_DOMAIN);
-        LOGGER.info(debugFormat, COMPONENTS_IMAGE_PULL_POLICY_ENV, COMPONENTS_IMAGE_PULL_POLICY);
-        LOGGER.info(debugFormat, OPERATOR_IMAGE_PULL_POLICY_ENV, OPERATOR_IMAGE_PULL_POLICY);
-        LOGGER.info(debugFormat, OLM_OPERATOR_NAME_ENV, OLM_OPERATOR_NAME);
-        LOGGER.info(debugFormat, OLM_APP_BUNDLE_PREFIX_ENV, OLM_APP_BUNDLE_PREFIX);
-        LOGGER.info(debugFormat, OLM_OPERATOR_VERSION_ENV, OLM_OPERATOR_VERSION);
-        LOGGER.info(debugFormat, DEFAULT_TO_DENY_NETWORK_POLICIES_ENV, DEFAULT_TO_DENY_NETWORK_POLICIES);
-        LOGGER.info(debugFormat, CLUSTER_OPERATOR_INSTALL_TYPE_ENV, CLUSTER_OPERATOR_INSTALL_TYPE);
+        LOGGER.info(debugFormat, "CONFIG", config);
+        values.forEach((key, value) -> LOGGER.info(debugFormat, key, value));
     }
 
     public static boolean isOlmInstall() {
@@ -160,5 +162,31 @@ public class Environment {
 
     public static boolean useLatestReleasedBridge() {
         return Environment.BRIDGE_IMAGE.equals(Environment.BRIDGE_IMAGE_DEFAULT);
+    }
+
+    private static String getOrDefault(String varName, String defaultValue) {
+        return getOrDefault(varName, String::toString, defaultValue);
+    }
+
+    private static <T> T getOrDefault(String var, Function<String, T> converter, T defaultValue) {
+        String value = System.getenv(var) != null ? System.getenv(var) : (Objects.requireNonNull(jsonEnv).get(var) != null ? jsonEnv.get(var).asText() : null);
+        T returnValue = defaultValue;
+        if (value != null) {
+            returnValue = converter.apply(value);
+        }
+        values.put(var, String.valueOf(returnValue));
+        return returnValue;
+    }
+
+    private static JsonNode loadJsonEnv() {
+        config = System.getenv().getOrDefault(CONFIG_ENV, Paths.get(System.getProperty("user.dir"), "config.json").toAbsolutePath().toString());
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            File jsonFile = new File(config).getAbsoluteFile();
+            return mapper.readTree(jsonFile);
+        } catch (Exception e) {
+            LOGGER.info("Json configuration not provider or not exists");
+            return mapper.createObjectNode();
+        }
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -25,12 +25,12 @@ public class Environment {
 
     private static final Logger LOGGER = LogManager.getLogger(Environment.class);
     private static final Map<String, String> VALUES = new HashMap<>();
-    private static final JsonNode JSON_DATA = loadJsonEnv();
+    private static final JsonNode JSON_DATA = loadConfigurationFile();
 
     /**
-     * Specify config json/yaml path with env variables values
+     * Specify the system test configuration file path from an environmental variable
      */
-    private static final String CONFIG_ENV = "CONFIG";
+    private static final String CONFIG_FILE_PATH_ENVAR = "ST_CONFIG_PATH";
     /**
      * Specify organization which owns image used in system tests.
      */
@@ -183,8 +183,8 @@ public class Environment {
         return returnValue;
     }
 
-    private static JsonNode loadJsonEnv() {
-        config = System.getenv().getOrDefault(CONFIG_ENV,
+    private static JsonNode loadConfigurationFile() {
+        config = System.getenv().getOrDefault(CONFIG_FILE_PATH_ENVAR,
                 Paths.get(System.getProperty("user.dir"), "config.json").toAbsolutePath().toString());
         ObjectMapper mapper = new ObjectMapper();
         try {

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -652,7 +652,7 @@ public abstract class AbstractST implements TestSeparator {
             assertionError = new AssertionError(e);
         }
 
-        if (Environment.SKIP_TEARDOWN == null) {
+        if (!Environment.SKIP_TEARDOWN) {
             tearDownEnvironmentAfterEach();
         }
 
@@ -663,7 +663,7 @@ public abstract class AbstractST implements TestSeparator {
 
     @AfterAll
     void teardownEnvironmentClass() {
-        if (Environment.SKIP_TEARDOWN == null) {
+        if (!Environment.SKIP_TEARDOWN) {
             tearDownEnvironmentAfterAll();
             teardownEnvForOperator();
         }


### PR DESCRIPTION
Signed-off-by: David Kornel <kornys@outlook.com>

### Type of change

- Enhancement

### Description

Load variables in ST from json config

example of config

```
{
  "DOCKER_TAG": "dev",
  "TEST_LOG_DIR": "/tmp/testlogs",
}
```

### Checklist


- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

