### PR TITLE
[systemtest] Fix of LogSettingST

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
@@ -231,17 +231,6 @@ class LogSettingST extends AbstractST {
     @OpenShiftOnly
     @Order(9)
     void testLoggersConnectS2I() {
-        KafkaConnectS2IResource.kafkaConnectS2I(CONNECTS2I_NAME, CLUSTER_NAME, 1)
-            .editSpec()
-                .withNewInlineLogging()
-                    .withLoggers(CONNECT_LOGGERS)
-                .endInlineLogging()
-                .withNewJvmOptions()
-                    .withGcLoggingEnabled(true)
-                .endJvmOptions()
-            .endSpec()
-            .done();
-
         assertThat("KafkaConnectS2I's log level is set properly", checkLoggersLevel(CONNECT_LOGGERS, CONNECTS2I_MAP), is(true));
     }
 
@@ -554,6 +543,19 @@ class LogSettingST extends AbstractST {
                 .endJvmOptions()
                 .endSpec()
             .done();
+
+        if (cluster.isNotKubernetes()) {
+            KafkaConnectS2IResource.kafkaConnectS2I(CONNECTS2I_NAME, CLUSTER_NAME, 1)
+                .editSpec()
+                    .withNewInlineLogging()
+                        .withLoggers(CONNECT_LOGGERS)
+                    .endInlineLogging()
+                    .withNewJvmOptions()
+                        .withGcLoggingEnabled(true)
+                    .endJvmOptions()
+                .endSpec()
+                .done();
+        }
     }
 
     private String startDeploymentMeasuring() {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR gonna fix two tests that were failing in our nightlies. The problem was that ConnectS2I was deleted after `testLoggersConnectS2I` - all resources created in tests are deleted after them. So I moved it to `@BeforeAll` block and added `if(cluster.isNotKubernetes())` to determine, if test is running on k8s or not. 

### Checklist

- [x] Make sure all tests pass


