### PR TITLE
Fix the scale subresource

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
@@ -102,7 +102,7 @@ public class KafkaBridge extends CustomResource implements UnknownPropertyPreser
     public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);
     public static final String SPEC_REPLICAS_PATH = ".spec.replicas";
     public static final String STATUS_REPLICAS_PATH = ".status.replicas";
-    public static final String LABEL_SELECTOR_PATH = ".status.selector";
+    public static final String LABEL_SELECTOR_PATH = ".status.labelSelector";
 
     private String apiVersion;
     private ObjectMeta metadata;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
@@ -100,7 +100,7 @@ public class KafkaConnect extends CustomResource implements UnknownPropertyPrese
     public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);
     public static final String SPEC_REPLICAS_PATH = ".spec.replicas";
     public static final String STATUS_REPLICAS_PATH = ".status.replicas";
-    public static final String LABEL_SELECTOR_PATH = ".status.selector";
+    public static final String LABEL_SELECTOR_PATH = ".status.labelSelector";
 
     private String apiVersion;
     private KafkaConnectSpec spec;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
@@ -103,7 +103,7 @@ public class KafkaConnectS2I extends CustomResource implements UnknownPropertyPr
     public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);
     public static final String SPEC_REPLICAS_PATH = ".spec.replicas";
     public static final String STATUS_REPLICAS_PATH = ".status.replicas";
-    public static final String LABEL_SELECTOR_PATH = ".status.selector";
+    public static final String LABEL_SELECTOR_PATH = ".status.labelSelector";
 
     private String apiVersion;
     private ObjectMeta metadata;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
@@ -115,7 +115,7 @@ public class KafkaMirrorMaker extends CustomResource implements UnknownPropertyP
     public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);
     public static final String SPEC_REPLICAS_PATH = ".spec.replicas";
     public static final String STATUS_REPLICAS_PATH = ".status.replicas";
-    public static final String LABEL_SELECTOR_PATH = ".status.selector";
+    public static final String LABEL_SELECTOR_PATH = ".status.labelSelector";
 
     private String apiVersion;
     private ObjectMeta metadata;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
@@ -94,7 +94,7 @@ public class KafkaMirrorMaker2 extends CustomResource implements UnknownProperty
     public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);
     public static final String SPEC_REPLICAS_PATH = ".spec.replicas";
     public static final String STATUS_REPLICAS_PATH = ".status.replicas";
-    public static final String LABEL_SELECTOR_PATH = ".status.selector";
+    public static final String LABEL_SELECTOR_PATH = ".status.labelSelector";
 
     private String apiVersion;
     private KafkaMirrorMaker2Spec spec;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaBridgeStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaBridgeStatus.java
@@ -6,10 +6,8 @@ package io.strimzi.api.kafka.model.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
-import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -30,7 +28,7 @@ public class KafkaBridgeStatus extends Status {
 
     private String url;
     private int replicas;
-    private LabelSelector podSelector;
+    private String labelSelector;
 
     @Description("The URL at which external client applications can access the Kafka Bridge.")
     public String getUrl() {
@@ -52,13 +50,12 @@ public class KafkaBridgeStatus extends Status {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    @KubeLink(group = "meta", version = "v1", kind = "labelselector")
     @Description("Label selector for pods providing this resource.")
-    public LabelSelector getPodSelector() {
-        return podSelector;
+    public String getLabelSelector() {
+        return labelSelector;
     }
 
-    public void setPodSelector(LabelSelector podSelector) {
-        this.podSelector = podSelector;
+    public void setLabelSelector(String labelSelector) {
+        this.labelSelector = labelSelector;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectStatus.java
@@ -6,11 +6,9 @@ package io.strimzi.api.kafka.model.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.crdgenerator.annotations.Description;
-import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -34,7 +32,7 @@ public class KafkaConnectStatus extends Status {
     private String url;
     private List<ConnectorPlugin> connectorPlugins;
     private int replicas;
-    private LabelSelector podSelector;
+    private String labelSelector;
 
     @Description("The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.")
     public String getUrl() {
@@ -66,13 +64,12 @@ public class KafkaConnectStatus extends Status {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    @KubeLink(group = "meta", version = "v1", kind = "labelselector")
     @Description("Label selector for pods providing this resource.")
-    public LabelSelector getPodSelector() {
-        return podSelector;
+    public String getLabelSelector() {
+        return labelSelector;
     }
 
-    public void setPodSelector(LabelSelector podSelector) {
-        this.podSelector = podSelector;
+    public void setLabelSelector(String labelSelector) {
+        this.labelSelector = labelSelector;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaMirrorMakerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaMirrorMakerStatus.java
@@ -6,10 +6,8 @@ package io.strimzi.api.kafka.model.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
-import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -29,7 +27,7 @@ public class KafkaMirrorMakerStatus extends Status {
     private static final long serialVersionUID = 1L;
 
     private int replicas;
-    private LabelSelector podSelector;
+    private String labelSelector;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Description("The current number of pods being used to provide this resource.")
@@ -42,13 +40,12 @@ public class KafkaMirrorMakerStatus extends Status {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    @KubeLink(group = "meta", version = "v1", kind = "labelselector")
     @Description("Label selector for pods providing this resource.")
-    public LabelSelector getPodSelector() {
-        return podSelector;
+    public String getLabelSelector() {
+        return labelSelector;
     }
 
-    public void setPodSelector(LabelSelector podSelector) {
-        this.podSelector = podSelector;
+    public void setLabelSelector(String labelSelector) {
+        this.labelSelector = labelSelector;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -109,7 +108,7 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
                 }
 
                 kafkaBridgeStatus.setReplicas(bridge.getReplicas());
-                kafkaBridgeStatus.setPodSelector(new LabelSelectorBuilder().withMatchLabels(bridge.getSelectorLabels().toMap()).build());
+                kafkaBridgeStatus.setLabelSelector(bridge.getSelectorLabels().toSelectorString());
 
                 updateStatus(assemblyResource, reconciliation, kafkaBridgeStatus).onComplete(statusResult -> {
                     // If both features succeeded, createOrUpdate succeeded as well

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -156,7 +155,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                     }
 
                     kafkaConnectStatus.setReplicas(connect.getReplicas());
-                    kafkaConnectStatus.setPodSelector(new LabelSelectorBuilder().withMatchLabels(connect.getSelectorLabels().toMap()).build());
+                    kafkaConnectStatus.setLabelSelector(connect.getSelectorLabels().toSelectorString());
 
                     this.maybeUpdateStatusCommon(resourceOperator, kafkaConnect, reconciliation, kafkaConnectStatus,
                         (connect1, status) -> new KafkaConnectBuilder(connect1).withStatus(status).build()).onComplete(statusResult -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -166,7 +165,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<Ope
                     }
 
                     kafkaConnectS2Istatus.setReplicas(connect.getReplicas());
-                    kafkaConnectS2Istatus.setPodSelector(new LabelSelectorBuilder().withMatchLabels(connect.getSelectorLabels().toMap()).build());
+                    kafkaConnectS2Istatus.setLabelSelector(connect.getSelectorLabels().toSelectorString());
 
                     updateStatus(kafkaConnectS2I, reconciliation, kafkaConnectS2Istatus).onComplete(statusResult -> {
                         // If both features succeeded, createOrUpdate succeeded as well

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -13,7 +13,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 
@@ -162,7 +161,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                     kafkaMirrorMaker2Status.setUrl(KafkaMirrorMaker2Resources.url(mirrorMaker2Cluster.getCluster(), namespace, KafkaMirrorMaker2Cluster.REST_API_PORT));
 
                     kafkaMirrorMaker2Status.setReplicas(mirrorMaker2Cluster.getReplicas());
-                    kafkaMirrorMaker2Status.setPodSelector(new LabelSelectorBuilder().withMatchLabels(mirrorMaker2Cluster.getSelectorLabels().toMap()).build());
+                    kafkaMirrorMaker2Status.setLabelSelector(mirrorMaker2Cluster.getSelectorLabels().toSelectorString());
 
                     this.maybeUpdateStatusCommon(resourceOperator, kafkaMirrorMaker2, reconciliation, kafkaMirrorMaker2Status,
                         (mirrormaker2, status) -> new KafkaMirrorMaker2Builder(mirrormaker2).withStatus(status).build()).onComplete(statusResult -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -110,7 +109,7 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
                         StatusUtils.setStatusConditionAndObservedGeneration(assemblyResource, kafkaMirrorMakerStatus, reconciliationResult);
 
                         kafkaMirrorMakerStatus.setReplicas(mirror.getReplicas());
-                        kafkaMirrorMakerStatus.setPodSelector(new LabelSelectorBuilder().withMatchLabels(mirror.getSelectorLabels().toMap()).build());
+                        kafkaMirrorMakerStatus.setLabelSelector(mirror.getSelectorLabels().toSelectorString());
 
                         updateStatus(assemblyResource, reconciliation, kafkaMirrorMakerStatus).onComplete(statusResult -> {
                             // If both features succeeded, createOrUpdate succeeded as well

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -178,7 +178,7 @@ public class KafkaBridgeAssemblyOperatorTest {
                 List<KafkaBridge> capturedStatuses = bridgeCaptor.getAllValues();
                 assertThat(capturedStatuses.get(0).getStatus().getUrl(), is("http://foo-bridge-service.test.svc:8080"));
                 assertThat(capturedStatuses.get(0).getStatus().getReplicas(), is(bridge.getReplicas()));
-                assertThat(capturedStatuses.get(0).getStatus().getPodSelector().getMatchLabels(), is(bridge.getSelectorLabels().toMap()));
+                assertThat(capturedStatuses.get(0).getStatus().getLabelSelector(), is(bridge.getSelectorLabels().toSelectorString()));
                 assertThat(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), is("True"));
                 assertThat(capturedStatuses.get(0).getStatus().getConditions().get(0).getType(), is("Ready"));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -192,7 +192,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
                 assertThat(connectStatus.getUrl(), is("http://foo-connect-api.test.svc:8083"));
                 assertThat(connectStatus.getReplicas(), is(connect.getReplicas()));
-                assertThat(connectStatus.getPodSelector().getMatchLabels(), is(connect.getSelectorLabels().toMap()));
+                assertThat(connectStatus.getLabelSelector(), is(connect.getSelectorLabels().toSelectorString()));
                 assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
                 assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
 
@@ -854,7 +854,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
                 assertThat(connectStatus.getUrl(), is("http://foo-connect-api.test.svc:8083"));
                 assertThat(connectStatus.getReplicas(), is(connect.getReplicas()));
-                assertThat(connectStatus.getPodSelector().getMatchLabels(), is(connect.getSelectorLabels().toMap()));
+                assertThat(connectStatus.getLabelSelector(), is(connect.getSelectorLabels().toSelectorString()));
                 assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
                 assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
                 if (connectorOperator) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
@@ -168,7 +168,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                 List<KafkaMirrorMaker2> capturedMirrorMaker2s = mirrorMaker2Captor.getAllValues();
                 assertThat(capturedMirrorMaker2s.get(0).getStatus().getUrl(), is("http://foo-mirrormaker2-api.test.svc:8083"));
                 assertThat(capturedMirrorMaker2s.get(0).getStatus().getReplicas(), is(mirrorMaker2.getReplicas()));
-                assertThat(capturedMirrorMaker2s.get(0).getStatus().getPodSelector().getMatchLabels(), is(mirrorMaker2.getSelectorLabels().toMap()));
+                assertThat(capturedMirrorMaker2s.get(0).getStatus().getLabelSelector(), is(mirrorMaker2.getSelectorLabels().toSelectorString()));
                 assertThat(capturedMirrorMaker2s.get(0).getStatus().getConditions().get(0).getStatus(), is("True"));
                 assertThat(capturedMirrorMaker2s.get(0).getStatus().getConditions().get(0).getType(), is("Ready"));
                 async.flag();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -174,7 +174,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                 assertThat(capturedMM, hasSize(1));
                 KafkaMirrorMaker mm = capturedMM.get(0);
                 assertThat(mm.getStatus().getReplicas(), is(mirror.getReplicas()));
-                assertThat(mm.getStatus().getPodSelector().getMatchLabels(), is(mirror.getSelectorLabels().toMap()));
+                assertThat(mm.getStatus().getLabelSelector(), is(mirror.getSelectorLabels().toSelectorString()));
                 assertThat(mm.getStatus().getConditions().get(0).getType(), is("Ready"));
                 assertThat(mm.getStatus().getConditions().get(0).getStatus(), is("True"));
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1972,10 +1972,8 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |string
 |connectorPlugins    1.2+<.<|The list of connector plugins available in this Kafka Connect deployment.
 |xref:type-ConnectorPlugin-{context}[`ConnectorPlugin`] array
-|podSelector         1.2+<.<|Label selector for pods providing this resource. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta[meta/v1 labelselector].
-
-
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta[LabelSelector]
+|labelSelector       1.2+<.<|Label selector for pods providing this resource.
+|string
 |replicas            1.2+<.<|The current number of pods being used to provide this resource.
 |integer
 |====
@@ -2088,10 +2086,8 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 |xref:type-ConnectorPlugin-{context}[`ConnectorPlugin`] array
 |buildConfigName     1.2+<.<|The name of the build configuration.
 |string
-|podSelector         1.2+<.<|Label selector for pods providing this resource. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta[meta/v1 labelselector].
-
-
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta[LabelSelector]
+|labelSelector       1.2+<.<|Label selector for pods providing this resource.
+|string
 |replicas            1.2+<.<|The current number of pods being used to provide this resource.
 |integer
 |====
@@ -2521,10 +2517,8 @@ Used in: xref:type-KafkaMirrorMaker-{context}[`KafkaMirrorMaker`]
 |xref:type-Condition-{context}[`Condition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
-|podSelector         1.2+<.<|Label selector for pods providing this resource. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta[meta/v1 labelselector].
-
-
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta[LabelSelector]
+|labelSelector       1.2+<.<|Label selector for pods providing this resource.
+|string
 |replicas            1.2+<.<|The current number of pods being used to provide this resource.
 |integer
 |====
@@ -2692,10 +2686,8 @@ Used in: xref:type-KafkaBridge-{context}[`KafkaBridge`]
 |integer
 |url                 1.2+<.<|The URL at which external client applications can access the Kafka Bridge.
 |string
-|podSelector         1.2+<.<|Label selector for pods providing this resource. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta[meta/v1 labelselector].
-
-
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta[LabelSelector]
+|labelSelector       1.2+<.<|Label selector for pods providing this resource.
+|string
 |replicas            1.2+<.<|The current number of pods being used to provide this resource.
 |integer
 |====
@@ -2915,10 +2907,8 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |xref:type-ConnectorPlugin-{context}[`ConnectorPlugin`] array
 |connectors          1.2+<.<|List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.
 |map array
-|podSelector         1.2+<.<|Label selector for pods providing this resource. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta[meta/v1 labelselector].
-
-
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta[LabelSelector]
+|labelSelector       1.2+<.<|Label selector for pods providing this resource.
+|string
 |replicas            1.2+<.<|The current number of pods being used to provide this resource.
 |integer
 |====

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -40,7 +40,7 @@ spec:
     scale:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
-      labelSelectorPath: .status.selector
+      labelSelectorPath: .status.labelSelector
   validation:
     openAPIV3Schema:
       properties:
@@ -1091,24 +1091,8 @@ spec:
                     type: string
                     description: The class of the connector plugin.
               description: The list of connector plugins available in this Kafka Connect deployment.
-            podSelector:
-              type: object
-              properties:
-                matchExpressions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      values:
-                        type: array
-                        items:
-                          type: string
-                matchLabels:
-                  type: object
+            labelSelector:
+              type: string
               description: Label selector for pods providing this resource.
             replicas:
               type: integer

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -40,7 +40,7 @@ spec:
     scale:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
-      labelSelectorPath: .status.selector
+      labelSelectorPath: .status.labelSelector
   validation:
     openAPIV3Schema:
       properties:
@@ -1105,24 +1105,8 @@ spec:
             buildConfigName:
               type: string
               description: The name of the build configuration.
-            podSelector:
-              type: object
-              properties:
-                matchExpressions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      values:
-                        type: array
-                        items:
-                          type: string
-                matchLabels:
-                  type: object
+            labelSelector:
+              type: string
               description: Label selector for pods providing this resource.
             replicas:
               type: integer

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -50,7 +50,7 @@ spec:
     scale:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
-      labelSelectorPath: .status.selector
+      labelSelectorPath: .status.labelSelector
   validation:
     openAPIV3Schema:
       properties:
@@ -1153,24 +1153,8 @@ spec:
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the operator.
-            podSelector:
-              type: object
-              properties:
-                matchExpressions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      values:
-                        type: array
-                        items:
-                          type: string
-                matchLabels:
-                  type: object
+            labelSelector:
+              type: string
               description: Label selector for pods providing this resource.
             replicas:
               type: integer

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -42,7 +42,7 @@ spec:
     scale:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
-      labelSelectorPath: .status.selector
+      labelSelectorPath: .status.labelSelector
   validation:
     openAPIV3Schema:
       properties:
@@ -794,24 +794,8 @@ spec:
             url:
               type: string
               description: The URL at which external client applications can access the Kafka Bridge.
-            podSelector:
-              type: object
-              properties:
-                matchExpressions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      values:
-                        type: array
-                        items:
-                          type: string
-                matchLabels:
-                  type: object
+            labelSelector:
+              type: string
               description: Label selector for pods providing this resource.
             replicas:
               type: integer

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -37,7 +37,7 @@ spec:
     scale:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
-      labelSelectorPath: .status.selector
+      labelSelectorPath: .status.labelSelector
   validation:
     openAPIV3Schema:
       properties:
@@ -1178,24 +1178,8 @@ spec:
               items:
                 type: object
               description: List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.
-            podSelector:
-              type: object
-              properties:
-                matchExpressions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      values:
-                        type: array
-                        items:
-                          type: string
-                matchLabels:
-                  type: object
+            labelSelector:
+              type: string
               description: Label selector for pods providing this resource.
             replicas:
               type: integer

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -36,7 +36,7 @@ spec:
     scale:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
-      labelSelectorPath: .status.selector
+      labelSelectorPath: .status.labelSelector
   validation:
     openAPIV3Schema:
       properties:
@@ -1087,24 +1087,8 @@ spec:
                     type: string
                     description: The class of the connector plugin.
               description: The list of connector plugins available in this Kafka Connect deployment.
-            podSelector:
-              type: object
-              properties:
-                matchExpressions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      values:
-                        type: array
-                        items:
-                          type: string
-                matchLabels:
-                  type: object
+            labelSelector:
+              type: string
               description: Label selector for pods providing this resource.
             replicas:
               type: integer

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -36,7 +36,7 @@ spec:
     scale:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
-      labelSelectorPath: .status.selector
+      labelSelectorPath: .status.labelSelector
   validation:
     openAPIV3Schema:
       properties:
@@ -1101,24 +1101,8 @@ spec:
             buildConfigName:
               type: string
               description: The name of the build configuration.
-            podSelector:
-              type: object
-              properties:
-                matchExpressions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      values:
-                        type: array
-                        items:
-                          type: string
-                matchLabels:
-                  type: object
+            labelSelector:
+              type: string
               description: Label selector for pods providing this resource.
             replicas:
               type: integer

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -46,7 +46,7 @@ spec:
     scale:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
-      labelSelectorPath: .status.selector
+      labelSelectorPath: .status.labelSelector
   validation:
     openAPIV3Schema:
       properties:
@@ -1149,24 +1149,8 @@ spec:
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the operator.
-            podSelector:
-              type: object
-              properties:
-                matchExpressions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      values:
-                        type: array
-                        items:
-                          type: string
-                matchLabels:
-                  type: object
+            labelSelector:
+              type: string
               description: Label selector for pods providing this resource.
             replicas:
               type: integer

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -38,7 +38,7 @@ spec:
     scale:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
-      labelSelectorPath: .status.selector
+      labelSelectorPath: .status.labelSelector
   validation:
     openAPIV3Schema:
       properties:
@@ -790,24 +790,8 @@ spec:
             url:
               type: string
               description: The URL at which external client applications can access the Kafka Bridge.
-            podSelector:
-              type: object
-              properties:
-                matchExpressions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      values:
-                        type: array
-                        items:
-                          type: string
-                matchLabels:
-                  type: object
+            labelSelector:
+              type: string
               description: Label selector for pods providing this resource.
             replicas:
               type: integer

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -33,7 +33,7 @@ spec:
     scale:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
-      labelSelectorPath: .status.selector
+      labelSelectorPath: .status.labelSelector
   validation:
     openAPIV3Schema:
       properties:
@@ -1174,24 +1174,8 @@ spec:
               items:
                 type: object
               description: List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.
-            podSelector:
-              type: object
-              properties:
-                matchExpressions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      values:
-                        type: array
-                        items:
-                          type: string
-                matchLabels:
-                  type: object
+            labelSelector:
+              type: string
               description: Label selector for pods providing this resource.
             replicas:
               type: integer

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -35,7 +35,7 @@ spec:
     scale:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
-      labelSelectorPath: .status.selector
+      labelSelectorPath: .status.labelSelector
   validation:
     openAPIV3Schema:
       properties:
@@ -1203,24 +1203,8 @@ spec:
                     description: The class of the connector plugin.
               description: The list of connector plugins available in this Kafka Connect
                 deployment.
-            podSelector:
-              type: object
-              properties:
-                matchExpressions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      values:
-                        type: array
-                        items:
-                          type: string
-                matchLabels:
-                  type: object
+            labelSelector:
+              type: string
               description: Label selector for pods providing this resource.
             replicas:
               type: integer

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -35,7 +35,7 @@ spec:
     scale:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
-      labelSelectorPath: .status.selector
+      labelSelectorPath: .status.labelSelector
   validation:
     openAPIV3Schema:
       properties:
@@ -1220,24 +1220,8 @@ spec:
             buildConfigName:
               type: string
               description: The name of the build configuration.
-            podSelector:
-              type: object
-              properties:
-                matchExpressions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      values:
-                        type: array
-                        items:
-                          type: string
-                matchLabels:
-                  type: object
+            labelSelector:
+              type: string
               description: Label selector for pods providing this resource.
             replicas:
               type: integer

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -45,7 +45,7 @@ spec:
     scale:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
-      labelSelectorPath: .status.selector
+      labelSelectorPath: .status.labelSelector
   validation:
     openAPIV3Schema:
       properties:
@@ -1293,24 +1293,8 @@ spec:
               type: integer
               description: The generation of the CRD that was last reconciled by the
                 operator.
-            podSelector:
-              type: object
-              properties:
-                matchExpressions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      values:
-                        type: array
-                        items:
-                          type: string
-                matchLabels:
-                  type: object
+            labelSelector:
+              type: string
               description: Label selector for pods providing this resource.
             replicas:
               type: integer

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -37,7 +37,7 @@ spec:
     scale:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
-      labelSelectorPath: .status.selector
+      labelSelectorPath: .status.labelSelector
   validation:
     openAPIV3Schema:
       properties:
@@ -893,24 +893,8 @@ spec:
               type: string
               description: The URL at which external client applications can access
                 the Kafka Bridge.
-            podSelector:
-              type: object
-              properties:
-                matchExpressions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      values:
-                        type: array
-                        items:
-                          type: string
-                matchLabels:
-                  type: object
+            labelSelector:
+              type: string
               description: Label selector for pods providing this resource.
             replicas:
               type: integer

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -32,7 +32,7 @@ spec:
     scale:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
-      labelSelectorPath: .status.selector
+      labelSelectorPath: .status.labelSelector
   validation:
     openAPIV3Schema:
       properties:
@@ -1315,24 +1315,8 @@ spec:
                 type: object
               description: List of MirrorMaker 2.0 connector statuses, as reported
                 by the Kafka Connect REST API.
-            podSelector:
-              type: object
-              properties:
-                matchExpressions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      values:
-                        type: array
-                        items:
-                          type: string
-                matchLabels:
-                  type: object
+            labelSelector:
+              type: string
               description: Label selector for pods providing this resource.
             replicas:
               type: integer

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -346,7 +346,7 @@ public class Labels {
      * @return A string which can be used as the Kuberneter label selector (e.g. key1=value1,key2=value2).
      */
     public String toSelectorString() {
-        return labels.keySet().stream().map(key -> key + "=" + labels.get(key)).collect(Collectors.joining(","));
+        return labels.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue()).collect(Collectors.joining(","));
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -343,6 +343,13 @@ public class Labels {
     }
 
     /**
+     * @return A string which can be used as the Kuberneter label selector (e.g. key1=value1,key2=value2).
+     */
+    public String toSelectorString() {
+        return labels.keySet().stream().map(key -> key + "=" + labels.get(key)).collect(Collectors.joining(","));
+    }
+
+    /**
      * @param cluster The cluster.
      * @return A singleton instance with the given {@code cluster} for the {@code strimzi.io/cluster} key.
      */

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
@@ -101,7 +101,7 @@ public class LabelsTest {
 
     @Test
     public void testToLabelSelectorString()   {
-        Map sourceMap = new HashMap<String, String>(5);
+        Map sourceMap = new HashMap<String, String>(4);
         sourceMap.put(Labels.STRIMZI_CLUSTER_LABEL, "my-cluster");
         sourceMap.put(Labels.STRIMZI_KIND_LABEL, "Kafka");
         sourceMap.put(Labels.STRIMZI_NAME_LABEL, "my-cluster-kafka");

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
@@ -100,6 +100,20 @@ public class LabelsTest {
     }
 
     @Test
+    public void testToLabelSelectorString()   {
+        Map sourceMap = new HashMap<String, String>(5);
+        sourceMap.put(Labels.STRIMZI_CLUSTER_LABEL, "my-cluster");
+        sourceMap.put(Labels.STRIMZI_KIND_LABEL, "Kafka");
+        sourceMap.put(Labels.STRIMZI_NAME_LABEL, "my-cluster-kafka");
+        sourceMap.put("key1", "value1");
+        Labels labels = Labels.fromMap(sourceMap);
+
+        String expected = "key1=value1," + Labels.STRIMZI_CLUSTER_LABEL + "=my-cluster," + Labels.STRIMZI_KIND_LABEL + "=Kafka," + Labels.STRIMZI_NAME_LABEL + "=my-cluster-kafka";
+
+        assertThat(labels.toSelectorString(), is(expected));
+    }
+
+    @Test
     public void testWithUserLabels()   {
         Labels start = Labels.forStrimziCluster("my-cluster");
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

As reported in #3432, the scale subresource has currently misconfigured the selector.
1) The CRD points to `.status.selector` which is a wrong name
2) The selector should be a String and not LabelSelector

This PR fixes the issue. I had to rename the `podSelector` to `labelSelector` because changing the typo of existing field would not allow operator upgrades. But since this field is used only for the scale subresource and nothing else, the format and name change should not cause any problems. If anyone things so, we can also keep the old field and just deprecate it. But it didn't seemed needed for me.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging