### PR TITLE
Add 0.19.0 to upgrade tests

### DIFF
--- a/systemtest/src/main/resources/StrimziUpgradeST.json
+++ b/systemtest/src/main/resources/StrimziUpgradeST.json
@@ -281,10 +281,50 @@
   },
   {
     "fromVersion":"0.18.0",
-    "toVersion":"HEAD",
+    "toVersion":"0.19.0",
     "fromExamples":"strimzi-0.18.0",
-    "toExamples":"HEAD",
+    "toExamples":"strimzi-0.19.0",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.18.0/strimzi-0.18.0.zip",
+    "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.19.0/strimzi-0.19.0.zip",
+    "generateTopics": false,
+    "imagesBeforeKafkaUpdate": {
+      "zookeeper": "strimzi/kafka:0.19.0-kafka-2.4.0",
+      "kafka": "strimzi/kafka:0.19.0-kafka-2.4.0",
+      "topicOperator": "strimzi/operator:0.19.0",
+      "userOperator": "strimzi/operator:0.19.0"
+    },
+    "imagesAfterKafkaUpdate": {
+      "zookeeper": "strimzi/kafka:0.19.0-kafka-2.5.0",
+      "kafka": "strimzi/kafka:0.19.0-kafka-2.5.0",
+      "topicOperator": "strimzi/operator:0.19.0",
+      "userOperator": "strimzi/operator:0.19.0"
+    },
+    "proceduresBefore": {
+      "kafkaVersion": "",
+      "logMessageVersion": ""
+    },
+    "proceduresAfter": {
+      "kafkaVersion": "",
+      "logMessageVersion": ""
+    },
+    "client": {
+      "beforeKafkaUpdate": "strimzi/test-client:0.18.0-kafka-2.5.0",
+      "afterKafkaUpdate": "strimzi/test-client:0.19.0-kafka-2.5.0",
+      "continuousClientsMessages": 0
+    },
+    "environmentInfo": {
+      "maxK8sVersion": "latest",
+      "status": "stable",
+      "flakyEnvVariable": "none",
+      "reason" : "Test is working on all environment used by QE."
+    }
+  },
+  {
+    "fromVersion":"0.19.0",
+    "toVersion":"HEAD",
+    "fromExamples":"strimzi-0.19.0",
+    "toExamples":"HEAD",
+    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.19.0/strimzi-0.19.0.zip",
     "urlTo":"HEAD",
     "generateTopics": true,
     "imagesBeforeKafkaUpdate": {
@@ -308,7 +348,7 @@
       "logMessageVersion": ""
     },
     "client": {
-      "beforeKafkaUpdate": "strimzi/test-client:0.18.0-kafka-2.5.0",
+      "beforeKafkaUpdate": "strimzi/test-client:0.19.0-kafka-2.5.0",
       "afterKafkaUpdate": "strimzi/test-client:latest-kafka-2.5.0",
       "continuousClientsMessages": 500
     },

--- a/systemtest/src/main/resources/StrimziUpgradeST.json
+++ b/systemtest/src/main/resources/StrimziUpgradeST.json
@@ -288,8 +288,8 @@
     "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.19.0/strimzi-0.19.0.zip",
     "generateTopics": false,
     "imagesBeforeKafkaUpdate": {
-      "zookeeper": "strimzi/kafka:0.19.0-kafka-2.4.0",
-      "kafka": "strimzi/kafka:0.19.0-kafka-2.4.0",
+      "zookeeper": "strimzi/kafka:0.19.0-kafka-2.5.0",
+      "kafka": "strimzi/kafka:0.19.0-kafka-2.5.0",
       "topicOperator": "strimzi/operator:0.19.0",
       "userOperator": "strimzi/operator:0.19.0"
     },


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We should add the 0.19.0 release to the upgrade tests so that the upgrade from 0.18.0 -> 0.19.0 and 0.19.0 -> master are covered