### PR TITLE
Option to reduce sensitive information output by report.sh

### DIFF
--- a/tools/report.sh
+++ b/tools/report.sh
@@ -27,6 +27,7 @@ fi
 
 usage() {
 	echo "Usage: $0 --namespace=<string> --cluster=<string> --secrets=(off|hidden|all)" 1>&2;
+	echo "Default level of secret verbosity is 'hidden' (only secret key will be reported)."
 	exit 1; 
 }
 

--- a/tools/report.sh
+++ b/tools/report.sh
@@ -3,7 +3,7 @@
 oc_installed=false
 kubectl_installed=false
 platform="kubectl"
-secrets="all"
+secrets="hidden"
 
 oc &>/dev/null
 
@@ -58,14 +58,15 @@ if [ -z $cluster ] && [ -z $namespace ]; then
 fi
 
 if [ -z $secrets ]; then
-  secrets="all"
+  secrets="hidden"
 fi
 
 if [ "$secrets" != "all" ] && [ "$secrets" != "off" ] && [ "$secrets" != "hidden" ]; then
   echo "Unknown secrets verbosity level. Use one of 'off', 'hidden' or 'all'."
   echo " 'all' - secret keys and data values are reported"
-  echo " 'hidden' - secrets with only data keys"
-  echo " 'off' - secrets are not reported"
+  echo " 'hidden' - secrets with only data keys are reported"
+  echo " 'off' - secrets are not reported at all"
+  echo "Default value is 'hidden'"
   usage
 fi
 


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement / new feature

### Description
There was a request to add an option to set up verbosity level when reporting `Secret`s resources in the cluster.

Implementation:
1. fetch secret data `oc get secret <secretname> -o=jsonpath='{.data}'`
2. parse keys (each line is `key: value`)
3. replace `key: value` by `key: ***`

### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

