### PR TITLE
Add longer timeout option for CC STs

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -52,9 +52,9 @@ public class KafkaUtils {
         ResourceManager.waitForResourceStatus(KafkaResource.kafkaClient(), kafka, state);
     }
 
-    public static void waitUntilKafkaStatusConditionContainsMessage(String clusterName, String namespace, String message) {
-        TestUtils.waitFor("Kafka status contains exception with non-existing secret name",
-            Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
+    public static void waitUntilKafkaStatusConditionContainsMessage(String clusterName, String namespace, String message, long timeout) {
+        TestUtils.waitFor("Kafka Status with message [" + message + "]",
+            Constants.GLOBAL_POLL_INTERVAL, timeout, () -> {
                 List<Condition> conditions = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get().getStatus().getConditions();
                 for (Condition condition : conditions) {
                     if (condition.getMessage().matches(message)) {
@@ -63,6 +63,10 @@ public class KafkaUtils {
                 }
                 return false;
             });
+    }
+
+    public static void waitUntilKafkaStatusConditionContainsMessage(String clusterName, String namespace, String message) {
+        waitUntilKafkaStatusConditionContainsMessage(clusterName, namespace, message, Constants.GLOBAL_STATUS_TIMEOUT);
     }
 
     public static void waitForZkMntr(String clusterName, Pattern pattern, int... podIndexes) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -108,7 +110,7 @@ public class CruiseControlIsolatedST extends AbstractST {
 
         LOGGER.info("Deploying single node Kafka with CruiseControl");
         KafkaResource.kafkaWithCruiseControlWithoutWait(CLUSTER_NAME, 1, 1);
-        KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(CLUSTER_NAME, NAMESPACE, errMessage);
+        KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(CLUSTER_NAME, NAMESPACE, errMessage, Duration.ofMinutes(6).toMillis());
 
         KafkaStatus kafkaStatus = KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
 


### PR DESCRIPTION
### Type of change

Refactoring

### Description

It seems that in most environments the `CruiseControlIsolatedST.testCruiseControlWithSingleNodeKafka` test requires slightly more that the default 3 mins to return a result and so fails with a timeout error.

This PR adds a timeout option to the system test util method which waits for Kafka status message and extends the timeout of CC ST mentioned above to ensure it can complete without error.

It also makes the error message for the status condition message checker more generic as it currently refers to "secrets"?

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally