### PR TITLE
Removed ServiceMonitor selector

### DIFF
--- a/examples/metrics/prometheus-install/prometheus.yaml
+++ b/examples/metrics/prometheus-install/prometheus.yaml
@@ -55,9 +55,6 @@ metadata:
 spec:
   replicas: 1
   serviceAccountName: prometheus-server
-  serviceMonitorSelector:
-    matchLabels:
-      app: strimzi
   podMonitorSelector:
     matchLabels:
       app: strimzi


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Refactoring

### Description

After removing the `ServiceMonitor` resource for scraping metrics, the `serviceMonitorSelector` in the `Prometheus` custom resource isn't needed anymore.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

