### PR TITLE
[mm2] Fix status of mm2 if replicas are set to 0

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -156,7 +156,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                 .compose(i -> deploymentOperations.scaleUp(namespace, mirrorMaker2Cluster.getName(), mirrorMaker2Cluster.getReplicas()))
                 .compose(i -> deploymentOperations.waitForObserved(namespace, mirrorMaker2Cluster.getName(), 1_000, operationTimeoutMs))
                 .compose(i -> mirrorMaker2HasZeroReplicas ? Future.succeededFuture() : deploymentOperations.readiness(namespace, mirrorMaker2Cluster.getName(), 1_000, operationTimeoutMs))
-                .compose(i -> reconcileConnectors(reconciliation, kafkaMirrorMaker2, mirrorMaker2Cluster, kafkaMirrorMaker2Status))
+                .compose(i -> mirrorMaker2HasZeroReplicas ? Future.succeededFuture() : reconcileConnectors(reconciliation, kafkaMirrorMaker2, mirrorMaker2Cluster, kafkaMirrorMaker2Status))
                 .map((Void) null)
                 .onComplete(reconciliationResult -> {
                     StatusUtils.setStatusConditionAndObservedGeneration(kafkaMirrorMaker2, kafkaMirrorMaker2Status, reconciliationResult);


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR gonna fix problem with mm2 if we set replicas to 0 - after next reconciliation the mm2 change it's state to `NotReady`, because of timeout on connection to the service: 
```
connection timed out: my-cluster-mirrormaker2-api.mirrormaker2-cluster-test.svc.cluster.local/172.30.68.8:8083
```
But after #3431 should be in `Ready` state.

Status after fix:
```
status:
    conditions:
    - lastTransitionTime: 2020-08-05T14:29:11.372975Z
      status: "True"
      type: Ready
    labelSelector: strimzi.io/cluster=my-cluster,strimzi.io/name=my-cluster-mirrormaker2,strimzi.io/kind=KafkaMirrorMaker2
    observedGeneration: 2
    replicas: 0

```

### Checklist

- [x] Make sure all tests pass

