### PR TITLE
[systemtest][connect] Add test for mounting secrets and config maps as volumes

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
-import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.Secret;


### PR DESCRIPTION
### Type of change

- New test

### Description

This PR gonna add test for mounting secrets and config maps as volumes and then create ENVs for it -> the ENVs should contain values of secrets and config maps. This feature is useful when we want to apply configuration to `KafkaConnector`.

### Checklist

- [X] Write tests
- [ ] Make sure all tests pass