### PR TITLE
[systemtest][cc] Add test for single node Kafka with CruiseControl

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.cruisecontrol;
 
 import io.strimzi.api.kafka.model.KafkaTopicSpec;
+import io.strimzi.api.kafka.model.status.KafkaStatus;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.api.kafka.operator.assembly.KafkaRebalanceAnnotation;
 import io.strimzi.api.kafka.operator.assembly.KafkaRebalanceState;
@@ -13,6 +14,7 @@ import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaRebalanceUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -25,6 +27,7 @@ import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.resources.ResourceManager.cmdKubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 @Tag(REGRESSION)
 @Tag(CRUISE_CONTROL)
@@ -98,6 +101,28 @@ public class CruiseControlIsolatedST extends AbstractST {
         LOGGER.info("Verifying that KafkaRebalance is in the {} state", KafkaRebalanceState.Ready);
 
         KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(CLUSTER_NAME, KafkaRebalanceState.Ready);
+    }
+
+    @Test
+    void testCruiseControlWithSingleNodeKafka() {
+        String errMessage =  "Kafka " + NAMESPACE + "/" + CLUSTER_NAME + " has invalid configuration." +
+            " Cruise Control cannot be deployed with a single-node Kafka cluster. It requires " +
+            "at least two Kafka nodes.";
+
+        LOGGER.info("Deploying single node Kafka with CruiseControl");
+        KafkaResource.kafkaWithCruiseControlWithoutWait(CLUSTER_NAME, 1, 1);
+        KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(CLUSTER_NAME, NAMESPACE, errMessage);
+
+        KafkaStatus kafkaStatus = KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
+
+        assertThat(kafkaStatus.getConditions().get(0).getReason(), is("InvalidResourceException"));
+
+        LOGGER.info("Increasing Kafka nodes to 3");
+        KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka -> kafka.getSpec().getKafka().setReplicas(3));
+        KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
+
+        kafkaStatus = KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
+        assertThat(kafkaStatus.getConditions().get(0).getMessage(), is(not(errMessage)));
     }
 
     @BeforeAll


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement / new feature

### Description

After fix #3334 when you deploy single node Kafka, the `InvalidResourceExeption` appear, the CC cannot be deployed only with one Kafka broker. This PR will add test for this fix.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass


