### PR TITLE
[systemtest][mm2] Test for Identity Replication Policy

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -689,7 +689,7 @@ class MirrorMaker2ST extends AbstractST {
         // Deploy target kafka
         KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).done();
         // Create topic
-        KafkaTopicResource.topic(kafkaClusterSourceName, originalTopicName).done();
+        KafkaTopicResource.topic(kafkaClusterSourceName, originalTopicName, 3).done();
 
         KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).done();
 
@@ -726,10 +726,11 @@ class MirrorMaker2ST extends AbstractST {
 
         LOGGER.info("Checking if the mirrored topic name is same as the original one");
 
-        KafkaTopicList kafkaTopicList = KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).list();
-        assertNotNull(
-            kafkaTopicList.getItems().stream().filter(kafkaTopic -> kafkaTopic.getMetadata().getName().equals(originalTopicName)).findFirst()
-        );
+        KafkaTopic kafkaTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(originalTopicName).get();
+        assertNotNull(kafkaTopic);
+        assertThat(kafkaTopic.getMetadata().getName(), equalTo(originalTopicName));
+        assertThat(kafkaTopic.getSpec().getPartitions(), equalTo(3));
+        assertThat(kafkaTopic.getSpec().getReplicas(), equalTo(1));
     }
 
     @BeforeAll


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test

### Description

After #3423 we are able to add the `IdentityReplicationPolicy` to `KafkaMirrorMaker2` `sourceConnector` spec -> how is it mentioned in the issues:
```
Identity replication policy is useful for active-passive cluster mirroring, cluster backups or for migrations from one cluster to another. It can be configured in MM2 and makes sure that MM2 will not be prefixing the mirrored topics with the original cluster alias but keeps the original names.
```

I wanted to add it to original `testMirrorMaker2()` test, but it would break the whole test and the main functionality wouldn't be tested, that's why I added the separated test.

### Checklist

- [x] Write test
- [x] Make sure all tests pass