### PR TITLE
Update CC to version including CPU fix + enabled CPUCapacityGoal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # CHANGELOG
 
+## 0.20.0
+
+* Updated to Cruise Control 2.0.124, which fixes a previous issue with CPU utilization statistics for containers. As a result, the CPUCapacityGoal has now been enabled.
+
 ## 0.19.0
 
 * Add support for authorization using Open Policy Agent

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
@@ -30,11 +30,7 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
                 CruiseControl.DISK_CAPACITY_GOAL,
                 CruiseControl.NETWORK_INBOUND_CAPACITY_GOAL,
                 CruiseControl.NETWORK_OUTBOUND_CAPACITY_GOAL,
-                // TODO: The CPU metric are currently not reported correctly when running on Kubernetes
-                //       we should add this back in once fixed upstream,
-                //       CC issue: https://github.com/linkedin/cruise-control/issues/1242
-                //       Strimzi issue: https://github.com/strimzi/strimzi-kafka-operator/issues/3215
-                //CruiseControl.CPU_CAPACITY_GOAL,
+                CruiseControl.CPU_CAPACITY_GOAL,
                 CruiseControl.REPLICA_DISTRIBUTION_GOAL,
                 CruiseControl.POTENTIAL_NETWORK_OUTAGE_GOAL,
                 CruiseControl.DISK_USAGE_DISTRIBUTION_GOAL,
@@ -60,12 +56,8 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
                     CruiseControl.REPLICA_CAPACITY_GOAL,
                     CruiseControl.DISK_CAPACITY_GOAL,
                     CruiseControl.NETWORK_INBOUND_CAPACITY_GOAL,
-                    CruiseControl.NETWORK_OUTBOUND_CAPACITY_GOAL
-                    // TODO: The CPU metric are currently not reported correctly when running on Kubernetes
-                    //       we should add this back in once fixed upstream,
-                    //       CC issue: https://github.com/linkedin/cruise-control/issues/1242
-                    //       Strimzi issue: https://github.com/strimzi/strimzi-kafka-operator/issues/3215
-                    //CruiseControl.CPU_CAPACITY_GOAL
+                    CruiseControl.NETWORK_OUTBOUND_CAPACITY_GOAL,
+                    CruiseControl.CPU_CAPACITY_GOAL
             )
     );
 
@@ -97,7 +89,7 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
     private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
 
     static {
-        Map<String, String> config = new HashMap<>(7);
+        Map<String, String> config = new HashMap<>(8);
         config.put("partition.metrics.window.ms", Integer.toString(300_000));
         config.put("num.partition.metrics.windows", "1");
         config.put("broker.metrics.window.ms", Integer.toString(300_000));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -91,6 +91,7 @@ public class KafkaBrokerConfigurationBuilder {
             writer.println("cruise.control.metrics.reporter.ssl.truststore.location=/tmp/kafka/cluster.truststore.p12");
             writer.println("cruise.control.metrics.reporter.ssl.truststore.password=${CERTS_STORE_PASSWORD}");
             writer.println("cruise.control.metrics.topic.auto.create=true");
+            writer.println("cruise.control.metrics.reporter.kubernetes.mode=true");
             if (numPartitions != null) {
                 writer.println("cruise.control.metrics.topic.num.partitions=" + numPartitions);
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -83,6 +83,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "cruise.control.metrics.reporter.ssl.truststore.location=/tmp/kafka/cluster.truststore.p12\n" +
                 "cruise.control.metrics.reporter.ssl.truststore.password=${CERTS_STORE_PASSWORD}\n" +
                 "cruise.control.metrics.topic.auto.create=true\n" +
+                "cruise.control.metrics.reporter.kubernetes.mode=true\n" +
                 "cruise.control.metrics.topic.num.partitions=1\n" +
                 "cruise.control.metrics.topic.replication.factor=1"));
     }

--- a/docker-images/kafka/kafka-thirdparty-libs/2.4.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.4.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.5.0</strimzi-oauth.version>
-        <cruise-control.version>2.0.108</cruise-control.version>
+        <cruise-control.version>2.0.124</cruise-control.version>
         <opa-authorizer.version>0.4.1</opa-authorizer.version>
     </properties>
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.5.0</strimzi-oauth.version>
-        <cruise-control.version>2.0.108</cruise-control.version>
+        <cruise-control.version>2.0.124</cruise-control.version>
         <opa-authorizer.version>0.4.1</opa-authorizer.version>
     </properties>
 

--- a/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.0.108</cruise-control.version>
+        <cruise-control.version>2.0.124</cruise-control.version>
     </properties>
 
     <repositories>

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -13,12 +13,10 @@ The supported goals, in the default descending order of priority, are as follows
 
 . Rack-awareness
 . Replica capacity
-. Capacity: Disk capacity, Network inbound capacity, Network outbound capacity
-//.. CPU capacity
+. Capacity: Disk capacity, Network inbound capacity, Network outbound capacity, CPU capacity
 . Replica distribution
 . Potential network output
-. Resource distribution: Disk utilization distribution, Network inbound utilization distribution, Network outbound utilization distribution
-//.. CPU utilization distribution
+. Resource distribution: Disk utilization distribution, Network inbound utilization distribution, Network outbound utilization distribution, CPU utilization distribution
 . Leader bytes-in rate distribution
 . Topic replica distribution
 . Leader replica distribution
@@ -28,7 +26,7 @@ The supported goals, in the default descending order of priority, are as follows
 
 For more information on each optimization goal, see link:https://github.com/linkedin/cruise-control/wiki/Pluggable-Components#goals[Goals^] in the Cruise Control Wiki.
 
-NOTE: CPU goals, intra-broker disk goals, "Write your own" goals, and Kafka assigner goals are not yet supported.
+NOTE: Intra-broker disk goals, "Write your own" goals, and Kafka assigner goals are not yet supported.
 
 [discrete]
 == Goals configuration in Strimzi custom resources
@@ -56,7 +54,7 @@ Cruise Control will ignore this goal if doing so enables all the configured hard
 In Cruise Control, the following xref:master-goals[master optimization goals] are preset as hard goals:
 
 [source]
-RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal
+RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CPUCapacityGoal
 
 You configure hard goals in the Cruise Control deployment configuration, by editing the `hard.goals` property in `Kafka.spec.cruiseControl.config`.
 
@@ -105,7 +103,7 @@ Goals that are not listed in the master optimization goals are not available for
 Unless you change the Cruise Control xref:proc-deploying-cruise-control-{context}[deployment configuration], Strimzi will inherit the following master optimization goals from Cruise Control, in descending priority order:
 
 [source]
-RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; ReplicaDistributionGoal; PotentialNwOutGoal; DiskUsageDistributionGoal; NetworkInboundUsageDistributionGoal; NetworkOutboundUsageDistributionGoal; TopicReplicaDistributionGoal; LeaderReplicaDistributionGoal; LeaderBytesInDistributionGoal; PreferredLeaderElectionGoal
+RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CPUCapacityGoal; ReplicaDistributionGoal; PotentialNwOutGoal; DiskUsageDistributionGoal; NetworkInboundUsageDistributionGoal; NetworkOutboundUsageDistributionGoal; TopicReplicaDistributionGoal; LeaderReplicaDistributionGoal; LeaderBytesInDistributionGoal; PreferredLeaderElectionGoal
 
 Five of these goals are preset as xref:hard-soft-goals[hard goals].
 

--- a/examples/cruise-control/kafka-rebalance-with-goals.yaml
+++ b/examples/cruise-control/kafka-rebalance-with-goals.yaml
@@ -6,6 +6,7 @@ metadata:
     strimzi.io/cluster: my-cluster
 spec:
   goals:
+    - CPUCapacityGoal
     - NetworkInboundCapacityGoal
     - DiskCapacityGoal
     - RackAwareGoal

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -76,8 +76,7 @@ public class CruiseControlApiST extends AbstractST {
         assertThat(response, containsString("DiskCapacityGoal"));
         assertThat(response, containsString("NetworkInboundCapacityGoal"));
         assertThat(response, containsString("NetworkOutboundCapacityGoal"));
-        // TODO: This Goal is currently not working properly on Kubernetes. It will be added in once this issue is fixed: https://github.com/linkedin/cruise-control/issues/1242
-        //assertThat(response, containsString("CpuCapacityGoal"));
+        assertThat(response, containsString("CpuCapacityGoal"));
         assertThat(response, containsString("ReplicaDistributionGoal"));
         assertThat(response, containsString("DiskUsageDistributionGoal"));
         assertThat(response, containsString("NetworkInboundUsageDistributionGoal"));


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring
- Documentation

### Description

This updates CC to 2.0.124 which includes @kyguy's [upstream PR](https://github.com/linkedin/cruise-control/pull/1277) to fix the CPU usage stats in the CC metrics reporter. It also enables the CPU capacity goal and updates the docs accordingly.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md