### PR TITLE
[systemtest][mm] Add test for scaling mm to zero

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
@@ -680,6 +680,7 @@ public class MirrorMakerST extends AbstractST {
             .endMetadata()
             .done();
 
+        long oldObsGen = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getObservedGeneration();
         String mmDepName = KafkaMirrorMakerResources.deploymentName(CLUSTER_NAME);
         List<String> mmPods = kubeClient().listPodNames("type", "kafka-mirror-maker");
         assertThat(mmPods.size(), is(3));
@@ -692,9 +693,11 @@ public class MirrorMakerST extends AbstractST {
 
         mmPods = kubeClient().listPodNames("type", "kafka-mirror-maker");
         KafkaMirrorMakerStatus mmStatus = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
+        long actualObsGen = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getObservedGeneration();
 
         assertThat(mmPods.size(), is(0));
         assertThat(mmStatus.getConditions().get(0).getType(), is("Ready"));
+        assertThat(actualObsGen, is(not(oldObsGen)));
     }
     
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
@@ -24,7 +24,6 @@ import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.utils.StUtils;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaMirrorMakerUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
@@ -688,7 +687,6 @@ public class MirrorMakerST extends AbstractST {
         LOGGER.info("Scaling MirrorMaker to zero");
         KafkaMirrorMakerResource.replaceMirrorMakerResource(CLUSTER_NAME, mm -> mm.getSpec().setReplicas(0));
 
-        KafkaMirrorMakerUtils.waitForKafkaMirrorMakerReady(CLUSTER_NAME);
         PodUtils.waitForPodsReady(kubeClient().getDeploymentSelectors(mmDepName), 0, true);
 
         mmPods = kubeClient().listPodNames("type", "kafka-mirror-maker");


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test

### Description

After #3412 we are able to deploy (scale) the KafkaMirrorMaker to zero replicas and the resource will be `Ready`. This PR tests this feature. 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

