### PR TITLE
Improve the printed columns for some CRDs

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
@@ -51,7 +51,27 @@ import static java.util.Collections.unmodifiableList;
                                 specReplicasPath = KafkaConnector.SPEC_REPLICAS_PATH,
                                 statusReplicasPath = KafkaConnector.STATUS_REPLICAS_PATH
                         )
-                )
+                ),
+                additionalPrinterColumns = {
+                        @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Cluster",
+                                description = "The name of the Kafka Connect cluster this connector belongs to",
+                                jsonPath = ".metadata.labels.strimzi\\.io/cluster",
+                                type = "string"
+                        ),
+                        @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Connector class",
+                                description = "The class used by this connector",
+                                jsonPath = ".spec.class",
+                                type = "string"
+                        ),
+                        @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Max Tasks",
+                                description = "Maximum number of tasks",
+                                jsonPath = ".spec.tasksMax",
+                                type = "integer"
+                        )
+                }
         )
 )
 @Buildable(

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
@@ -51,7 +51,15 @@ import static java.util.Collections.unmodifiableList;
                 },
                 subresources = @Crd.Spec.Subresources(
                         status = @Crd.Spec.Subresources.Status()
-                )
+                ),
+                additionalPrinterColumns = {
+                        @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Cluster",
+                                description = "The name of the Kafka cluster this resource rebalances",
+                                jsonPath = ".metadata.labels.strimzi\\.io/cluster",
+                                type = "string"
+                        )
+                }
         )
 )
 @Buildable(

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
@@ -60,6 +60,12 @@ import static java.util.Collections.unmodifiableList;
                 ),
                 additionalPrinterColumns = {
                         @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Cluster",
+                                description = "The name of the Kafka cluster this topic belongs to",
+                                jsonPath = ".metadata.labels.strimzi\\.io/cluster",
+                                type = "string"
+                        ),
+                        @Crd.Spec.AdditionalPrinterColumn(
                                 name = "Partitions",
                                 description = "The desired number of partitions in the topic",
                                 jsonPath = ".spec.partitions",

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -59,6 +59,12 @@ import static java.util.Collections.unmodifiableList;
                 ),
                 additionalPrinterColumns = {
                         @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Cluster",
+                                description = "The name of the Kafka cluster this user belongs to",
+                                jsonPath = ".metadata.labels.strimzi\\.io/cluster",
+                                type = "string"
+                        ),
+                        @Crd.Spec.AdditionalPrinterColumn(
                                 name = "Authentication",
                                 description = "How the user is authenticated",
                                 jsonPath = ".spec.authentication.type",
@@ -71,7 +77,6 @@ import static java.util.Collections.unmodifiableList;
                                 type = "string"
                         )
                 }
-
         )
 )
 @Buildable(

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
@@ -31,6 +31,10 @@ spec:
     categories:
       - strimzi
   additionalPrinterColumns:
+    - name: Cluster
+      description: The name of the Kafka cluster this topic belongs to
+      JSONPath: .metadata.labels.strimzi\.io/cluster
+      type: string
     - name: Partitions
       description: The desired number of partitions in the topic
       JSONPath: .spec.partitions

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
@@ -31,6 +31,10 @@ spec:
     categories:
       - strimzi
   additionalPrinterColumns:
+    - name: Cluster
+      description: The name of the Kafka cluster this user belongs to
+      JSONPath: .metadata.labels.strimzi\.io/cluster
+      type: string
     - name: Authentication
       description: How the user is authenticated
       JSONPath: .spec.authentication.type

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
@@ -27,6 +27,19 @@ spec:
       - kctr
     categories:
       - strimzi
+  additionalPrinterColumns:
+    - name: Cluster
+      description: The name of the Kafka Connect cluster this connector belongs to
+      JSONPath: .metadata.labels.strimzi\.io/cluster
+      type: string
+    - name: Connector class
+      description: The class used by this connector
+      JSONPath: .spec.class
+      type: string
+    - name: Max Tasks
+      description: Maximum number of tasks
+      JSONPath: .spec.tasksMax
+      type: integer
   subresources:
     status: {}
     scale:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/049-Crd-kafkarebalance.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/049-Crd-kafkarebalance.yaml
@@ -27,6 +27,11 @@ spec:
       - kr
     categories:
       - strimzi
+  additionalPrinterColumns:
+    - name: Cluster
+      description: The name of the Kafka cluster this resource rebalances
+      JSONPath: .metadata.labels.strimzi\.io/cluster
+      type: string
   subresources:
     status: {}
   validation:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
@@ -27,6 +27,10 @@ spec:
     categories:
       - strimzi
   additionalPrinterColumns:
+    - name: Cluster
+      description: The name of the Kafka cluster this topic belongs to
+      JSONPath: .metadata.labels.strimzi\.io/cluster
+      type: string
     - name: Partitions
       description: The desired number of partitions in the topic
       JSONPath: .spec.partitions

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
@@ -27,6 +27,10 @@ spec:
     categories:
       - strimzi
   additionalPrinterColumns:
+    - name: Cluster
+      description: The name of the Kafka cluster this user belongs to
+      JSONPath: .metadata.labels.strimzi\.io/cluster
+      type: string
     - name: Authentication
       description: How the user is authenticated
       JSONPath: .spec.authentication.type

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
@@ -23,6 +23,19 @@ spec:
       - kctr
     categories:
       - strimzi
+  additionalPrinterColumns:
+    - name: Cluster
+      description: The name of the Kafka Connect cluster this connector belongs to
+      JSONPath: .metadata.labels.strimzi\.io/cluster
+      type: string
+    - name: Connector class
+      description: The class used by this connector
+      JSONPath: .spec.class
+      type: string
+    - name: Max Tasks
+      description: Maximum number of tasks
+      JSONPath: .spec.tasksMax
+      type: integer
   subresources:
     status: {}
     scale:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
@@ -23,6 +23,11 @@ spec:
       - kr
     categories:
       - strimzi
+  additionalPrinterColumns:
+    - name: Cluster
+      description: The name of the Kafka cluster this resource rebalances
+      JSONPath: .metadata.labels.strimzi\.io/cluster
+      type: string
   subresources:
     status: {}
   validation:

--- a/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -26,6 +26,10 @@ spec:
     categories:
     - strimzi
   additionalPrinterColumns:
+  - name: Cluster
+    description: The name of the Kafka cluster this topic belongs to
+    JSONPath: .metadata.labels.strimzi\.io/cluster
+    type: string
   - name: Partitions
     description: The desired number of partitions in the topic
     JSONPath: .spec.partitions

--- a/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -26,6 +26,10 @@ spec:
     categories:
     - strimzi
   additionalPrinterColumns:
+  - name: Cluster
+    description: The name of the Kafka cluster this user belongs to
+    JSONPath: .metadata.labels.strimzi\.io/cluster
+    type: string
   - name: Authentication
     description: How the user is authenticated
     JSONPath: .spec.authentication.type

--- a/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -22,6 +22,19 @@ spec:
     - kctr
     categories:
     - strimzi
+  additionalPrinterColumns:
+  - name: Cluster
+    description: The name of the Kafka Connect cluster this connector belongs to
+    JSONPath: .metadata.labels.strimzi\.io/cluster
+    type: string
+  - name: Connector class
+    description: The class used by this connector
+    JSONPath: .spec.class
+    type: string
+  - name: Max Tasks
+    description: Maximum number of tasks
+    JSONPath: .spec.tasksMax
+    type: integer
   subresources:
     status: {}
     scale:

--- a/install/cluster-operator/049-Crd-kafkarebalance.yaml
+++ b/install/cluster-operator/049-Crd-kafkarebalance.yaml
@@ -22,6 +22,11 @@ spec:
     - kr
     categories:
     - strimzi
+  additionalPrinterColumns:
+  - name: Cluster
+    description: The name of the Kafka cluster this resource rebalances
+    JSONPath: .metadata.labels.strimzi\.io/cluster
+    type: string
   subresources:
     status: {}
   validation:

--- a/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -26,6 +26,10 @@ spec:
     categories:
     - strimzi
   additionalPrinterColumns:
+  - name: Cluster
+    description: The name of the Kafka cluster this topic belongs to
+    JSONPath: .metadata.labels.strimzi\.io/cluster
+    type: string
   - name: Partitions
     description: The desired number of partitions in the topic
     JSONPath: .spec.partitions

--- a/install/user-operator/04-Crd-kafkauser.yaml
+++ b/install/user-operator/04-Crd-kafkauser.yaml
@@ -26,6 +26,10 @@ spec:
     categories:
     - strimzi
   additionalPrinterColumns:
+  - name: Cluster
+    description: The name of the Kafka cluster this user belongs to
+    JSONPath: .metadata.labels.strimzi\.io/cluster
+    type: string
   - name: Authentication
     description: How the user is authenticated
     JSONPath: .spec.authentication.type


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR improves the printed columns for some of our CRs. It mainly adds a new `Cluster` column which is based on the `strimzi.io/cluster` label and can be used to quickly see to which cluster the resource belongs. Additionally, it also adds connector class and max tasks fields to the Connector CR.

Following example shows how the resources look like (including the topic without the cluster label):

```
NAME                                           CLUSTER      PARTITIONS   REPLICATION FACTOR
kafkatopic.kafka.strimzi.io/kafka-test-apps    my-cluster   3            3
kafkatopic.kafka.strimzi.io/kafka-test-apps2                3            3

NAME                                 CLUSTER      AUTHENTICATION   AUTHORIZATION
kafkauser.kafka.strimzi.io/my-user   my-cluster   tls              simple

NAME                                           CLUSTER
kafkarebalance.kafka.strimzi.io/my-rebalance   my-cluster

NAME                                                  CLUSTER              CONNECTOR CLASS                                           MAX TASKS
kafkaconnector.kafka.strimzi.io/my-source-connector   my-connect-cluster   org.apache.kafka.connect.file.FileStreamSourceConnector   2
```

This change was inspired by #3326.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally