### PR TITLE
[Tests] auto-detect kubernetes cluster

### DIFF
--- a/test/src/main/java/io/strimzi/test/k8s/cluster/KubeCluster.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/KubeCluster.java
@@ -67,7 +67,7 @@ public interface KubeCluster {
             }
         }
         if (clusters == null) {
-            clusters = new KubeCluster[]{new OpenShift(), new Minikube(), new Minishift()};
+            clusters = new KubeCluster[]{new Minikube(), new Kubernetes(), new Minishift(), new OpenShift()};
         }
         KubeCluster cluster = null;
         for (KubeCluster kc : clusters) {

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Kubernetes.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Kubernetes.java
@@ -27,7 +27,7 @@ public class Kubernetes implements KubeCluster {
     @Override
     public boolean isClusterUp() {
         try {
-            return Exec.exec(CMD, "cluster-info").exitStatus();
+            return Exec.exec(CMD, "cluster-info").exitStatus() && !Exec.exec(CMD, "api-resources").out().contains("openshift.io");
         } catch (KubeClusterException e) {
             e.printStackTrace();
             return false;

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/OpenShift.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/OpenShift.java
@@ -22,7 +22,7 @@ public class OpenShift implements KubeCluster {
     @Override
     public boolean isClusterUp() {
         try {
-            return Exec.exec(OC, "status").exitStatus();
+            return Exec.exec(OC, "status").exitStatus() && Exec.exec(OC, "api-resources").out().contains("openshift.io");
         } catch (KubeClusterException e) {
             e.printStackTrace();
             return false;


### PR DESCRIPTION
Signed-off-by: David Kornel <kornys@outlook.com>

### Type of change

- Enhancement

### Description

I always switch context of clusters which I use for testing, I have kubectl, oc, minikube, microk8s installed and systemtest does not auto detect which cluster I currently use. With this change tests correctly detect which cluster I use without passing env variable.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

