### PR TITLE
[ST] Upgrade tests methodsource + generated test name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,6 @@
         <opentracing-kafka.version>0.1.4</opentracing-kafka.version>
         <strimzi-oauth.version>0.6.0</strimzi-oauth.version>
 
-        <junit-json-params.version>5.5.1-r0</junit-json-params.version>
         <test-containers.version>1.14.0</test-containers.version>
         <javax.json-api.version>1.1.4</javax.json-api.version>
         <javax.json.version>1.1.4</javax.json.version>
@@ -896,6 +895,25 @@
                             <forkCount>0</forkCount>
                             <!-- This is workaround for https://issues.apache.org/jira/browse/SUREFIRE-1809 -->
                             <useModulePath>false</useModulePath>
+                            <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+                                <disable>false</disable>
+                                <version>3.0</version>
+                                <usePhrasedFileName>false</usePhrasedFileName>
+                                <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+                                <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+                                <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+                            </statelessTestsetReporter>
+                            <consoleOutputReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5ConsoleOutputReporter">
+                                <disable>false</disable>
+                                <encoding>UTF-8</encoding>
+                                <usePhrasedFileName>true</usePhrasedFileName>
+                            </consoleOutputReporter>
+                            <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoReporter">
+                                <disable>false</disable>
+                                <usePhrasedFileName>false</usePhrasedFileName>
+                                <usePhrasedClassNameInRunning>false</usePhrasedClassNameInRunning>
+                                <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
+                            </statelessTestsetInfoReporter>
                         </configuration>
                     </execution>
                 </executions>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -134,11 +134,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.joshka</groupId>
-            <artifactId>junit-json-params</artifactId>
-            <version>${junit-json-params.version}</version>
-        </dependency>
-        <dependency>
             <groupId>javax.json</groupId>
             <artifactId>javax.json-api</artifactId>
             <version>${javax.json-api.version}</version>


### PR DESCRIPTION
Signed-off-by: David Kornel <kornys@outlook.com>

### Type of change


- Refactoring

### Description

1. Set up surefire/failsafe to use displayname in xunit files
2. Using  junit jupiter methodsource for parametrized upgrade tests instead of 3rd party lib
3. Generating names for upgrade parametrized test


