### PR TITLE
[systemtest][fix] Forgotten USER_PATH in tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/OpenShiftTemplatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/OpenShiftTemplatesST.java
@@ -204,7 +204,7 @@ public class OpenShiftTemplatesST extends AbstractST {
                 TestUtils.CRD_KAFKA_CONNECT,
                 TestUtils.CRD_KAFKA_CONNECT_S2I,
                 TestUtils.CRD_TOPIC,
-                "src/rbac/role-edit-kafka.yaml");
+                TestUtils.USER_PATH + "/src/rbac/role-edit-kafka.yaml");
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

In #3548 wasn't added the `TestUtils.USER_PATH` for the `"src/rbac/role-edit-kafka.yaml"` and because of that the acceptance profile was failing. This PR fixes it. 

### Checklist

- [x] Make sure all tests pass


