### PR TITLE
Make CO diff logging less verbose

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
@@ -187,9 +187,16 @@ public class KafkaBrokerConfigurationDiff extends AbstractResourceDiff {
                 }
             }
 
-            log.debug("Kafka Broker {} Config Differs : {}", brokerId, d);
-            log.debug("Current Kafka Broker Config path {} has value {}", pathValueWithoutSlash, lookupPath(source, pathValue));
-            log.debug("Desired Kafka Broker Config path {} has value {}", pathValueWithoutSlash, lookupPath(target, pathValue));
+            if ("remove".equals(op)) {
+                // there is a lot of properties set by default - not having them in desired causes very noisy log output
+                log.trace("Kafka Broker {} Config Differs : {}", brokerId, d);
+                log.trace("Current Kafka Broker Config path {} has value {}", pathValueWithoutSlash, lookupPath(source, pathValue));
+                log.trace("Desired Kafka Broker Config path {} has value {}", pathValueWithoutSlash, lookupPath(target, pathValue));
+            } else {
+                log.debug("Kafka Broker {} Config Differs : {}", brokerId, d);
+                log.debug("Current Kafka Broker Config path {} has value {}", pathValueWithoutSlash, lookupPath(source, pathValue));
+                log.debug("Desired Kafka Broker Config path {} has value {}", pathValueWithoutSlash, lookupPath(target, pathValue));
+            }
         }
 
         return updatedCE;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
@@ -117,10 +117,16 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractResourceDiff {
                     updateOrAdd(pathValueWithoutSlash, desiredMap, updatedCE);
                 }
             }
-
-            log.debug("Kafka Broker {} Logging Config Differs : {}", brokerId, d);
-            log.debug("Current Kafka Broker Logging Config path {} has value {}", pathValueWithoutSlash, lookupPath(source, pathValue));
-            log.debug("Desired Kafka Broker Logging Config path {} has value {}", pathValueWithoutSlash, lookupPath(target, pathValue));
+            if ("remove".equals(op)) {
+                // there is a lot of properties set by default - not having them in desired causes very noisy log output
+                log.trace("Kafka Broker {} Logging Config Differs : {}", brokerId, d);
+                log.trace("Current Kafka Broker Logging Config path {} has value {}", pathValueWithoutSlash, lookupPath(source, pathValue));
+                log.trace("Desired Kafka Broker Logging Config path {} has value {}", pathValueWithoutSlash, lookupPath(target, pathValue));
+            } else {
+                log.debug("Kafka Broker {} Logging Config Differs : {}", brokerId, d);
+                log.debug("Current Kafka Broker Logging Config path {} has value {}", pathValueWithoutSlash, lookupPath(source, pathValue));
+                log.debug("Desired Kafka Broker Logging Config path {} has value {}", pathValueWithoutSlash, lookupPath(target, pathValue));
+            }
         }
         return updatedCE;
     }


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement

### Description
When desired Kafka configuration (or logging conf.)  does not contain some property, diff algorithm evaluates this as `nonnull -> null` and thus it prints debug info about it. In most cases, Kafka CR contains only a few options, which leads to too noisy debug output.
Fixed by printing removed options on `TRACE` level.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

