### PR TITLE
[DOC] Cruise Control docs enhancements for capacity limits, etc.

### DIFF
--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -7,16 +7,20 @@
 
 To rebalance a Kafka cluster, Cruise Control uses optimization goals to generate xref:con-optimization-proposals-{context}[optimization proposals], which you can approve or reject.  
 
-Optimization goals are constraints on workload redistribution and resource utilization across a Kafka cluster.
-With a few exceptions, Strimzi supports all the optimization goals developed in the Cruise Control project. 
+Optimization goals are constraints on workload redistribution and resource utilization across a Kafka cluster. Strimzi supports most of the optimization goals developed in the Cruise Control project. 
 The supported goals, in the default descending order of priority, are as follows:
 
 . Rack-awareness
 . Replica capacity
-. Capacity: Disk capacity, Network inbound capacity, Network outbound capacity, CPU capacity
+. _Capacity_: Disk capacity, Network inbound capacity, Network outbound capacity, CPU capacity
 . Replica distribution
 . Potential network output
-. Resource distribution: Disk utilization distribution, Network inbound utilization distribution, Network outbound utilization distribution, CPU utilization distribution
+. _Resource distribution_: Disk utilization distribution, Network inbound utilization distribution, Network outbound utilization distribution, CPU utilization distribution
++
+[NOTE]
+====
+The resource distribution goals are controlled using xref:capacity-configuration[capacity limits] on broker resources.
+====
 . Leader bytes-in rate distribution
 . Topic replica distribution
 . Leader replica distribution
@@ -32,7 +36,7 @@ NOTE: Intra-broker disk goals, "Write your own" goals, and Kafka assigner goals 
 == Goals configuration in Strimzi custom resources
 
 You configure optimization goals in `Kafka` and `KafkaRebalance` custom resources. Cruise Control has configurations for xref:hard-soft-goals[hard] optimization goals that must be satisfied, as well as xref:master-goals[master], xref:#default-goals[default], and xref:#user-provided-goals[user-provided] optimization goals. 
-Optimization goals are subject to any xref:capacity-configuration[capacity limits] on broker resources.
+Optimization goals for resource distribution (disk, network inbound, network outbound, and CPU) are subject to any xref:capacity-configuration[capacity limits] on broker resources.
 
 The following sections describe each goal configuration in more detail.
 
@@ -103,9 +107,9 @@ Goals that are not listed in the master optimization goals are not available for
 Unless you change the Cruise Control xref:proc-deploying-cruise-control-{context}[deployment configuration], Strimzi will inherit the following master optimization goals from Cruise Control, in descending priority order:
 
 [source]
-RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CPUCapacityGoal; ReplicaDistributionGoal; PotentialNwOutGoal; DiskUsageDistributionGoal; NetworkInboundUsageDistributionGoal; NetworkOutboundUsageDistributionGoal; TopicReplicaDistributionGoal; LeaderReplicaDistributionGoal; LeaderBytesInDistributionGoal; PreferredLeaderElectionGoal
+RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CPUCapacityGoal; ReplicaDistributionGoal; PotentialNwOutGoal; DiskUsageDistributionGoal; NetworkInboundUsageDistributionGoal; NetworkOutboundUsageDistributionGoal; CpuUsageDistributionGoal; TopicReplicaDistributionGoal; LeaderReplicaDistributionGoal; LeaderBytesInDistributionGoal; PreferredLeaderElectionGoal
 
-Five of these goals are preset as xref:hard-soft-goals[hard goals].
+Six of these goals are preset as xref:hard-soft-goals[hard goals].
 
 To reduce complexity, we recommend that you use the inherited master optimization goals, unless you need to _completely_ exclude one or more goals from use in `KafkaRebalance` resources. The priority order of the master optimization goals can be modified, if desired, in the configuration for xref:default-goals[default optimization goals].
 

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -173,7 +173,7 @@ If no default optimization goals are specified, the cached proposal is generated
 === User-provided optimization goals
 
 _User-provided optimization goals_ narrow down the configured default goals for a particular optimization proposal. 
-You can set them, as required, in `spec.goals` in the `KafkaRebalance` custom resource:
+You can set them, as required, in `spec.goals` in a `KafkaRebalance` custom resource:
 
 ----
 KafkaRebalance.spec.goals
@@ -188,7 +188,9 @@ User-provided optimization goals must:
 * Include all configured xref:hard-soft-goals[hard goals], or an error occurs
 * Be a subset of the master optimization goals
 
-To ignore the configured hard goals in an optimization proposal, add the `skipHardGoalCheck: true` option to the `KafkaRebalance` custom resource.
+To ignore the configured hard goals in the generated optimization proposal, add the `skipHardGoalCheck: true` option to the `KafkaRebalance` custom resource.
+
+To apply an optimization proposal and rebalance the Kafka cluster, you annotate the `KafkaRebalance` custom resource. 
 
 .Additional resources
 

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -7,7 +7,8 @@
 
 To rebalance a Kafka cluster, Cruise Control uses optimization goals to generate xref:con-optimization-proposals-{context}[optimization proposals], which you can approve or reject.  
 
-Optimization goals are constraints on workload redistribution and resource utilization across a Kafka cluster. Strimzi supports most of the optimization goals developed in the Cruise Control project. 
+Optimization goals are constraints on workload redistribution and resource utilization across a Kafka cluster. 
+Strimzi supports most of the optimization goals developed in the Cruise Control project. 
 The supported goals, in the default descending order of priority, are as follows:
 
 . Rack-awareness
@@ -36,7 +37,7 @@ NOTE: Intra-broker disk goals, "Write your own" goals, and Kafka assigner goals 
 == Goals configuration in Strimzi custom resources
 
 You configure optimization goals in `Kafka` and `KafkaRebalance` custom resources. Cruise Control has configurations for xref:hard-soft-goals[hard] optimization goals that must be satisfied, as well as xref:master-goals[master], xref:#default-goals[default], and xref:#user-provided-goals[user-provided] optimization goals. 
-Optimization goals for resource distribution (disk, network inbound, network outbound, and CPU) are subject to any xref:capacity-configuration[capacity limits] on broker resources.
+Optimization goals for resource distribution (disk, network inbound, network outbound, and CPU) are subject to xref:capacity-configuration[capacity limits] on broker resources.
 
 The following sections describe each goal configuration in more detail.
 

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -188,7 +188,7 @@ User-provided optimization goals must:
 * Include all configured xref:hard-soft-goals[hard goals], or an error occurs
 * Be a subset of the master optimization goals
 
-To ignore the configured hard goals when generating an optimization proposal, add the `skipHardGoalCheck: true` property to the `KafkaRebalance` custom resource.
+To ignore the configured hard goals when generating an optimization proposal, add the `skipHardGoalCheck: true` property to the `KafkaRebalance` custom resource. See xref:proc-generating-optimization-proposals-{context}[]. 
 
 .Additional resources
 

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -188,9 +188,7 @@ User-provided optimization goals must:
 * Include all configured xref:hard-soft-goals[hard goals], or an error occurs
 * Be a subset of the master optimization goals
 
-To ignore the configured hard goals in the generated optimization proposal, add the `skipHardGoalCheck: true` option to the `KafkaRebalance` custom resource.
-
-To apply an optimization proposal and rebalance the Kafka cluster, you annotate the `KafkaRebalance` custom resource. 
+To ignore the configured hard goals when generating an optimization proposal, add the `skipHardGoalCheck: true` property to the `KafkaRebalance` custom resource.
 
 .Additional resources
 

--- a/documentation/modules/cruise-control/con-rebalance-performance.adoc
+++ b/documentation/modules/cruise-control/con-rebalance-performance.adoc
@@ -75,7 +75,7 @@ The relevant configurations are summarized below:
 
 | `default.replica.movement.strategies`             .2+| 
   The list of strategies (in priority order) used to determine the order in which partition reassignment commands are executed for generated proposals. Use a comma separated string for server and a YAML array for `KafkaRebalance` resources.
-.2+|Base Replica Movement Strategy
+.2+| `BaseReplicaMovementStrategy`
 | `replicaMovementStrategies`
 
 |============================================================================================================================

--- a/documentation/modules/cruise-control/con-rebalance-performance.adoc
+++ b/documentation/modules/cruise-control/con-rebalance-performance.adoc
@@ -49,13 +49,13 @@ If the reassignments are equivalent, then it passes them to the next strategy in
 Cruise Control provides several configuration options for tuning the rebalance parameters discussed above.
 You can set these tuning options at either the xref:ref-cruise-control-configuration-{context}[Cruise Control server] or xref:proc-generating-optimization-proposals-{context}[optimization proposal] levels:
 
-* The Cruise Control server setting can be set in the Kafka custom resource under `Kafka.spec.kafka.spec.cruiseControl.spec`. 
+* The Cruise Control server setting can be set in the Kafka custom resource under `Kafka.spec.cruiseControl.config`. 
 * The individual rebalance performance configurations can be set under `KafkaRebalance.spec`. 
 
-The relevant configurations are summarised below:
+The relevant configurations are summarized below:
 
 |============================================================================================================================
-| Server / KafkaRebalance Configuration                | Description                                          | Default Value
+| Server and `KafkaRebalance` Configuration                | Description                                          | Default Value
 
 | `num.concurrent.partition.movements.per.broker`   .2+| 
   The maximum number of inter-broker partition movements in each partition reassignment batch              .2+| 5 
@@ -75,7 +75,7 @@ The relevant configurations are summarised below:
 
 | `default.replica.movement.strategies`             .2+| 
   The list of strategies (in priority order) used to determine the order in which partition reassignment commands are executed for generated proposals. Use a comma separated string for server and a YAML array for `KafkaRebalance` resources.
-.2+| `BaseReplicaMovementStrategy`
+.2+|Base Replica Movement Strategy
 | `replicaMovementStrategies`
 
 |============================================================================================================================

--- a/documentation/modules/cruise-control/proc-approving-optimization-proposal.adoc
+++ b/documentation/modules/cruise-control/proc-approving-optimization-proposal.adoc
@@ -68,7 +68,7 @@ kubectl describe kafkarebalance _rebalance-cr-name_
 
 ** Rebalancing: The cluster rebalance operation is in progress. 
 
-** Ready: The cluster rebalancing operation completed successfully.
+** Ready: The cluster rebalancing operation completed successfully. The `KafkaRebalance` custom resource cannot be reused.
 
 ** NotReady: An error occurred--see xref:proc-fixing-problems-with-kafkarebalance-{context}[].  
 

--- a/documentation/modules/cruise-control/proc-generating-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/proc-generating-optimization-proposals.adoc
@@ -7,7 +7,7 @@
 
 When you create or update a `KafkaRebalance` resource, Cruise Control generates an xref:con-optimization-proposals-{context}[optimization proposal] for the Kafka cluster based on the configured xref:con-optimization-goals-{context}[optimization goals].
 
-Analyze the summary information in the optimization proposal and decide whether to approve it. 
+Analyze the information in the optimization proposal and decide whether to approve it. 
 
 .Prerequisites
 
@@ -48,6 +48,23 @@ spec:
   goals:
     - RackAwareGoal
     - ReplicaCapacityGoal
+----
+
+.. To ignore the configured hard goals, add the `skipHardGoalCheck: true` property:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaRebalance
+metadata:
+  name: my-rebalance
+  labels: 
+    strimzi.io/cluster: my-cluster
+spec:    
+  goals:
+    - RackAwareGoal
+    - ReplicaCapacityGoal
+skipHardGoalCheck: true
 ----
 
 . Create or update the resource:

--- a/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
+++ b/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
@@ -62,10 +62,17 @@ spec:
 [discrete]
 == Capacity configuration
 
-Cruise Control uses _capacity limits_ to determine if certain resource-based optimization goals are being broken. 
+Cruise Control uses _capacity limits_ to determine if optimization goals for resource distribution are being broken. 
+There are four goals of this type:
 
-You specify capacity limits for Kafka broker resources in the `brokerCapacity` property in `Kafka.spec.cruiseControl` .
-Capacity limits can be set for the following broker resources using the standard Kubernetes byte units K, M, G and T or their bibyte (power of two) equivalents Ki, Mi, Gi and Ti:
+* `DiskUsageDistributionGoal`            - Disk utilization distribution
+* `CpuUsageDistributionGoal`             - CPU utilization distribution    
+* `NetworkInboundUsageDistributionGoal`  - Network inbound utilization distribution
+* `NetworkOutboundUsageDistributionGoal` - Network outbound utilization distribution
+
+You specify capacity limits for Kafka broker resources in the `brokerCapacity` property in `Kafka.spec.cruiseControl` . 
+They are enabled by default and you can change their default values. 
+Capacity limits can be set for the following broker resources, using the standard Kubernetes byte units (K, M, G and T) or their bibyte (power of two) equivalents (Ki, Mi, Gi and Ti):
 
 * `disk`            - Disk storage per broker (Default: 100000Mi)
 * `cpuUtilization`  - CPU utilization as a percentage (Default: 100)

--- a/documentation/modules/overview/con-kafka-concepts-key.adoc
+++ b/documentation/modules/overview/con-kafka-concepts-key.adoc
@@ -7,7 +7,7 @@
 
 Knowledge of the key concepts of Kafka is important in understanding how Strimzi works.
 
-A Kafka cluster comprises multiple brokers
+A Kafka cluster comprises multiple brokers.
 Topics are used to receive and store data in a Kafka cluster.
 Topics are split by partitions, where the data is written.
 Partitions are replicated across topics for fault tolerance.


### PR DESCRIPTION
Signed-off-by: Daniel Laing <dlaing@redhat.com>

### Type of change

- Documentation

### Description

Updated guide: *Using Strimzi*

Various changes to the "Cruise Control for Cluster rebalancing" section.

- Explain the relationship between the resource distribution / utilization goals and the capacity limits that apply to them. Currently, this is not very obvious unless you know how Cruise Control works.

- Fix a typo in "Rebalance performance tuning overview" (configuration of a `Kafka` custom resource).

- In relation to enhancement #3296 , state that `KafkaRebalance` custom resource cannot be reused after the status changes to `ready`.

- Added the `CpuUsageDistributionGoal` to the list of master optimization goals (this was missed in earlier PRs)

- Try to improve the table in "Rebalance performance tuning overview".

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging - **Issue #3296**
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards