### PR TITLE
[systemtest] Fix for testDynamicallySetBridgeLoggingLevels

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -371,6 +371,9 @@ class LoggingChangeST extends AbstractST {
         ilOff.setLoggers(loggers);
 
         KafkaResource.kafkaPersistent(CLUSTER_NAME, 1, 1).done();
+
+        KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).done();
+
         KafkaBridgeResource.kafkaBridge(CLUSTER_NAME, KafkaResources.tlsBootstrapAddress(CLUSTER_NAME), 1)
                 .editSpec()
                     .withInlineLogging(ilOff)

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/AllNamespacesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/AllNamespacesST.java
@@ -13,11 +13,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import static io.strimzi.systemtest.Constants.BRIDGE;
-import static io.strimzi.systemtest.Constants.CONNECT;
-import static io.strimzi.systemtest.Constants.CONNECT_S2I;
-import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
-import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.OLM;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -45,35 +40,30 @@ public class AllNamespacesST extends OlmAbstractST {
     }
 
     @Test
-    @Tag(CONNECT)
     @Order(4)
     void testDeployExampleKafkaConnect() {
         doTestDeployExampleKafkaConnect();
     }
 
     @Test
-    @Tag(CONNECT_S2I)
     @Order(5)
     void testDeployExampleKafkaConnectS2I() {
         doTestDeployExampleKafkaConnectS2I();
     }
 
     @Test
-    @Tag(BRIDGE)
     @Order(6)
     void testDeployExampleKafkaBridge() {
         doTestDeployExampleKafkaBridge();
     }
 
     @Test
-    @Tag(MIRROR_MAKER)
     @Order(7)
     void testDeployExampleKafkaMirrorMaker() {
         doTestDeployExampleKafkaMirrorMaker();
     }
 
     @Test
-    @Tag(MIRROR_MAKER2)
     @Order(8)
     void testDeployExampleKafkaMirrorMaker2() {
         doTestDeployExampleKafkaMirrorMaker2();

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/SingleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/SingleNamespaceST.java
@@ -15,11 +15,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import static io.strimzi.systemtest.Constants.BRIDGE;
-import static io.strimzi.systemtest.Constants.CONNECT;
-import static io.strimzi.systemtest.Constants.CONNECT_S2I;
-import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
-import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.OLM;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -49,35 +44,30 @@ public class SingleNamespaceST extends OlmAbstractST {
     }
 
     @Test
-    @Tag(CONNECT)
     @Order(4)
     void testDeployExampleKafkaConnect() {
         doTestDeployExampleKafkaConnect();
     }
 
     @Test
-    @Tag(CONNECT_S2I)
     @Order(5)
     void testDeployExampleKafkaConnectS2I() {
         doTestDeployExampleKafkaConnectS2I();
     }
 
     @Test
-    @Tag(BRIDGE)
     @Order(6)
     void testDeployExampleKafkaBridge() {
         doTestDeployExampleKafkaBridge();
     }
 
     @Test
-    @Tag(MIRROR_MAKER)
     @Order(7)
     void testDeployExampleKafkaMirrorMaker() {
         doTestDeployExampleKafkaMirrorMaker();
     }
 
     @Test
-    @Tag(MIRROR_MAKER2)
     @Order(8)
     void testDeployExampleKafkaMirrorMaker2() {
         doTestDeployExampleKafkaMirrorMaker2();


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

After #3200 we have to deploy `KafkaClients` pod before deploying the `KafkaBridge` -> the `testDynamicallySetBridgeLoggingLevels` was failing because of that, so this PR fixes it.

### Checklist

- [ ] Make sure all tests pass

