### PR TITLE
[systemtest][upgrade] Attempt to deflake the upgrade tests and fix sending/receiving messages during upgrade

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/ClientArgument.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/ClientArgument.java
@@ -24,6 +24,7 @@ public enum ClientArgument {
 
     // Producer
     BOOTSTRAP_SERVER("--bootstrap-server"),
+    BROKER_LIST("--broker-list"),
     PRODUCER_CONFIG("--producer.config"),
     ACKS("--acks"),
     TIMEOUT("--timeout"),

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/VerifiableClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/VerifiableClient.java
@@ -128,17 +128,18 @@ public class VerifiableClient {
 
         this.setAllowedArguments(this.clientType);
         this.clientArgumentMap = new ClientArgumentMap();
-        this.clientArgumentMap.put(ClientArgument.BOOTSTRAP_SERVER, bootstrapServer);
         this.clientArgumentMap.put(ClientArgument.TOPIC, topicName);
         this.clientArgumentMap.put(ClientArgument.MAX_MESSAGES, Integer.toString(maxMessages));
         if (kafkaUsername != null) this.clientArgumentMap.put(ClientArgument.USER,  kafkaUsername.replace("-", "_"));
 
+        String image = kubeClient().getPod(this.podName).getSpec().getContainers().get(0).getImage();
+        String clientVersion = image.substring(image.length() - 5);
+
+        this.clientArgumentMap.put(allowParameter("2.5.0", clientVersion) ? ClientArgument.BOOTSTRAP_SERVER : ClientArgument.BROKER_LIST, bootstrapServer);
+
         if (clientType == ClientType.CLI_KAFKA_VERIFIABLE_CONSUMER) {
             this.consumerGroupName = verifiableClientBuilder.consumerGroupName;
             this.clientArgumentMap.put(ClientArgument.GROUP_ID, consumerGroupName);
-
-            String image = kubeClient().getPod(this.podName).getSpec().getContainers().get(0).getImage();
-            String clientVersion = image.substring(image.length() - 5);
 
             if (allowParameter("2.3.0", clientVersion)) {
                 this.consumerInstanceId = verifiableClientBuilder.consumerInstanceId;
@@ -299,6 +300,7 @@ public class VerifiableClient {
             case CLI_KAFKA_VERIFIABLE_PRODUCER:
                 allowedArguments.add(ClientArgument.TOPIC);
                 allowedArguments.add(ClientArgument.BOOTSTRAP_SERVER);
+                allowedArguments.add(ClientArgument.BROKER_LIST);
                 allowedArguments.add(ClientArgument.MAX_MESSAGES);
                 allowedArguments.add(ClientArgument.THROUGHPUT);
                 allowedArguments.add(ClientArgument.ACKS);
@@ -310,6 +312,7 @@ public class VerifiableClient {
                 break;
             case CLI_KAFKA_VERIFIABLE_CONSUMER:
                 allowedArguments.add(ClientArgument.BOOTSTRAP_SERVER);
+                allowedArguments.add(ClientArgument.BROKER_LIST);
                 allowedArguments.add(ClientArgument.TOPIC);
                 allowedArguments.add(ClientArgument.GROUP_ID);
                 allowedArguments.add(ClientArgument.MAX_MESSAGES);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -82,8 +82,8 @@ public class StrimziUpgradeST extends AbstractST {
     private final String topicName = "my-topic";
     private final String userName = "my-user";
     private final int upgradeTopicCount = 40;
-    // ExpectedTopicCount contains additionally consumer-offset topic and my-topic
-    private int expectedTopicCount = upgradeTopicCount + 2;
+    // ExpectedTopicCount contains additionally consumer-offset topic, my-topic and continuous-topic
+    private final int expectedTopicCount = upgradeTopicCount + 3;
 
     private final String latestReleasedOperator = "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.19.0/strimzi-0.19.0.zip";
 
@@ -270,9 +270,8 @@ public class StrimziUpgradeST extends AbstractST {
             // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
             if (KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(continuousTopicName).get() == null) {
                 KafkaTopicResource.topic(CLUSTER_NAME, continuousTopicName, 3, 3, 2).done();
-                // Add continuous topic to expectedTopicCunt which will be check after upgrade procedures
-                expectedTopicCount += 1;
             }
+
             String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
             KafkaClientsResource.producerStrimzi(producerName, KafkaResources.plainBootstrapAddress(CLUSTER_NAME), continuousTopicName, continuousClientsMessageCount, producerAdditionConfiguration).done();
             KafkaClientsResource.consumerStrimzi(consumerName, KafkaResources.plainBootstrapAddress(CLUSTER_NAME), continuousTopicName, continuousClientsMessageCount, "", continuousConsumerGroup).done();


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

In #3200 I totally forgot that the change of `--broker-list` to `--boostrap-server` can affect older versions of Kafka (during the upgrade) -> I tested it only with Kafka 2.5.0 and 2.6.0, problem is that `--boostrap-server` option was added to `2.5.0`. So I added ternary operator to determine which option use based on `Kafka` version.

Also this is an attempt to deflake the upgrade tests. I assume that main problem of the flakyness was this block of code:

```
if (KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(continuousTopicName).get() == null) {
                KafkaTopicResource.topic(CLUSTER_NAME, continuousTopicName, 3, 3, 2).done();
                // Add continuous topic to expectedTopicCount which will be check after upgrade procedures
                expectedTopicCount += 1;
            }
```
The problem is that if happen that topic is deleted and recreated, the `expectedTopicCount` will be increased and next check will not pass. This assumption is based on given result from PR run:

```
[WARNING] Flakes: 
[WARNING] io.strimzi.systemtest.upgrade.StrimziUpgradeST.testUpgradeStrimziVersion(JsonObject)[9]
[ERROR]   Run 1: StrimziUpgradeST.testUpgradeStrimziVersion:97->performUpgrade:351 KafkaTopic list doesn't have expected size
Expected: is <44>
     but: was <43>
[INFO]   Run 2: PASS
```

### Checklist

- [x] Make sure all tests pass


