### PR TITLE
ST: Wait for pods deletion during recovery

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
@@ -44,7 +44,7 @@ class RecoveryST extends AbstractST {
         String entityOperatorDeploymentName = KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME);
         String entityOperatorDeploymentUid = kubeClient().getDeploymentUid(entityOperatorDeploymentName);
         kubeClient().deleteDeployment(entityOperatorDeploymentName);
-
+        PodUtils.waitForPodsWithPrefixDeletion(entityOperatorDeploymentName);
         LOGGER.info("Waiting for recovery {}", entityOperatorDeploymentName);
         DeploymentUtils.waitForDeploymentRecovery(entityOperatorDeploymentName, entityOperatorDeploymentUid);
         DeploymentUtils.waitForDeploymentAndPodsReady(entityOperatorDeploymentName, 1);
@@ -191,7 +191,7 @@ class RecoveryST extends AbstractST {
         String kafkaBridgeDeploymentName = KafkaBridgeResources.deploymentName(CLUSTER_NAME);
         String kafkaBridgeDeploymentUid = kubeClient().getDeploymentUid(kafkaBridgeDeploymentName);
         kubeClient().deleteDeployment(kafkaBridgeDeploymentName);
-
+        PodUtils.waitForPodsWithPrefixDeletion(kafkaBridgeDeploymentName);
         LOGGER.info("Waiting for deployment {} recovery", kafkaBridgeDeploymentName);
         DeploymentUtils.waitForDeploymentRecovery(kafkaBridgeDeploymentName, kafkaBridgeDeploymentUid);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
@@ -11,6 +11,7 @@ import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.ConfigMapUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.ServiceUtils;
 import io.strimzi.test.timemeasuring.Operation;
 import org.apache.logging.log4j.LogManager;
@@ -61,6 +62,7 @@ class RecoveryST extends AbstractST {
         String kafkaStatefulSetUid = kubeClient().getStatefulSetUid(kafkaStatefulSetName);
         kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName(ResourceManager.getCoDeploymentName()).scale(0, true);
         kubeClient().deleteStatefulSet(kafkaStatefulSetName);
+        PodUtils.waitForPodsWithPrefixDeletion(kafkaStatefulSetName);
         kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName(ResourceManager.getCoDeploymentName()).scale(1, true);
 
         LOGGER.info("Waiting for recovery {}", kafkaStatefulSetName);
@@ -80,6 +82,7 @@ class RecoveryST extends AbstractST {
         String zookeeperStatefulSetUid = kubeClient().getStatefulSetUid(zookeeperStatefulSetName);
         kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName(ResourceManager.getCoDeploymentName()).scale(0, true);
         kubeClient().deleteStatefulSet(zookeeperStatefulSetName);
+        PodUtils.waitForPodsWithPrefixDeletion(zookeeperStatefulSetName);
         kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName(ResourceManager.getCoDeploymentName()).scale(1, true);
 
         LOGGER.info("Waiting for recovery {}", zookeeperStatefulSetName);


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

After fabric8 version updated, we are facing issues with `RecoveryST`, especially with Kafka STS recovery on azure. This change should avoid problems on azure, where STS is not recovered due to race probably.

### Checklist


- [x] Make sure all tests pass


