### PR TITLE
[systemtest] Add forgotten profile tags to tests

### DIFF
--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -148,29 +148,36 @@ The following table shows currently used tags:
 
 | Name               | Description                                                                        |
 | :----------------: | :--------------------------------------------------------------------------------: |
-| travis             | Marks tests executed on Travis                                                     |
 | acceptance         | Acceptance tests, which guarantee, that basic functionality of Strimzi is working. |
 | regression         | Regression tests, which contains all non-flaky tests.                              |
 | upgrade            | Upgrade tests for specific versions of the Strimzi.                                |
+| travis             | Marks tests executed on Travis                                                     |
 | flaky              | Execute all flaky tests (tests, which are failing from time to time)               |
+| scalability        | Execute scalability tests                                                          |
+| specific           | Specific tests, which cannot be easily added to other categories                   |
 | nodeport           | Execute tests which use external lister of type nodeport                           |
 | loadbalancer       | Execute tests which use external lister of type loadbalancer                       |
-| bridge             | Execute tests which use Kafka Bridge                                               |
-| specific           | Specific tests, which cannot be easily added to other categories                   |
 | networkpolicies    | Execute tests which use Kafka with Network Policies                                |
-| tracing            | Execute tests for Tracing                                                          |
 | prometheus         | Execute tests for Kafka with Prometheus                                            |
-| oauth              | Execute tests which use OAuth                                                      |
+| tracing            | Execute tests for Tracing                                                          |
 | helm               | Execute tests which use Helm for deploy cluster operator                           |
-| olm                | Execute tests which use OLM for deploy cluster operator                            |
+| oauth              | Execute tests which use OAuth                                                      |
+| recovery           | Execute recovery tests                                                             |
 | connectoroperator  | Execute tests which deploy KafkaConnector resource                                 |
 | connect            | Execute tests which deploy KafkaConnect resource                                   |
 | connects2i         | Execute tests which deploy KafkaConnectS2I resource                                |
 | mirrormaker        | Execute tests which deploy KafkaMirrorMaker resource                               |
 | mirrormaker2       | Execute tests which deploy KafkaMirrorMaker2 resource                              |
 | conneccomponents   | Execute tests which deploy KafkaConnect, KafkaConnectS2I, KafkaMirrorMaker2, KafkaConnector resources |
+| bridge             | Execute tests which use Kafka Bridge                                               |
 | internalclients    | Execute tests which use internal (from pod) kafka clients in tests                 |
 | externalclients    | Execute tests which use external (from code) kafka clients in tests                |
+| olm                | Execute tests which use OLM for deploy cluster operator                            |
+| metrics            | Execute tests where metrics are used                                               |
+| cruisecontrol      | Execute tests which deploy CruiseControl resource                                  |
+| scale              | Execute tests where are resources (its pods) scaled up/down                        |
+| rollingupdate      | Execute tests where is rolling update triggered                                    |
+| norollingupdate    | Execute tests where resource (and its pods) should not roll                        |
 
 If your Kubernetes cluster doesn't support for example, Network Policies or NodePort services, you can easily skip those tests with `-DexcludeGroups=networkpolicies,nodeport`.
 

--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -151,7 +151,7 @@ The following table shows currently used tags:
 | acceptance         | Acceptance tests, which guarantee, that basic functionality of Strimzi is working. |
 | regression         | Regression tests, which contains all non-flaky tests.                              |
 | upgrade            | Upgrade tests for specific versions of the Strimzi.                                |
-| travis             | Marks tests executed on Travis                                                     |
+| smoke              | Marks tests executed on Travis                                                     |
 | flaky              | Execute all flaky tests (tests, which are failing from time to time)               |
 | scalability        | Execute scalability tests                                                          |
 | specific           | Specific tests, which cannot be easily added to other categories                   |
@@ -172,12 +172,10 @@ The following table shows currently used tags:
 | bridge             | Execute tests which use Kafka Bridge                                               |
 | internalclients    | Execute tests which use internal (from pod) kafka clients in tests                 |
 | externalclients    | Execute tests which use external (from code) kafka clients in tests                |
-| olm                | Execute tests which use OLM for deploy cluster operator                            |
+| olm                | Execute tests which test examples from Strimzi manifests                          |
 | metrics            | Execute tests where metrics are used                                               |
 | cruisecontrol      | Execute tests which deploy CruiseControl resource                                  |
-| scale              | Execute tests where are resources (its pods) scaled up/down                        |
 | rollingupdate      | Execute tests where is rolling update triggered                                    |
-| norollingupdate    | Execute tests where resource (and its pods) should not roll                        |
 
 If your Kubernetes cluster doesn't support for example, Network Policies or NodePort services, you can easily skip those tests with `-DexcludeGroups=networkpolicies,nodeport`.
 

--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -151,7 +151,7 @@ The following table shows currently used tags:
 | acceptance         | Acceptance tests, which guarantee, that basic functionality of Strimzi is working. |
 | regression         | Regression tests, which contains all non-flaky tests.                              |
 | upgrade            | Upgrade tests for specific versions of the Strimzi.                                |
-| smoke              | Marks tests executed on Travis                                                     |
+| smoke              | Execute all smoke tests                                                            |
 | flaky              | Execute all flaky tests (tests, which are failing from time to time)               |
 | scalability        | Execute scalability tests                                                          |
 | specific           | Specific tests, which cannot be easily added to other categories                   |

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -255,4 +255,9 @@ public interface Constants {
      * Tag for tests where resource should not roll
      */
     String NO_ROLLING_UPDATE = "norollingupdate";
+
+    /**
+     * Tag for tests where OLM is used for deploying CO
+     */
+    String OLM = "olm";
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -240,4 +240,19 @@ public interface Constants {
      * Tag for tests where cruise control used
      */
     String CRUISE_CONTROL = "cruisecontrol";
+
+    /**
+     * Tag for tests which contains scaling of specific resource
+     */
+    String SCALE = "scale";
+
+    /**
+     * Tag for tests which contains rolling update of resource
+     */
+    String ROLLING_UPDATE = "rollingupdate";
+
+    /**
+     * Tag for tests where resource should not roll
+     */
+    String NO_ROLLING_UPDATE = "norollingupdate";
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -129,7 +129,7 @@ public interface Constants {
     /**
      * Tag for acceptance tests executed during Travis builds.
      */
-    String TRAVIS = "travis";
+    String SMOKE = "smoke";
 
     /**
      * Tag for tests, which results are not 100% reliable on all testing environments.
@@ -242,19 +242,9 @@ public interface Constants {
     String CRUISE_CONTROL = "cruisecontrol";
 
     /**
-     * Tag for tests which contains scaling of specific resource
-     */
-    String SCALE = "scale";
-
-    /**
      * Tag for tests which contains rolling update of resource
      */
     String ROLLING_UPDATE = "rollingupdate";
-
-    /**
-     * Tag for tests where resource should not roll
-     */
-    String NO_ROLLING_UPDATE = "norollingupdate";
 
     /**
      * Tag for tests where OLM is used for deploying CO

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -127,7 +127,7 @@ public interface Constants {
     String UPGRADE = "upgrade";
 
     /**
-     * Tag for acceptance tests executed during Travis builds.
+     * Tag for smoke tests
      */
     String SMOKE = "smoke";
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
@@ -68,12 +68,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CONNECTOR_OPERATOR;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.CONNECT_S2I;
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.Constants.SCALE;
 import static io.strimzi.systemtest.Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.NotReady;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
@@ -74,7 +74,7 @@ import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.CONNECT_S2I;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
-import static io.strimzi.systemtest.Constants.SCALE;
+import static io.strimzi.systemtest.Constants.SCALABILITY;
 import static io.strimzi.systemtest.Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.NotReady;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
@@ -608,6 +608,7 @@ class ConnectS2IST extends AbstractST {
     }
 
     @Test
+    @Tag(SCALABILITY)
     void testScaleConnectS2IWithoutConnectorToZero() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
 
@@ -631,6 +632,8 @@ class ConnectS2IST extends AbstractST {
     }
 
     @Test
+    @Tag(CONNECTOR_OPERATOR)
+    @Tag(SCALABILITY)
     void testScaleConnectS2IWithConnectorToZero() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
 
@@ -671,6 +674,7 @@ class ConnectS2IST extends AbstractST {
     }
 
     @Test
+    @Tag(SCALABILITY)
     void testScaleConnectS2ISubresource() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -343,7 +343,7 @@ class ConnectST extends AbstractST {
         List<String> connectPods = kubeClient().listPodNames(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND);
         int initialReplicas = connectPods.size();
         assertThat(initialReplicas, is(1));
-        final int scaleTo = initialReplicas + 1;
+        final int scaleTo = initialReplicas + 3;
 
         LOGGER.info("Scaling up to {}", scaleTo);
         KafkaConnectResource.replaceKafkaConnectResource(CLUSTER_NAME, c -> c.getSpec().setReplicas(scaleTo));

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -67,8 +67,8 @@ import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
-import static io.strimzi.systemtest.Constants.SCALE;
-import static io.strimzi.systemtest.Constants.TRAVIS;
+import static io.strimzi.systemtest.Constants.SCALABILITY;
+import static io.strimzi.systemtest.Constants.SMOKE;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.NotReady;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -138,7 +138,7 @@ class ConnectST extends AbstractST {
     }
 
     @Test
-    @Tag(TRAVIS)
+    @Tag(SMOKE)
     @Tag(INTERNAL_CLIENTS_USED)
     void testKafkaConnectWithFileSinkPlugin() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
@@ -331,7 +331,7 @@ class ConnectST extends AbstractST {
     }
 
     @Test
-    @Tag(SCALE)
+    @Tag(SCALABILITY)
     void testKafkaConnectScaleUpScaleDown() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
         LOGGER.info("Running kafkaConnectScaleUP {} in namespace", NAMESPACE);
@@ -863,7 +863,7 @@ class ConnectST extends AbstractST {
     }
 
     @Test
-    @Tag(SCALE)
+    @Tag(SCALABILITY)
     void testScaleConnectWithoutConnectorToZero() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
 
@@ -888,7 +888,7 @@ class ConnectST extends AbstractST {
     }
 
     @Test
-    @Tag(SCALE)
+    @Tag(SCALABILITY)
     @Tag(CONNECTOR_OPERATOR)
     void testScaleConnectWithConnectorToZero() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
@@ -931,7 +931,7 @@ class ConnectST extends AbstractST {
     }
 
     @Test
-    @Tag(SCALE)
+    @Tag(SCALABILITY)
     @Tag(CONNECTOR_OPERATOR)
     void testScaleConnectAndConnectorSubresource() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -67,6 +67,7 @@ import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.Constants.SCALE;
 import static io.strimzi.systemtest.Constants.TRAVIS;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.NotReady;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
@@ -330,6 +331,7 @@ class ConnectST extends AbstractST {
     }
 
     @Test
+    @Tag(SCALE)
     void testKafkaConnectScaleUpScaleDown() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
         LOGGER.info("Running kafkaConnectScaleUP {} in namespace", NAMESPACE);
@@ -861,6 +863,7 @@ class ConnectST extends AbstractST {
     }
 
     @Test
+    @Tag(SCALE)
     void testScaleConnectWithoutConnectorToZero() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
 
@@ -885,6 +888,8 @@ class ConnectST extends AbstractST {
     }
 
     @Test
+    @Tag(SCALE)
+    @Tag(CONNECTOR_OPERATOR)
     void testScaleConnectWithConnectorToZero() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
 
@@ -926,6 +931,8 @@ class ConnectST extends AbstractST {
     }
 
     @Test
+    @Tag(SCALE)
+    @Tag(CONNECTOR_OPERATOR)
     void testScaleConnectAndConnectorSubresource() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -885,7 +885,6 @@ class KafkaST extends AbstractST {
     }
 
     @Test
-    @Tag(REGRESSION)
     void testKafkaJBODDeleteClaimsTrue() {
         int kafkaReplicas = 2;
         int diskSizeGi = 10;
@@ -909,7 +908,6 @@ class KafkaST extends AbstractST {
     }
 
     @Test
-    @Tag(REGRESSION)
     void testKafkaJBODDeleteClaimsFalse() {
         int kafkaReplicas = 2;
         int diskSizeGi = 10;
@@ -1160,6 +1158,7 @@ class KafkaST extends AbstractST {
     }
 
     @Test
+    @Tag(INTERNAL_CLIENTS_USED)
     void testAppDomainLabels() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
@@ -63,7 +63,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @Tag(REGRESSION)
-@Tag(INTERNAL_CLIENTS_USED)
 public class ListenersST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(ListenersST.class);
 
@@ -342,6 +341,7 @@ public class ListenersST extends AbstractST {
 
     @Test
     @Tag(NODEPORT_SUPPORTED)
+    @Tag(EXTERNAL_CLIENTS_USED)
     void testOverrideNodePortConfiguration() {
         int brokerNodePort = 32000;
         int brokerId = 0;
@@ -501,6 +501,8 @@ public class ListenersST extends AbstractST {
 
     @Test
     @Tag(NODEPORT_SUPPORTED)
+    @Tag(EXTERNAL_CLIENTS_USED)
+    @Tag(INTERNAL_CLIENTS_USED)
     void testCustomSoloCertificatesForNodePort() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
@@ -571,6 +573,8 @@ public class ListenersST extends AbstractST {
 
     @Test
     @Tag(NODEPORT_SUPPORTED)
+    @Tag(EXTERNAL_CLIENTS_USED)
+    @Tag(INTERNAL_CLIENTS_USED)
     void testCustomChainCertificatesForNodePort() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
@@ -643,6 +647,8 @@ public class ListenersST extends AbstractST {
 
     @Test
     @Tag(LOADBALANCER_SUPPORTED)
+    @Tag(EXTERNAL_CLIENTS_USED)
+    @Tag(INTERNAL_CLIENTS_USED)
     void testCustomSoloCertificatesForLoadBalancer() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
@@ -713,6 +719,8 @@ public class ListenersST extends AbstractST {
 
     @Test
     @Tag(LOADBALANCER_SUPPORTED)
+    @Tag(EXTERNAL_CLIENTS_USED)
+    @Tag(INTERNAL_CLIENTS_USED)
     void testCustomChainCertificatesForLoadBalancer() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
@@ -787,6 +795,8 @@ public class ListenersST extends AbstractST {
 
     @Test
     @Tag(ACCEPTANCE)
+    @Tag(EXTERNAL_CLIENTS_USED)
+    @Tag(INTERNAL_CLIENTS_USED)
     @OpenShiftOnly
     void testCustomSoloCertificatesForRoute() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
@@ -857,6 +867,8 @@ public class ListenersST extends AbstractST {
     }
 
     @Test
+    @Tag(EXTERNAL_CLIENTS_USED)
+    @Tag(INTERNAL_CLIENTS_USED)
     @OpenShiftOnly
     void testCustomChainCertificatesForRoute() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
@@ -929,6 +941,8 @@ public class ListenersST extends AbstractST {
 
     @Test
     @Tag(LOADBALANCER_SUPPORTED)
+    @Tag(EXTERNAL_CLIENTS_USED)
+    @Tag(INTERNAL_CLIENTS_USED)
     @SuppressWarnings({"checkstyle:MethodLength"})
     void testCustomCertLoadBalancerAndTlsRollingUpdate() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
@@ -1126,6 +1140,8 @@ public class ListenersST extends AbstractST {
 
     @Test
     @Tag(NODEPORT_SUPPORTED)
+    @Tag(EXTERNAL_CLIENTS_USED)
+    @Tag(INTERNAL_CLIENTS_USED)
     @SuppressWarnings({"checkstyle:MethodLength"})
     void testCustomCertNodePortAndTlsRollingUpdate() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
@@ -1319,6 +1335,8 @@ public class ListenersST extends AbstractST {
     }
 
     @Test
+    @Tag(EXTERNAL_CLIENTS_USED)
+    @Tag(INTERNAL_CLIENTS_USED)
     @OpenShiftOnly
     @SuppressWarnings({"checkstyle:MethodLength"})
     void testCustomCertRouteAndTlsRollingUpdate() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafkaclients/externalClients/BasicExternalKafkaClientTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafkaclients/externalClients/BasicExternalKafkaClientTest.java
@@ -13,6 +13,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -24,9 +25,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.IntPredicate;
 
+import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 
+@Tag(EXTERNAL_CLIENTS_USED)
 class BasicExternalKafkaClientTest {
 
     private static final Logger LOGGER = LogManager.getLogger(BasicExternalKafkaClient.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
@@ -47,6 +47,7 @@ import java.util.stream.Collectors;
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
+import static io.strimzi.systemtest.Constants.CONNECT_S2I;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -62,6 +63,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Tag(MIRROR_MAKER)
 @Tag(MIRROR_MAKER2)
 @Tag(BRIDGE)
+@Tag(CONNECT_S2I)
 @Tag(CONNECT_COMPONENTS)
 @TestMethodOrder(OrderAnnotation.class)
 class LogSettingST extends AbstractST {

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -35,8 +35,8 @@ import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.LOGGING_RELOADING_INTERVAL;
-import static io.strimzi.systemtest.Constants.NO_ROLLING_UPDATE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.Constants.ROLLING_UPDATE;
 import static io.strimzi.systemtest.Constants.STRIMZI_DEPLOYMENT_NAME;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -190,7 +190,7 @@ class LoggingChangeST extends AbstractST {
     }
 
     @Test
-    @Tag(NO_ROLLING_UPDATE)
+    @Tag(ROLLING_UPDATE)
     @SuppressWarnings({"checkstyle:MethodLength"})
     void testDynamicallySetEOloggingLevels() throws InterruptedException {
         InlineLogging ilOff = new InlineLogging();
@@ -357,7 +357,7 @@ class LoggingChangeST extends AbstractST {
 
     @Test
     @Tag(BRIDGE)
-    @Tag(NO_ROLLING_UPDATE)
+    @Tag(ROLLING_UPDATE)
     void testDynamicallySetBridgeLoggingLevels() throws InterruptedException {
         InlineLogging ilOff = new InlineLogging();
         Map<String, String> loggers = new HashMap<>();
@@ -463,7 +463,7 @@ class LoggingChangeST extends AbstractST {
     }
 
     @Test
-    @Tag(NO_ROLLING_UPDATE)
+    @Tag(ROLLING_UPDATE)
     void testDynamicallySetClusterOperatorLoggingLevels() throws InterruptedException {
         Map<String, String> coPod = DeploymentUtils.depSnapshot(STRIMZI_DEPLOYMENT_NAME);
         String coPodName = kubeClient().listPodsByPrefixInName(STRIMZI_DEPLOYMENT_NAME).get(0).getMetadata().getName();

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -33,7 +33,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.LOGGING_RELOADING_INTERVAL;
+import static io.strimzi.systemtest.Constants.NO_ROLLING_UPDATE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.Constants.STRIMZI_DEPLOYMENT_NAME;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -188,6 +190,7 @@ class LoggingChangeST extends AbstractST {
     }
 
     @Test
+    @Tag(NO_ROLLING_UPDATE)
     @SuppressWarnings({"checkstyle:MethodLength"})
     void testDynamicallySetEOloggingLevels() throws InterruptedException {
         InlineLogging ilOff = new InlineLogging();
@@ -353,6 +356,8 @@ class LoggingChangeST extends AbstractST {
     }
 
     @Test
+    @Tag(BRIDGE)
+    @Tag(NO_ROLLING_UPDATE)
     void testDynamicallySetBridgeLoggingLevels() throws InterruptedException {
         InlineLogging ilOff = new InlineLogging();
         Map<String, String> loggers = new HashMap<>();
@@ -458,6 +463,7 @@ class LoggingChangeST extends AbstractST {
     }
 
     @Test
+    @Tag(NO_ROLLING_UPDATE)
     void testDynamicallySetClusterOperatorLoggingLevels() throws InterruptedException {
         Map<String, String> coPod = DeploymentUtils.depSnapshot(STRIMZI_DEPLOYMENT_NAME);
         String coPodName = kubeClient().listPodsByPrefixInName(STRIMZI_DEPLOYMENT_NAME).get(0).getMetadata().getName();

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -44,9 +44,11 @@ import java.util.regex.Pattern;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.BRIDGE;
+import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.METRICS;
+import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -132,6 +134,7 @@ public class MetricsST extends AbstractST {
     }
 
     @Test
+    @Tag(CONNECT)
     void testKafkaConnectRequests() {
         Pattern connectRequests = Pattern.compile("kafka_connect_node_request_total\\{clientid=\".*\",} ([\\d.][^\\n]+)");
         ArrayList<Double> values = MetricsUtils.collectSpecificMetric(connectRequests, kafkaConnectMetricsData);
@@ -139,6 +142,7 @@ public class MetricsST extends AbstractST {
     }
 
     @Test
+    @Tag(CONNECT)
     void testKafkaConnectResponse() {
         Pattern connectResponse = Pattern.compile("kafka_connect_node_response_total\\{clientid=\".*\",} ([\\d.][^\\n]+)");
         ArrayList<Double> values = MetricsUtils.collectSpecificMetric(connectResponse, kafkaConnectMetricsData);
@@ -146,6 +150,7 @@ public class MetricsST extends AbstractST {
     }
 
     @Test
+    @Tag(CONNECT)
     void testKafkaConnectIoNetwork() {
         Pattern connectIoNetwork = Pattern.compile("kafka_connect_network_io_total\\{clientid=\".*\",} ([\\d.][^\\n]+)");
         ArrayList<Double> values = MetricsUtils.collectSpecificMetric(connectIoNetwork, kafkaConnectMetricsData);
@@ -288,6 +293,7 @@ public class MetricsST extends AbstractST {
     }
 
     @Test
+    @Tag(MIRROR_MAKER2)
     void testMirrorMaker2Metrics() {
         kafkaMirrorMaker2MetricsData = MetricsUtils.collectKafkaMirrorMaker2PodsMetrics(MIRROR_MAKER_CLUSTER);
         Pattern connectResponse = Pattern.compile("kafka_connect_worker_connector_count ([\\d.][^\\n]+)");

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -44,10 +44,11 @@ import java.util.List;
 import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
-import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
+import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.Constants.SCALE;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -569,6 +570,7 @@ class MirrorMaker2ST extends AbstractST {
     }
 
     @Test
+    @Tag(SCALE)
     void testScaleMirrorMaker2Subresource() {
         // Deploy source kafka
         KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
@@ -645,6 +647,7 @@ class MirrorMaker2ST extends AbstractST {
     }
 
     @Test
+    @Tag(SCALE)
     void testScaleMirrorMaker2ToZero() {
         // Deploy source kafka
         KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -48,7 +48,7 @@ import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.REGRESSION;
-import static io.strimzi.systemtest.Constants.SCALE;
+import static io.strimzi.systemtest.Constants.SCALABILITY;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -570,7 +570,7 @@ class MirrorMaker2ST extends AbstractST {
     }
 
     @Test
-    @Tag(SCALE)
+    @Tag(SCALABILITY)
     void testScaleMirrorMaker2Subresource() {
         // Deploy source kafka
         KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
@@ -647,7 +647,7 @@ class MirrorMaker2ST extends AbstractST {
     }
 
     @Test
-    @Tag(SCALE)
+    @Tag(SCALABILITY)
     void testScaleMirrorMaker2ToZero() {
         // Deploy source kafka
         KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
@@ -47,7 +47,7 @@ import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.REGRESSION;
-import static io.strimzi.systemtest.Constants.SCALE;
+import static io.strimzi.systemtest.Constants.SCALABILITY;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -627,7 +627,7 @@ public class MirrorMakerST extends AbstractST {
     }
 
     @Test
-    @Tag(SCALE)
+    @Tag(SCALABILITY)
     void testScaleMirrorMakerSubresource() {
         // Deploy source kafka
         KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
@@ -661,7 +661,7 @@ public class MirrorMakerST extends AbstractST {
     }
 
     @Test
-    @Tag(SCALE)
+    @Tag(SCALABILITY)
     void testScaleMirrorMakerToZero() {
         // Deploy source kafka
         KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
@@ -47,6 +47,7 @@ import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.Constants.SCALE;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -626,6 +627,7 @@ public class MirrorMakerST extends AbstractST {
     }
 
     @Test
+    @Tag(SCALE)
     void testScaleMirrorMakerSubresource() {
         // Deploy source kafka
         KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
@@ -659,6 +661,7 @@ public class MirrorMakerST extends AbstractST {
     }
 
     @Test
+    @Tag(SCALE)
     void testScaleMirrorMakerToZero() {
         // Deploy source kafka
         KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/AllNamespacesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/AllNamespacesST.java
@@ -18,8 +18,10 @@ import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_S2I;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
+import static io.strimzi.systemtest.Constants.OLM;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Tag(OLM)
 public class AllNamespacesST extends OlmAbstractST {
 
     public static final String NAMESPACE = "olm-namespace";

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/AllNamespacesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/AllNamespacesST.java
@@ -6,20 +6,23 @@ package io.strimzi.systemtest.olm;
 
 import io.strimzi.systemtest.resources.operator.OlmResource;
 import io.strimzi.systemtest.resources.ResourceManager;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.strimzi.systemtest.Constants.BRIDGE;
+import static io.strimzi.systemtest.Constants.CONNECT;
+import static io.strimzi.systemtest.Constants.CONNECT_S2I;
+import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
+import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class AllNamespacesST extends OlmAbstractST {
 
     public static final String NAMESPACE = "olm-namespace";
-
-    private static final Logger LOGGER = LogManager.getLogger(AllNamespacesST.class);
 
     @Test
     @Order(1)
@@ -40,30 +43,35 @@ public class AllNamespacesST extends OlmAbstractST {
     }
 
     @Test
+    @Tag(CONNECT)
     @Order(4)
     void testDeployExampleKafkaConnect() {
         doTestDeployExampleKafkaConnect();
     }
 
     @Test
+    @Tag(CONNECT_S2I)
     @Order(5)
     void testDeployExampleKafkaConnectS2I() {
         doTestDeployExampleKafkaConnectS2I();
     }
 
     @Test
+    @Tag(BRIDGE)
     @Order(6)
     void testDeployExampleKafkaBridge() {
         doTestDeployExampleKafkaBridge();
     }
 
     @Test
+    @Tag(MIRROR_MAKER)
     @Order(7)
     void testDeployExampleKafkaMirrorMaker() {
         doTestDeployExampleKafkaMirrorMaker();
     }
 
     @Test
+    @Tag(MIRROR_MAKER2)
     @Order(8)
     void testDeployExampleKafkaMirrorMaker2() {
         doTestDeployExampleKafkaMirrorMaker2();

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/SingleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/SingleNamespaceST.java
@@ -11,8 +11,15 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.strimzi.systemtest.Constants.BRIDGE;
+import static io.strimzi.systemtest.Constants.CONNECT;
+import static io.strimzi.systemtest.Constants.CONNECT_S2I;
+import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
+import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class SingleNamespaceST extends OlmAbstractST {
@@ -40,30 +47,35 @@ public class SingleNamespaceST extends OlmAbstractST {
     }
 
     @Test
+    @Tag(CONNECT)
     @Order(4)
     void testDeployExampleKafkaConnect() {
         doTestDeployExampleKafkaConnect();
     }
 
     @Test
+    @Tag(CONNECT_S2I)
     @Order(5)
     void testDeployExampleKafkaConnectS2I() {
         doTestDeployExampleKafkaConnectS2I();
     }
 
     @Test
+    @Tag(BRIDGE)
     @Order(6)
     void testDeployExampleKafkaBridge() {
         doTestDeployExampleKafkaBridge();
     }
 
     @Test
+    @Tag(MIRROR_MAKER)
     @Order(7)
     void testDeployExampleKafkaMirrorMaker() {
         doTestDeployExampleKafkaMirrorMaker();
     }
 
     @Test
+    @Tag(MIRROR_MAKER2)
     @Order(8)
     void testDeployExampleKafkaMirrorMaker2() {
         doTestDeployExampleKafkaMirrorMaker2();

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/SingleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/SingleNamespaceST.java
@@ -20,8 +20,10 @@ import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_S2I;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
+import static io.strimzi.systemtest.Constants.OLM;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Tag(OLM)
 public class SingleNamespaceST extends OlmAbstractST {
 
     public static final String NAMESPACE = "olm-namespace";

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
@@ -64,10 +64,12 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static io.strimzi.api.kafka.model.KafkaResources.externalBootstrapServiceName;
+import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECTOR_OPERATOR;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.CONNECT_S2I;
+import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
@@ -93,6 +95,7 @@ class CustomResourceStatusST extends AbstractST {
 
     @Test
     @Tag(NODEPORT_SUPPORTED)
+    @Tag(EXTERNAL_CLIENTS_USED)
     void testKafkaStatus() {
         LOGGER.info("Checking status of deployed kafka cluster");
         KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
@@ -199,6 +202,7 @@ class CustomResourceStatusST extends AbstractST {
     }
 
     @Test
+    @Tag(BRIDGE)
     void testKafkaBridgeStatus() {
         String bridgeUrl = KafkaBridgeResources.url(CLUSTER_NAME, NAMESPACE, 8080);
         KafkaBridgeResource.kafkaBridge(CLUSTER_NAME, KafkaResources.plainBootstrapAddress(CLUSTER_NAME), 1).done();
@@ -299,6 +303,7 @@ class CustomResourceStatusST extends AbstractST {
     }
 
     @Test
+    @Tag(CONNECTOR_OPERATOR)
     void testKafkaConnectorWithoutClusterConfig() {
         // This test check NPE when connect cluster is not specified in labels
         // Check for NPE in CO logs is performed after every test in BaseST
@@ -362,6 +367,7 @@ class CustomResourceStatusST extends AbstractST {
     }
 
     @Test
+    @Tag(MIRROR_MAKER2)
     void testKafkaMirrorMaker2WrongBootstrap() {
         KafkaMirrorMaker2Resource.kafkaMirrorMaker2WithoutWait(
                 KafkaMirrorMaker2Resource.defaultKafkaMirrorMaker2(CLUSTER_NAME,

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.RECOVERY;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -48,6 +49,7 @@ class NamespaceDeletionRecoveryST extends AbstractST {
     private String storageClassName = "retain";
 
     @Test
+    @Tag(INTERNAL_CLIENTS_USED)
     void testTopicAvailable() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
@@ -104,6 +106,7 @@ class NamespaceDeletionRecoveryST extends AbstractST {
     }
 
     @Test
+    @Tag(INTERNAL_CLIENTS_USED)
     void testTopicNotAvailable() throws InterruptedException {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
@@ -176,6 +177,7 @@ public class TopicST extends AbstractST {
     }
 
     @Test
+    @Tag(INTERNAL_CLIENTS_USED)
     void testSendingMessagesToNonExistingTopic() {
         int sent = 0;
 
@@ -220,6 +222,7 @@ public class TopicST extends AbstractST {
     }
 
     @Test
+    @Tag(INTERNAL_CLIENTS_USED)
     void testDeleteTopicEnableFalse() {
         String topicName = "my-deleted-topic";
         String isolatedKafkaCluster = CLUSTER_NAME + "-isolated";

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.Constants.ROLLING_UPDATE;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -38,6 +39,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @Tag(REGRESSION)
 @Tag(INTERNAL_CLIENTS_USED)
+@Tag(ROLLING_UPDATE)
 class AlternativeReconcileTriggersST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(RollingUpdateST.class);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.Constants.ROLLING_UPDATE;
 import static io.strimzi.systemtest.k8s.Events.Created;
 import static io.strimzi.systemtest.k8s.Events.Pulled;
 import static io.strimzi.systemtest.k8s.Events.Scheduled;
@@ -40,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag(REGRESSION)
 @Tag(INTERNAL_CLIENTS_USED)
+@Tag(ROLLING_UPDATE)
 class KafkaRollerST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(RollingUpdateST.class);
     static final String NAMESPACE = "kafka-roller-cluster-test";

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -55,10 +55,9 @@ import java.util.stream.Collectors;
 import static io.strimzi.api.kafka.model.KafkaResources.kafkaStatefulSetName;
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
-import static io.strimzi.systemtest.Constants.NO_ROLLING_UPDATE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.Constants.ROLLING_UPDATE;
-import static io.strimzi.systemtest.Constants.SCALE;
+import static io.strimzi.systemtest.Constants.SCALABILITY;
 import static io.strimzi.systemtest.k8s.Events.Killing;
 import static io.strimzi.systemtest.matchers.Matchers.hasAllOfReasons;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -238,7 +237,7 @@ class RollingUpdateST extends AbstractST {
 
     @Test
     @Tag(ACCEPTANCE)
-    @Tag(SCALE)
+    @Tag(SCALABILITY)
     void testKafkaAndZookeeperScaleUpScaleDown() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
@@ -350,7 +349,7 @@ class RollingUpdateST extends AbstractST {
     }
 
     @Test
-    @Tag(SCALE)
+    @Tag(SCALABILITY)
     void testZookeeperScaleUpScaleDown() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
@@ -470,7 +469,7 @@ class RollingUpdateST extends AbstractST {
     }
 
     @Test
-    @Tag(NO_ROLLING_UPDATE)
+    @Tag(ROLLING_UPDATE)
     void testManualKafkaConfigMapChangeDontTriggerRollingUpdate() {
         KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -55,7 +55,10 @@ import java.util.stream.Collectors;
 import static io.strimzi.api.kafka.model.KafkaResources.kafkaStatefulSetName;
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.Constants.NO_ROLLING_UPDATE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.Constants.ROLLING_UPDATE;
+import static io.strimzi.systemtest.Constants.SCALE;
 import static io.strimzi.systemtest.k8s.Events.Killing;
 import static io.strimzi.systemtest.matchers.Matchers.hasAllOfReasons;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -76,6 +79,7 @@ class RollingUpdateST extends AbstractST {
     private static final Pattern ZK_SERVER_STATE = Pattern.compile("zk_server_state\\s+(leader|follower)");
 
     @Test
+    @Tag(ROLLING_UPDATE)
     void testRecoveryDuringZookeeperRollingUpdate() throws Exception {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
@@ -154,6 +158,7 @@ class RollingUpdateST extends AbstractST {
     }
 
     @Test
+    @Tag(ROLLING_UPDATE)
     void testRecoveryDuringKafkaRollingUpdate() throws Exception {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
@@ -233,6 +238,7 @@ class RollingUpdateST extends AbstractST {
 
     @Test
     @Tag(ACCEPTANCE)
+    @Tag(SCALE)
     void testKafkaAndZookeeperScaleUpScaleDown() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
@@ -344,6 +350,7 @@ class RollingUpdateST extends AbstractST {
     }
 
     @Test
+    @Tag(SCALE)
     void testZookeeperScaleUpScaleDown() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
@@ -447,6 +454,7 @@ class RollingUpdateST extends AbstractST {
     }
 
     @Test
+    @Tag(ROLLING_UPDATE)
     void testBrokerConfigurationChangeTriggerRollingUpdate() {
         KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3).done();
 
@@ -462,6 +470,7 @@ class RollingUpdateST extends AbstractST {
     }
 
     @Test
+    @Tag(NO_ROLLING_UPDATE)
     void testManualKafkaConfigMapChangeDontTriggerRollingUpdate() {
         KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3).done();
 
@@ -479,6 +488,7 @@ class RollingUpdateST extends AbstractST {
     }
 
     @Test
+    @Tag(ROLLING_UPDATE)
     void testExternalLoggingChangeTriggerRollingUpdate() {
         // EO dynamic logging is tested in io.strimzi.systemtest.log.LoggingChangeST.testDynamicallySetEOloggingLevels
         KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3).done();
@@ -536,6 +546,7 @@ class RollingUpdateST extends AbstractST {
     }
 
     @Test
+    @Tag(ROLLING_UPDATE)
     void testClusterOperatorFinishAllRollingUpdates() {
         KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3).done();
 
@@ -572,6 +583,7 @@ class RollingUpdateST extends AbstractST {
     @Description("Test for checking that overriding of bootstrap server, triggers the rolling update and verifying that" +
             " new bootstrap DNS is appended inside certificate in subject alternative names property.")
     @Test
+    @Tag(ROLLING_UPDATE)
     void testTriggerRollingUpdateAfterOverrideBootstrap() throws CertificateException {
         String bootstrapDns = "kafka-test.XXXX.azure.XXXX.net";
 
@@ -618,6 +630,7 @@ class RollingUpdateST extends AbstractST {
     }
 
     @Test
+    @Tag(ROLLING_UPDATE)
     void testMetricsChange() {
         //Kafka
         Map<String, Object> kafkaRule = new HashMap<>();

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -78,6 +78,7 @@ import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.NETWORKPOLICIES_SUPPORTED;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.Constants.ROLLING_UPDATE;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.NotReady;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static java.util.Arrays.asList;
@@ -267,6 +268,7 @@ class SecurityST extends AbstractST {
 
     @Test
     @Tag(INTERNAL_CLIENTS_USED)
+    @Tag(ROLLING_UPDATE)
     void testAutoRenewClusterCaCertsTriggeredByAnno() {
         autoRenewSomeCaCertsTriggeredByAnno(asList(
                 clusterCaCertificateSecretName(CLUSTER_NAME)),
@@ -280,6 +282,7 @@ class SecurityST extends AbstractST {
 
     @Test
     @Tag(INTERNAL_CLIENTS_USED)
+    @Tag(ROLLING_UPDATE)
     void testAutoRenewClientsCaCertsTriggeredByAnno() {
         autoRenewSomeCaCertsTriggeredByAnno(asList(
                 clientsCaCertificateSecretName(CLUSTER_NAME)),
@@ -294,6 +297,7 @@ class SecurityST extends AbstractST {
     @Test
     @Tag(ACCEPTANCE)
     @Tag(INTERNAL_CLIENTS_USED)
+    @Tag(ROLLING_UPDATE)
     void testAutoRenewAllCaCertsTriggeredByAnno() {
         autoRenewSomeCaCertsTriggeredByAnno(asList(
                 clusterCaCertificateSecretName(CLUSTER_NAME),
@@ -434,6 +438,7 @@ class SecurityST extends AbstractST {
 
     @Test
     @Tag(INTERNAL_CLIENTS_USED)
+    @Tag(ROLLING_UPDATE)
     void testAutoReplaceClusterCaKeysTriggeredByAnno() {
         autoReplaceSomeKeysTriggeredByAnno(asList(clusterCaKeySecretName(CLUSTER_NAME)),
                 true,
@@ -443,6 +448,7 @@ class SecurityST extends AbstractST {
 
     @Test
     @Tag(INTERNAL_CLIENTS_USED)
+    @Tag(ROLLING_UPDATE)
     void testAutoReplaceClientsCaKeysTriggeredByAnno() {
         autoReplaceSomeKeysTriggeredByAnno(asList(clientsCaKeySecretName(CLUSTER_NAME)),
                 false,
@@ -452,6 +458,7 @@ class SecurityST extends AbstractST {
 
     @Test
     @Tag(INTERNAL_CLIENTS_USED)
+    @Tag(ROLLING_UPDATE)
     void testAutoReplaceAllCaKeysTriggeredByAnno() {
         autoReplaceSomeKeysTriggeredByAnno(asList(clusterCaKeySecretName(CLUSTER_NAME),
                 clientsCaKeySecretName(CLUSTER_NAME)),
@@ -534,6 +541,7 @@ class SecurityST extends AbstractST {
     }
 
     @Test
+    @Tag(INTERNAL_CLIENTS_USED)
     void testCertRenewalInMaintenanceWindow() {
         String secretName = CLUSTER_NAME + "-cluster-ca-cert";
         LocalDateTime maintenanceWindowStart = LocalDateTime.now().withSecond(0);

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -29,6 +29,7 @@ import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
+import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.OAUTH;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -38,6 +39,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 @Tag(OAUTH)
 @Tag(REGRESSION)
 @Tag(NODEPORT_SUPPORTED)
+@Tag(EXTERNAL_CLIENTS_USED)
 @ExtendWith(VertxExtension.class)
 public class OauthAbstractST extends AbstractST {
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
@@ -49,9 +49,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import static io.strimzi.api.kafka.model.KafkaResources.kafkaStatefulSetName;
-import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
+import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
@@ -291,6 +292,7 @@ public class OauthPlainST extends OauthAbstractST {
 
     @Description("As a oauth bridge, I should be able to send messages to bridge endpoint.")
     @Test
+    @Tag(BRIDGE)
     void testProducerConsumerBridge(Vertx vertx) throws InterruptedException, ExecutionException, TimeoutException {
         oauthExternalKafkaClient.verifyProducedAndConsumedMessages(
             oauthExternalKafkaClient.sendMessagesPlain(),

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsST.java
@@ -47,9 +47,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
-import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
+import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.OAUTH;
@@ -62,10 +63,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 
 @Tag(OAUTH)
-@Tag(ACCEPTANCE)
 @Tag(REGRESSION)
 @Tag(NODEPORT_SUPPORTED)
 @Tag(EXTERNAL_CLIENTS_USED)
+@Tag(ACCEPTANCE)
 public class OauthTlsST extends OauthAbstractST {
 
     private OauthExternalKafkaClient oauthExternalKafkaClientTls;
@@ -137,6 +138,7 @@ public class OauthTlsST extends OauthAbstractST {
 
     @Description("As a oauth bridge, i am able to send messages to bridge endpoint using encrypted communication")
     @Test
+    @Tag(BRIDGE)
     void testProducerConsumerBridge(Vertx vertx) throws InterruptedException, ExecutionException, TimeoutException {
         oauthExternalKafkaClientTls.verifyProducedAndConsumedMessages(
             oauthExternalKafkaClientTls.sendMessagesTls(),

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/OpenShiftTemplatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/OpenShiftTemplatesST.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+import static io.strimzi.systemtest.Constants.CONNECT;
+import static io.strimzi.systemtest.Constants.CONNECT_S2I;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.TestUtils.map;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -153,6 +155,7 @@ public class OpenShiftTemplatesST extends AbstractST {
     }
 
     @Test
+    @Tag(CONNECT)
     void testConnect() {
         String clusterName = "test-connect";
         oc.createResourceAndApply("strimzi-connect", map("CLUSTER_NAME", clusterName,
@@ -164,7 +167,8 @@ public class OpenShiftTemplatesST extends AbstractST {
     }
 
     @Test
-    void testS2i() {
+    @Tag(CONNECT_S2I)
+    void testConnectS2I() {
         String clusterName = "test-s2i";
         oc.createResourceAndApply("strimzi-connect-s2i", map("CLUSTER_NAME", clusterName,
                 "INSTANCES", "1"));

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.LOADBALANCER_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.Constants.SPECIFIC;
@@ -57,6 +58,7 @@ public class SpecificST extends AbstractST {
 
     @Test
     @Tag(LOADBALANCER_SUPPORTED)
+    @Tag(EXTERNAL_CLIENTS_USED)
     void testRackAware() {
         String rackKey = "rack-key";
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 1, 1)
@@ -112,6 +114,7 @@ public class SpecificST extends AbstractST {
 
     @Test
     @Tag(LOADBALANCER_SUPPORTED)
+    @Tag(EXTERNAL_CLIENTS_USED)
     void testLoadBalancerIpOverride() {
         String bootstrapOverrideIP = "10.0.0.1";
         String brokerOverrideIP = "10.0.0.2";
@@ -180,6 +183,7 @@ public class SpecificST extends AbstractST {
 
     @Test
     @Tag(LOADBALANCER_SUPPORTED)
+    @Tag(EXTERNAL_CLIENTS_USED)
     void testLoadBalancerSourceRanges() {
         String networkInterfaces = Exec.exec("ip", "route").out();
         Pattern ipv4InterfacesPattern = Pattern.compile("[0-9]+.[0-9]+.[0-9]+.[0-9]+\\/[0-9]+ dev (eth0|enp11s0u1).*");

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -59,12 +59,13 @@ import java.util.Objects;
 import java.util.Stack;
 import java.util.stream.Collectors;
 
+import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.CONNECT_S2I;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -837,6 +838,7 @@ public class TracingST extends AbstractST {
     }
 
     @Tag(NODEPORT_SUPPORTED)
+    @Tag(BRIDGE)
     @Test
     void testKafkaBridgeService(Vertx vertx) throws Exception {
         WebClient client = WebClient.create(vertx, new WebClientOptions().setSsl(false));

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.UPGRADE;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -88,6 +89,7 @@ public class StrimziUpgradeST extends AbstractST {
 
     @ParameterizedTest()
     @JsonFileSource(resources = "/StrimziUpgradeST.json")
+    @Tag(INTERNAL_CLIENTS_USED)
     void testUpgradeStrimziVersion(JsonObject parameters) throws Exception {
 
         assumeTrue(StUtils.isAllowOnCurrentEnvironment(parameters.getJsonObject("environmentInfo").getString("flakyEnvVariable")));
@@ -122,6 +124,7 @@ public class StrimziUpgradeST extends AbstractST {
     }
 
     @Test
+    @Tag(INTERNAL_CLIENTS_USED)
     void testChainUpgrade() throws Exception {
         ClassLoader classLoader = getClass().getClassLoader();
         InputStream inputStream = classLoader.getResourceAsStream("StrimziUpgradeST.json");

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
@@ -38,6 +38,7 @@ import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECTOR_OPERATOR;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.CONNECT_S2I;
+import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -82,6 +83,7 @@ class AllNamespaceST extends AbstractNamespaceST {
      * Test the case when MirrorMaker will be deployed in different namespace than CO when CO watches all namespaces
      */
     @Test
+    @Tag(MIRROR_MAKER)
     void testDeployMirrorMakerAcrossMultipleNamespace() {
         LOGGER.info("Deploying KafkaMirrorMaker in different namespace than CO when CO watches all namespaces");
         checkMirrorMakerForKafkaInDifNamespaceThanCO(SECOND_CLUSTER_NAME);

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
@@ -17,6 +17,7 @@ import io.strimzi.systemtest.resources.crd.KafkaResource;
 import java.util.Arrays;
 import java.util.List;
 
+import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
@@ -55,6 +56,7 @@ class MultipleNamespaceST extends AbstractNamespaceST {
      * Test the case when MirrorMaker will be deployed in different namespace across multiple namespaces
      */
     @Test
+    @Tag(MIRROR_MAKER)
     void testDeployMirrorMakerAcrossMultipleNamespace() {
         LOGGER.info("Deploying KafkaMirrorMaker in different namespace than CO when CO watches multiple namespaces");
         checkMirrorMakerForKafkaInDifNamespaceThanCO(CLUSTER_NAME);


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- "Bugfix"

### Description

In some cases we didn't added tags for all stuff that we are using in our tests, this PR gonna add them to all tests. I added tags: `SCALE` -> tests where resource is scaled up/down
`ROLLING_UPDATE` -> tests where RU is triggered
`NO_ROLLING_UPDATE` -> tests where RU should not trigger
`OLM` -> tests where is OLM used for deploying the CO

Also I updated documentation (`TESTING.md`)

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation

