### PR TITLE
[systemtest][mm2] Add checks for mirroring headers to separate test

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -10,6 +10,8 @@ import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.time.Duration;
+
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 /**
@@ -43,7 +45,8 @@ public class ClientUtils {
     }
 
     public static void waitTillContinuousClientsFinish(String producerName, String consumerName, String namespace, int messageCount) {
-        long timeout = (long) messageCount * 1000;
+        // need to add at least 1-2minutes for finishing the jobs
+        long timeout = (long) messageCount * 1000 + Duration.ofMinutes(2).toMillis();
         LOGGER.info("Waiting till producer {} and consumer {} finish for the following {} ms", producerName, consumerName, timeout);
         TestUtils.waitFor("continuous clients finished", Constants.GLOBAL_POLL_INTERVAL, timeout,
             () -> kubeClient().getClient().batch().jobs().inNamespace(namespace).withName(producerName).get().getStatus().getSucceeded().equals(1) &&
@@ -51,7 +54,8 @@ public class ClientUtils {
     }
 
     public static void waitForClientSuccess(String jobName, String namespace, int messageCount) {
-        long timeout = (long) messageCount * 3000;
+        // need to add at least 1-2minutes for finishing the job
+        long timeout = (long) messageCount * 1000 + Duration.ofMinutes(2).toMillis();
         LOGGER.info("Waiting for producer/consumer:{} will be finished in next {} ms", jobName, timeout);
         TestUtils.waitFor("job finished", Constants.GLOBAL_POLL_INTERVAL, timeout,
             () -> kubeClient().getClient().batch().jobs().inNamespace(namespace).withName(jobName).get().getStatus().getSucceeded().equals(1));


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Refactoring

### Description

After discussion we decided to move checks if mm2 correctly mirroring messages from `testMirrorMaker2` to separate test. The main problem is that we are getting the headers from consumer (job) pod and for example on `oc cluster up` it can be flaky -> some logs are not correctly propagated. So to be sure that basic functionality of mm2 is working and get rid of flaky checks in `testMirrorMaker2` I moved it to `testMirrorMaker2CorrectlyMirrorsHeaders`.

### Checklist

- [ ] Update tests
- [ ] Make sure all tests pass

