### PR TITLE
Update the Helm Chart index with 0.19.0

### DIFF
--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -2,6 +2,60 @@ apiVersion: v1
 entries:
   strimzi-kafka-operator:
   - apiVersion: v1
+    appVersion: 0.19.0
+    created: "2020-07-27T20:10:46.405537+02:00"
+    description: 'Strimzi: Apache Kafka running on Kubernetes'
+    digest: 9aefea97d6e6a98fbb5ce90d209063d4723f33088a9bf0d83144397805b09fe5
+    home: https://strimzi.io/
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    keywords:
+    - kafka
+    - queue
+    - stream
+    - event
+    - messaging
+    - datastore
+    - topic
+    maintainers:
+    - name: Frawless
+    - name: ppatierno
+    - name: samuel-hawker
+    - name: scholzj
+    - name: tombentley
+    name: strimzi-kafka-operator
+    sources:
+    - https://github.com/strimzi/strimzi-kafka-operator
+    urls:
+    - https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.19.0/strimzi-kafka-operator-helm-2-chart-0.19.0.tgz
+    version: 0.19.0
+  - apiVersion: v2
+    appVersion: 0.19.0
+    created: "2020-07-27T20:10:46.414004+02:00"
+    description: 'Strimzi: Apache Kafka running on Kubernetes'
+    digest: 1b4d8d15e156ffc13589891f97dd519df7dc7d47228446278250ee9a9d0b4736
+    home: https://strimzi.io/
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    keywords:
+    - kafka
+    - queue
+    - stream
+    - event
+    - messaging
+    - datastore
+    - topic
+    maintainers:
+    - name: Frawless
+    - name: ppatierno
+    - name: samuel-hawker
+    - name: scholzj
+    - name: tombentley
+    name: strimzi-kafka-operator
+    sources:
+    - https://github.com/strimzi/strimzi-kafka-operator
+    urls:
+    - https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.19.0/strimzi-kafka-operator-helm-3-chart-0.19.0.tgz
+    version: 0.19.0
+  - apiVersion: v1
     appVersion: 0.18.0
     created: "2020-05-20T19:37:53.265811+02:00"
     description: 'Strimzi: Apache Kafka running on Kubernetes'
@@ -578,4 +632,4 @@ entries:
     urls:
     - https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.6.0/strimzi-kafka-operator-0.6.0.tgz
     version: 0.6.0
-generated: "2020-05-20T19:37:53.256729+02:00"
+generated: "2020-07-27T20:10:46.395564+02:00"


### PR DESCRIPTION
After the 0.19.0 release, we need to update the Helm Chart index to make sure it ha the 0.19.0 release also for the next releases.