### PR TITLE
Git ignoring JVM crash logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ systemtest/my-plugins/
 
 # Hacking directory with different script utilities and more complex YAML examples used by developers for development and testing
 /hacking/
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*


### PR DESCRIPTION
This PR just adds ignoring virtual machine crash logs for git.