### PR TITLE
[DOC] Remove the old certificates after a renewal of Cluster CA

### DIFF
--- a/documentation/modules/security/proc-renewing-ca-certs-manually.adoc
+++ b/documentation/modules/security/proc-renewing-ca-certs-manually.adoc
@@ -6,8 +6,10 @@
 
 = Renewing CA certificates manually
 
-Unless the `Kafka.spec.clusterCa.generateCertificateAuthority` and `Kafka.spec.clientsCa.generateCertificateAuthority` objects are set to `false`, the cluster and clients CA certificates will auto-renew at the start of their respective certificate renewal periods. 
-You can manually renew one or both of these certificates before the certificate renewal period starts, if required for security reasons. 
+Unless the `Kafka.spec.clusterCa.generateCertificateAuthority` and `Kafka.spec.clientsCa.generateCertificateAuthority` objects are set to `false`,
+the cluster and clients CA certificates will auto-renew at the start of their respective certificate renewal periods.
+
+You can manually renew one or both of these certificates before the certificate renewal period starts, if required for security reasons.
 A renewed certificate uses the same private key as the old certificate.
 
 .Prerequisites
@@ -17,8 +19,9 @@ A renewed certificate uses the same private key as the old certificate.
 
 .Procedure
 
-* Apply the `strimzi.io/force-renew` annotation to the `Secret` that contains the CA certificate that you want to renew.
+. Apply the `strimzi.io/force-renew` annotation to the `Secret` that contains the CA certificate that you want to renew.
 +
+.Annotation for Secret that forces renewal of certificates
 [cols="3*",options="header",stripes="none",separator=¦]
 |===
 
@@ -27,16 +30,21 @@ A renewed certificate uses the same private key as the old certificate.
 ¦Annotate command
 
 ¦Cluster CA
-¦_<cluster-name>_-cluster-ca-cert
-m¦kubectl annotate secret _<cluster-name>_-cluster-ca-cert strimzi.io/force-renew=true
+¦_KAFKA-CLUSTER-NAME_-cluster-ca-cert
+m¦kubectl annotate secret _KAFKA-CLUSTER-NAME_-cluster-ca-cert strimzi.io/force-renew=true
 
 ¦Clients CA
-¦_<cluster-name>_-clients-ca-cert
-m¦kubectl annotate secret _<cluster-name>_-clients-ca-cert strimzi.io/force-renew=true
+¦_KAFKA-CLUSTER-NAME_-clients-ca-cert
+m¦kubectl annotate secret _KAFKA-CLUSTER-NAME_-clients-ca-cert strimzi.io/force-renew=true
 
 |===
 
-At the next reconciliation the Cluster Operator will generate a new CA certificate for the `Secret` that you annotated. 
+. Delete old certificates from the Secret.
++
+When components are using the new certificates, older certificates might still be active.
+Delete the old certificates to remove any potential security risk.
+
+At the next reconciliation the Cluster Operator will generate a new CA certificate for the `Secret` that you annotated.
 If maintenance time windows are configured, the Cluster Operator will generate the new CA certificate at the first reconciliation within the next maintenance time window.
 
 Client applications must reload the cluster and clients CA certificates that were renewed by the Cluster Operator.

--- a/documentation/modules/security/proc-renewing-ca-certs-manually.adoc
+++ b/documentation/modules/security/proc-renewing-ca-certs-manually.adoc
@@ -38,16 +38,16 @@ m¦kubectl annotate secret _KAFKA-CLUSTER-NAME_-cluster-ca-cert strimzi.io/force
 m¦kubectl annotate secret _KAFKA-CLUSTER-NAME_-clients-ca-cert strimzi.io/force-renew=true
 
 |===
++
+At the next reconciliation the Cluster Operator will generate a new CA certificate for the `Secret` that you annotated.
+If maintenance time windows are configured, the Cluster Operator will generate the new CA certificate at the first reconciliation within the next maintenance time window.
++
+Client applications must reload the cluster and clients CA certificates that were renewed by the Cluster Operator.
 
 . Delete old certificates from the Secret.
 +
 When components are using the new certificates, older certificates might still be active.
 Delete the old certificates to remove any potential security risk.
-
-At the next reconciliation the Cluster Operator will generate a new CA certificate for the `Secret` that you annotated.
-If maintenance time windows are configured, the Cluster Operator will generate the new CA certificate at the first reconciliation within the next maintenance time window.
-
-Client applications must reload the cluster and clients CA certificates that were renewed by the Cluster Operator.
 
 .Additional resources
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Add a note to delete old certificates when manually renewing certificates.
Update to the _Renewing CA certificates manually_ procedure in the _Using Guide_


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

