### PR TITLE
ST: Remove NPE during log collecting

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -394,9 +394,12 @@ public class ResourceManager {
             } else {
                 List<String> log = new ArrayList<>(asList("\n", kind, " status:\n", "\nConditions:\n"));
 
-                for (Condition condition : customResource.getStatus().getConditions()) {
-                    log.add("\tType: " + condition.getType() + "\n");
-                    log.add("\tMessage: " + condition.getMessage() + "\n");
+                List<Condition> conditions = customResource.getStatus().getConditions();
+                if (conditions != null) {
+                    for (Condition condition : customResource.getStatus().getConditions()) {
+                        log.add("\tType: " + condition.getType() + "\n");
+                        log.add("\tMessage: " + condition.getMessage() + "\n");
+                    }
                 }
 
                 log.add("\nPods with conditions and messages:\n\n");

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -434,7 +434,9 @@ public class ResourceManager {
             () -> operation.inNamespace(resource.getMetadata().getNamespace())
                     .withName(resource.getMetadata().getName())
                     .get().getStatus().getConditions().stream().anyMatch(condition -> condition.getType().equals(status)),
-            () -> logCurrentResourceStatus(resource));
+            () -> logCurrentResourceStatus(operation.inNamespace(resource.getMetadata().getNamespace())
+                    .withName(resource.getMetadata().getName())
+                    .get()));
 
         LOGGER.info("{}: {} is in desired state: {}", resource.getKind(), resource.getMetadata().getName(), status);
         return resource;


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

NPE is raised when tests setup fail cause, for example, imagePullBackOff (wrong configuration for example). This change will avoid this and also get a new version of resource every time time when `logCurrentResourceStatus()` is called.

### Checklist

- [ ] Make sure all tests pass

