### PR TITLE
Add support for different types under one field in a CRD

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/TopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TopicOperatorSpec.java
@@ -17,7 +17,7 @@ import lombok.EqualsAndHashCode;
  * Representation of a Strimzi-managed Topic Operator deployment.
  */
 @Deprecated
-@DeprecatedType(replacedWithType = "io.strimzi.api.kafka.model.EntityTopicOperatorSpec")
+@DeprecatedType(replacedWithType = io.strimzi.api.kafka.model.EntityTopicOperatorSpec.class)
 @Buildable(
         editableEnabled = false,
         builderPackage = Constants.FABRIC8_KUBERNETES_API

--- a/api/src/main/java/io/strimzi/api/kafka/model/TopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TopicOperatorSpec.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.Affinity;
+import io.strimzi.api.annotations.DeprecatedType;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
@@ -16,6 +17,7 @@ import lombok.EqualsAndHashCode;
  * Representation of a Strimzi-managed Topic Operator deployment.
  */
 @Deprecated
+@DeprecatedType(replacedWithType = "io.strimzi.api.kafka.model.EntityTopicOperatorSpec")
 @Buildable(
         editableEnabled = false,
         builderPackage = Constants.FABRIC8_KUBERNETES_API

--- a/crd-annotations/src/main/java/io/strimzi/api/annotations/DeprecatedType.java
+++ b/crd-annotations/src/main/java/io/strimzi/api/annotations/DeprecatedType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DeprecatedType {
+    /**
+     * @return The type which should be used as replacement
+     */
+    String replacedWithType();
+}

--- a/crd-annotations/src/main/java/io/strimzi/api/annotations/DeprecatedType.java
+++ b/crd-annotations/src/main/java/io/strimzi/api/annotations/DeprecatedType.java
@@ -15,5 +15,5 @@ public @interface DeprecatedType {
     /**
      * @return The type which should be used as replacement
      */
-    String replacedWithType();
+    Class<?> replacedWithType();
 }

--- a/crd-generator/pom.xml
+++ b/crd-generator/pom.xml
@@ -24,6 +24,10 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
@@ -425,10 +425,11 @@ public class DocGenerator {
 
         if (deprecatedType != null || langDeprecated != null) {
             if (deprecatedType == null || langDeprecated == null) {
-                err(cls.getCanonicalName() + " must be annotated with both @" + Deprecated.class.getName()
+                err(cls.getName() + " must be annotated with both @" + Deprecated.class.getName()
                         + " and @" + DeprecatedProperty.class.getName());
             }
-            if (deprecatedType.replacedWithType() != null
+            if (deprecatedType != null
+                    && deprecatedType.replacedWithType() != null
                     && !deprecatedType.replacedWithType().isEmpty()) {
                 Class<?> replacementClss;
 

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
@@ -127,7 +127,7 @@ public class DocGenerator {
         Set<Class<?>> classes = usedIn.get(c);
 
         if (classes == null) {
-            classes = new HashSet<>(2);
+            classes = new HashSet<>(1);
             usedIn.put(c, classes);
         }
 

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/Property.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/Property.java
@@ -4,16 +4,6 @@
  */
 package io.strimzi.crdgenerator;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.client.CustomResource;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
@@ -26,6 +16,18 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.crdgenerator.annotations.Alternative;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -297,6 +299,13 @@ class Property implements AnnotatedElement {
 
     boolean isDiscriminator() {
         return getName().equals(discriminator(m.getDeclaringClass()));
+    }
+
+    List<Property> getAlternatives() {
+        List<Property> alternatives =
+                Property.properties(getType().getType()).values().stream()
+                        .filter(p -> p.getAnnotation(Alternative.class) != null).collect(Collectors.toList());
+        return alternatives;
     }
 
     @Override

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/Property.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/Property.java
@@ -38,6 +38,7 @@ class Property implements AnnotatedElement {
     private AnnotatedElement a;
     private Member m;
     private PropertyType type;
+
     public Property(Method method) {
         name = propertyName(method);
         owner = method.getDeclaringClass();

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Alternation.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Alternation.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.crdgenerator.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for classes which represent a choice between two or more possibilities identified by the
+ * {@link Alternative}-annotated properties of the annotated class.
+ * The JSON schema generated uses a {@code oneOf} constraint to force the choice between the alternative properties.
+ * The annotated class will typically need to have custom Jackson serialization which can determine from the serialized
+ * form which of the alternatives to deserialize.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Alternation {
+}

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Alternative.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Alternative.java
@@ -9,20 +9,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * One of several alternatives in an {@link Alternation}-annotated class.
+ */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD})
-public @interface OneOfType {
-    /** @return List of alternatives */
-    Alternative[] value();
-
-    @interface Alternative {
-        @interface Field {
-            /** @return The name of a field */
-            String value();
-        }
-
-        /** @return Fields in this alternative */
-        Field[] value();
-    }
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface Alternative {
 }
-

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/OneOfType.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/OneOfType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.crdgenerator.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface OneOfType {
+    /** @return List of alternatives */
+    Alternative[] value();
+
+    @interface Alternative {
+        @interface Field {
+            /** @return The name of a field */
+            String value();
+        }
+
+        /** @return Fields in this alternative */
+        Field[] value();
+    }
+}
+

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/DocGeneratorTest.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/DocGeneratorTest.java
@@ -15,6 +15,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DocGeneratorTest {
 
@@ -25,6 +26,6 @@ public class DocGeneratorTest {
         DocGenerator crdGenerator = new DocGenerator(1, singletonList(ExampleCrd.class), w, new KubeLinker("{KubeApiReferenceBase}"));
         crdGenerator.generate(ExampleCrd.class);
         String s = w.toString();
-        assertThat(s, is(CrdTestUtils.readResource("simpleTest.adoc")));
+        assertEquals(CrdTestUtils.readResource("simpleTest.adoc"), s);
     }
 }

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/DocGeneratorTest.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/DocGeneratorTest.java
@@ -25,6 +25,6 @@ public class DocGeneratorTest {
         DocGenerator crdGenerator = new DocGenerator(1, singletonList(ExampleCrd.class), w, new KubeLinker("{KubeApiReferenceBase}"));
         crdGenerator.generate(ExampleCrd.class);
         String s = w.toString();
-        assertThat(CrdTestUtils.readResource("simpleTest.adoc"), is(s));
+        assertThat(s, is(CrdTestUtils.readResource("simpleTest.adoc")));
     }
 }

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -16,7 +16,6 @@ import io.strimzi.crdgenerator.annotations.Example;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.OneOf;
-import io.strimzi.crdgenerator.annotations.OneOfType;
 import io.strimzi.crdgenerator.annotations.Pattern;
 
 import java.util.List;
@@ -281,7 +280,6 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
         this.affinity = affinity;
     }
 
-    @OneOfType({@OneOfType.Alternative(@OneOfType.Alternative.Field("mapValue")), @OneOfType.Alternative(@OneOfType.Alternative.Field("listValue"))})
     public MapOrList getAlternatives() {
         return alternatives;
     }
@@ -290,7 +288,6 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
         this.alternatives = alternatives;
     }
 
-    @OneOfType({@OneOfType.Alternative(@OneOfType.Alternative.Field("type1Value")), @OneOfType.Alternative(@OneOfType.Alternative.Field("type2Value"))})
     public Type1OrType2 getTypedAlternatives() {
         return typedAlternatives;
     }

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -16,6 +16,7 @@ import io.strimzi.crdgenerator.annotations.Example;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.OneOf;
+import io.strimzi.crdgenerator.annotations.OneOfType;
 import io.strimzi.crdgenerator.annotations.Pattern;
 
 import java.util.List;
@@ -115,6 +116,8 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
     private String either;
     private String or;
 
+    private MapOrList alternatives;
+    private Type1OrType2 typedAlternatives;
 
     @Description("Example of complex type.")
     public static class ObjectProperty {
@@ -276,5 +279,23 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
 
     public void setAffinity(Affinity affinity) {
         this.affinity = affinity;
+    }
+
+    @OneOfType({@OneOfType.Alternative(@OneOfType.Alternative.Field("mapValue")), @OneOfType.Alternative(@OneOfType.Alternative.Field("listValue"))})
+    public MapOrList getAlternatives() {
+        return alternatives;
+    }
+
+    public void setAlternatives(MapOrList alternatives) {
+        this.alternatives = alternatives;
+    }
+
+    @OneOfType({@OneOfType.Alternative(@OneOfType.Alternative.Field("type1Value")), @OneOfType.Alternative(@OneOfType.Alternative.Field("type2Value"))})
+    public Type1OrType2 getTypedAlternatives() {
+        return typedAlternatives;
+    }
+
+    public void setTypedAlternatives(Type1OrType2 alternatives) {
+        this.typedAlternatives = typedAlternatives;
     }
 }

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/MapOrList.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/MapOrList.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.strimzi.crdgenerator.annotations.Alternation;
+import io.strimzi.crdgenerator.annotations.Alternative;
 
 import java.io.IOException;
 import java.util.List;
@@ -24,6 +26,7 @@ import java.util.Map;
 
 @JsonDeserialize(using = MapOrList.Deserializer.class)
 @JsonSerialize(using = MapOrList.Serializer.class)
+@Alternation
 public class MapOrList {
     private Map<String, String> mapValue;
     private List<String> listValue;
@@ -38,10 +41,12 @@ public class MapOrList {
         listValue = list;
     }
 
+    @Alternative
     public Map<String, String> getMapValue()    {
         return mapValue;
     }
 
+    @Alternative
     public List<String> getListValue()    {
         return listValue;
     }

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/MapOrList.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/MapOrList.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.crdgenerator;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@JsonDeserialize(using = MapOrList.Deserializer.class)
+@JsonSerialize(using = MapOrList.Serializer.class)
+public class MapOrList {
+    private Map<String, String> mapValue;
+    private List<String> listValue;
+
+    public MapOrList(Map<String, String> map)   {
+        mapValue = map;
+        listValue = null;
+    }
+
+    public MapOrList(List<String> list)   {
+        mapValue = null;
+        listValue = list;
+    }
+
+    public Map<String, String> getMapValue()    {
+        return mapValue;
+    }
+
+    public List<String> getListValue()    {
+        return listValue;
+    }
+
+    public static class Serializer extends JsonSerializer<MapOrList> {
+        @Override
+        public void serialize(MapOrList value, JsonGenerator generator, SerializerProvider provider) throws IOException {
+            if (value != null) {
+                if (value.listValue != null)    {
+                    generator.writeObject(value.listValue);
+                } else if (value.mapValue != null)  {
+                    generator.writeObject(value.mapValue);
+                } else {
+                    generator.writeNull();
+                }
+            } else {
+                generator.writeNull();
+            }
+        }
+    }
+
+    public static class Deserializer extends JsonDeserializer<MapOrList> {
+        @Override
+        public MapOrList deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException {
+            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectCodec oc = jsonParser.getCodec();
+            JsonNode node = oc.readTree(jsonParser);
+            MapOrList mapOrList;
+
+            if (node.isArray()) {
+                ObjectReader reader = objectMapper.readerFor(new TypeReference<List<String>>() { });
+                List<String> list = reader.readValue(node);
+                mapOrList = new MapOrList(list);
+            } else {
+                ObjectReader reader = objectMapper.readerFor(new TypeReference<Map<String, String>>() { });
+                Map<String, String> map = reader.readValue(node);
+                mapOrList = new MapOrList(map);
+            }
+            return mapOrList;
+        }
+    }
+}

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/Type1OrType2.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/Type1OrType2.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.crdgenerator;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.io.IOException;
+
+@JsonDeserialize(using = Type1OrType2.Deserializer.class)
+@JsonSerialize(using = Type1OrType2.Serializer.class)
+public class Type1OrType2 {
+    private Type1 type1Value;
+    private Type2 type2Value;
+
+    public Type1OrType2(Type1 type1Value)   {
+        type1Value = type1Value;
+        type2Value = null;
+    }
+
+    public Type1OrType2(Type2 type2Value)   {
+        type1Value = null;
+        type2Value = type2Value;
+    }
+
+    public Type1 getMapValue()    {
+        return type1Value;
+    }
+
+    public Type2 getListValue()    {
+        return type2Value;
+    }
+
+    public static class Serializer extends JsonSerializer<Type1OrType2> {
+        @Override
+        public void serialize(Type1OrType2 value, JsonGenerator generator, SerializerProvider provider) throws IOException {
+            if (value != null) {
+                if (value.type1Value != null)    {
+                    generator.writeObject(value.type1Value);
+                } else if (value.type2Value != null)  {
+                    generator.writeObject(value.type2Value);
+                } else {
+                    generator.writeNull();
+                }
+            } else {
+                generator.writeNull();
+            }
+        }
+    }
+
+    public static class Deserializer extends JsonDeserializer<Type1OrType2> {
+        @Override
+        public Type1OrType2 deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException {
+            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectCodec oc = jsonParser.getCodec();
+            JsonNode node = oc.readTree(jsonParser);
+            Type1OrType2 type1OrType2;
+
+            if (node.isObject() && node.fieldNames().hasNext() && node.fieldNames().next().equals("key1")) {
+                ObjectReader reader = objectMapper.readerFor(new TypeReference<Type1>() { });
+                Type1 value = reader.readValue(node);
+                type1OrType2 = new Type1OrType2(value);
+            } else if (node.isObject() && node.fieldNames().hasNext() && node.fieldNames().next().equals("key2")) {
+                ObjectReader reader = objectMapper.readerFor(new TypeReference<Type2>() { });
+                Type2 value = reader.readValue(node);
+                type1OrType2 = new Type1OrType2(value);
+            } else {
+                return null;
+            }
+
+            return type1OrType2;
+        }
+    }
+
+    public class Type1 {
+        private String key1;
+
+        public String getKey1() {
+            return key1;
+        }
+
+        public void setKey1(String key1) {
+            this.key1 = key1;
+        }
+    }
+
+    public class Type2 {
+        private String key2;
+
+        public String getKey2() {
+            return key2;
+        }
+
+        public void setKey2(String key2) {
+            this.key2 = key2;
+        }
+    }
+}

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/Type1OrType2.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/Type1OrType2.java
@@ -18,11 +18,14 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.strimzi.api.annotations.DeprecatedType;
+import io.strimzi.crdgenerator.annotations.Alternation;
+import io.strimzi.crdgenerator.annotations.Alternative;
 
 import java.io.IOException;
 
 @JsonDeserialize(using = Type1OrType2.Deserializer.class)
 @JsonSerialize(using = Type1OrType2.Serializer.class)
+@Alternation
 public class Type1OrType2 {
     private Type1 type1Value;
     private Type2 type2Value;
@@ -37,10 +40,12 @@ public class Type1OrType2 {
         type2Value = type2Value;
     }
 
+    @Alternative
     public Type1 getMapValue()    {
         return type1Value;
     }
 
+    @Alternative
     public Type2 getListValue()    {
         return type2Value;
     }
@@ -88,7 +93,7 @@ public class Type1OrType2 {
     }
 
     @Deprecated
-    @DeprecatedType(replacedWithType = "io.strimzi.crdgenerator.Type1OrType2$Type2")
+    @DeprecatedType(replacedWithType = io.strimzi.crdgenerator.Type1OrType2.Type2.class)
     public class Type1 {
         private String key1;
 

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/Type1OrType2.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/Type1OrType2.java
@@ -63,19 +63,20 @@ public class Type1OrType2 {
     }
 
     public static class Deserializer extends JsonDeserializer<Type1OrType2> {
+        private static ObjectMapper mapper = new ObjectMapper();
+
         @Override
         public Type1OrType2 deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException {
-            ObjectMapper objectMapper = new ObjectMapper();
             ObjectCodec oc = jsonParser.getCodec();
             JsonNode node = oc.readTree(jsonParser);
             Type1OrType2 type1OrType2;
 
             if (node.isObject() && node.fieldNames().hasNext() && node.fieldNames().next().equals("key1")) {
-                ObjectReader reader = objectMapper.readerFor(new TypeReference<Type1>() { });
+                ObjectReader reader = mapper.readerFor(new TypeReference<Type1>() { });
                 Type1 value = reader.readValue(node);
                 type1OrType2 = new Type1OrType2(value);
             } else if (node.isObject() && node.fieldNames().hasNext() && node.fieldNames().next().equals("key2")) {
-                ObjectReader reader = objectMapper.readerFor(new TypeReference<Type2>() { });
+                ObjectReader reader = mapper.readerFor(new TypeReference<Type2>() { });
                 Type2 value = reader.readValue(node);
                 type1OrType2 = new Type1OrType2(value);
             } else {

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/Type1OrType2.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/Type1OrType2.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.strimzi.api.annotations.DeprecatedType;
 
 import java.io.IOException;
 
@@ -85,6 +86,8 @@ public class Type1OrType2 {
         }
     }
 
+    @Deprecated
+    @DeprecatedType(replacedWithType = "io.strimzi.crdgenerator.Type1OrType2$Type2")
     public class Type1 {
         private String key1;
 

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
@@ -9,6 +9,8 @@
 
 
 |{KubeApiReferenceBase}#affinity-v1-core[Affinity]
+|alternatives            1.2+<.<|
+|map or string array
 |arrayOfBoundTypeVar     1.2+<.<|
 |xref:type-Number-{context}[`Number`] array
 |arrayOfBoundTypeVar2    1.2+<.<|
@@ -73,6 +75,8 @@
 |object array
 |stringProperty          1.2+<.<|
 |string
+|typedAlternatives       1.2+<.<|
+|xref:type-Type1-{context}[`Type1`] or xref:type-Type2-{context}[`Type2`]
 |====
 
 [id='type-Number-{context}']
@@ -137,6 +141,32 @@ It must have the value `right` for the type `PolymorphicRight`.
 |discrim         1.2+<.<|
 |string
 |rightProperty   1.2+<.<|when descrim=right, the right-hand property.
+|string
+|====
+
+[id='type-Type1-{context}']
+# `Type1` schema reference
+
+Used in: xref:type-ExampleCrd-{context}[`ExampleCrd`]
+
+
+[options="header"]
+|====
+|Property     |Description
+|key1  1.2+<.<|
+|string
+|====
+
+[id='type-Type2-{context}']
+# `Type2` schema reference
+
+Used in: xref:type-ExampleCrd-{context}[`ExampleCrd`]
+
+
+[options="header"]
+|====
+|Property     |Description
+|key2  1.2+<.<|
 |string
 |====
 

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
@@ -147,6 +147,9 @@ It must have the value `right` for the type `PolymorphicRight`.
 [id='type-Type1-{context}']
 # `Type1` schema reference
 
+*The type `Type1` has been deprecated.*
+Please use xref:type-Type2-{context}[`Type2`] instead.
+
 Used in: xref:type-ExampleCrd-{context}[`ExampleCrd`]
 
 

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
@@ -10,7 +10,7 @@
 
 |{KubeApiReferenceBase}#affinity-v1-core[Affinity]
 |alternatives            1.2+<.<|
-|map or string array
+|string array or map
 |arrayOfBoundTypeVar     1.2+<.<|
 |xref:type-Number-{context}[`Number`] array
 |arrayOfBoundTypeVar2    1.2+<.<|
@@ -76,7 +76,7 @@
 |stringProperty          1.2+<.<|
 |string
 |typedAlternatives       1.2+<.<|
-|xref:type-Type1-{context}[`Type1`] or xref:type-Type2-{context}[`Type2`]
+|xref:type-Type2-{context}[`Type2`] or xref:type-Type1-{context}[`Type1`]
 |====
 
 [id='type-Number-{context}']
@@ -144,6 +144,19 @@ It must have the value `right` for the type `PolymorphicRight`.
 |string
 |====
 
+[id='type-Type2-{context}']
+# `Type2` schema reference
+
+Used in: xref:type-ExampleCrd-{context}[`ExampleCrd`]
+
+
+[options="header"]
+|====
+|Property     |Description
+|key2  1.2+<.<|
+|string
+|====
+
 [id='type-Type1-{context}']
 # `Type1` schema reference
 
@@ -157,19 +170,6 @@ Used in: xref:type-ExampleCrd-{context}[`ExampleCrd`]
 |====
 |Property     |Description
 |key1  1.2+<.<|
-|string
-|====
-
-[id='type-Type2-{context}']
-# `Type2` schema reference
-
-Used in: xref:type-ExampleCrd-{context}[`ExampleCrd`]
-
-
-[options="header"]
-|====
-|Property     |Description
-|key2  1.2+<.<|
 |string
 |====
 

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -238,10 +238,10 @@ spec:
                         type: "string"
         alternatives:
           oneOf:
-          - type: "object"
           - type: "array"
             items:
               type: "string"
+          - type: "object"
         arrayOfBoundTypeVar:
           type: "array"
           items:
@@ -437,11 +437,11 @@ spec:
           oneOf:
           - type: "object"
             properties:
-              key1:
+              key2:
                 type: "string"
           - type: "object"
             properties:
-              key2:
+              key1:
                 type: "string"
       oneOf:
       - properties:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -236,6 +236,12 @@ spec:
                           type: "string"
                       topologyKey:
                         type: "string"
+        alternatives:
+          oneOf:
+          - type: "object"
+          - type: "array"
+            items:
+              type: "string"
         arrayOfBoundTypeVar:
           type: "array"
           items:
@@ -427,6 +433,16 @@ spec:
         stringProperty:
           type: "string"
           pattern: ".*"
+        typedAlternatives:
+          oneOf:
+          - type: "object"
+            properties:
+              key1:
+                type: "string"
+          - type: "object"
+            properties:
+              key2:
+                type: "string"
       oneOf:
       - properties:
           either: {}

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -242,6 +242,12 @@ spec:
                           type: "string"
                       topologyKey:
                         type: "string"
+        alternatives:
+          oneOf:
+          - type: "object"
+          - type: "array"
+            items:
+              type: "string"
         arrayOfBoundTypeVar:
           type: "array"
           items:
@@ -433,6 +439,16 @@ spec:
         stringProperty:
           type: "string"
           pattern: ".*"
+        typedAlternatives:
+          oneOf:
+          - type: "object"
+            properties:
+              key1:
+                type: "string"
+          - type: "object"
+            properties:
+              key2:
+                type: "string"
       oneOf:
       - properties:
           either: {}

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -244,10 +244,10 @@ spec:
                         type: "string"
         alternatives:
           oneOf:
-          - type: "object"
           - type: "array"
             items:
               type: "string"
+          - type: "object"
         arrayOfBoundTypeVar:
           type: "array"
           items:
@@ -443,11 +443,11 @@ spec:
           oneOf:
           - type: "object"
             properties:
-              key1:
+              key2:
                 type: "string"
           - type: "object"
             properties:
-              key2:
+              key1:
                 type: "string"
       oneOf:
       - properties:

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1213,6 +1213,9 @@ Used in: xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 [id='type-TopicOperatorSpec-{context}']
 ### `TopicOperatorSpec` schema reference
 
+*The type `TopicOperatorSpec` has been deprecated.*
+Please use xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`] instead.
+
 Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In some cases it is useful to be able to have multiple different types under the same field in the CRD. For example when replacing some fields which are too limited etc. One of the examples of where this will be useful is https://github.com/strimzi/proposals/blob/master/005-improving-configurability-of-kafka-listeners.md

This PR adds support for `OneOfType` annotation which allows you to specify that a single field can accept multiple types. It can be used for example like this:

```java
    @OneOfType({
        @OneOfType.Alternative(@OneOfType.Alternative.Field("type1Value")), 
        @OneOfType.Alternative(@OneOfType.Alternative.Field("type2Value"))
    })
    public Type1OrType2 getTypedAlternatives() {
        return typedAlternatives;
    }
```

In this case the `typedAlternatives` field can be set either to `Type1` or to `Type2`. It is expected the the field with mixed values would be represented by a single class which will contain the alternating fields. In the example above it would be a class like this:

```java
public class Type1OrType2 {
    private Type1 type1Value;
    private Type2 type2Value;

    public Type1OrType2(Type1 type1Value)   {
        type1Value = type1Value;
        type2Value = null;
    }

    public Type1OrType2(Type2 type2Value)   {
        type1Value = null;
        type2Value = type2Value;
    }
}
```

The `@OneOfType.Alternative.Field` annotation value is pointing to the fields in the `Type1OrType2` class.

It also adds new annotation `DeprecatedType` for deprecating the whole type. This renders a deprecation notice in the reference API. This is useful for deprecating one of the alternatives.