### PR TITLE
[tests] Make log less noisy if cluster is not up

### DIFF
--- a/test/src/main/java/io/strimzi/test/k8s/cluster/KubeCluster.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/KubeCluster.java
@@ -22,8 +22,6 @@ public interface KubeCluster {
 
     String ENV_VAR_TEST_CLUSTER = "TEST_CLUSTER";
     Config CONFIG = Config.autoConfigure(System.getenv().getOrDefault("TEST_CLUSTER_CONTEXT", null));
-    Logger LOGGER = LogManager.getLogger(KubeCluster.class);
-
 
     /** Return true iff this kind of cluster installed on the local machine. */
     boolean isAvailable();

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/KubeCluster.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/KubeCluster.java
@@ -22,6 +22,7 @@ public interface KubeCluster {
 
     String ENV_VAR_TEST_CLUSTER = "TEST_CLUSTER";
     Config CONFIG = Config.autoConfigure(System.getenv().getOrDefault("TEST_CLUSTER_CONTEXT", null));
+    Logger LOGGER = LogManager.getLogger(KubeCluster.class);
 
 
     /** Return true iff this kind of cluster installed on the local machine. */

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Kubernetes.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Kubernetes.java
@@ -10,6 +10,8 @@ import io.strimzi.test.k8s.KubeClient;
 import io.strimzi.test.k8s.cmdClient.KubeCmdClient;
 import io.strimzi.test.k8s.cmdClient.Kubectl;
 import io.strimzi.test.k8s.exceptions.KubeClusterException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A {@link KubeCluster} implementation for any {@code Kubernetes} cluster.
@@ -18,6 +20,7 @@ public class Kubernetes implements KubeCluster {
 
     public static final String CMD = "kubectl";
     private static final String OLM_NAMESPACE = "operators";
+    private static final Logger LOGGER = LogManager.getLogger(Kubernetes.class);
 
     @Override
     public boolean isAvailable() {

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Kubernetes.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Kubernetes.java
@@ -29,7 +29,7 @@ public class Kubernetes implements KubeCluster {
         try {
             return Exec.exec(CMD, "cluster-info").exitStatus() && !Exec.exec(CMD, "api-resources").out().contains("openshift.io");
         } catch (KubeClusterException e) {
-            e.printStackTrace();
+            LOGGER.debug("Error:", e);
             return false;
         }
     }

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Minikube.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Minikube.java
@@ -29,7 +29,7 @@ public class Minikube implements KubeCluster {
         try {
             return Exec.exec(CMD, "status").exitStatus();
         } catch (KubeClusterException e) {
-            e.printStackTrace();
+            LOGGER.debug("Error: ", e);
             return false;
         }
     }

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Minikube.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Minikube.java
@@ -10,6 +10,8 @@ import io.strimzi.test.k8s.KubeClient;
 import io.strimzi.test.k8s.exceptions.KubeClusterException;
 import io.strimzi.test.k8s.cmdClient.KubeCmdClient;
 import io.strimzi.test.k8s.cmdClient.Kubectl;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A {@link KubeCluster} implementation for {@code minikube} and {@code minishift}.
@@ -18,6 +20,8 @@ public class Minikube implements KubeCluster {
 
     public static final String CMD = "minikube";
     private static final String OLM_NAMESPACE = "operators";
+    private static final Logger LOGGER = LogManager.getLogger(Minikube.class);
+
 
     @Override
     public boolean isAvailable() {

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Minishift.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Minishift.java
@@ -8,11 +8,14 @@ import io.strimzi.test.executor.Exec;
 import io.strimzi.test.k8s.exceptions.KubeClusterException;
 import io.strimzi.test.k8s.cmdClient.KubeCmdClient;
 import io.strimzi.test.k8s.cmdClient.Oc;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class Minishift implements KubeCluster {
 
     private static final String CMD = "minishift";
     private static final String OLM_NAMESPACE = "openshift-operators";
+    private static final Logger LOGGER = LogManager.getLogger(Minishift.class);
 
     @Override
     public boolean isAvailable() {

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Minishift.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Minishift.java
@@ -26,6 +26,7 @@ public class Minishift implements KubeCluster {
             return output.contains("Minishift:  Running")
                     && output.contains("OpenShift:  Running");
         } catch (KubeClusterException e) {
+            LOGGER.debug("Error:", e);
             return false;
         }
     }

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/OpenShift.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/OpenShift.java
@@ -24,7 +24,7 @@ public class OpenShift implements KubeCluster {
         try {
             return Exec.exec(OC, "status").exitStatus() && Exec.exec(OC, "api-resources").out().contains("openshift.io");
         } catch (KubeClusterException e) {
-            e.printStackTrace();
+            LOGGER.debug("Error:", e);
             return false;
         }
     }

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/OpenShift.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/OpenShift.java
@@ -8,11 +8,14 @@ import io.strimzi.test.executor.Exec;
 import io.strimzi.test.k8s.exceptions.KubeClusterException;
 import io.strimzi.test.k8s.cmdClient.KubeCmdClient;
 import io.strimzi.test.k8s.cmdClient.Oc;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class OpenShift implements KubeCluster {
 
     private static final String OC = "oc";
     private static final String OLM_NAMESPACE = "openshift-operators";
+    private static final Logger LOGGER = LogManager.getLogger(OpenShift.class);
 
     @Override
     public boolean isAvailable() {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Fix

### Description

After #3406 and change of cluster order checks (before was `new KubeCluster[]{new OpenShift(), new Minikube(), new Minishift()};` and now is `new KubeCluster[]{new Minikube(), new Kubernetes(), new Minishift(), new OpenShift()};`) it shows us that log, if some exception happens, is a bit noisy. It will not make the test fail, it only prints the stack trace. 

I wanted to add this print of stack trace to debug mode, so the test log will be more readable.

### Checklist

- [ ] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

