### PR TITLE
feat: Cleanup kafka assembly futures (Part 1)

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -378,7 +378,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
      * Holds the mutable state during a reconciliation
      *
      * Ensures state from one reconciliation step can be persisted to others
-     * Reconciliations steps are functions are methods on ReconciliationState so they can return the ReconciliationState class
+     * Reconciliations steps are methods on ReconciliationState so they can return the ReconciliationState class
      */
     class ReconciliationState {
 
@@ -2049,11 +2049,13 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                 log.trace("{}: Found address {} for Route {}", reconciliation, bootstrapAddress, routeName);
                             }
 
+                            future.complete();
                             return Future.succeededFuture();
                         },
                             error -> {
                                 log.warn("{}: No route address found in the Status section of Route {} resource. Route was probably not provisioned by the OpenShift router.", reconciliation, routeName);
-                                return Future.failedFuture("No route address found in the Status section of Route " + routeName + " resource. Route was probably not provisioned by the OpenShift router.");
+                                future.fail("No route address found in the Status section of Route " + routeName + " resource. Route was probably not provisioned by the OpenShift router.");
+                                return Future.failedFuture(error);
                             });
                 }, res -> {
                     if (res.succeeded()) {


### PR DESCRIPTION
### Type of change
- Refactoring

### Description

Cleanup assembly futures to make them more readable
remove unneeded promises, use compose success/failure handler where
appropriate

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

