### PR TITLE
[systemtest] Support changing the replica movement strategy

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -250,4 +250,13 @@ public interface Constants {
      * Tag for tests where OLM is used for deploying CO
      */
     String OLM = "olm";
+
+    /**
+     * Cruise Control related parameters
+     */
+    String CRUISE_CONTROL_NAME = "Cruise Control";
+    String CRUISE_CONTROL_CONTAINER_NAME = "cruise-control";
+    String CRUISE_CONTROL_CONFIGURATION_ENV = "CRUISE_CONTROL_CONFIGURATION";
+    String CRUISE_CONTROL_CAPACITY_FILE_PATH = "/tmp/capacity.json";
+    String CRUISE_CONTROL_CONFIGURATION_FILE_PATH = "/tmp/cruisecontrol.properties";
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -72,12 +72,11 @@ public abstract class AbstractST implements TestSeparator {
     }
 
     protected KubeClusterResource cluster = KubeClusterResource.getInstance();
+    protected static TimeMeasuringSystem timeMeasuringSystem = TimeMeasuringSystem.getInstance();
+    private static final Logger LOGGER = LogManager.getLogger(AbstractST.class);
+
     protected static final String CLUSTER_NAME = "my-cluster";
     protected static final String KAFKA_CLIENTS_NAME = CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS;
-
-    protected static TimeMeasuringSystem timeMeasuringSystem = TimeMeasuringSystem.getInstance();
-
-    private static final Logger LOGGER = LogManager.getLogger(AbstractST.class);
     protected static final String KAFKA_IMAGE_MAP = "STRIMZI_KAFKA_IMAGES";
     protected static final String KAFKA_CONNECT_IMAGE_MAP = "STRIMZI_KAFKA_CONNECT_IMAGES";
     protected static final String KAFKA_MIRROR_MAKER_2_IMAGE_MAP = "STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES";
@@ -86,13 +85,7 @@ public abstract class AbstractST implements TestSeparator {
     protected static final String KAFKA_INIT_IMAGE = "STRIMZI_DEFAULT_KAFKA_INIT_IMAGE";
     protected static final String TLS_SIDECAR_EO_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE";
     protected static final String TEST_TOPIC_NAME = "test-topic";
-
-    protected static final String CRUISE_CONTROL_NAME = "Cruise Control";
-    protected static final String CRUISE_CONTROL_POD_PREFIX = CLUSTER_NAME + "-cruise-control-";
-    protected static final String CRUISE_CONTROL_CONTAINER_NAME = "cruise-control";
-    protected static final String CRUISE_CONTROL_CONFIGURATION_ENV = "CRUISE_CONTROL_CONFIGURATION";
-    protected static final String CRUISE_CONTROL_CAPACITY_FILE_PATH = "/tmp/capacity.json";
-    protected static final String CRUISE_CONTROL_CONFIGURATION_FILE_PATH = "/tmp/cruisecontrol.properties";
+    public static final String CRUISE_CONTROL_POD_PREFIX = CLUSTER_NAME + "-cruise-control-";
 
     protected String testClass;
     protected String testName;

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -87,6 +87,13 @@ public abstract class AbstractST implements TestSeparator {
     protected static final String TLS_SIDECAR_EO_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE";
     protected static final String TEST_TOPIC_NAME = "test-topic";
 
+    protected static final String CRUISE_CONTROL_NAME = "Cruise Control";
+    protected static final String CRUISE_CONTROL_POD_PREFIX = CLUSTER_NAME + "-cruise-control-";
+    protected static final String CRUISE_CONTROL_CONTAINER_NAME = "cruise-control";
+    protected static final String CRUISE_CONTROL_CONFIGURATION_ENV = "CRUISE_CONTROL_CONFIGURATION";
+    protected static final String CRUISE_CONTROL_CAPACITY_FILE_PATH = "/tmp/capacity.json";
+    protected static final String CRUISE_CONTROL_CONFIGURATION_FILE_PATH = "/tmp/cruisecontrol.properties";
+
     protected String testClass;
     protected String testName;
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.CruiseControlSpecBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters;
 import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
@@ -67,10 +68,10 @@ public class CruiseControlConfigurationST extends AbstractST {
     @Test
     void testCapacityFile() {
 
-        String cruiseControlPodName = kubeClient().listPodsByPrefixInName(CRUISE_CONTROL_POD_PREFIX).get(0).getMetadata().getName();
+        String cruiseControlPodName = kubeClient().listPodsByPrefixInName(AbstractST.CRUISE_CONTROL_POD_PREFIX).get(0).getMetadata().getName();
 
         JsonObject cruiseControlCapacityFileContent =
-            new JsonObject(cmdKubeClient().execInPod(cruiseControlPodName, "/bin/bash", "-c", "cat " + CRUISE_CONTROL_CAPACITY_FILE_PATH).out());
+            new JsonObject(cmdKubeClient().execInPod(cruiseControlPodName, "/bin/bash", "-c", "cat " + Constants.CRUISE_CONTROL_CAPACITY_FILE_PATH).out());
 
         assertThat(cruiseControlCapacityFileContent.getJsonArray("brokerCapacities"), not(nullValue()));
 
@@ -107,11 +108,11 @@ public class CruiseControlConfigurationST extends AbstractST {
 
         StatefulSetUtils.waitTillSsHasRolled(kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaPods);
 
-        LOGGER.info("Verifying that in {} is not present in the Kafka cluster", CRUISE_CONTROL_NAME);
+        LOGGER.info("Verifying that in {} is not present in the Kafka cluster", Constants.CRUISE_CONTROL_NAME);
         assertThat(KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getSpec().getCruiseControl(), nullValue());
 
-        LOGGER.info("Verifying that {} pod is not present", CRUISE_CONTROL_POD_PREFIX);
-        PodUtils.waitUntilPodStabilityReplicasCount(CRUISE_CONTROL_POD_PREFIX, 0);
+        LOGGER.info("Verifying that {} pod is not present", AbstractST.CRUISE_CONTROL_POD_PREFIX);
+        PodUtils.waitUntilPodStabilityReplicasCount(AbstractST.CRUISE_CONTROL_POD_PREFIX, 0);
 
         LOGGER.info("Verifying that in Kafka config map there is no configuration to cruise control metric reporter");
         assertThrows(WaitException.class, () -> CruiseControlUtils.verifyCruiseControlMetricReporterConfigurationInKafkaConfigMapIsPresent(CruiseControlUtils.getKafkaCruiseControlMetricsReporterConfiguration(CLUSTER_NAME)));
@@ -131,7 +132,7 @@ public class CruiseControlConfigurationST extends AbstractST {
         LOGGER.info("Verifying that in Kafka config map there is configuration to cruise control metric reporter");
         CruiseControlUtils.verifyCruiseControlMetricReporterConfigurationInKafkaConfigMapIsPresent(CruiseControlUtils.getKafkaCruiseControlMetricsReporterConfiguration(CLUSTER_NAME));
 
-        LOGGER.info("Verifying that {} topics are created after CC is instantiated.", CRUISE_CONTROL_NAME);
+        LOGGER.info("Verifying that {} topics are created after CC is instantiated.", Constants.CRUISE_CONTROL_NAME);
 
         CruiseControlUtils.verifyThatCruiseControlTopicsArePresent();
     }
@@ -174,11 +175,11 @@ public class CruiseControlConfigurationST extends AbstractST {
     @Test
     void testConfigurationReflection() throws IOException {
 
-        Pod cruiseControlPod = kubeClient().listPodsByPrefixInName(CRUISE_CONTROL_POD_PREFIX).get(0);
+        Pod cruiseControlPod = kubeClient().listPodsByPrefixInName(AbstractST.CRUISE_CONTROL_POD_PREFIX).get(0);
 
         String cruiseControlPodName = cruiseControlPod.getMetadata().getName();
 
-        String configurationFileContent = cmdKubeClient().execInPod(cruiseControlPodName, "/bin/bash", "-c", "cat " + CRUISE_CONTROL_CONFIGURATION_FILE_PATH).out();
+        String configurationFileContent = cmdKubeClient().execInPod(cruiseControlPodName, "/bin/bash", "-c", "cat " + Constants.CRUISE_CONTROL_CONFIGURATION_FILE_PATH).out();
 
         InputStream configurationFileStream = new ByteArrayInputStream(configurationFileContent.getBytes(StandardCharsets.UTF_8));
 
@@ -196,7 +197,7 @@ public class CruiseControlConfigurationST extends AbstractST {
         EnvVar cruiseControlConfiguration = null;
 
         for (EnvVar envVar : Objects.requireNonNull(cruiseControlContainer).getEnv()) {
-            if (envVar.getName().equals(CRUISE_CONTROL_CONFIGURATION_ENV)) {
+            if (envVar.getName().equals(Constants.CRUISE_CONTROL_CONFIGURATION_ENV)) {
                 cruiseControlConfiguration = envVar;
             }
         }
@@ -206,7 +207,7 @@ public class CruiseControlConfigurationST extends AbstractST {
         Properties containerConfiguration = new Properties();
         containerConfiguration.load(configurationContainerStream);
 
-        LOGGER.info("Verifying that all configuration in the cruise control container matching the cruise control file {} properties", CRUISE_CONTROL_CONFIGURATION_FILE_PATH);
+        LOGGER.info("Verifying that all configuration in the cruise control container matching the cruise control file {} properties", Constants.CRUISE_CONTROL_CONFIGURATION_FILE_PATH);
         List<String> checkCCProperties = Arrays.asList(
                 CruiseControlConfigurationParameters.PARTITION_METRICS_WINDOWS.getName(),
                 CruiseControlConfigurationParameters.PARTITION_METRICS_WINDOW_MS.getName(),
@@ -224,9 +225,9 @@ public class CruiseControlConfigurationST extends AbstractST {
     @Order(5)
     @Test
     void testConfigurationFileIsCreated() {
-        String cruiseControlPodName = kubeClient().listPodsByPrefixInName(CRUISE_CONTROL_POD_PREFIX).get(0).getMetadata().getName();
+        String cruiseControlPodName = kubeClient().listPodsByPrefixInName(AbstractST.CRUISE_CONTROL_POD_PREFIX).get(0).getMetadata().getName();
 
-        String cruiseControlConfigurationFileContent = cmdKubeClient().execInPod(cruiseControlPodName, "/bin/bash", "-c", "cat " + CRUISE_CONTROL_CONFIGURATION_FILE_PATH).out();
+        String cruiseControlConfigurationFileContent = cmdKubeClient().execInPod(cruiseControlPodName, "/bin/bash", "-c", "cat " + Constants.CRUISE_CONTROL_CONFIGURATION_FILE_PATH).out();
 
         assertThat(cruiseControlConfigurationFileContent, not(nullValue()));
     }
@@ -260,15 +261,15 @@ public class CruiseControlConfigurationST extends AbstractST {
         StatefulSetUtils.waitForNoRollingUpdate(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), kafkaSnapShot);
 
         LOGGER.info("Verifying new configuration in the Kafka CR");
-        Pod cruiseControlPod = kubeClient().listPodsByPrefixInName(CRUISE_CONTROL_POD_PREFIX).get(0);
+        Pod cruiseControlPod = kubeClient().listPodsByPrefixInName(AbstractST.CRUISE_CONTROL_POD_PREFIX).get(0);
 
         // Get CruiseControl resource properties
         cruiseControlContainer = cruiseControlPod.getSpec().getContainers().stream()
-                .filter(container -> container.getName().equals(CRUISE_CONTROL_CONTAINER_NAME))
+                .filter(container -> container.getName().equals(Constants.CRUISE_CONTROL_CONTAINER_NAME))
                 .findFirst().orElse(null);
 
         cruiseControlConfiguration = Objects.requireNonNull(cruiseControlContainer).getEnv().stream()
-                .filter(envVar -> envVar.getName().equals(CRUISE_CONTROL_CONFIGURATION_ENV))
+                .filter(envVar -> envVar.getName().equals(Constants.CRUISE_CONTROL_CONFIGURATION_ENV))
                 .findFirst().orElse(null);
 
         InputStream configurationContainerStream = new ByteArrayInputStream(

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -63,14 +63,6 @@ public class CruiseControlConfigurationST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(CruiseControlConfigurationST.class);
     private static final String NAMESPACE = "cruise-control-configuration-test";
 
-    private static final String CRUISE_CONTROL_NAME = "Cruise Control";
-    private static final String CRUISE_CONTROL_POD_PREFIX = CLUSTER_NAME + "-cruise-control-";
-    private static final String CRUISE_CONTROL_CONTAINER_NAME = "cruise-control";
-    private static final String CRUISE_CONTROL_CONFIGURATION_ENV = "CRUISE_CONTROL_CONFIGURATION";
-
-    private static final String CRUISE_CONTROL_CAPACITY_FILE_PATH = "/tmp/capacity.json";
-    private static final String CRUISE_CONTROL_CONFIGURATION_FILE_PATH = "/tmp/cruisecontrol.properties";
-
     @Order(1)
     @Test
     void testCapacityFile() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.cruisecontrol;
 
+import io.strimzi.api.kafka.model.CruiseControlResources;
 import io.strimzi.api.kafka.model.KafkaTopicSpec;
 import io.strimzi.api.kafka.model.status.KafkaRebalanceStatus;
 import io.strimzi.api.kafka.model.status.KafkaStatus;
@@ -11,11 +12,13 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceAnnotation;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaRebalanceUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -23,11 +26,16 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
+import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -151,6 +159,44 @@ public class CruiseControlIsolatedST extends AbstractST {
 
         KafkaRebalanceUtils.annotateKafkaRebalanceResource(CLUSTER_NAME, KafkaRebalanceAnnotation.approve);
         KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(CLUSTER_NAME, KafkaRebalanceState.Ready);
+    }
+
+    @Test
+    void testCruiseControlReplicaMovementStrategy() {
+        final String replicaMovementStrategies = "default.replica.movement.strategies";
+        String newReplicaMovementStrategies = "com.linkedin.kafka.cruisecontrol.executor.strategy.PrioritizeSmallReplicaMovementStrategy," +
+                "com.linkedin.kafka.cruisecontrol.executor.strategy.PrioritizeLargeReplicaMovementStrategy," +
+                "com.linkedin.kafka.cruisecontrol.executor.strategy.PostponeUrpReplicaMovementStrategy";
+
+        KafkaResource.kafkaWithCruiseControl(CLUSTER_NAME, 3, 3).done();
+        KafkaClientsResource.deployKafkaClients(KAFKA_CLIENTS_NAME).done();
+
+        String ccPodName = kubeClient().listPodsByPrefixInName(CruiseControlResources.deploymentName(CLUSTER_NAME)).get(0).getMetadata().getName();
+
+        LOGGER.info("Check for default CruiseControl replicaMovementStrategy in pod configuration file.");
+        Map<String, Object> actualStrategies = KafkaResource.kafkaClient().inNamespace(NAMESPACE)
+                .withName(CLUSTER_NAME).get().getSpec().getCruiseControl().getConfig();
+        assertThat(actualStrategies, anEmptyMap());
+
+        String ccConfFileContent = cmdKubeClient().execInPodContainer(ccPodName, CRUISE_CONTROL_CONTAINER_NAME, "cat", CRUISE_CONTROL_CONFIGURATION_FILE_PATH).out();
+        assertThat(ccConfFileContent, not(containsString(replicaMovementStrategies)));
+
+        Map<String, String> kafkaRebalanceSnapshot = DeploymentUtils.depSnapshot(CruiseControlResources.deploymentName(CLUSTER_NAME));
+
+        Map<String, Object> ccConfigMap = new HashMap<>();
+        ccConfigMap.put(replicaMovementStrategies, newReplicaMovementStrategies);
+
+        KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka -> {
+            LOGGER.info("Set non-default CruiseControl replicaMovementStrategies to KafkaRebalance resource.");
+            kafka.getSpec().getCruiseControl().setConfig(ccConfigMap);
+        });
+
+        LOGGER.info("Verifying that CC pod is rolling, because of change size of disk");
+        DeploymentUtils.waitTillDepHasRolled(CruiseControlResources.deploymentName(CLUSTER_NAME), 1, kafkaRebalanceSnapshot);
+
+        ccPodName = kubeClient().listPodsByPrefixInName(CruiseControlResources.deploymentName(CLUSTER_NAME)).get(0).getMetadata().getName();
+        ccConfFileContent = cmdKubeClient().execInPodContainer(ccPodName, CRUISE_CONTROL_CONTAINER_NAME, "cat", CRUISE_CONTROL_CONFIGURATION_FILE_PATH).out();
+        assertThat(ccConfFileContent, containsString(newReplicaMovementStrategies));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.status.KafkaStatus;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceAnnotation;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
+import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
@@ -178,7 +179,7 @@ public class CruiseControlIsolatedST extends AbstractST {
                 .withName(CLUSTER_NAME).get().getSpec().getCruiseControl().getConfig();
         assertThat(actualStrategies, anEmptyMap());
 
-        String ccConfFileContent = cmdKubeClient().execInPodContainer(ccPodName, CRUISE_CONTROL_CONTAINER_NAME, "cat", CRUISE_CONTROL_CONFIGURATION_FILE_PATH).out();
+        String ccConfFileContent = cmdKubeClient().execInPodContainer(ccPodName, Constants.CRUISE_CONTROL_CONTAINER_NAME, "cat", Constants.CRUISE_CONTROL_CONFIGURATION_FILE_PATH).out();
         assertThat(ccConfFileContent, not(containsString(replicaMovementStrategies)));
 
         Map<String, String> kafkaRebalanceSnapshot = DeploymentUtils.depSnapshot(CruiseControlResources.deploymentName(CLUSTER_NAME));
@@ -195,7 +196,7 @@ public class CruiseControlIsolatedST extends AbstractST {
         DeploymentUtils.waitTillDepHasRolled(CruiseControlResources.deploymentName(CLUSTER_NAME), 1, kafkaRebalanceSnapshot);
 
         ccPodName = kubeClient().listPodsByPrefixInName(CruiseControlResources.deploymentName(CLUSTER_NAME)).get(0).getMetadata().getName();
-        ccConfFileContent = cmdKubeClient().execInPodContainer(ccPodName, CRUISE_CONTROL_CONTAINER_NAME, "cat", CRUISE_CONTROL_CONFIGURATION_FILE_PATH).out();
+        ccConfFileContent = cmdKubeClient().execInPodContainer(ccPodName, Constants.CRUISE_CONTROL_CONTAINER_NAME, "cat", Constants.CRUISE_CONTROL_CONFIGURATION_FILE_PATH).out();
         assertThat(ccConfFileContent, containsString(newReplicaMovementStrategies));
     }
 


### PR DESCRIPTION
This is additional work after pull/3368

Signed-off-by: Michal Tóth <mtoth@redhat.com>

### Tests for CruiseControl ReplicaMovementStrategy

- Tests

### Description

Test checks presence of available strategies for replica movement.
This is additional work after https://github.com/strimzi/strimzi-kafka-operator/pull/3368/

### Checklist

- [x] Write tests
- [x] Make sure all tests pass