### PR TITLE
[systemtest][fix] logCurrentResourceStatus NPE fix

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -398,8 +398,10 @@ public class ResourceManager {
                 List<Condition> conditions = customResource.getStatus().getConditions();
                 if (conditions != null) {
                     for (Condition condition : customResource.getStatus().getConditions()) {
-                        log.add("\tType: " + condition.getType() + "\n");
-                        log.add("\tMessage: " + condition.getMessage() + "\n");
+                        if (condition.getMessage() != null) {
+                            log.add("\tType: " + condition.getType() + "\n");
+                            log.add("\tMessage: " + condition.getMessage() + "\n");
+                        }
                     }
                 }
 
@@ -418,7 +420,7 @@ public class ResourceManager {
                 LOGGER.info("{}", String.join("", log));
             }
         } catch (NullPointerException e) {
-            LOGGER.debug("Cannot print messages and conditions for CR because it doesn't exist in given namespace");
+            LOGGER.debug("Cannot provide CR status, because the CR is null or messages/conditions are empty");
         }
 
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -384,7 +384,7 @@ public class ResourceManager {
      * @param customResource - Kafka, KafkaConnect etc. - every resource that HasMetadata and HasStatus (Strimzi status)
      */
     public static <T extends HasMetadata & HasStatus> void logCurrentResourceStatus(T customResource) {
-        if (customResource != null) {
+        try {
             List<String> printWholeCR = Arrays.asList(KafkaConnector.RESOURCE_KIND, KafkaTopic.RESOURCE_KIND, KafkaUser.RESOURCE_KIND);
 
             String kind = customResource.getKind();
@@ -417,7 +417,10 @@ public class ResourceManager {
                 }
                 LOGGER.info("{}", String.join("", log));
             }
+        } catch (NullPointerException e) {
+            LOGGER.debug("Cannot print messages and conditions for CR because it doesn't exist in given namespace");
         }
+
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

Even I tried to fix our method for printing current status of CR - messages and conditions from pods - it sometimes happen that it throws the NPE. So I'm adding `if`s to check if the current condition message/status is not null.

### Checklist

- [x] Make sure all tests pass

