### PR TITLE
Fix CHANGELOG.md after Cruise Control upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 
 * Add support for Kafka 2.6.0 and remove support for 2.4.0 and 2.4.1
 * Remove TLS sidecars from Kafka pods => Kafka now uses native TLS to connect to ZooKeeper
-* Updated to Cruise Control 2.0.124, which fixes a previous issue with CPU utilization statistics for containers. As a result, the CPUCapacityGoal has now been enabled.
+* Updated to Cruise Control 2.5.11, which adds Kafka 2.6.0 support and fixes a previous issue with CPU utilization statistics for containers. As a result, the CPUCapacityGoal has now been enabled.
 * Cruise Control metrics integration:
-  * enable metrics JMX exporter configuration in the `cruiseControl` property of the Kafka custom resource
-  * new Grafana dashboard for the Cruise Control metrics
+  * Enable metrics JMX exporter configuration in the `cruiseControl` property of the Kafka custom resource
+  * New Grafana dashboard for the Cruise Control metrics
 * Configure Cluster Operator logging using ConfigMap instead of environment variable and support dynamic changes  
 * Switch to use the `AclAuthorizer` class for the `simple` Kafka authorization type. `AclAuthorizer` contains new features such as the ability to control the amount of authorization logs in the broker logs.
 


### PR DESCRIPTION
In #3516 we forgot to update the CHANGELOG.md file with the new Cruise Control version. This PR fixes that. It also fixes the capitalisation of some other records in the change log file.