### PR TITLE
Add checks to KafkaCluster CC configs to ensure cc metrics topic replicas > minISR

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -3559,4 +3559,120 @@ public class KafkaClusterTest {
         assertThat(ex.getMessage(), is("Kafka " + namespace + "/" + cluster + " has invalid configuration. " +
                 "Cruise Control cannot be deployed with a single-node Kafka cluster. It requires at least two Kafka nodes."));
     }
+
+    @Test
+    public void testCruiseControlWithHigherMinISR() {
+        Map<String, Object> config = new HashMap<>();
+        int minInsyncReplicas = 2;
+        config.put(KafkaCluster.CC_REPLICATION_FACTOR_CONFIG_FIELD, 1);
+        config.put(KafkaCluster.KAFKA_MIN_INSYNC_REPLICA_CONFIG_FIELD, minInsyncReplicas);
+
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withReplicas(minInsyncReplicas + 1)
+                        .withConfig(config)
+                    .endKafka()
+                    .withNewCruiseControl()
+                    .endCruiseControl()
+                .endSpec()
+                .build();
+
+        KafkaCluster kafka = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
+        assertThat(kafka.ccReplicationFactor, is(String.valueOf(minInsyncReplicas + 1)));
+    }
+
+    @Test
+    public void testCruiseControlDefaultWithHigherMinISR() {
+        Map<String, Object> config = new HashMap<>();
+        int minInsyncReplicas = 2;
+        config.put(KafkaCluster.KAFKA_MIN_INSYNC_REPLICA_CONFIG_FIELD, minInsyncReplicas);
+
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withReplicas(minInsyncReplicas + 1)
+                        .withConfig(config)
+                    .endKafka()
+                    .withNewCruiseControl()
+                    .endCruiseControl()
+                .endSpec()
+                .build();
+
+        KafkaCluster kafka = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
+        assertThat(kafka.ccReplicationFactor, is(String.valueOf(minInsyncReplicas + 1)));
+    }
+
+    @Test
+    public void testCruiseControlWithSameMinISR() {
+        Map<String, Object> config = new HashMap<>();
+        int minInsyncReplicas = 2;
+        config.put(KafkaCluster.CC_REPLICATION_FACTOR_CONFIG_FIELD, minInsyncReplicas);
+        config.put(KafkaCluster.KAFKA_MIN_INSYNC_REPLICA_CONFIG_FIELD, minInsyncReplicas);
+
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withReplicas(minInsyncReplicas + 1)
+                        .withConfig(config)
+                    .endKafka()
+                    .withNewCruiseControl()
+                    .endCruiseControl()
+                .endSpec()
+                .build();
+
+        KafkaCluster kafka = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
+        assertThat(kafka.ccReplicationFactor, is(String.valueOf(minInsyncReplicas + 1)));
+    }
+
+    @Test
+    public void testCruiseControlWithLowerMinISR() {
+        Map<String, Object> config = new HashMap<>();
+        int minInsyncReplicas = 2;
+        int ccMetricTopicReplicas = minInsyncReplicas + 1;
+        config.put(KafkaCluster.CC_REPLICATION_FACTOR_CONFIG_FIELD, ccMetricTopicReplicas);
+        config.put(KafkaCluster.KAFKA_MIN_INSYNC_REPLICA_CONFIG_FIELD, minInsyncReplicas);
+
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withReplicas(minInsyncReplicas + 1)
+                        .withConfig(config)
+                    .endKafka()
+                    .withNewCruiseControl()
+                    .endCruiseControl()
+                .endSpec()
+                .build();
+
+        KafkaCluster kafka = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
+        assertThat(kafka.ccReplicationFactor, is(String.valueOf(ccMetricTopicReplicas)));
+    }
+
+    @Test
+    public void testCruiseControlWithCCMTRGreaterThanReplicas() {
+        Map<String, Object> config = new HashMap<>();
+        int minInsyncReplicas = 2;
+        int ccMetricTopicReplicas = minInsyncReplicas + 1;
+        config.put(KafkaCluster.CC_REPLICATION_FACTOR_CONFIG_FIELD, ccMetricTopicReplicas);
+        config.put(KafkaCluster.KAFKA_MIN_INSYNC_REPLICA_CONFIG_FIELD, minInsyncReplicas);
+
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withReplicas(minInsyncReplicas)
+                        .withConfig(config)
+                    .endKafka()
+                    .withNewCruiseControl()
+                    .endCruiseControl()
+                .endSpec()
+                .build();
+
+        KafkaCluster kafka = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
+        assertThat(kafka.ccReplicationFactor, is(String.valueOf(minInsyncReplicas)));
+    }
 }


### PR DESCRIPTION
### Type of change

Bugfix

### Description

This addresses issue #3389, where the CC metrics reporter could not send metrics to their topics if the clusters `min.insync.replicas` was set to > 1. This PR adds checks to the `KafakCluster.fromCRD` method to preferably set the CC metrics topic replication factor to minISR + 1. It also has checks to make sure that the chosen value is less than or equal to the number of brokers. 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging