### PR TITLE
[DOC] using kubectl on custom resources

### DIFF
--- a/documentation/assemblies/managing/assembly-cluster-recovery-volume.adoc
+++ b/documentation/assemblies/managing/assembly-cluster-recovery-volume.adoc
@@ -2,7 +2,7 @@
 //
 // assembly-management-tasks.adoc
 
-[id="cluster-recovery_{context}"]
+[id="cluster-recovery-{context}"]
 = Recovering a cluster from persistent volumes
 
 You can recover a Kafka cluster from persistent volumes (PVs) if they are still present.

--- a/documentation/assemblies/managing/assembly-management-tasks.adoc
+++ b/documentation/assemblies/managing/assembly-management-tasks.adoc
@@ -2,13 +2,13 @@
 //
 // master.adoc
 
-[id="configuration-points_{context}"]
+[id="management-tasks-{context}"]
 = Managing Strimzi
 
 This chapter covers tasks to maintain a deployment of Strimzi.
 
 //using kubectl commands and status
-include::assembly-resource-status-access.adoc[leveloffset=+1]
+include::assembly-working-with-resources.adoc[leveloffset=+1]
 
 //Discover internal bootstrap service and HTTP Bridge
 include::modules/con-service-discovery.adoc[leveloffset=+1]

--- a/documentation/assemblies/managing/assembly-management-tasks.adoc
+++ b/documentation/assemblies/managing/assembly-management-tasks.adoc
@@ -7,11 +7,11 @@
 
 This chapter covers tasks to maintain a deployment of Strimzi.
 
+//using kubectl commands and status
+include::assembly-resource-status-access.adoc[leveloffset=+1]
+
 //Discover internal bootstrap service and HTTP Bridge
 include::modules/con-service-discovery.adoc[leveloffset=+1]
-
-//Check the status of a resource
-include::assembly-resource-status-access.adoc[leveloffset=+1]
 
 //Recover a cluster from a PV
 include::assembly-cluster-recovery-volume.adoc[leveloffset=+1]

--- a/documentation/assemblies/managing/assembly-resource-status-access.adoc
+++ b/documentation/assemblies/managing/assembly-resource-status-access.adoc
@@ -3,9 +3,14 @@
 // assembly-management-tasks.adoc
 
 [id="resource-status-access_{context}"]
-= Checking the status of a custom resource
+= Working with custom resources
 
-The `status` property of a Strimzi custom resource publishes information about the resource to users and tools that need it.
+You can use `kubectl` commands to retrieve information and perform other operations on Strimzi custom resources.
+
+Using `kubectl` with the `status` property of a custom resource allows you to publish information about the resource to users and tools that need it.
+
+//accessing resource information
+include::modules/con-custom-resources-info.adoc[leveloffset=+1]
 
 //reference table for resource status
 include::modules/con-custom-resources-status.adoc[leveloffset=+1]

--- a/documentation/assemblies/managing/assembly-working-with-resources.adoc
+++ b/documentation/assemblies/managing/assembly-working-with-resources.adoc
@@ -2,7 +2,7 @@
 //
 // assembly-management-tasks.adoc
 
-[id="resource-status-access_{context}"]
+[id="working-with-resources-{context}"]
 = Working with custom resources
 
 You can use `kubectl` commands to retrieve information and perform other operations on Strimzi custom resources.

--- a/documentation/assemblies/managing/assembly-working-with-resources.adoc
+++ b/documentation/assemblies/managing/assembly-working-with-resources.adoc
@@ -7,7 +7,7 @@
 
 You can use `kubectl` commands to retrieve information and perform other operations on Strimzi custom resources.
 
-Using `kubectl` with the `status` property of a custom resource allows you to publish information about the resource to users and tools that need it.
+Using `kubectl` with the `status` subresource of a custom resource allows you to get the information about the resource.
 
 //accessing resource information
 include::modules/con-custom-resources-info.adoc[leveloffset=+1]

--- a/documentation/modules/managing/con-custom-resources-info.adoc
+++ b/documentation/modules/managing/con-custom-resources-info.adoc
@@ -1,0 +1,126 @@
+// Module included in the following assemblies:
+//
+// assembly-resource-status-access.adoc
+
+[id='con-custom-resources-info-{context}']
+= Performing `kubectl` operations on custom resources
+
+Use `kubectl` commands, such as `get`, `describe`, `edit`, or `delete`, to perform operations on resource types.
+For example, `kubectl get kafkatopics` retrieves a list of all Kafka topics and `kubectl get kafkas` retrieves all Kafka clusters.
+
+When referencing resource types, you can use both singular and plural naming:
+`kubectl get kafkas` gets the same results as `kubectl get kafka`.
+
+You can also use the _short name_ of the resource.
+Learning short names can save time when managing Strimzi.
+The _short name_ for `Kafka` is `k`, so you can run `kubectl get k` to list all your deployed Kafka clusters.
+
+[source,shell]
+----
+kubectl get k
+
+NAME         DESIRED KAFKA REPLICAS   DESIRED ZK REPLICAS
+my-cluster   3                        3
+----
+
+.Long and short names for each Strimzi resource
+[cols="3*",options="header",stripes="none"]
+|===
+
+m|Strimzi resource      |Long name          |Short name
+
+| Kafka                 | kafka             | k
+| Kafka Topic           | kafkatopic        | kt
+| Kafka User            | kafkauser         | ku
+| Kafka Connect         | kafkaconnect      | kc
+| Kafka Connect S2I     | kafkaconnects2i   | kcs2i
+| Kafka Connector       | kafkaconnector    | kctr
+| Kafka Mirror Maker    | kafkamirrormaker  | kmm
+| Kafka Mirror Maker 2  | kafkamirrormaker2 | kmm2
+| Kafka Bridge          | kafkabridge       | kb
+| Kafka Rebalance       | kafkarebalance    | kr
+
+|===
+
+== Resource categories
+
+Categories of custom resources can also be used in `kubectl` commands.
+
+All Strimzi custom resources belong to the category `strimzi`, so you can use `strimzi` to get all the Strimzi resources with one command.
+
+For example running `kubectl get strimzi` lists all Strimzi custom resources in a given namespace.
+
+[source,shell]
+----
+kubectl get strimzi
+
+NAME                                   DESIRED KAFKA REPLICAS DESIRED ZK REPLICAS
+kafka.kafka.strimzi.io/my-cluster      3                      3
+
+NAME                                   PARTITIONS REPLICATION FACTOR
+kafkatopic.kafka.strimzi.io/kafka-apps 3          3
+
+NAME                                   AUTHENTICATION AUTHORIZATION
+kafkauser.kafka.strimzi.io/my-user     tls            simple
+----
+
+The `kubectl get strimzi -o name` command returns all resource types and resource names.
+The `-o name` option fetches the output in the _type/name_ format
+
+[source,shell]
+----
+kubectl get strimzi -o name
+
+kafka.kafka.strimzi.io/my-cluster
+kafkatopic.kafka.strimzi.io/kafka-apps
+kafkauser.kafka.strimzi.io/my-user
+----
+
+You can combine this `strimzi` command with others commands.
+For example, you can pass it into a `kubectl delete` command to delete all resources in a single command.
+
+[source,shell]
+----
+kubectl delete $(kubectl get strimzi -o name)
+
+kafka.kafka.strimzi.io "my-cluster" deleted
+kafkatopic.kafka.strimzi.io "kafka-apps" deleted
+kafkauser.kafka.strimzi.io "my-user" deleted
+----
+
+Deleting all resources in a single operation might be useful, for example,
+when your testing new Strimzi features.
+
+== Querying the status of sub-resources
+
+There are other values you can pass to the `-o` option.
+For example, by using `-o yaml` you get the output in YAML format.
+Usng `-o json` will return it as JSON.
+
+You can see all the options in `kubectl get --help`.
+
+One of the most useful options is `jsonpath`, which allows you to pass JSONPath expressions to query the Kubernetes API.
+A JSONPath expression can extract or navigate specific parts of any resource.
+
+For example, you can use the JSONPath expression `{.status.listeners[?(@.type=="tls")].bootstrapServers}`
+to get the bootstrap address from the status of the Kafka custom resource and use it in your Kafka clients.
+
+Here, the command finds the `bootstrapServers` value of the `tls` listeners.
+
+[source,shell]
+----
+kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.type=="tls")].bootstrapServers}{"\n"}'
+
+my-cluster-kafka-bootstrap.myproject.svc:9093
+----
+
+By changing the type condition to `@.type=="external"` or `@.type=="plain"` you can also get the address of the other Kafka listeners.
+
+[source,shell]
+----
+kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.type=="external")].bootstrapServers}{"\n"}'
+
+192.168.1.247:9094
+----
+
+You can use `jsonpath` to extract any other property or group of properties from any custom resource.

--- a/documentation/modules/managing/con-custom-resources-info.adoc
+++ b/documentation/modules/managing/con-custom-resources-info.adoc
@@ -6,14 +6,14 @@
 = Performing `kubectl` operations on custom resources
 
 Use `kubectl` commands, such as `get`, `describe`, `edit`, or `delete`, to perform operations on resource types.
-For example, `kubectl get kafkatopics` retrieves a list of all Kafka topics and `kubectl get kafkas` retrieves all Kafka clusters.
+For example, `kubectl get kafkatopics` retrieves a list of all Kafka topics and `kubectl get kafkas` retrieves all deployed Kafka clusters.
 
-When referencing resource types, you can use both singular and plural naming:
+When referencing resource types, you can use both singular and plural names:
 `kubectl get kafkas` gets the same results as `kubectl get kafka`.
 
 You can also use the _short name_ of the resource.
-Learning short names can save time when managing Strimzi.
-The _short name_ for `Kafka` is `k`, so you can run `kubectl get k` to list all your deployed Kafka clusters.
+Learning short names can save you time when managing Strimzi.
+The short name for `Kafka` is `k`, so you can also run `kubectl get k` to list all Kafka clusters.
 
 [source,shell]
 ----
@@ -48,7 +48,7 @@ Categories of custom resources can also be used in `kubectl` commands.
 
 All Strimzi custom resources belong to the category `strimzi`, so you can use `strimzi` to get all the Strimzi resources with one command.
 
-For example running `kubectl get strimzi` lists all Strimzi custom resources in a given namespace.
+For example, running `kubectl get strimzi` lists all Strimzi custom resources in a given namespace.
 
 [source,shell]
 ----
@@ -76,7 +76,7 @@ kafkatopic.kafka.strimzi.io/kafka-apps
 kafkauser.kafka.strimzi.io/my-user
 ----
 
-You can combine this `strimzi` command with others commands.
+You can combine this `strimzi` command with other commands.
 For example, you can pass it into a `kubectl delete` command to delete all resources in a single command.
 
 [source,shell]
@@ -89,7 +89,7 @@ kafkauser.kafka.strimzi.io "my-user" deleted
 ----
 
 Deleting all resources in a single operation might be useful, for example,
-when your testing new Strimzi features.
+when you are testing new Strimzi features.
 
 == Querying the status of sub-resources
 
@@ -99,7 +99,7 @@ Usng `-o json` will return it as JSON.
 
 You can see all the options in `kubectl get --help`.
 
-One of the most useful options is `jsonpath`, which allows you to pass JSONPath expressions to query the Kubernetes API.
+One of the most useful options is the {K8SJsonPath}, which allows you to pass JSONPath expressions to query the Kubernetes API.
 A JSONPath expression can extract or navigate specific parts of any resource.
 
 For example, you can use the JSONPath expression `{.status.listeners[?(@.type=="tls")].bootstrapServers}`


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

New section for the _Managing Strimzi/Working with custom resources_ chapter in the _Using Guide_
Based on a recent Strimzi blog post, the section describes how to use `kubctl` to retrieve information on custom resources, as well as listing the shortnames that can be used in commands.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

