### PR TITLE
ST: Improve log collecting

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.logs;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.strimzi.systemtest.Constants;
 import io.strimzi.test.k8s.KubeClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -76,17 +77,17 @@ public class LogCollector {
 
     public void collectDeployments() {
         LOGGER.info("Collecting Deployments in Namespace {}", namespace);
-        writeFile(logDir + "/deployments.log", cmdKubeClient().list("deployment").toString());
+        writeFile(logDir + "/deployments.log", cmdKubeClient().getResourcesAsYaml(Constants.DEPLOYMENT));
     }
 
     public void collectStatefulSets() {
         LOGGER.info("Collecting StatefulSets in Namespace {}", namespace);
-        writeFile(logDir + "/statefulsets.log", cmdKubeClient().list("statefulset").toString());
+        writeFile(logDir + "/statefulsets.log", cmdKubeClient().getResourcesAsYaml(Constants.STATEFUL_SET));
     }
 
     public void collectReplicaSets() {
         LOGGER.info("Collecting ReplicaSet in Namespace {}", namespace);
-        writeFile(logDir + "/replicasets.log", cmdKubeClient().list("replicaset").toString());
+        writeFile(logDir + "/replicasets.log", cmdKubeClient().getResourcesAsYaml("replicaset"));
     }
 
     public void collectStrimzi() {

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -370,6 +370,11 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     }
 
     @Override
+    public String getResourcesAsYaml(String resourceType) {
+        return Exec.exec(namespacedCommand("get", resourceType, "-o", "yaml")).out();
+    }
+
+    @Override
     public void createResourceAndApply(String template, Map<String, String> params) {
         List<String> cmd = namespacedCommand("process", template, "-l", "app=" + template, "-o", "yaml");
         for (Map.Entry<String, String> entry : params.entrySet()) {

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
@@ -163,6 +163,8 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
 
     String getResourceAsYaml(String resourceType, String resourceName);
 
+    String getResourcesAsYaml(String resourceType);
+
     void createResourceAndApply(String template, Map<String, String> params);
 
     String describe(String resourceType, String resourceName);


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Enhancement / new feature

### Description

In systemtest we have log collector, which collects information about pods, deployments, STS, events etc. However, for deployments, STS and RS we stored only names, which make debug harder. This PR improve log collector to collect whole deployment/sts/rs as yaml resource and store it in file.

### Checklist

- [x] Make sure all tests pass

