### PR TITLE
Add Identity Replication policy to MirrorMaker2

### DIFF
--- a/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
@@ -194,7 +194,7 @@
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>mirror-maker-2-extensions</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>0.1.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
@@ -190,5 +190,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Mirror Maker 2 Extensions -->
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>mirror-maker-2-extensions</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 </project>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
@@ -194,7 +194,7 @@
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>mirror-maker-2-extensions</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>0.1.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
@@ -190,5 +190,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Mirror Maker 2 Extensions -->
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>mirror-maker-2-extensions</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 </project>

--- a/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
+++ b/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
@@ -3,7 +3,7 @@ kind: KafkaMirrorMaker2
 metadata:
   name: my-mirror-maker-2
 spec:
-  version: 2.5.0
+  version: 2.6.0
   replicas: 1
   connectCluster: "my-target-cluster"
   clusters:

--- a/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
+++ b/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
@@ -1,0 +1,35 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaMirrorMaker2
+metadata:
+  name: my-mirror-maker-2
+spec:
+  version: 2.5.0
+  replicas: 1
+  connectCluster: "my-target-cluster"
+  clusters:
+  - alias: "my-source-cluster"
+    bootstrapServers: my-source-cluster-kafka-bootstrap:9092
+  - alias: "my-target-cluster"
+    bootstrapServers: my-target-cluster-kafka-bootstrap:9092
+    config:
+      config.storage.replication.factor: 1
+      offset.storage.replication.factor: 1
+      status.storage.replication.factor: 1
+  mirrors:
+  - sourceCluster: "my-source-cluster"
+    targetCluster: "my-target-cluster"
+    sourceConnector:
+      config:
+        replication.factor: 1
+        offset-syncs.topic.replication.factor: 1
+        sync.topic.acls.enabled: "false"
+        replication.policy.separator: ""
+        replication.policy.class: "io.strimzi.kafka.connect.mirror.IdentityReplicationPolicy"
+    heartbeatConnector:
+      config:
+        heartbeats.topic.replication.factor: 1
+    checkpointConnector:
+      config:
+        checkpoints.topic.replication.factor: 1
+    topicsPattern: ".*"
+    groupsPattern: ".*"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR relates to the issue #2546 

In the context of a DRP scenario with an active-passive replication, we wanted to have prefixless topics on the destination cluster.

People on the issue notice that this is a common scenario that could be beneficial to others. This is why this PR propose a way to integrate this custom replication policy directly into Strimzi image.

In the MirrorMaker2 CRD, we can choose this replication policy by adding the following configuration:

```
...
mirrors:
  - sourceCluster:  "source-cluster"
    targetCluster: "target-cluster"
    sourceConnector:
      config:
       ...
        replication.policy.class: org.strimzi.kafka.connect.mirror.IdentityReplicationPolicy
...
```

I'm please to read your change suggestions

Thanks for reviews.

Note:

This custom replication has been inspired from the following implementation: https://github.com/aws-samples/mirrormaker2-msk-migration#custommm2replicationpolicy

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

