### PR TITLE
[DOC] Fix lower and upper case letters in SimpleAclAuthorizer

### DIFF
--- a/documentation/modules/oauth/con-oauth-authorization-intro.adoc
+++ b/documentation/modules/oauth/con-oauth-authorization-intro.adoc
@@ -15,7 +15,7 @@ Security policies and permissions defined in Keycloak are used to grant access t
 Users and clients are matched against policies that permit access to perform specific actions on Kafka brokers.
 
 Kafka allows all users full access to brokers by default,
-and also provides the `SimpleACLAuthorizer` plugin to configure authorization based on Access Control Lists (ACLs).
+and also provides the `SimpleAclAuthorizer` plugin to configure authorization based on Access Control Lists (ACLs).
 ZooKeeper stores ACL rules that grant or deny access to resources based on _username_.
 However, OAuth 2.0 token-based authorization with  Keycloak offers far greater flexibility on how you wish to implement access control to Kafka brokers.
 In addition, you can configure your Kafka brokers to use OAuth 2.0 authorization and ACLs.

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -68,7 +68,7 @@ spec:
 <1> Type `keycloak` enables Keycloak authorization.
 <2> URI of the Keycloak token endpoint. For production, always use HTTPs.
 <3> The client ID of the OAuth 2.0 client definition in Keycloak that has Authorization Services enabled. Typically, `kafka` is used as the ID.
-<4> (Optional) Delegate authorization to Kafka `SimpleACLAuthorizer` if access is denied by Keycloak Authorization Services policies.
+<4> (Optional) Delegate authorization to Kafka `SimpleAclAuthorizer` if access is denied by Keycloak Authorization Services policies.
 The default is `false`.
 <5> (Optional) Disable TLS hostname verification. Default is `false`.
 <6> (Optional) Designated xref:ref-kafka-authorization-super-user-deployment-configuration-kafka[super users].

--- a/documentation/modules/overview/con-security-configuration-authorization.adoc
+++ b/documentation/modules/overview/con-security-configuration-authorization.adoc
@@ -4,9 +4,9 @@
 
 [id="security-configuration-authorization_{context}"]
 = Authorization
-You can apply authorization to a Kafka cluster using `SimpleACLAuthorizer`.
+You can apply authorization to a Kafka cluster using `SimpleAclAuthorizer`.
 If applied to a Kafka cluster, authorization is enabled for all listeners used for client connection.
 
-`SimpleACLAuthorizer` uses Access Control Lists (ACLs) to define which users have access to which resources.
+`SimpleAclAuthorizer` uses Access Control Lists (ACLs) to define which users have access to which resources.
 
 _Super users_ provide user access to all resources in a Kafka cluster or to a specific broker.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

In some places of our documentation we seem to be using `SimpleACLAuthorizer` with capital `ACL`. That is not right since the actual class name is `SimpleAclAuthorizer`. This PR changes the capitalization.
