### PR TITLE
[systemtest] Fix tests failing on ocp4.x

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -374,7 +374,7 @@ public class Crds {
         }
     }
 
-    public static int getCrdsCount() {
+    public static int getNumCrds() {
         return CRDS.length;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -373,4 +373,8 @@ public class Crds {
             throw new RuntimeException(e);
         }
     }
+
+    public static int getCrdsCount() {
+        return CRDS.length;
+    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -423,7 +423,7 @@ public abstract class AbstractST implements TestSeparator {
         LOGGER.info("Verifying labels for CRDs");
         String crds = cmdKubeClient().exec("get", "crds", "--selector=app=strimzi", "-o", "jsonpath='{.items[*].metadata.name}'").out();
         crds = crds.replace(" ", "\n").trim();
-        assertThat(crds.split("\n").length, is(Crds.getCrdsCount()));
+        assertThat(crds.split("\n").length, is(Crds.getNumCrds()));
 
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -421,12 +421,10 @@ public abstract class AbstractST implements TestSeparator {
 
     void verifyLabelsForCRDs() {
         LOGGER.info("Verifying labels for CRDs");
-        kubeClient().listCustomResourceDefinition().stream()
-            .filter(crd -> crd.getMetadata().getName().startsWith("kafka"))
-            .forEach(crd -> {
-                LOGGER.info("Verifying labels for custom resource {}", crd.getMetadata().getName());
-                assertThat(crd.getMetadata().getLabels().get("app"), is("strimzi"));
-            });
+        String crds = cmdKubeClient().exec("get", "crds", "--selector=app=strimzi", "-o", "jsonpath='{.items[*].metadata.name}'").out();
+        crds = crds.replace(" ", "\n").trim();
+        assertThat(crds.split("\n").length, is(Crds.getCrdsCount()));
+
     }
 
     void verifyLabelsForKafkaAndZKServices(String clusterName, String appName) {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes `testDeployKafkaClusterViaTemplate` where the `client.customResourceDefinitions().list().getItems()` throws exception about k8s list. It seems like there is some problem with Fabric8 version (this will be hopefully fixed by @stanlyDoge). So I made a small workaround to get number of CRDs that contains label `app=strimzi` -> for this I needed the exact number of CRDs that we are applying -> so for this I created the `getCrdsCount()` method.

The `testDeployKafkaClusterViaTemplate` affected these two tests: `testLabelsAndAnnotationForPVC` and `testEODeletion`.


### Checklist

- [ ] Make sure all tests pass

