### PR TITLE
[systemtest][fixes] Some fixes and add method for listing deployed resources

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest.connect;
 
-import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.strimzi.api.kafka.Crds;
@@ -40,7 +39,6 @@ import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectS2IUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentConfigUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
@@ -143,6 +141,8 @@ class ConnectST extends AbstractST {
     void testKafkaConnectWithFileSinkPlugin() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
 
+        KafkaTopicResource.topic(CLUSTER_NAME, CONNECT_TOPIC_NAME).done();
+
         KafkaConnectResource.kafkaConnect(CLUSTER_NAME, 1)
             .editSpec()
                 .addToConfig("key.converter.schemas.enable", false)
@@ -150,7 +150,6 @@ class ConnectST extends AbstractST {
                 .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
                 .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
             .endSpec().done();
-        KafkaTopicResource.topic(CLUSTER_NAME, CONNECT_TOPIC_NAME).done();
 
         String kafkaConnectPodName = kubeClient().listPods(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
 
@@ -172,10 +171,6 @@ class ConnectST extends AbstractST {
         );
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "99");
-
-        LOGGER.info("Deleting topic {} from CR", CONNECT_TOPIC_NAME);
-        KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(CONNECT_TOPIC_NAME).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
-        KafkaTopicUtils.waitForKafkaTopicDeletion(CONNECT_TOPIC_NAME);
     }
 
     @Test
@@ -196,6 +191,8 @@ class ConnectST extends AbstractST {
 
         KafkaUser kafkaUser = KafkaUserResource.scramShaUser(CLUSTER_NAME, USER_NAME).done();
 
+        KafkaTopicResource.topic(CLUSTER_NAME, CONNECT_TOPIC_NAME).done();
+
         KafkaConnectResource.kafkaConnect(CLUSTER_NAME, 1)
                 .withNewSpec()
                     .withBootstrapServers(KafkaResources.plainBootstrapAddress(CLUSTER_NAME))
@@ -214,8 +211,6 @@ class ConnectST extends AbstractST {
                     .withReplicas(1)
                 .endSpec()
                 .done();
-
-        KafkaTopicResource.topic(CLUSTER_NAME, CONNECT_TOPIC_NAME).done();
 
         String kafkaConnectPodName = kubeClient().listPods(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
         String kafkaConnectLogs = kubeClient().logs(kafkaConnectPodName);
@@ -248,10 +243,6 @@ class ConnectST extends AbstractST {
         );
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "99");
-
-        KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(CONNECT_TOPIC_NAME).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
-        LOGGER.info("Topic {} deleted", CONNECT_TOPIC_NAME);
-        KafkaTopicUtils.waitForKafkaTopicDeletion(CONNECT_TOPIC_NAME);
     }
 
     @Test
@@ -293,9 +284,6 @@ class ConnectST extends AbstractST {
         assertThat(output, containsString("\"connector.class\":\"org.apache.kafka.connect.file.FileStreamSourceConnector\""));
         assertThat(output, containsString("\"tasks.max\":\"2\""));
         assertThat(output, containsString("\"topic\":\"" + TOPIC_NAME + "\""));
-
-        LOGGER.info("Deleting connector {} CR", connectorName);
-        cmdKubeClient().deleteByName("kafkaconnector", connectorName);
     }
 
 
@@ -377,6 +365,8 @@ class ConnectST extends AbstractST {
 
         KafkaUser kafkaUser = KafkaUserResource.tlsUser(CLUSTER_NAME, USER_NAME).done();
 
+        KafkaTopicResource.topic(CLUSTER_NAME, CONNECT_TOPIC_NAME).done();
+
         KafkaConnectResource.kafkaConnect(CLUSTER_NAME, 1)
                 .editSpec()
                     .addToConfig("key.converter.schemas.enable", false)
@@ -399,8 +389,6 @@ class ConnectST extends AbstractST {
                     .endKafkaClientAuthenticationTls()
                 .endSpec()
                 .done();
-
-        KafkaTopicResource.topic(CLUSTER_NAME, CONNECT_TOPIC_NAME).done();
 
         String kafkaConnectPodName = kubeClient().listPods(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
         String kafkaConnectLogs = kubeClient().logs(kafkaConnectPodName);
@@ -433,10 +421,6 @@ class ConnectST extends AbstractST {
         );
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "99");
-
-        LOGGER.info("Deleting topic {} from CR", CONNECT_TOPIC_NAME);
-        KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(CONNECT_TOPIC_NAME).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
-        KafkaTopicUtils.waitForKafkaTopicDeletion(CONNECT_TOPIC_NAME);
     }
 
     @Test
@@ -455,6 +439,8 @@ class ConnectST extends AbstractST {
             .done();
 
         KafkaUser kafkaUser = KafkaUserResource.scramShaUser(CLUSTER_NAME, USER_NAME).done();
+
+        KafkaTopicResource.topic(CLUSTER_NAME, CONNECT_TOPIC_NAME).done();
 
         KafkaConnectResource.kafkaConnect(CLUSTER_NAME, 1)
                 .editSpec()
@@ -478,8 +464,6 @@ class ConnectST extends AbstractST {
                     .endKafkaClientAuthenticationScramSha512()
                 .endSpec()
                 .done();
-
-        KafkaTopicResource.topic(CLUSTER_NAME, CONNECT_TOPIC_NAME).done();
 
         String kafkaConnectPodName = kubeClient().listPods(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
         String kafkaConnectLogs = kubeClient().logs(kafkaConnectPodName);
@@ -510,10 +494,6 @@ class ConnectST extends AbstractST {
         );
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "99");
-
-        LOGGER.info("Deleting topic {} from CR", CONNECT_TOPIC_NAME);
-        KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(CONNECT_TOPIC_NAME).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
-        KafkaTopicUtils.waitForKafkaTopicDeletion(CONNECT_TOPIC_NAME);
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -14,7 +14,6 @@ import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
 import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaResources;
-import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.PasswordSecretSourceBuilder;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationScramSha512;
@@ -175,7 +174,7 @@ class ConnectST extends AbstractST {
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "99");
 
         LOGGER.info("Deleting topic {} from CR", CONNECT_TOPIC_NAME);
-        cmdKubeClient().deleteByName(KafkaTopic.CRD_NAME, CONNECT_TOPIC_NAME);
+        KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(CONNECT_TOPIC_NAME).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
         KafkaTopicUtils.waitForKafkaTopicDeletion(CONNECT_TOPIC_NAME);
     }
 
@@ -436,7 +435,7 @@ class ConnectST extends AbstractST {
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "99");
 
         LOGGER.info("Deleting topic {} from CR", CONNECT_TOPIC_NAME);
-        cmdKubeClient().deleteByName("kafkatopic", CONNECT_TOPIC_NAME);
+        KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(CONNECT_TOPIC_NAME).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
         KafkaTopicUtils.waitForKafkaTopicDeletion(CONNECT_TOPIC_NAME);
     }
 
@@ -513,7 +512,7 @@ class ConnectST extends AbstractST {
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "99");
 
         LOGGER.info("Deleting topic {} from CR", CONNECT_TOPIC_NAME);
-        cmdKubeClient().deleteByName("kafkatopic", CONNECT_TOPIC_NAME);
+        KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(CONNECT_TOPIC_NAME).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
         KafkaTopicUtils.waitForKafkaTopicDeletion(CONNECT_TOPIC_NAME);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -1779,7 +1779,7 @@ class KafkaST extends AbstractST {
 
         basicExternalKafkaClientTls.verifyProducedAndConsumedMessages(
                 basicExternalKafkaClientTls.sendMessagesTls(),
-                basicExternalKafkaClientTls.sendMessagesTls()
+                basicExternalKafkaClientTls.receiveMessagesTls()
         );
 
         assertThrows(Exception.class, () -> {

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -106,40 +106,39 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class KafkaST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(KafkaST.class);
-
+    private static final String TEMPLATE_PATH = TestUtils.USER_PATH + "/../examples/templates/cluster-operator";
     public static final String NAMESPACE = "kafka-cluster-test";
+    private static final String OPENSHIFT_CLUSTER_NAME = "openshift-my-cluster";
 
     @Test
     @OpenShiftOnly
     void testDeployKafkaClusterViaTemplate() {
-        cluster.createCustomResources(TestUtils.USER_PATH + "/../examples/templates/cluster-operator");
+        cluster.createCustomResources(TEMPLATE_PATH);
         String templateName = "strimzi-ephemeral";
-        String clusterName = "openshift-my-cluster";
-        cmdKubeClient().createResourceAndApply(templateName, map("CLUSTER_NAME", clusterName));
+        cmdKubeClient().createResourceAndApply(templateName, map("CLUSTER_NAME", OPENSHIFT_CLUSTER_NAME));
 
-        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(clusterName), 3);
-        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(clusterName), 3);
-        DeploymentUtils.waitForDeploymentAndPodsReady(KafkaResources.entityOperatorDeploymentName(clusterName), 1);
+        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(OPENSHIFT_CLUSTER_NAME), 3);
+        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(OPENSHIFT_CLUSTER_NAME), 3);
+        DeploymentUtils.waitForDeploymentAndPodsReady(KafkaResources.entityOperatorDeploymentName(OPENSHIFT_CLUSTER_NAME), 1);
 
         //Testing docker images
-        testDockerImagesForKafkaCluster(clusterName, NAMESPACE, 3, 3, false);
+        testDockerImagesForKafkaCluster(OPENSHIFT_CLUSTER_NAME, NAMESPACE, 3, 3, false);
 
         //Testing labels
-        verifyLabelsForKafkaCluster(clusterName, templateName);
+        verifyLabelsForKafkaCluster(OPENSHIFT_CLUSTER_NAME, templateName);
 
-        LOGGER.info("Deleting Kafka cluster {} after test", clusterName);
-        cmdKubeClient().deleteByName("Kafka", clusterName);
+        LOGGER.info("Deleting Kafka cluster {} after test", OPENSHIFT_CLUSTER_NAME);
+        cmdKubeClient().deleteByName("Kafka", OPENSHIFT_CLUSTER_NAME);
 
         //Wait for kafka deletion
-        cmdKubeClient().waitForResourceDeletion("Kafka", clusterName);
+        cmdKubeClient().waitForResourceDeletion("Kafka", OPENSHIFT_CLUSTER_NAME);
         kubeClient().listPods().stream()
-            .filter(p -> p.getMetadata().getName().startsWith(clusterName))
+            .filter(p -> p.getMetadata().getName().startsWith(OPENSHIFT_CLUSTER_NAME))
             .forEach(p -> PodUtils.deletePodWithWait(p.getMetadata().getName()));
 
-        StatefulSetUtils.waitForStatefulSetDeletion(KafkaResources.kafkaStatefulSetName(clusterName));
-        StatefulSetUtils.waitForStatefulSetDeletion(KafkaResources.zookeeperStatefulSetName(clusterName));
-        DeploymentUtils.waitForDeploymentDeletion(KafkaResources.entityOperatorDeploymentName(clusterName));
-        cluster.deleteCustomResources(TestUtils.USER_PATH + "/../examples/templates/cluster-operator");
+        StatefulSetUtils.waitForStatefulSetDeletion(KafkaResources.kafkaStatefulSetName(OPENSHIFT_CLUSTER_NAME));
+        StatefulSetUtils.waitForStatefulSetDeletion(KafkaResources.zookeeperStatefulSetName(OPENSHIFT_CLUSTER_NAME));
+        DeploymentUtils.waitForDeploymentDeletion(KafkaResources.entityOperatorDeploymentName(OPENSHIFT_CLUSTER_NAME));
     }
 
     @Test
@@ -1957,6 +1956,14 @@ class KafkaST extends AbstractST {
     @Override
     protected void tearDownEnvironmentAfterEach() throws Exception {
         super.tearDownEnvironmentAfterEach();
+        if (cluster.getListOfDeployedResources().contains(TEMPLATE_PATH)) {
+            cluster.deleteCustomResources(TEMPLATE_PATH);
+        }
+
+        kubeClient().listPods().stream()
+            .filter(p -> p.getMetadata().getName().startsWith(OPENSHIFT_CLUSTER_NAME))
+            .forEach(p -> PodUtils.deletePodWithWait(p.getMetadata().getName()));
+
         kubeClient().getClient().customResources(CustomResourceDefinitionContext.fromCrd(Crds.kafkaTopic()), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class).inNamespace(NAMESPACE).delete();
         kubeClient().getClient().persistentVolumeClaims().inNamespace(NAMESPACE).delete();
     }

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -340,4 +340,9 @@ public class KubeClusterResource {
     public boolean isNotKubernetes() {
         return cluster.cluster() instanceof Minishift || cluster.cluster() instanceof OpenShift;
     }
+
+    /** Returns list of currently deployed resources */
+    public List<String> getListOfDeployedResources() {
+        return deploymentResources;
+    }
 }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

In nightlies we can see that in `KafkaST` if the `testDeployKafkaClusterViaTemplate` fails the template resources are not properly deleted, so I added the deletion for whole template and all pods with `openshift` name. The test failure and the skip of deletion caused that whole `KafkaST` was failing, so it ran again. This will (hopefully) fix this problem.

Second problem was with KafkaConnect topic deletion, where the `CONNECT_TOPIC` was bind to the connector created in the test, so the right after the `.withPropagationPolicy(DeletionPropagation.FOREGROUND).delete()` was executed, topic was recreated. So I changed the order of resource creation and removed the unnecessary deletions and waits, as this is done by `ResourceManager`

### Checklist

- [ ] Make sure all tests pass


