### PR TITLE
[ST] use junit5 extensionContext + code cleanup

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/interfaces/TestSeparator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/interfaces/TestSeparator.java
@@ -10,8 +10,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.Collections;
 
@@ -21,17 +21,17 @@ public interface TestSeparator {
     String SEPARATOR_CHAR = "#";
 
     @BeforeEach
-    default void beforeEachTest(TestInfo testInfo) {
-        TimeMeasuringSystem.getInstance().setTestName(testInfo.getTestClass().get().getName(), testInfo.getTestMethod().get().getName());
+    default void beforeEachTest(ExtensionContext testContext) {
+        TimeMeasuringSystem.getInstance().setTestName(testContext.getRequiredTestClass().getName(), testContext.getRequiredTestMethod().getName());
         TimeMeasuringSystem.getInstance().startOperation(Operation.TEST_EXECUTION);
         LOGGER.info(String.join("", Collections.nCopies(76, SEPARATOR_CHAR)));
-        LOGGER.info(String.format("%s.%s-STARTED", testInfo.getTestClass().get().getName(), testInfo.getTestMethod().get().getName()));
+        LOGGER.info(String.format("%s.%s-STARTED", testContext.getRequiredTestClass().getName(), testContext.getRequiredTestMethod().getName()));
     }
 
     @AfterEach
-    default void afterEachTest(TestInfo testInfo) {
+    default void afterEachTest(ExtensionContext testContext) {
         TimeMeasuringSystem.getInstance().stopOperation(Operation.TEST_EXECUTION);
-        LOGGER.info(String.format("%s.%s-FINISHED", testInfo.getTestClass().get().getName(), testInfo.getTestMethod().get().getName()));
+        LOGGER.info(String.format("%s.%s-FINISHED", testContext.getRequiredTestClass().getName(), testContext.getRequiredTestMethod().getName()));
         LOGGER.info(String.join("", Collections.nCopies(76, SEPARATOR_CHAR)));
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -79,15 +79,6 @@ public class ResourceManager {
 
     private static String coDeploymentName = Constants.STRIMZI_DEPLOYMENT_NAME;
 
-    private static ResourceManager instance;
-
-    public static synchronized ResourceManager getInstance() {
-        if (instance == null) {
-            instance = new ResourceManager();
-        }
-        return instance;
-    }
-
     private ResourceManager() {}
 
     public static KubeClient kubeClient() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -625,26 +624,26 @@ public abstract class AbstractST implements TestSeparator {
     }
 
     @BeforeEach
-    void createTestResources(TestInfo testInfo) {
-        if (testInfo.getTestMethod().isPresent()) {
-            testName = testInfo.getTestMethod().get().getName();
+    void createTestResources(ExtensionContext testContext) {
+        if (testContext.getTestMethod().isPresent()) {
+            testName = testContext.getTestMethod().get().getName();
         }
         ResourceManager.setMethodResources();
     }
 
     @BeforeAll
-    void setTestClassName(TestInfo testInfo) {
-        if (testInfo.getTestClass().isPresent()) {
-            testClass = testInfo.getTestClass().get().getName();
+    void setTestClassName(ExtensionContext testContext) {
+        if (testContext.getTestClass().isPresent()) {
+            testClass = testContext.getTestClass().get().getName();
         }
     }
 
     @AfterEach
-    void teardownEnvironmentMethod(ExtensionContext context) throws Exception {
+    void teardownEnvironmentMethod(ExtensionContext testContext) throws Exception {
         TimeMeasuringSystem.getInstance().stopOperation(Operation.TEST_EXECUTION);
         AssertionError assertionError = null;
         try {
-            long testDuration = timeMeasuringSystem.getDurationInSeconds(context.getTestClass().get().getName(), context.getTestMethod().get().getName(), Operation.TEST_EXECUTION.name());
+            long testDuration = timeMeasuringSystem.getDurationInSeconds(testContext.getRequiredTestClass().getName(), testContext.getRequiredTestMethod().getName(), Operation.TEST_EXECUTION.name());
             assertNoCoErrorsLogged(testDuration);
         } catch (AssertionError e) {
             LOGGER.error("Cluster Operator contains unexpected errors!");


### PR DESCRIPTION
Signed-off-by: David Kornel <kornys@outlook.com>

### Type of change

_Select the type of your PR_

- Refactoring

### Description

1. Using junit5 extension context, which is common for querying test information in callbacks/tests, instead of testinfo which should be used for work with testplan
2. Removed singleton construction from ResourceManager because it was never used and it does not make sense to have it there if all methods and attributes are static.

