### PR TITLE
Minor correction in docs for configuring TLS for internal clients

### DIFF
--- a/documentation/modules/security/proc-configuring-internal-clients-to-trust-cluster-ca.adoc
+++ b/documentation/modules/security/proc-configuring-internal-clients-to-trust-cluster-ca.adoc
@@ -19,7 +19,7 @@ The steps describe how to mount the Cluster Secret that verifies the identity of
 
 * The Cluster Operator must be running.
 * There needs to be a `Kafka` resource within the Kubernetes cluster.
-* You need a Kafka client application outside the Kubernetes cluster that will connect using TLS, and needs to trust the cluster CA certificate.
+* You need a Kafka client application inside the Kubernetes cluster that will connect using TLS, and needs to trust the cluster CA certificate.
 * The client application must be running in the same namespace as the `Kafka` resource.
 
 .Using PKCS #12 format (.p12)


### PR DESCRIPTION
Kafka client application should be running inside the Kubernetes cluster

### Type of change

- Documentation

### Description

Minor correction in docs for configuring TLS for internal clients.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

