### PR TITLE
[SYSTEMTEST] Disambiguate topic deletion

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -4,6 +4,7 @@
 * [Lightbend](https://www.lightbend.com/)
 * [Axual](https://axual.com/): [Optimizing Kafka Cluster Deployments in Kubernetes](https://itnext.io/optimizing-kafka-cluster-deployments-in-kubernetes-ceda3f95c157)
 * [Grupo MASMOVIL](https://www.grupomasmovil.com/)
+* [IBM](https://www.ibm.com/cloud/event-streams)
 
 Are you currently using Strimzi in production?
 Please let us know by adding your company name and, if you want, a description of your use case to this document!

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
 import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.PasswordSecretSourceBuilder;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationScramSha512;
@@ -171,7 +172,7 @@ class ConnectST extends AbstractST {
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "99");
 
         LOGGER.info("Deleting topic {} from CR", CONNECT_TOPIC_NAME);
-        cmdKubeClient().deleteByName("kafkatopic", CONNECT_TOPIC_NAME);
+        cmdKubeClient().deleteByName(KafkaTopic.CRD_NAME, CONNECT_TOPIC_NAME);
         KafkaTopicUtils.waitForKafkaTopicDeletion(CONNECT_TOPIC_NAME);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -357,6 +357,7 @@ public class MetricsST extends AbstractST {
 
     @BeforeAll
     void setupEnvironment() throws Exception {
+        LOGGER.info("Setting up Environment for MetricsST");
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
 


### PR DESCRIPTION
### Type of change
- Bugfix

### Description

In a cluster with multiple custom resource kinds with shortname
kafkatopics, the test can fail to delete the topic. By using the
CRD name, disambiguates the type for deletion.

Also added a log line to the MetricsST to signal its start,
multiple runs locally have seen it hang with no printed output
so this output makes the runner aware of when the test actually begins

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

