### PR TITLE
Fix Init container when two node address have the same type

### DIFF
--- a/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriter.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriter.java
@@ -118,7 +118,11 @@ public class InitWriter {
             return null;
         }
 
-        Map<String, String> addressMap = addresses.stream().collect(Collectors.toMap(NodeAddress::getType, NodeAddress::getAddress));
+        Map<String, String> addressMap = addresses.stream()
+                .collect(Collectors.toMap(NodeAddress::getType, NodeAddress::getAddress, (address1, address2) -> {
+                    log.warn("Found multiple addresses with the same type. Only the first address '{}' will be used.", address1);
+                    return address1;
+                }));
 
         // If user set preferred address type, we should check it first
         if (config.getAddressType() != null && addressMap.containsKey(config.getAddressType())) {

--- a/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterTest.java
+++ b/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterTest.java
@@ -172,6 +172,23 @@ public class InitWriterTest {
         assertThat(address, is(nullValue()));
     }
 
+    @Test
+    public void testFindAddressWithMultipleAddressesOfSameType()   {
+        List<NodeAddress> addresses = new ArrayList<>(3);
+        addresses.add(new NodeAddressBuilder().withType("ExternalDNS").withAddress("my.external.address").build());
+        addresses.add(new NodeAddressBuilder().withType("ExternalDNS").withAddress("my.external.address2").build());
+        addresses.add(new NodeAddressBuilder().withType("InternalDNS").withAddress("my.internal.address").build());
+        addresses.add(new NodeAddressBuilder().withType("InternalDNS").withAddress("my.internal.address2").build());
+        addresses.add(new NodeAddressBuilder().withType("InternalIP").withAddress("192.168.2.94").build());
+
+        InitWriterConfig config = InitWriterConfig.fromMap(envVars);
+        KubernetesClient client = mockKubernetesClient(config.getNodeName(), labels, addresses);
+        InitWriter writer = new InitWriter(client, config);
+        String address = writer.findAddress(addresses);
+
+        assertThat(address, is("my.external.address"));
+    }
+
     /**
      * Mock a Kubernetes client for getting cluster node information
      *


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

As described in #3458, the init container will currently fail when a node has multiple addresses of the same type. This PR fixes this error to some extent: If there are two addresses with the same type, we will use the first one and ignore the other one. Since there is no other identifier, there is not much better we can do and I think it should happen only in rare situations (ot at least this was the first report of this kind).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging