### PR TITLE
Upgrade Cruise Control for Kafka 2.6 support

### DIFF
--- a/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.5.0</strimzi-oauth.version>
-        <cruise-control.version>2.0.124</cruise-control.version>
+        <cruise-control.version>2.5.11</cruise-control.version>
         <opa-authorizer.version>0.4.1</opa-authorizer.version>
     </properties>
 
@@ -160,25 +160,13 @@
             <artifactId>cruise-control-metrics-reporter</artifactId>
             <version>${cruise-control.version}</version>
             <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
+                 <exclusion>
                     <groupId>org.apache.kafka</groupId>
-                    <artifactId>kafka_2.11</artifactId>
-                </exclusion>
+                    <artifactId>kafka_2.12</artifactId>
+                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.kafka</groupId>
                     <artifactId>kafka-clients</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-math3</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.5.0</strimzi-oauth.version>
-        <cruise-control.version>2.0.124</cruise-control.version>
+        <cruise-control.version>2.5.11</cruise-control.version>
         <opa-authorizer.version>0.4.1</opa-authorizer.version>
     </properties>
 
@@ -161,24 +161,12 @@
             <version>${cruise-control.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.apache.kafka</groupId>
-                    <artifactId>kafka_2.11</artifactId>
+                    <artifactId>kafka_2.12</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.kafka</groupId>
                     <artifactId>kafka-clients</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-math3</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.0.124</cruise-control.version>
+        <cruise-control.version>2.5.11</cruise-control.version>
     </properties>
 
     <repositories>

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -13,7 +13,6 @@ import io.strimzi.systemtest.utils.specific.CruiseControlUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -31,9 +30,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Tag(REGRESSION)
 @Tag(CRUISE_CONTROL)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-//until fix of CC for Kafka version 2.6.0 and new version of CC will be released, these tests will be disabled
-//TODO: enable these tests when all issues with CC and Kafka version 2.6.0 will be resolved
-@Disabled
 public class CruiseControlApiST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(CruiseControlApiST.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -23,7 +23,6 @@ import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -52,9 +51,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @Tag(REGRESSION)
 @Tag(CRUISE_CONTROL)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-//until fix of CC for Kafka version 2.6.0 and new version of CC will be released, these tests will be disabled
-//TODO: enable these tests when all issues with CC and Kafka version 2.6.0 will be resolved
-@Disabled
 public class CruiseControlConfigurationST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(CruiseControlConfigurationST.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -19,7 +19,6 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -33,9 +32,6 @@ import static org.hamcrest.Matchers.not;
 
 @Tag(REGRESSION)
 @Tag(CRUISE_CONTROL)
-//until fix of CC for Kafka version 2.6.0 and new version of CC will be released, these tests will be disabled
-//TODO: enable these tests when all issues with CC and Kafka version 2.6.0 will be resolved
-@Disabled
 public class CruiseControlIsolatedST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(CruiseControlIsolatedST.class);


### PR DESCRIPTION
### Type of change

Enhancement

### Description

This PR upgrades Cruise Control to version 2.5.11 which includes fixes for Kafka 2.6 support. 

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally