### PR TITLE
Fix finding node address with duplicate type

### DIFF
--- a/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriter.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriter.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class InitWriter {
 
@@ -100,47 +99,5 @@ public class InitWriter {
         }
 
         return isWritten;
-    }
-
-    /**
-     * Tries to find the right address of the node. The different addresses has different prioprities:
-     *      1. ExternalDNS
-     *      2. ExternalIP
-     *      3. Hostname
-     *      4. InternalDNS
-     *      5. InternalIP
-     *
-     * @param addresses List of addresses which are assigned to our node
-     * @return  Address of the node
-     */
-    protected String findAddress(List<NodeAddress> addresses)   {
-        if (addresses == null)  {
-            return null;
-        }
-
-        Map<String, String> addressMap = addresses.stream()
-                .collect(Collectors.toMap(NodeAddress::getType, NodeAddress::getAddress, (address1, address2) -> {
-                    log.warn("Found multiple addresses with the same type. Only the first address '{}' will be used.", address1);
-                    return address1;
-                }));
-
-        // If user set preferred address type, we should check it first
-        if (config.getAddressType() != null && addressMap.containsKey(config.getAddressType())) {
-            return addressMap.get(config.getAddressType());
-        }
-
-        if (addressMap.containsKey("ExternalDNS"))  {
-            return addressMap.get("ExternalDNS");
-        } else if (addressMap.containsKey("ExternalIP"))  {
-            return addressMap.get("ExternalIP");
-        } else if (addressMap.containsKey("InternalDNS"))  {
-            return addressMap.get("InternalDNS");
-        } else if (addressMap.containsKey("InternalIP"))  {
-            return addressMap.get("InternalIP");
-        } else if (addressMap.containsKey("Hostname")) {
-            return addressMap.get("Hostname");
-        }
-
-        return null;
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/cluster/model/NodeUtilsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/cluster/model/NodeUtilsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.NodeAddress;
+import io.fabric8.kubernetes.api.model.NodeAddressBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+
+public class NodeUtilsTest {
+    private static final List<NodeAddress> ADDRESSES = new ArrayList<>(3);
+
+    static {
+        ADDRESSES.add(new NodeAddressBuilder().withType("ExternalDNS").withAddress("my.external.address").build());
+        ADDRESSES.add(new NodeAddressBuilder().withType("InternalDNS").withAddress("my.internal.address").build());
+        ADDRESSES.add(new NodeAddressBuilder().withType("InternalIP").withAddress("192.168.2.94").build());
+    }
+
+    @Test
+    public void testFindAddressWithAddressType()   {
+        String address = NodeUtils.findAddress(ADDRESSES, "InternalDNS");
+
+        assertThat(address, is("my.internal.address"));
+    }
+
+    @Test
+    public void testFindAddressReturnsExternalAddress()   {
+        String address = NodeUtils.findAddress(ADDRESSES, null);
+
+        assertThat(address, is("my.external.address"));
+    }
+
+    @Test
+    public void testFindAddressNullWithInvalidAddressTypes()   {
+        List<NodeAddress> addresses = new ArrayList<>(3);
+        addresses.add(new NodeAddressBuilder().withType("SomeAddress").withAddress("my.external.address").build());
+        addresses.add(new NodeAddressBuilder().withType("SomeOtherAddress").withAddress("my.internal.address").build());
+        addresses.add(new NodeAddressBuilder().withType("YetAnotherAddress").withAddress("192.168.2.94").build());
+
+        String address = NodeUtils.findAddress(addresses, null);
+
+        assertThat(address, is(nullValue()));
+    }
+
+    @Test
+    public void testFindAddressNullWhenAddressesNull()   {
+        List<NodeAddress> addresses = null;
+
+        String address = NodeUtils.findAddress(addresses, null);
+
+        assertThat(address, is(nullValue()));
+    }
+
+    @Test
+    public void testFindAddressWithMultipleAddressesOfSameType()   {
+        List<NodeAddress> addresses = new ArrayList<>(3);
+        addresses.add(new NodeAddressBuilder().withType("ExternalDNS").withAddress("my.external.address").build());
+        addresses.add(new NodeAddressBuilder().withType("ExternalDNS").withAddress("my.external.address2").build());
+        addresses.add(new NodeAddressBuilder().withType("InternalDNS").withAddress("my.internal.address").build());
+        addresses.add(new NodeAddressBuilder().withType("InternalDNS").withAddress("my.internal.address2").build());
+        addresses.add(new NodeAddressBuilder().withType("InternalIP").withAddress("192.168.2.94").build());
+
+        String address = NodeUtils.findAddress(addresses, null);
+
+        assertThat(address, is("my.external.address"));
+    }
+}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This is attempt number 2 to fix #3458. In the previous PR (#3472) I fixed it in wrong method which was used only from tests 🤦‍♂️ . This attempt should fix it in the right method for both CO and the init container. It also moves the corresponding tests to the right place and removes the method I fixed before which was used only from the tests 🙄. Hopefully now it should work fine.

_Note: I do not have an environment which creates node with multiple addresses for the same type. That is why this is hard to test in some real env and relies on unit tests. Only test with regular non-duplicate addresses is done in real environment._

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

