### PR TITLE
Fix Prometheus additional configuration documentation

### DIFF
--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus.adoc
@@ -34,10 +34,8 @@ sed -i '' 's/namespace: .*/namespace: _my-namespace_/' prometheus.yaml
 . Edit the `PodMonitor` resource in `strimzi-pod-monitor.yaml` to define Prometheus jobs that will scrape the metrics data from pods.
 `PodMonitor` is used to scrape data directly from pods and is used for Apache Kafka, ZooKeeper, Operators, and Kafka Bridge. Update the `namespaceSelector.matchNames` property with the namespace where the pods to scrape the metrics from are running.
 
-. The provided Grafana dashboards show metrics about CPU, memory and volume disks usage.
-These metrics come from cadvisor and kubelet directly on the nodes.
-In order to have Prometheus scraping for these metrics, an additional configuration is needed.
-This is because the Prometheus operator does not have a corresponding of `PodMonitor` for scraping metrics coming from nodes directly.
+. The Grafana dashboards provided show metrics for CPU, memory and disk volume usage, which come directly from the Kubernetes cAdvisor agent and kubelet on the nodes.
+An additional configuration is needed because the Prometheus operator does not have something like `PodMonitor` for scraping metrics directly from nodes.
 
 .. Create a `Secret` resource:
 +

--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus.adoc
@@ -37,7 +37,7 @@ sed -i '' 's/namespace: .*/namespace: _my-namespace_/' prometheus.yaml
 . The provided Grafana dashboards show metrics about CPU, memory and volume disks usage.
 These metrics come from cadvisor and kubelet directly on the nodes.
 In order to have Prometheus scraping for these metrics, an additional configuration is needed.
-This is because the Prometheus operator doesn't have a corresponding of `PodMonitor` for scraping metrics coming from nodes directly.
+This is because the Prometheus operator does not have a corresponding of `PodMonitor` for scraping metrics coming from nodes directly.
 
 .. Create a `Secret` resource:
 +

--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus.adoc
@@ -34,7 +34,10 @@ sed -i '' 's/namespace: .*/namespace: _my-namespace_/' prometheus.yaml
 . Edit the `PodMonitor` resource in `strimzi-pod-monitor.yaml` to define Prometheus jobs that will scrape the metrics data from pods.
 `PodMonitor` is used to scrape data directly from pods and is used for Apache Kafka, ZooKeeper, Operators, and Kafka Bridge. Update the `namespaceSelector.matchNames` property with the namespace where the pods to scrape the metrics from are running.
 
-. To use another role:
+. The provided Grafana dashboards show metrics about CPU, memory and volume disks usage.
+These metrics come from cadvisor and kubelet directly on the nodes.
+In order to have Prometheus scraping for these metrics, an additional configuration is needed.
+This is because the Prometheus operator doesn't have a corresponding of `PodMonitor` for scraping metrics coming from nodes directly.
 
 .. Create a `Secret` resource:
 +


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Documentation

### Description

The documentation section about the Prometheus additional configuration for scraping metrics from cadvisor and kubelet (on nodes) is not clear.
This PR tries to address that.

### Checklist

- [x] Update documentation
