### PR TITLE
Disable test-containers build as part of the Make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifneq ($(RELEASE_VERSION),latest)
   GITHUB_VERSION = $(RELEASE_VERSION)
 endif
 
-SUBDIRS=kafka-agent mirror-maker-agent tracing-agent crd-annotations test crd-generator api mockkube certificate-manager operator-common config-model config-model-generator cluster-operator topic-operator user-operator kafka-init test-container docker-images helm-charts/helm2 helm-charts/helm3 install examples
+SUBDIRS=kafka-agent mirror-maker-agent tracing-agent crd-annotations test crd-generator api mockkube certificate-manager operator-common config-model config-model-generator cluster-operator topic-operator user-operator kafka-init docker-images helm-charts/helm2 helm-charts/helm3 install examples
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
 all: prerequisites_check $(SUBDIRS) crd_install helm_install


### PR DESCRIPTION
#3496 added the `test-containers` module to the `make` build. That seems to be crashing the Jenkins builds and is blocking other PRs such as the OAuth work. It has also chicken-egg problem right now since it might rely on the images produced by the same build.

This PR removes it for now to help us move forward in other PRs. #3500 will add it back after we figure out how to best do it.