### PR TITLE
[DOC] clarify the config for mounting secrets as volumes

### DIFF
--- a/documentation/modules/proc-kafka-connect-mounting-volumes.adoc
+++ b/documentation/modules/proc-kafka-connect-mounting-volumes.adoc
@@ -38,11 +38,11 @@ stringData:
     dbPassword: my-password
 ----
 <1> The connector configuration in properties file format.
-<2> Database _username_ and _password_ properties used in the configuration.
+<2> Database username and password properties used in the configuration.
 
 . Create or edit the Kafka Connect resource.
 +
-Configure the configuration provider in the `config` section and the `externalConfiguration` section of the `KafkaConnect` or `KafkaConnectS2I` custom resource to reference the secret.
+In the `config` section and the `externalConfiguration` section of the `KafkaConnect` or `KafkaConnectS2I` custom resource, configure the configuration provider to reference the secret.
 +
 For example:
 +
@@ -67,7 +67,7 @@ spec:
 <1> The alias for the configuration provider, which is used to define other configuration parameters.
 Use a comma-separated list if you want to add more than one provider.
 <2> The `FileConfigProvider` is the configuration provider that provides values from properties files.
-The parameter uses the alias from `config.providers`, taking the form `config.providers.${alias}.class`. 
+The parameter uses the alias from `config.providers`, taking the form `config.providers.${alias}.class`.
 <3> The name of the volume containing the Secret.
 <4> The name of the Secret.
 

--- a/documentation/modules/proc-kafka-connect-mounting-volumes.adoc
+++ b/documentation/modules/proc-kafka-connect-mounting-volumes.adoc
@@ -64,8 +64,10 @@ spec:
         secret:
           secretName: mysecret <4>
 ----
-<1> The alias for the configuration provider. Use a comma-separated list if you want to add more than one provider.
+<1> The alias for the configuration provider, which is used to define other configuration parameters.
+Use a comma-separated list if you want to add more than one provider.
 <2> The `FileConfigProvider` is the configuration provider that provides values from properties files.
+The parameter uses the alias from `config.providers`, taking the form `config.providers.${alias}.class`. 
 <3> The name of the volume containing the Secret.
 <4> The name of the Secret.
 

--- a/documentation/modules/proc-kafka-connect-mounting-volumes.adoc
+++ b/documentation/modules/proc-kafka-connect-mounting-volumes.adoc
@@ -4,9 +4,16 @@
 
 [id='proc-kafka-connect-mounting-volumes-{context}']
 
-= Mounting Secrets as volumes
+= Mounting Secrets as volumes for connector configuration
 
-You can create a Kubernetes Secret, mount it as a volume to Kafka Connect, and then use it to configure a Kafka Connect connector.
+You can create a Kubernetes Secret, mount it as a volume to Kafka Connect,
+and then use it to configure a Kafka Connect connector.
+
+Configuration providers allow you to load configuration values from the Secret.
+In this procedure, the configuration provider is named `file`.
+A Secret named `mysecret` is mounted to a volume named `connector-config`.
+The Kafka `FileConfigProvider` class is used to read and extract database _username_ and _password_ property values from the Secret
+to use in the connector configuration.
 
 .Prerequisites
 
@@ -15,6 +22,7 @@ You can create a Kubernetes Secret, mount it as a volume to Kafka Connect, and t
 .Procedure
 
 . Create a secret containing a properties file that defines the configuration options for your connector configuration.
++
 For example:
 +
 [source,yaml,subs=attributes+]
@@ -25,13 +33,17 @@ metadata:
   name: mysecret
 type: Opaque
 stringData:
-  connector.properties: |-
-    dbUsername: my-user
+  connector.properties: |- <1>
+    dbUsername: my-user <2>
     dbPassword: my-password
 ----
+<1> Properties file containing the connector configuration.
+<2> Database _username_ and _password_ properties used in the configuration.
 
 . Create or edit the Kafka Connect resource.
-Configure the `FileConfigProvider` in the `config` section and the `externalConfiguration` section of the `KafkaConnect` or `KafkaConnectS2I` custom resource to reference the secret.
++
+Configure the configuration provider in the `config` section and the `externalConfiguration` section of the `KafkaConnect` or `KafkaConnectS2I` custom resource to reference the secret.
++
 For example:
 +
 [source,yaml,subs="attributes+"]
@@ -43,21 +55,24 @@ metadata:
 spec:
   # ...
   config:
-    config.providers: file
-    config.providers.file.class: org.apache.kafka.common.config.provider.FileConfigProvider
+    config.providers: file <1>
+    config.providers.file.class: org.apache.kafka.common.config.provider.FileConfigProvider <2>
   #...
   externalConfiguration:
     volumes:
-      - name: connector-config
+      - name: connector-config <3>
         secret:
-          secretName: mysecret
+          secretName: mysecret <4>
 ----
+<1> The name of the configuration provider. Use a comma-separted list for more than one provider.
+<2> The `FileConfigProvider` class used by the configuration provider to access the properties file.
+<3> The name of the volume containing the Secret.
+<4> The name of the Secret.
 
 . Apply the changes to your Kafka Connect deployment.
 +
-Use `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _your-file_
+kubectl apply -f _KAFKA-CONNECT-CONFIG-FILE_
 
 . Configure your connector
 * If you are using the Kafka Connect HTTP REST interface, use the values from the mounted properties file in your JSON payload with connector configuration.
@@ -65,20 +80,23 @@ For example:
 +
 [source,json,subs="attributes+"]
 ----
-{  
+{
    "name":"my-connector",
    "config":{
       "connector.class":"MyDbConnector",
       "tasks.max":"3",
       "database": "my-postgresql:5432",
-      "username":"${file:/opt/kafka/external-configuration/connector-config/connector.properties:dbUsername}",
-      "password":"${file:/opt/kafka/external-configuration/connector-config/connector.properties:dbPassword}",
+      "username":"${file:/opt/kafka/external-configuration/connector-config/connector.properties:dbUsername}", <1>
+      "password":"${file:/opt/kafka/external-configuration/connector-config/connector.properties:dbPassword}", <2>
       # ...
    }
 }
 ----
+<1> Path to the username property value. The path takes the form `/opt/kafka/external-configuration/_SECRET-VOLUME-NAME_/_PROPERTIES-FILENAME:USERNAME-VALUE_`.
+<2> Path to the password property value. The path takes the form `/opt/kafka/external-configuration/_SECRET-VOLUME-NAME_/_PROPERTIES-FILENAME:PASSWORD-VALUE_`.
 
 * If you are using a `KafkaConnector` resource, use the values from the mounted properties file in the `spec.config` section of your custom resource.
++
 For example:
 +
 [source,yaml,subs="attributes+"]

--- a/documentation/modules/proc-kafka-connect-mounting-volumes.adoc
+++ b/documentation/modules/proc-kafka-connect-mounting-volumes.adoc
@@ -9,11 +9,11 @@
 You can create a Kubernetes Secret, mount it as a volume to Kafka Connect,
 and then use it to configure a Kafka Connect connector.
 
-Configuration providers allow you to load configuration values from the Secret.
-In this procedure, the configuration provider is named `file`.
-A Secret named `mysecret` is mounted to a volume named `connector-config`.
-The Kafka `FileConfigProvider` class is used to read and extract database _username_ and _password_ property values from the Secret
-to use in the connector configuration.
+Configuration providers allow you to load configuration values from external sources.
+
+In this procedure, a Secret named `mysecret` is mounted to a volume named `connector-config`.
+The Kafka `FileConfigProvider` is given the alias `file`,
+and used to read and extract database _username_ and _password_ property values from the file to use in the connector configuration.
 
 .Prerequisites
 
@@ -21,7 +21,7 @@ to use in the connector configuration.
 
 .Procedure
 
-. Create a secret containing a properties file that defines the configuration options for your connector configuration.
+. Create a secret containing properties that define the configuration options for your connector configuration.
 +
 For example:
 +
@@ -37,7 +37,7 @@ stringData:
     dbUsername: my-user <2>
     dbPassword: my-password
 ----
-<1> Properties file containing the connector configuration.
+<1> The connector configuration in properties file format.
 <2> Database _username_ and _password_ properties used in the configuration.
 
 . Create or edit the Kafka Connect resource.
@@ -64,8 +64,8 @@ spec:
         secret:
           secretName: mysecret <4>
 ----
-<1> The name of the configuration provider. Use a comma-separted list for more than one provider.
-<2> The `FileConfigProvider` class used by the configuration provider to access the properties file.
+<1> The alias for the configuration provider. Use a comma-separated list if you want to add more than one provider.
+<2> The `FileConfigProvider` is the configuration provider that provides values from properties files.
 <3> The name of the volume containing the Secret.
 <4> The name of the Secret.
 
@@ -92,8 +92,8 @@ For example:
    }
 }
 ----
-<1> Path to the username property value. The path takes the form `/opt/kafka/external-configuration/_SECRET-VOLUME-NAME_/_PROPERTIES-FILENAME:USERNAME-VALUE_`.
-<2> Path to the password property value. The path takes the form `/opt/kafka/external-configuration/_SECRET-VOLUME-NAME_/_PROPERTIES-FILENAME:PASSWORD-VALUE_`.
+<1> Path to the username property value. The path takes the form `/opt/kafka/external-configuration/_SECRET-VOLUME-NAME_/_PROPERTIES-FILENAME:USERNAME-PROPERTY_`.
+<2> Path to the password property value. The path takes the form `/opt/kafka/external-configuration/_SECRET-VOLUME-NAME_/_PROPERTIES-FILENAME:PASSWORD-PROPERTY_`.
 
 * If you are using a `KafkaConnector` resource, use the values from the mounted properties file in the `spec.config` section of your custom resource.
 +


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Added some additional information to the _Mounting Secrets as volumes for connector configuration_ in the _Using Guide_ to make it clearer how config providers are used.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

