### PR TITLE
[DOC] Docs improvements for configuring SCRAM-SHA-512 authentication in Kafka Connect

### DIFF
--- a/documentation/assemblies/assembly-kafka-connect-authentication.adoc
+++ b/documentation/assemblies/assembly-kafka-connect-authentication.adoc
@@ -9,7 +9,7 @@
 
 [id='assembly-kafka-connect-authentication-{context}']
 
-= Connecting to Kafka brokers with Authentication
+= Connecting to Kafka brokers with authentication
 
 By default, Kafka Connect will try to connect to Kafka brokers without authentication.
 Authentication is enabled through the `KafkaConnect` and `KafkaConnectS2I` resources.

--- a/documentation/modules/con-kafka-connect-authentication.adoc
+++ b/documentation/modules/con-kafka-connect-authentication.adoc
@@ -5,26 +5,29 @@
 [id='con-kafka-connect-authentication{context}']
 = Authentication support in Kafka Connect
 
-Authentication is configured through the `authentication` property in `KafkaConnect.spec` and `KafkaConnectS2I.spec`.
-The `authentication` property specifies the type of the authentication mechanisms which should be used and additional configuration details depending on the mechanism.
-The supported authentication types are:
+You can configure authentication for Kafka Connect in the `authentication` property in `KafkaConnect.spec` and `KafkaConnectS2I.spec`. 
+The `authentication` property specifies which of the supported authentication mechanisms to use, and additional configuration depending on the mechanism.
+
+The following types of authentication are supported for Kafka Connect:
 
 * TLS client authentication
 * SASL-based authentication using the SCRAM-SHA-512 mechanism
 * SASL-based authentication using the PLAIN mechanism
 * xref:assembly-oauth-authentication_str[OAuth 2.0 token based authentication]
 
-== TLS Client Authentication
+The following sections explain how each authentication mechanism works. 
 
-To use TLS client authentication, set the `type` property to the value `tls`.
+== TLS Client authentication
+
+To use TLS client authentication, set the `authentication.type` property to `tls`.
 TLS client authentication uses a TLS certificate to authenticate.
-The certificate is specified in the `certificateAndKey` property and is always loaded from a Kubernetes secret.
-In the secret, the certificate must be stored in X509 format under two different keys: public and private.
+The certificate is specified in the `certificateAndKey` property and is always loaded from a Kubernetes Secret.
+In the Secret, the certificate must be stored in X509 format under two different keys: public and private.
 
 NOTE: TLS client authentication can be used only with TLS connections.
 For more details about TLS configuration in Kafka Connect see xref:assembly-kafka-connect-tls-{context}[].
 
-.An example TLS client authentication configuration
+.Example showing TLS client authentication for Kafka Connect
 [source,yaml,subs=attributes+]
 ----
 apiVersion: {KafkaApiVersion}
@@ -42,17 +45,16 @@ spec:
   # ...
 ----
 
-== SASL based SCRAM-SHA-512 authentication
+To use this method, see xref:proc-configuring-kafka-connect-authentication-tls-{context}[].
 
-To configure Kafka Connect to use SASL-based SCRAM-SHA-512 authentication, set the `type` property to `scram-sha-512`.
-This authentication mechanism requires a username and password.
+== SASL-based SCRAM-SHA-512 authentication
 
-* Specify the username in the `username` property.
-* In the `passwordSecret` property, specify a link to a `Secret` containing the password. The `secretName` property contains the name of the `Secret` and the `password` property contains the name of the key under which the password is stored inside the `Secret`.
+To configure Kafka Connect to use SASL-based SCRAM-SHA-512 authentication, set the `authentication.type` property to `scram-sha-512`.
+This authentication mechanism requires a client username and password, which are contained in a Secret.
 
-IMPORTANT: Do not specify the actual password in the `password` field.
+The `KafkaConnect` or `KafkaConnectS2I` custom resource references the Secret and its fields under the `passwordSecret` property. 
 
-.An example SASL based SCRAM-SHA-512 client authentication configuration
+.Example showing SCRAM-SHA-512 client authentication for Kafka Connect
 [source,yaml,subs=attributes+]
 ----
 apiVersion: {KafkaApiVersion}
@@ -63,27 +65,43 @@ spec:
   # ...
   authentication:
     type: scram-sha-512
-    username: my-connect-user
+    username: my-connect-username <1>
     passwordSecret:
-      secretName: my-connect-user
-      password: my-connect-password-key
+      secretName: my-connect-secret-name <2>
+      password: my-connect-password-field <3>
   # ...
 ----
 
-== SASL based PLAIN authentication
+<1> `username`: The username.
+
+<2> `secretName`: The name of the Secret that contains the username and password.
+
+<3> `password`: The name of the field in the Secret under which the password is stored.
+
+[WARNING]
+====
+Do NOT specify the actual password in the `passwordSecret.password` property.
+====
+
+To use this method, see xref:proc-configuring-kafka-connect-authentication-scram-sha-512-{context}[].
+
+== SASL-based PLAIN authentication
 
 To configure Kafka Connect to use SASL-based PLAIN authentication, set the `type` property to `plain`.
 This authentication mechanism requires a username and password.
 
-WARNING: The SASL PLAIN mechanism will transfer the username and password across the network in cleartext.
+WARNING: The SASL PLAIN mechanism transfers the username and password across the network in cleartext.
 Only use SASL PLAIN authentication if TLS encryption is enabled.
 
 * Specify the username in the `username` property.
-* In the `passwordSecret` property, specify a link to a `Secret` containing the password. The `secretName` property contains the name of such a `Secret` and the `password` property contains the name of the key under which the password is stored inside the `Secret`.
+* In the `passwordSecret` property, specify a link to a `Secret` containing the password. The `secretName` property contains the name of such a `Secret` and the `password` property contains the name of the field under which the password is stored inside the `Secret`.
 
-IMPORTANT: Do not specify the actual password in the `password` field.
+[WARNING]
+====
+Do NOT specify the actual password in the `passwordSecret.password` property.
+====
 
-.An example showing SASL based PLAIN client authentication configuration
+.Example showing SASL PLAIN client authentication for Kafka Connect
 [source,yaml,subs=attributes+]
 ----
 apiVersion: {KafkaApiVersion}
@@ -94,9 +112,9 @@ spec:
   # ...
   authentication:
     type: plain
-    username: my-connect-user
+    username: my-connect-username
     passwordSecret:
-      secretName: my-connect-user
-      password: my-connect-password-key
+      secretName: my-connect-secret-name
+      password: my-connect-password-field
   # ...
 ----

--- a/documentation/modules/con-kafka-connect-authentication.adoc
+++ b/documentation/modules/con-kafka-connect-authentication.adoc
@@ -50,7 +50,7 @@ To use this method, see xref:proc-configuring-kafka-connect-authentication-tls-{
 == SASL-based SCRAM-SHA-512 authentication
 
 To configure Kafka Connect to use SASL-based SCRAM-SHA-512 authentication, set the `authentication.type` property to `scram-sha-512`.
-This authentication mechanism requires a client username and password, which are contained in a Secret.
+This authentication mechanism requires a client username and password. The password is contained in a Secret.
 
 The `KafkaConnect` or `KafkaConnectS2I` custom resource references the Secret and its fields under the `passwordSecret` property. 
 
@@ -74,12 +74,19 @@ spec:
 
 <1> `username`: The username.
 <2> `secretName`: The name of the Secret that contains the username and password.
-<3> `password`: The name of the field in the Secret under which the password is stored.
+<3> `password`: The name of the field in the Secret under which the password is stored. Do NOT specify the actual password.
 
-[WARNING]
-====
-Do NOT specify the actual password in the `passwordSecret.password` property.
-====
+.Example Secret YAML for SCRAM-SHA-512 client authentication for Kafka Connect
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-connect-secret-name
+type: Opaque
+data:
+  my-connect-password-field: LFTIyFRFlMmU2N2Tm
+----
 
 To use this method, see xref:proc-configuring-kafka-connect-authentication-scram-sha-512-{context}[].
 

--- a/documentation/modules/con-kafka-connect-authentication.adoc
+++ b/documentation/modules/con-kafka-connect-authentication.adoc
@@ -19,13 +19,9 @@ The following sections explain how each authentication mechanism works.
 
 == TLS Client authentication
 
-To use TLS client authentication, set the `authentication.type` property to `tls`.
+To use TLS client authentication, set the `spec.authentication.type` property to `tls`.
 TLS client authentication uses a TLS certificate to authenticate.
 The certificate is specified in the `certificateAndKey` property and is always loaded from a Kubernetes Secret.
-In the Secret, the certificate must be stored in X509 format under two different keys: public and private.
-
-NOTE: TLS client authentication can be used only with TLS connections.
-For more details about TLS configuration in Kafka Connect see xref:assembly-kafka-connect-tls-{context}[].
 
 .Example showing TLS client authentication for Kafka Connect
 [source,yaml,subs=attributes+]
@@ -45,12 +41,23 @@ spec:
   # ...
 ----
 
+In the Kubernetes Secret:
+
+* The certificate must be stored in X509 format under the field named by the `certificate`
+* The private key must be stored under the field named by the `key` property, as shown in the preceding example
+
 To use this method, see xref:proc-configuring-kafka-connect-authentication-tls-{context}[].
+
+NOTE: TLS client authentication can be used only with TLS connections.
+For more details about TLS configuration in Kafka Connect see xref:assembly-kafka-connect-tls-{context}[].
 
 == SASL-based SCRAM-SHA-512 authentication
 
-To configure Kafka Connect to use SASL-based SCRAM-SHA-512 authentication, set the `authentication.type` property to `scram-sha-512`.
-This authentication mechanism requires a client username and password. The password is contained in a Secret.
+To configure Kafka Connect to use SASL-based SCRAM-SHA-512 authentication, set the `spec.authentication.type` property to `scram-sha-512`.
+This authentication mechanism requires a client username and password.
+
+The password is contained in a Secret. 
+The name of the Secret is supplied as the value of the `secretName` property, and the field within the Secret is supplied as the `password` property.
 
 The `KafkaConnect` or `KafkaConnectS2I` custom resource references the Secret and its fields under the `passwordSecret` property. 
 

--- a/documentation/modules/con-kafka-connect-authentication.adoc
+++ b/documentation/modules/con-kafka-connect-authentication.adoc
@@ -73,9 +73,7 @@ spec:
 ----
 
 <1> `username`: The username.
-
 <2> `secretName`: The name of the Secret that contains the username and password.
-
 <3> `password`: The name of the field in the Secret under which the password is stored.
 
 [WARNING]

--- a/documentation/modules/proc-configuring-kafka-connect-authentication-scram-sha-512.adoc
+++ b/documentation/modules/proc-configuring-kafka-connect-authentication-scram-sha-512.adoc
@@ -7,7 +7,7 @@
 
 You can configure Kafka Connect to connect to Kafka brokers using SASL-based authentication using the SCRAM-SHA-512 mechanism.
 
-This procedure includes creating a Secret from a text file. The Secret will contain the password used for authentication in one of its fields. Secrets created by the User Operator can also be used.
+The following procedure includes creating a Secret from a text file. The Secret will contain the password used for authentication in one of its fields. Secrets created by the User Operator can also be used.
 
 .Prerequisites
 
@@ -31,7 +31,7 @@ echo -n _PASSWORD_ > _MY-CONNECT-PASSWORD_.txt
 kubectl create secret generic _MY-CONNECT-SECRET_ --from-file=_PASSWORD-FIELD-NAME_=./_MY-CONNECT-PASSWORD_.txt
 ----
 
-. Edit the `authentication` property in the `KafkaConnect` or `KafkaConnectS2I` custom resource.
+. Edit the `authentication` property in the `KafkaConnect` or `KafkaConnectS2I` custom resource to reference the username and Secret.
 For example:
 +
 [source,yaml,subs="+quotes,attributes"]

--- a/documentation/modules/proc-configuring-kafka-connect-authentication-scram-sha-512.adoc
+++ b/documentation/modules/proc-configuring-kafka-connect-authentication-scram-sha-512.adoc
@@ -5,25 +5,33 @@
 [id='proc-configuring-kafka-connect-authentication-scram-sha-512-{context}']
 = Configuring SCRAM-SHA-512 authentication in Kafka Connect
 
+You can configure Kafka Connect to connect to Kafka brokers using SASL-based authentication using the SCRAM-SHA-512 mechanism.
+
+This procedure includes creating a Secret from a text file. The Secret will contain the password used for authentication in one of its fields. Secrets created by the User Operator can also be used.
+
 .Prerequisites
 
 * A Kubernetes cluster
 * A running Cluster Operator
-* Username of the user which should be used for authentication
-* If they exist, the name of the `Secret` with the password used for authentication and the key under which the password is stored in the `Secret`
+* Username of the user for authentication
 
 .Procedure
 
-. (Optional) If they do not already exist, prepare a file with the password used in authentication and create the `Secret`.
+. Create a text file that contains the password, in cleartext, to use for authentication:
 +
-NOTE: Secrets created by the User Operator may be used.
-+
-This can be done using `kubectl create`:
-[source,shell,subs=+quotes]
-echo -n '_PASSWORD_' > _MY-PASSWORD.txt_
-kubectl create secret generic _MY-SECRET_ --from-file=_MY-PASSWORD.txt_
+[source,shell,subs="+quotes"]
+----
+echo -n _PASSWORD_ > _MY-CONNECT-PASSWORD_.txt
+----
 
-. Edit the `authentication` property in the `KafkaConnect` or `KafkaConnectS2I` resource.
+. Create the Secret from the file, setting your own field name (key) for the password:
++
+[source,shell,subs="+quotes"]
+----
+kubectl create secret generic _MY-CONNECT-SECRET_ --from-file=_PASSWORD-FIELD-NAME_=./_MY-CONNECT-PASSWORD_.txt
+----
+
+. Edit the `authentication` property in the `KafkaConnect` or `KafkaConnectS2I` custom resource.
 For example:
 +
 [source,yaml,subs="+quotes,attributes"]
@@ -36,15 +44,21 @@ spec:
   # ...
   authentication:
     type: scram-sha-512
-    username: _MY-USERNAME_
+    username: _MY-CONNECT-USERNAME_
     passwordSecret:
-      secretName: _MY-SECRET_
-      password: _MY-PASSWORD.txt_
+      secretName: _MY-CONNECT-SECRET-NAME_
+      password: _PASSWORD-FIELD-NAME_
   # ...
 ----
 +
-. Create or update the resource.
+[WARNING]
+====
+Do NOT specify the actual password in the `passwordSecret.password` property.
+====
+
+. Create or update the resource:
 +
-On Kubernetes this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _your-file_
+----
+kubectl apply -f _YOUR-FILE_
+----

--- a/documentation/modules/proc-configuring-kafka-connect-authentication-tls.adoc
+++ b/documentation/modules/proc-configuring-kafka-connect-authentication-tls.adoc
@@ -5,7 +5,7 @@
 [id='proc-configuring-kafka-connect-authentication-tls-{context}']
 = Configuring TLS client authentication in Kafka Connect
 
-You can configure Kafka Connect to connect to Kafka brokers TLS client authentication.
+You can configure Kafka Connect to connect to Kafka brokers using TLS client authentication.
 
 .Prerequisites
 

--- a/documentation/modules/proc-configuring-kafka-connect-authentication-tls.adoc
+++ b/documentation/modules/proc-configuring-kafka-connect-authentication-tls.adoc
@@ -5,6 +5,8 @@
 [id='proc-configuring-kafka-connect-authentication-tls-{context}']
 = Configuring TLS client authentication in Kafka Connect
 
+You can configure Kafka Connect to connect to Kafka brokers TLS client authentication.
+
 .Prerequisites
 
 * A Kubernetes cluster


### PR DESCRIPTION
Signed-off-by: Daniel Laing <dlaing@redhat.com>

### Type of change

- Documentation

### Description

Affected guide(s): _Using Strimzi_

Update the "Connecting to Kafka brokers with authentication" section in chapter 2 to make the Secrets configuration easier to understand.

* When referring to the `password` property in a `KafkaConnect` custom resource, changed terminology from a "key" to a "field". This aligns with the Kubernetes documentation  for [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/). However, the Kubernetes documentation is also a bit inconsistent; it appears to use both terms interchangeably when describing the data in Secrets.

* Add the warning about not using the actual password into the procedure for "Configuring SCRAM-SHA-512 authentication in Kafka Connect". At present, this warning only appears in the concept, "Authentication support in Kafka Connect".

* Various other updates to help with consistency of terminology.

> **TO DO:** Once these changes are approved, the terminology and format changes need to be applied to the "Kafka Bridge configuration" section.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

