### PR TITLE
KafkaRoller: Common Admin client, and always check canRoll

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -654,6 +654,7 @@ public class KafkaRoller {
      * @return A future which completes the the node id of the controller of the cluster,
      * or -1 if there is not currently a controller.
      */
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE") // seems to be completely spurious
     int controller(int podId, long timeout, TimeUnit unit, RestartContext restartContext) throws Exception {
         // Don't use all allClient here, because it will have cache metadata about which is the controller.
         try (Admin ac = adminClient(singletonList(podId), true)) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -657,7 +657,7 @@ public class KafkaRoller {
     @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE") // seems to be completely spurious
     int controller(int podId, long timeout, TimeUnit unit, RestartContext restartContext) throws Exception {
         // Don't use all allClient here, because it will have cache metadata about which is the controller.
-        try (Admin ac = adminClient(singletonList(podId), true)) {
+        try (Admin ac = adminClient(singletonList(podId), false)) {
             Node controllerNode = null;
             try {
                 DescribeClusterResult describeClusterResult = ac.describeCluster();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -661,9 +661,7 @@ public class KafkaRoller {
                 KafkaFuture<Node> controller = describeClusterResult.controller();
                 controllerNode = controller.get(timeout, unit);
                 restartContext.clearConnectionError();
-            } catch (ExecutionException e) {
-                maybeTcpProbe(podId, e, restartContext);
-            } catch (TimeoutException e) {
+            } catch (ExecutionException | TimeoutException e) {
                 maybeTcpProbe(podId, e, restartContext);
             }
             int id = controllerNode == null || Node.noNode().equals(controllerNode) ? -1 : controllerNode.id();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -350,10 +350,10 @@ public class KafkaRoller {
         } catch (ForceableProblem e) {
             if (restartContext.backOff.done() || e.forceNow) {
                 if (canRoll(podId, 60_000, TimeUnit.MILLISECONDS, true)) {
-                    log.warn("{}: Pod {} will be force-rolled", reconciliation, podName(podId));
+                    log.warn("{}: Pod {} will be force-rolled, due to error: {}", reconciliation, podName(podId), e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
                     restartAndAwaitReadiness(pod, operationTimeoutMs, TimeUnit.MILLISECONDS);
                 } else {
-                    log.warn("{}: Pod {} can't be force-rolled", reconciliation, podName(podId));
+                    log.warn("{}: Pod {} can't be safely force-rolled; original error: ", reconciliation, podName(podId), e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
                     throw e;
                 }
             } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -424,8 +424,10 @@ public class KafkaRoller {
         } catch (ForceableProblem e) {
             if (restartContext.backOff.done()) {
                 needsRestart = true;
+                brokerConfig = null;
+            } else {
+                throw e;
             }
-            brokerConfig = null;
         }
         if (!needsRestart) {
             log.trace("{}: Broker {}: description {}", reconciliation, podId, brokerConfig);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -612,7 +612,7 @@ public class ResourceUtils {
     public static AdminClientProvider adminClientProvider() {
         return new AdminClientProvider() {
             @Override
-            public Admin createAdminClient(String hostname, Secret clusterCaCertSecret, Secret keyCertSecret, String keyCertName) {
+            public Admin createAdminClient(String bootstrapHostnames, Secret clusterCaCertSecret, Secret keyCertSecret, String keyCertName) {
                 Admin mock = mock(AdminClient.class);
                 DescribeClusterResult dcr;
                 try {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -92,7 +92,7 @@ public class KafkaRollerTest {
         return "ns";
     }
 
-    private static <E extends Throwable> Function<Integer, E> noException() {
+    private static <X, E extends Throwable> Function<X, E> noException() {
         return podId -> null;
     }
 
@@ -225,7 +225,7 @@ public class KafkaRollerTest {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
         StatefulSet sts = buildStatefulSet();
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(sts, null, null, podOps,
-            null, null,
+                noException(), null,
             podId -> new RuntimeException("Test Exception"), noException(), noException(),
             brokerId -> succeededFuture(true),
             2);
@@ -241,7 +241,7 @@ public class KafkaRollerTest {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
         StatefulSet sts = buildStatefulSet();
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(sts, null, null, podOps,
-            null,
+            noException(),
             new RuntimeException("Test Exception"), noException(), noException(), noException(),
             brokerId -> succeededFuture(true),
             2);
@@ -258,7 +258,7 @@ public class KafkaRollerTest {
         StatefulSet sts = buildStatefulSet();
         AtomicInteger count = new AtomicInteger(3);
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(sts, null, null, podOps,
-            null, null, noException(), noException(), noException(),
+                noException(), null, noException(), noException(), noException(),
             brokerId ->
                     brokerId == 1 ? succeededFuture(count.getAndDecrement() == 0)
                             : succeededFuture(true),
@@ -276,7 +276,7 @@ public class KafkaRollerTest {
         StatefulSet sts = buildStatefulSet();
         AtomicInteger count = new AtomicInteger(2);
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(sts, null, null, podOps,
-            null, null, noException(), noException(), noException(),
+                noException(), null, noException(), noException(), noException(),
             brokerId -> {
                 if (brokerId == 2) {
                     boolean b = count.getAndDecrement() == 0;
@@ -297,7 +297,7 @@ public class KafkaRollerTest {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
         StatefulSet sts = buildStatefulSet();
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(sts, null, null, podOps,
-            null, null, noException(), noException(), noException(),
+                noException(), null, noException(), noException(), noException(),
             brokerId ->
                     brokerId == 1 ? succeededFuture(false)
                             : succeededFuture(true),
@@ -309,7 +309,7 @@ public class KafkaRollerTest {
                 asList(0, 3, 4, 2));
         // TODO assert subsequent rolls
         kafkaRoller = new TestingKafkaRoller(sts, null, null, podOps,
-            null, null, noException(), noException(), noException(),
+                noException(), null, noException(), noException(), noException(),
             brokerId -> succeededFuture(brokerId != 1),
             2);
         clearRestarted();
@@ -326,7 +326,7 @@ public class KafkaRollerTest {
         StatefulSet sts = buildStatefulSet();
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(sts, null, null,
                 podOps,
-            null, null, noException(), noException(), noException(),
+                noException(), null, noException(), noException(), noException(),
             brokerId ->
                     brokerId == 2 ? succeededFuture(false)
                             : succeededFuture(true),
@@ -339,7 +339,7 @@ public class KafkaRollerTest {
         clearRestarted();
         kafkaRoller = new TestingKafkaRoller(sts, null, null,
             podOps,
-            null, null, noException(), noException(), noException(),
+                noException(), null, noException(), noException(), noException(),
             brokerId -> succeededFuture(brokerId != 2),
             2);
         doFailingRollingRestart(testContext, kafkaRoller,
@@ -354,7 +354,7 @@ public class KafkaRollerTest {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
         StatefulSet sts = buildStatefulSet();
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(sts, null, null, podOps,
-                null, null,
+                noException(), null,
                 noException(), noException(), podId -> podId == 1 ? new KafkaRoller.ForceableProblem("could not get config exception") : null,
             brokerId -> succeededFuture(true), 2);
         // The algorithm should carry on rolling the pods
@@ -368,7 +368,7 @@ public class KafkaRollerTest {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
         StatefulSet sts = buildStatefulSet();
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(sts, null, null, podOps,
-                null, null,
+                noException(), null,
                 noException(), podId -> new KafkaRoller.ForceableProblem("could not get alter exception"), noException(),
             brokerId -> succeededFuture(true), 2);
         // The algorithm should carry on rolling the pods
@@ -382,7 +382,7 @@ public class KafkaRollerTest {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
         StatefulSet sts = buildStatefulSet();
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(sts, null, null, podOps,
-                null, null,
+                noException(), null,
                 noException(), noException(), noException(),
             brokerId -> succeededFuture(true), 2);
         // The algorithm should carry on rolling the pods
@@ -392,7 +392,7 @@ public class KafkaRollerTest {
 
     private TestingKafkaRoller rollerWithControllers(StatefulSet sts, PodOperator podOps, int... controllers) {
         return new TestingKafkaRoller(sts, null, null, podOps,
-            null, null, noException(), noException(), noException(),
+                noException(), null, noException(), noException(), noException(),
             brokerId -> succeededFuture(true),
             controllers);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -654,7 +654,7 @@ public class KafkaRollerTest {
         }
 
         @Override
-        protected Config brokerConfig(Admin ac, int brokerId) throws ForceableProblem, InterruptedException {
+        protected Config brokerConfig(int brokerId) throws ForceableProblem, InterruptedException {
             ForceableProblem problem = getConfigsException.apply(brokerId);
             if (problem != null) {
                 throw problem;
@@ -662,9 +662,15 @@ public class KafkaRollerTest {
         }
 
         @Override
+        protected Config brokerLogging(int brokerId) throws ForceableProblem, InterruptedException {
+            return new Config(emptyList());
+        }
+
+        @Override
         protected void dynamicUpdateBrokerConfig(int podId, Admin ac, KafkaBrokerConfigurationDiff configurationDiff, KafkaBrokerLoggingConfigurationDiff logDiff) throws ForceableProblem, InterruptedException {
             ForceableProblem problem = alterConfigsException.apply(podId);
             if (problem != null) {
+                throw problem;
             }
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -429,18 +429,16 @@ public class KafkaRollerTest {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
         StatefulSet sts = buildStatefulSet();
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(sts, null, null,
-                podOps,
-                noException(), null, noException(), noException(), noException(),
-                brokerId -> brokerId == 2 || brokerId == 3 ? succeededFuture(false) : succeededFuture(true),
-                2);
+            podOps,
+            noException(), null, noException(), noException(), noException(),
+            brokerId -> brokerId == 2 || brokerId == 3 ? succeededFuture(false) : succeededFuture(true),
+            2);
         doFailingRollingRestart(testContext, kafkaRoller,
-                asList(0, 1, 2, 3, 4),
-                KafkaRoller.ForceableProblem.class, "Pod c-kafka-2 is currently the controller and there are other pods still to roll",
-                // We expect all non-controller pods to be rolled
-                asList(0, 1, 4));
+            asList(0, 1, 2, 3, 4),
+            KafkaRoller.ForceableProblem.class, "Pod c-kafka-2 is currently the controller and there are other pods still to roll",
+            // We expect all non-controller pods to be rolled
+            asList(0, 1, 4));
     }
-
-
 
     private TestingKafkaRoller rollerWithControllers(StatefulSet sts, PodOperator podOps, int... controllers) {
         return new TestingKafkaRoller(sts, null, null, podOps,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -424,6 +424,24 @@ public class KafkaRollerTest {
                 emptyList());
     }
 
+    @Test
+    public void testControllerAndOneMoreNeverRollable(VertxTestContext testContext) throws InterruptedException {
+        PodOperator podOps = mockPodOps(podId -> succeededFuture());
+        StatefulSet sts = buildStatefulSet();
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(sts, null, null,
+                podOps,
+                noException(), null, noException(), noException(), noException(),
+                brokerId -> brokerId == 2 || brokerId == 3 ? succeededFuture(false) : succeededFuture(true),
+                2);
+        doFailingRollingRestart(testContext, kafkaRoller,
+                asList(0, 1, 2, 3, 4),
+                KafkaRoller.ForceableProblem.class, "Pod c-kafka-2 is currently the controller and there are other pods still to roll",
+                // We expect all non-controller pods to be rolled
+                asList(0, 1, 4));
+    }
+
+
+
     private TestingKafkaRoller rollerWithControllers(StatefulSet sts, PodOperator podOps, int... controllers) {
         return new TestingKafkaRoller(sts, null, null, podOps,
                 noException(), null, noException(), noException(), noException(),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -244,10 +244,10 @@ public class KafkaRollerTest {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
         StatefulSet sts = buildStatefulSet();
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(sts, null, null, podOps,
-                noException(), null,
-                podId -> podId == controller ? new RuntimeException("Test Exception") : null, noException(), noException(),
-                brokerId -> succeededFuture(true),
-                controller);
+            noException(), null,
+            podId -> podId == controller ? new RuntimeException("Test Exception") : null, noException(), noException(),
+            brokerId -> succeededFuture(true),
+            controller);
         // The algorithm should carry on rolling the pods (errors are logged),
         // because we never find the controller we get ascending order
         doSuccessfulRollingRestart(testContext, kafkaRoller,
@@ -388,9 +388,9 @@ public class KafkaRollerTest {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
         StatefulSet sts = buildStatefulSet();
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(sts, null, null, podOps,
-                noException(), null,
-                noException(), noException(), podId -> podId == controller ? new KafkaRoller.ForceableProblem("could not get config exception") : null,
-                brokerId -> succeededFuture(true), controller);
+            noException(), null,
+            noException(), noException(), podId -> podId == controller ? new KafkaRoller.ForceableProblem("could not get config exception") : null,
+            brokerId -> succeededFuture(true), controller);
         // The algorithm should carry on rolling the pods
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),

--- a/operator-common/src/main/java/io/strimzi/operator/common/AdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AdminClientProvider.java
@@ -15,11 +15,11 @@ public interface AdminClientProvider {
     /**
      * Create a Kafka Admin interface instance
      *
-     * @param hostname Kafka hostname to connect to for administration operations
+     * @param bootstrapHostnames Kafka hostname to connect to for administration operations
      * @param clusterCaCertSecret Secret containing the cluster CA certificate for TLS encryption
      * @param keyCertSecret Secret containing keystore for TLS client authentication
      * @param keyCertName Key inside the keyCertSecret for getting the keystore and the corresponding password
      * @return Instance of Kafka Admin interface
      */
-    Admin createAdminClient(String hostname, Secret clusterCaCertSecret, Secret keyCertSecret, String keyCertName);
+    Admin createAdminClient(String bootstrapHostnames, Secret clusterCaCertSecret, Secret keyCertSecret, String keyCertName);
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
@@ -42,7 +42,7 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
      * TLS encrypted connection and with TLS client authentication.
      */
     @Override
-    public Admin createAdminClient(String hostname, Secret clusterCaCertSecret, Secret keyCertSecret, String keyCertName) {
+    public Admin createAdminClient(String bootstrapHostnames, Secret clusterCaCertSecret, Secret keyCertSecret, String keyCertName) {
         Admin ac;
         String trustStorePassword = null;
         File truststoreFile = null;
@@ -64,7 +64,7 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
 
             try {
                 Properties p = new Properties();
-                p.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, hostname);
+                p.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapHostnames);
 
                 // configuring TLS encryption if requested
                 if (truststoreFile != null && trustStorePassword != null) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This is an alternative to #3534 which always checks `canRoll` before restarting. Unlike #3534 it doesn't treat the controller specially (or rather, only way the controller is special is that it's rolled last).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

