### PR TITLE
Improve the log message when CO skips patching of the SA

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperator.java
@@ -32,7 +32,7 @@ public class ServiceAccountOperator extends AbstractResourceOperator<KubernetesC
     @Override
     protected Future<ReconcileResult<ServiceAccount>> internalPatch(String namespace, String name, ServiceAccount current, ServiceAccount desired) {
         // Patching a SA causes new tokens to be created, which we should avoid
-        log.debug("{} {} in namespace {} has not been patched: patching service accounts generates new tokens which should be avoided!", resourceKind, name, namespace);
+        log.debug("{} {} in namespace {} has not been patched: patching service accounts generates new tokens which should be avoided.", resourceKind, name, namespace);
         return Future.succeededFuture(ReconcileResult.noop(current));
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperator.java
@@ -32,6 +32,7 @@ public class ServiceAccountOperator extends AbstractResourceOperator<KubernetesC
     @Override
     protected Future<ReconcileResult<ServiceAccount>> internalPatch(String namespace, String name, ServiceAccount current, ServiceAccount desired) {
         // Patching a SA causes new tokens to be created, which we should avoid
+        log.debug("{} {} in namespace {} has not been patched: patching service accounts generates new tokens which should be avoided!", resourceKind, name, namespace);
         return Future.succeededFuture(ReconcileResult.noop(current));
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When looking into #3300, I realised that we are not patching service accounts at all because it is causing changes to SA tokens. This is not obvious from our DEBUG logs, since the parent class logs following when it finds out that the service account already exists:

```
2020-08-12 20:00:31 DEBUG ServiceAccountOperator:102 - ServiceAccount myproject/my-cluster-kafka already exists, patching it
```

And there is no information about the patching being completed or not. So this PR adds the following message specifically for the service account to make it clear that no patching really happend.

```
2020-08-12 20:00:31 DEBUG ServiceAccountOperator:102 - ServiceAccount myproject/my-cluster-kafka already exists, patching it
2020-08-12 20:00:31 DEBUG ServiceAccountOperator:35 - ServiceAccount my-cluster-kafka in namespace myproject has not been patched: patching service accounts generates new tokens which should be avoided!
```

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally