### PR TITLE
[cc] Add test for topic exclusion, fix utils methods, change annotation location

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -35,7 +35,6 @@ import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControl
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.RebalanceOptions;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.AbstractOperator;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
@@ -56,6 +55,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlApi.CC_REST_API_SUMMARY;
+import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_IO_REBALANCE;
 
 /**
  * <p>Assembly operator for a "KafkaRebalance" assembly, which interacts with Cruise Control REST API</p>
@@ -128,9 +128,6 @@ public class KafkaRebalanceAssemblyOperator
 
     private static final Logger log = LogManager.getLogger(KafkaRebalanceAssemblyOperator.class.getName());
 
-    // this annotation with related possible values (approve, stop, refresh) is set by the user for interacting
-    // with the rebalance operator in order to start, stop or refresh rebalacing proposals and operations
-    public static final String ANNO_STRIMZI_IO_REBALANCE = Annotations.STRIMZI_DOMAIN + "rebalance";
     private static final long REBALANCE_POLLING_TIMER_MS = 5_000;
     private static final int MAX_API_RETRIES = 5;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -33,6 +33,7 @@ import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControl
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlRestException;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.MockCruiseControl;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
@@ -909,7 +910,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
         KafkaRebalance patchedKr = new KafkaRebalanceBuilder(kafkaRebalance)
                 .editMetadata()
-                    .addToAnnotations(KafkaRebalanceAssemblyOperator.ANNO_STRIMZI_IO_REBALANCE, annotationValue.toString())
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_REBALANCE, annotationValue.toString())
                 .endMetadata()
                 .build();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -24,6 +24,7 @@ import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControl
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlApiImpl;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.MockCruiseControl;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.RebalanceOptions;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
@@ -126,7 +127,7 @@ public class KafkaRebalanceStateMachineTest {
                             .withName(RESOURCE_NAME)
                             .withNamespace(CLUSTER_NAMESPACE)
                             .withLabels(Collections.singletonMap(Labels.STRIMZI_CLUSTER_LABEL, CLUSTER_NAME))
-                            .withAnnotations(Collections.singletonMap(KafkaRebalanceAssemblyOperator.ANNO_STRIMZI_IO_REBALANCE, userAnnotation == null ? "none" : userAnnotation))
+                            .withAnnotations(Collections.singletonMap(Annotations.ANNO_STRIMZI_IO_REBALANCE, userAnnotation == null ? "none" : userAnnotation))
                         .endMetadata()
                         .withSpec(rebalanceSpec);
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -20,6 +20,7 @@ public class Annotations {
     public static final String STRIMZI_LOGGING_ANNOTATION = STRIMZI_DOMAIN + "logging";
     public static final String STRIMZI_IO_USE_CONNECTOR_RESOURCES = STRIMZI_DOMAIN + "use-connector-resources";
     public static final String ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE = STRIMZI_DOMAIN + "manual-rolling-update";
+    public static final String ANNO_STRIMZI_IO_REBALANCE = STRIMZI_DOMAIN + "rebalance";
     @Deprecated
     public static final String ANNO_OP_STRIMZI_IO_MANUAL_ROLLING_UPDATE = "operator." + Annotations.STRIMZI_DOMAIN + "manual-rolling-update";
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -20,6 +20,8 @@ public class Annotations {
     public static final String STRIMZI_LOGGING_ANNOTATION = STRIMZI_DOMAIN + "logging";
     public static final String STRIMZI_IO_USE_CONNECTOR_RESOURCES = STRIMZI_DOMAIN + "use-connector-resources";
     public static final String ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE = STRIMZI_DOMAIN + "manual-rolling-update";
+    // this annotation with related possible values (approve, stop, refresh) is set by the user for interacting
+    // with the rebalance operator in order to start, stop or refresh rebalacing proposals and operations
     public static final String ANNO_STRIMZI_IO_REBALANCE = STRIMZI_DOMAIN + "rebalance";
     @Deprecated
     public static final String ANNO_OP_STRIMZI_IO_MANUAL_ROLLING_UPDATE = "operator." + Annotations.STRIMZI_DOMAIN + "manual-rolling-update";

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -225,7 +225,7 @@
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>cluster-operator</artifactId>
-            <version>0.20.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -222,6 +222,12 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>cluster-operator</artifactId>
+            <version>0.20.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -222,12 +222,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.strimzi</groupId>
-            <artifactId>cluster-operator</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaRebalanceResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaRebalanceResource.java
@@ -12,8 +12,10 @@ import io.strimzi.api.kafka.KafkaRebalanceList;
 import io.strimzi.api.kafka.model.DoneableKafkaRebalance;
 import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.KafkaRebalanceBuilder;
+import io.strimzi.api.kafka.operator.assembly.KafkaRebalanceState;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.test.TestUtils;
 
 import java.util.function.Consumer;
@@ -75,7 +77,8 @@ public class KafkaRebalanceResource {
     }
 
     private static KafkaRebalance waitFor(KafkaRebalance kafkaRebalance) {
-        return ResourceManager.waitForResourceStatus(kafkaRebalanceClient(), kafkaRebalance, "PendingProposal");
+        long timeout = ResourceOperation.getTimeoutForKafkaRebalanceState(KafkaRebalanceState.PendingProposal);
+        return ResourceManager.waitForResourceStatus(kafkaRebalanceClient(), kafkaRebalance, KafkaRebalanceState.PendingProposal.toString(), timeout);
     }
 
     private static KafkaRebalance deleteLater(KafkaRebalance kafkaRebalance) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
@@ -6,8 +6,10 @@ package io.strimzi.systemtest.utils.kafkaUtils;
 
 import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.operator.assembly.KafkaRebalanceAnnotation;
 import io.strimzi.api.kafka.operator.assembly.KafkaRebalanceState;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -45,7 +47,14 @@ public class KafkaRebalanceUtils {
 
     public static void waitForKafkaRebalanceCustomResourceState(String resourceName, KafkaRebalanceState state) {
         KafkaRebalance kafkaRebalance = KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get();
-        ResourceManager.waitForResourceStatus(KafkaRebalanceResource.kafkaRebalanceClient(), kafkaRebalance, state.toString());
+        ResourceManager.waitForResourceStatus(KafkaRebalanceResource.kafkaRebalanceClient(), kafkaRebalance, state.toString(), ResourceOperation.getTimeoutForKafkaRebalanceState(state));
+    }
+
+    public static String annotateKafkaRebalanceResource(String resourceName, KafkaRebalanceAnnotation annotation) {
+        LOGGER.info("Annotating KafkaRebalance:{} with annotation {}", resourceName, annotation.toString());
+        return ResourceManager.cmdKubeClient().namespace(kubeClient().getNamespace())
+            .execInCurrentNamespace("annotate", "kafkarebalance", resourceName, "strimzi.io/rebalance=" + annotation.toString())
+            .out();
     }
 
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
@@ -8,6 +8,7 @@ import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.operator.assembly.KafkaRebalanceAnnotation;
 import io.strimzi.api.kafka.operator.assembly.KafkaRebalanceState;
+import io.strimzi.operator.cluster.operator.assembly.KafkaRebalanceAssemblyOperator;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
@@ -53,7 +54,7 @@ public class KafkaRebalanceUtils {
     public static String annotateKafkaRebalanceResource(String resourceName, KafkaRebalanceAnnotation annotation) {
         LOGGER.info("Annotating KafkaRebalance:{} with annotation {}", resourceName, annotation.toString());
         return ResourceManager.cmdKubeClient().namespace(kubeClient().getNamespace())
-            .execInCurrentNamespace("annotate", "kafkarebalance", resourceName, "strimzi.io/rebalance=" + annotation.toString())
+            .execInCurrentNamespace("annotate", "kafkarebalance", resourceName, KafkaRebalanceAssemblyOperator.ANNO_STRIMZI_IO_REBALANCE + "=" + annotation.toString())
             .out();
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
@@ -8,7 +8,7 @@ import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.operator.assembly.KafkaRebalanceAnnotation;
 import io.strimzi.api.kafka.operator.assembly.KafkaRebalanceState;
-import io.strimzi.operator.cluster.operator.assembly.KafkaRebalanceAssemblyOperator;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
@@ -54,7 +54,7 @@ public class KafkaRebalanceUtils {
     public static String annotateKafkaRebalanceResource(String resourceName, KafkaRebalanceAnnotation annotation) {
         LOGGER.info("Annotating KafkaRebalance:{} with annotation {}", resourceName, annotation.toString());
         return ResourceManager.cmdKubeClient().namespace(kubeClient().getNamespace())
-            .execInCurrentNamespace("annotate", "kafkarebalance", resourceName, KafkaRebalanceAssemblyOperator.ANNO_STRIMZI_IO_REBALANCE + "=" + annotation.toString())
+            .execInCurrentNamespace("annotate", "kafkarebalance", resourceName, Annotations.ANNO_STRIMZI_IO_REBALANCE + "=" + annotation.toString())
             .out();
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.cruisecontrol;
 
 import io.strimzi.api.kafka.model.KafkaTopicSpec;
+import io.strimzi.api.kafka.model.status.KafkaRebalanceStatus;
 import io.strimzi.api.kafka.model.status.KafkaStatus;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.api.kafka.operator.assembly.KafkaRebalanceAnnotation;
@@ -24,8 +25,8 @@ import org.junit.jupiter.api.Test;
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.REGRESSION;
-import static io.strimzi.systemtest.resources.ResourceManager.cmdKubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
@@ -86,11 +87,7 @@ public class CruiseControlIsolatedST extends AbstractST {
 
         LOGGER.info("Triggering the rebalance with annotation {} of KafkaRebalance resource", "strimzi.io/rebalance=approve");
 
-        // attach the approve annotation -> RS
-        LOGGER.info("Executing command in the namespace {}", cmdKubeClient().namespace(NAMESPACE).namespace());
-        String response = ResourceManager.cmdKubeClient().namespace(NAMESPACE)
-            .execInCurrentNamespace("annotate", "kafkarebalance", CLUSTER_NAME, "strimzi.io/rebalance=" + KafkaRebalanceAnnotation.approve.toString())
-            .out();
+        String response = KafkaRebalanceUtils.annotateKafkaRebalanceResource(CLUSTER_NAME, KafkaRebalanceAnnotation.approve);
 
         LOGGER.info("Response from the annotation process {}", response);
 
@@ -123,6 +120,37 @@ public class CruiseControlIsolatedST extends AbstractST {
 
         kafkaStatus = KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
         assertThat(kafkaStatus.getConditions().get(0).getMessage(), is(not(errMessage)));
+    }
+
+    @Test
+    void testCruiseControlTopicExclusion() {
+        String excludedTopic1 = "excluded-topic-1";
+        String excludedTopic2 = "excluded-topic-2";
+        String includedTopic = "included-topic";
+
+        KafkaResource.kafkaWithCruiseControl(CLUSTER_NAME, 3, 3).done();
+        KafkaTopicResource.topic(CLUSTER_NAME, excludedTopic1).done();
+        KafkaTopicResource.topic(CLUSTER_NAME, excludedTopic2).done();
+        KafkaTopicResource.topic(CLUSTER_NAME, includedTopic).done();
+
+        KafkaRebalanceResource.kafkaRebalance(CLUSTER_NAME)
+            .editOrNewSpec()
+                .withExcludedTopics("excluded-.*")
+                .withReplicationThrottle(200000)
+                .withConcurrentLeaderMovements(1200)
+            .endSpec()
+            .done();
+
+        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(CLUSTER_NAME, KafkaRebalanceState.ProposalReady);
+
+        LOGGER.info("Checking status of KafkaRebalance");
+        KafkaRebalanceStatus kafkaRebalanceStatus = KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
+        assertThat(kafkaRebalanceStatus.getOptimizationResult().get("excludedTopics").toString(), containsString(excludedTopic1));
+        assertThat(kafkaRebalanceStatus.getOptimizationResult().get("excludedTopics").toString(), containsString(excludedTopic2));
+        assertThat(kafkaRebalanceStatus.getOptimizationResult().get("excludedTopics").toString(), not(containsString(includedTopic)));
+
+        KafkaRebalanceUtils.annotateKafkaRebalanceResource(CLUSTER_NAME, KafkaRebalanceAnnotation.approve);
+        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(CLUSTER_NAME, KafkaRebalanceState.Ready);
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -136,8 +136,6 @@ public class CruiseControlIsolatedST extends AbstractST {
         KafkaRebalanceResource.kafkaRebalance(CLUSTER_NAME)
             .editOrNewSpec()
                 .withExcludedTopics("excluded-.*")
-                .withReplicationThrottle(200000)
-                .withConcurrentLeaderMovements(1200)
             .endSpec()
             .done();
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix
- New test

### Description

After #3275 we are able to set which topics should be excluded, so theirs performance remains stable during the rebalance. Other than this I fixed `utils` methods -> all the states of `KafkaRebalance` had timeout 3 minutes -> I added there wrong method from `ResourceOperation` in my last PR. Also I added method for annotating the `KafkaRebalance`.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

