### PR TITLE
ST: Allow use latest-released version of Kafka Bridge during helm-system-tests

### DIFF
--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -243,6 +243,7 @@
                 <directory>..</directory>
                 <includes>
                     <include>kafka-versions.yaml</include>
+                    <include>bridge.version</include>
                 </includes>
             </resource>
         </resources>

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/HelmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/HelmResource.java
@@ -8,6 +8,7 @@ import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
+import io.strimzi.systemtest.utils.specific.BridgeUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeClusterResource;
 import org.apache.logging.log4j.LogManager;
@@ -45,7 +46,12 @@ public class HelmResource {
     public static void clusterOperator(long operationTimeout, long reconciliationInterval) {
         Map<String, String> values = Collections.unmodifiableMap(Stream.of(
                 entry("imageRepositoryOverride", Environment.STRIMZI_REGISTRY + "/" + Environment.STRIMZI_ORG),
-                entry("imageTagOverride", Environment.STRIMZI_TAG),
+                entry("image.tag", Environment.STRIMZI_TAG),
+                entry("topicOperator.image.tag", Environment.STRIMZI_TAG),
+                entry("userOperator.image.tag", Environment.STRIMZI_TAG),
+                entry("kafkaInit.image.tag", Environment.STRIMZI_TAG),
+                entry("jmxTrans.image.tag", Environment.STRIMZI_TAG),
+                entry("kafkaBridge.image.tag", Environment.useLatestReleasedBridge() ? "latest" : BridgeUtils.getBridgeVersion()),
                 entry("image.pullPolicy", Environment.OPERATOR_IMAGE_PULL_POLICY),
                 entry("resources.requests.memory", REQUESTS_MEMORY),
                 entry("resources.requests.cpu", REQUESTS_CPU),

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/BridgeUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/BridgeUtils.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.utils.specific;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.utils.HttpUtils;
+import io.strimzi.test.TestUtils;
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -16,6 +17,7 @@ import io.vertx.ext.web.codec.BodyCodec;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.InputStream;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -188,5 +190,15 @@ public class BridgeUtils {
                 }
             });
         return future.get(1, TimeUnit.MINUTES);
+    }
+
+    /**
+     * Returns Strimzi Kafka Bridge version which is associated with Strimzi Kafka Operator.
+     * The value is parsed from {@code /bridge.version} classpath resource and return it as a string.
+     * @return bridge version
+     */
+    public static String getBridgeVersion() {
+        InputStream bridgeVersionInputStream = BridgeUtils.class.getResourceAsStream("/bridge.version");
+        return TestUtils.readResource(bridgeVersionInputStream).replace("\n", "");
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -19,6 +19,7 @@ import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.operator.BundleResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.specific.BridgeUtils;
 import io.strimzi.test.executor.Exec;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -248,6 +249,7 @@ public class SpecificST extends AbstractST {
 
     @BeforeAll
     void setup() {
+        LOGGER.info(BridgeUtils.getBridgeVersion());
         ResourceManager.setClassResources();
         prepareEnvForOperator(NAMESPACE);
 


### PR DESCRIPTION

Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

This PR fix the issue when you want to run system tests with CO installed by helm against different version than latest. In case that  `DOCKER_TAG` was set to for example `0.19.0`, the kafka bridge tag was set to the same value, which is not intended (`0.19.0` operator use `0.18.0` bridge).

I did verification manually (because pipelines for that are not ready yet) and it's working for me. 

### Checklist

- [ ] Make sure all tests pass

