### PR TITLE
[systemtest] Add test for dynamic logging change of CO

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -458,9 +458,10 @@ class LoggingChangeST extends AbstractST {
     }
 
     @Test
-    void testDynamicallySetClusterOperatorLoggingLevels() {
+    void testDynamicallySetClusterOperatorLoggingLevels() throws InterruptedException {
         Map<String, String> coPod = DeploymentUtils.depSnapshot(STRIMZI_DEPLOYMENT_NAME);
         String coPodName = kubeClient().listPodsByPrefixInName(STRIMZI_DEPLOYMENT_NAME).get(0).getMetadata().getName();
+        String command = "cat /opt/strimzi/custom-config/log4j2.properties";
 
         String log4jConfig =
             "name = COConfig\n" +
@@ -471,19 +472,19 @@ class LoggingChangeST extends AbstractST {
             "    appender.console.layout.type = PatternLayout\n" +
             "    appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n\n" +
             "\n" +
-            "    rootLogger.level = INFO\n" +
+            "    rootLogger.level = OFF\n" +
             "    rootLogger.appenderRefs = stdout\n" +
             "    rootLogger.appenderRef.console.ref = STDOUT\n" +
             "    rootLogger.additivity = false\n" +
             "\n" +
             "    # Kafka AdminClient logging is a bit noisy at INFO level\n" +
             "    logger.kafka.name = org.apache.kafka\n" +
-            "    logger.kafka.level = WARN\n" +
+            "    logger.kafka.level = OFF\n" +
             "    logger.kafka.additivity = false\n" +
             "\n" +
             "    # Zookeeper is very verbose even on INFO level -> We set it to WARN by default\n" +
             "    logger.zookeepertrustmanager.name = org.apache.zookeeper\n" +
-            "    logger.zookeepertrustmanager.level = WARN\n" +
+            "    logger.zookeepertrustmanager.level = OFF\n" +
             "    logger.zookeepertrustmanager.additivity = false";
 
         ConfigMap coMap = new ConfigMapBuilder()
@@ -495,13 +496,15 @@ class LoggingChangeST extends AbstractST {
             .withData(Collections.singletonMap("log4j2.properties", log4jConfig))
             .build();
 
+        LOGGER.info("Checking that original logging config is different from the new one");
+        assertThat(log4jConfig, not(equalTo(cmdKubeClient().execInPod(coPodName, "/bin/bash", "-c", command).out().trim())));
+
         LOGGER.info("Changing logging for cluster-operator");
         kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(coMap);
 
-        String command = "cat /opt/strimzi/custom-config/log4j2.properties";
         LOGGER.info("Waiting for log4j2.properties will contain desired settings");
         TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> cmdKubeClient().execInPod(coPodName, "/bin/bash", "-c", command).out().contains(log4jConfig)
+            () -> cmdKubeClient().execInPod(coPodName, "/bin/bash", "-c", command).out().contains("rootLogger.level = OFF")
         );
 
         LOGGER.info("Checking log4j2.properties in CO pod");
@@ -510,6 +513,39 @@ class LoggingChangeST extends AbstractST {
 
         LOGGER.info("Checking if CO rolled it's pod");
         assertThat(coPod, equalTo(DeploymentUtils.depSnapshot(STRIMZI_DEPLOYMENT_NAME)));
+
+        LOGGER.info("Waiting {} ms log to be empty", LOGGING_RELOADING_INTERVAL * 2);
+        // wait some time and check whether logs after this time are empty
+        Thread.sleep(LOGGING_RELOADING_INTERVAL * 2);
+
+        LOGGER.info("Asserting if log will contain no records");
+        assertThat(StUtils.getLogFromPodByTime(coPodName, STRIMZI_DEPLOYMENT_NAME, "30s"), is(emptyString()));
+
+        LOGGER.info("Changing all levels from OFF to INFO/WARN");
+        log4jConfig = log4jConfig.replaceAll("OFF", "INFO");
+        coMap.setData(Collections.singletonMap("log4j2.properties", log4jConfig));
+
+        LOGGER.info("Changing logging for cluster-operator");
+        kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(coMap);
+
+        LOGGER.info("Waiting for log4j2.properties will contain desired settings");
+        TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> cmdKubeClient().execInPod(coPodName, "/bin/bash", "-c", command).out().contains("rootLogger.level = INFO")
+        );
+
+        LOGGER.info("Checking log4j2.properties in CO pod");
+        podLogConfig = cmdKubeClient().execInPod(coPodName, "/bin/bash", "-c", command).out().trim();
+        assertThat(podLogConfig, equalTo(log4jConfig));
+
+        LOGGER.info("Checking if CO rolled it's pod");
+        assertThat(coPod, equalTo(DeploymentUtils.depSnapshot(STRIMZI_DEPLOYMENT_NAME)));
+
+        LOGGER.info("Waiting {} ms log to be empty", LOGGING_RELOADING_INTERVAL * 2);
+        // wait some time and check whether logs after this time are empty
+        Thread.sleep(LOGGING_RELOADING_INTERVAL * 2);
+
+        LOGGER.info("Asserting if log will contain no records");
+        assertThat(StUtils.getLogFromPodByTime(coPodName, STRIMZI_DEPLOYMENT_NAME, "30s"), is(not(emptyString())));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -35,6 +35,7 @@ import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.LOGGING_RELOADING_INTERVAL;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.Constants.STRIMZI_DEPLOYMENT_NAME;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -454,6 +455,61 @@ class LoggingChangeST extends AbstractST {
         assertThat(StUtils.getLogFromPodByTime(bridgePodName, KafkaBridgeResources.deploymentName(CLUSTER_NAME), "30s"), is(emptyString()));
 
         assertThat("Bridge pod should not roll", DeploymentUtils.depSnapshot(KafkaBridgeResources.deploymentName(CLUSTER_NAME)), equalTo(bridgeSnapshot));
+    }
+
+    @Test
+    void testDynamicallySetClusterOperatorLoggingLevels() {
+        Map<String, String> coPod = DeploymentUtils.depSnapshot(STRIMZI_DEPLOYMENT_NAME);
+        String coPodName = kubeClient().listPodsByPrefixInName(STRIMZI_DEPLOYMENT_NAME).get(0).getMetadata().getName();
+
+        String log4jConfig =
+            "name = COConfig\n" +
+            "monitorInterval = 30\n" +
+            "\n" +
+            "    appender.console.type = Console\n" +
+            "    appender.console.name = STDOUT\n" +
+            "    appender.console.layout.type = PatternLayout\n" +
+            "    appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n\n" +
+            "\n" +
+            "    rootLogger.level = INFO\n" +
+            "    rootLogger.appenderRefs = stdout\n" +
+            "    rootLogger.appenderRef.console.ref = STDOUT\n" +
+            "    rootLogger.additivity = false\n" +
+            "\n" +
+            "    # Kafka AdminClient logging is a bit noisy at INFO level\n" +
+            "    logger.kafka.name = org.apache.kafka\n" +
+            "    logger.kafka.level = WARN\n" +
+            "    logger.kafka.additivity = false\n" +
+            "\n" +
+            "    # Zookeeper is very verbose even on INFO level -> We set it to WARN by default\n" +
+            "    logger.zookeepertrustmanager.name = org.apache.zookeeper\n" +
+            "    logger.zookeepertrustmanager.level = WARN\n" +
+            "    logger.zookeepertrustmanager.additivity = false";
+
+        ConfigMap coMap = new ConfigMapBuilder()
+            .withNewMetadata()
+                .addToLabels("app", "strimzi")
+                .withName(STRIMZI_DEPLOYMENT_NAME)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .withData(Collections.singletonMap("log4j2.properties", log4jConfig))
+            .build();
+
+        LOGGER.info("Changing logging for cluster-operator");
+        kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(coMap);
+
+        String command = "cat /opt/strimzi/custom-config/log4j2.properties";
+        LOGGER.info("Waiting for log4j2.properties will contain desired settings");
+        TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> cmdKubeClient().execInPod(coPodName, "/bin/bash", "-c", command).out().contains(log4jConfig)
+        );
+
+        LOGGER.info("Checking log4j2.properties in CO pod");
+        String podLogConfig = cmdKubeClient().execInPod(coPodName, "/bin/bash", "-c", command).out().trim();
+        assertThat(podLogConfig, equalTo(log4jConfig));
+
+        LOGGER.info("Checking if CO rolled it's pod");
+        assertThat(coPod, equalTo(DeploymentUtils.depSnapshot(STRIMZI_DEPLOYMENT_NAME)));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -514,9 +514,9 @@ class LoggingChangeST extends AbstractST {
         LOGGER.info("Checking if CO rolled it's pod");
         assertThat(coPod, equalTo(DeploymentUtils.depSnapshot(STRIMZI_DEPLOYMENT_NAME)));
 
-        LOGGER.info("Waiting {} ms log to be empty", LOGGING_RELOADING_INTERVAL * 2);
+        LOGGER.info("Waiting {} ms log to be empty", LOGGING_RELOADING_INTERVAL);
         // wait some time and check whether logs after this time are empty
-        Thread.sleep(LOGGING_RELOADING_INTERVAL * 2);
+        Thread.sleep(LOGGING_RELOADING_INTERVAL);
 
         LOGGER.info("Asserting if log will contain no records");
         assertThat(StUtils.getLogFromPodByTime(coPodName, STRIMZI_DEPLOYMENT_NAME, "30s"), is(emptyString()));
@@ -540,12 +540,14 @@ class LoggingChangeST extends AbstractST {
         LOGGER.info("Checking if CO rolled it's pod");
         assertThat(coPod, equalTo(DeploymentUtils.depSnapshot(STRIMZI_DEPLOYMENT_NAME)));
 
-        LOGGER.info("Waiting {} ms log to be empty", LOGGING_RELOADING_INTERVAL * 2);
-        // wait some time and check whether logs after this time are empty
-        Thread.sleep(LOGGING_RELOADING_INTERVAL * 2);
+        LOGGER.info("Waiting {} ms log not to be empty", LOGGING_RELOADING_INTERVAL);
+        // wait some time and check whether logs after this time are not empty
+        Thread.sleep(LOGGING_RELOADING_INTERVAL);
 
         LOGGER.info("Asserting if log will contain no records");
-        assertThat(StUtils.getLogFromPodByTime(coPodName, STRIMZI_DEPLOYMENT_NAME, "30s"), is(not(emptyString())));
+        String coLog = StUtils.getLogFromPodByTime(coPodName, STRIMZI_DEPLOYMENT_NAME, "30s");
+        assertThat(coLog, is(not(emptyString())));
+        assertThat(coLog.contains("INFO"), is(true));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -511,7 +511,7 @@ class LoggingChangeST extends AbstractST {
         String podLogConfig = cmdKubeClient().execInPod(coPodName, "/bin/bash", "-c", command).out().trim();
         assertThat(podLogConfig, equalTo(log4jConfig));
 
-        LOGGER.info("Checking if CO rolled it's pod");
+        LOGGER.info("Checking if CO rolled its pod");
         assertThat(coPod, equalTo(DeploymentUtils.depSnapshot(STRIMZI_DEPLOYMENT_NAME)));
 
         LOGGER.info("Waiting {} ms log to be empty", LOGGING_RELOADING_INTERVAL);
@@ -537,7 +537,7 @@ class LoggingChangeST extends AbstractST {
         podLogConfig = cmdKubeClient().execInPod(coPodName, "/bin/bash", "-c", command).out().trim();
         assertThat(podLogConfig, equalTo(log4jConfig));
 
-        LOGGER.info("Checking if CO rolled it's pod");
+        LOGGER.info("Checking if CO rolled its pod");
         assertThat(coPod, equalTo(DeploymentUtils.depSnapshot(STRIMZI_DEPLOYMENT_NAME)));
 
         LOGGER.info("Waiting {} ms log not to be empty", LOGGING_RELOADING_INTERVAL);


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test

### Description

After #3328 we are able to change logging of CO without rolling update -> by deploying the `ConfigMap` like we have in `050-ConfigMap-strimzi-cluster-operator`. I added test for it to check, that CO logging config in `log4j2.properties` will change and the pod will not roll.

Other than that I added version of Kafka `2.6.0` to test containers and removed the `2.4.0` and `2.4.1` -> this will happen on every Maven build, so it will be better to do it to prevent conflicts.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
