### PR TITLE
[systemtest] Implementation of job methods to the kubeClient()

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
@@ -70,7 +70,7 @@ public class KubernetesResource {
             TestUtils.waitFor("Job creation " + job.getMetadata().getName(), Constants.POLL_INTERVAL_FOR_RESOURCE_CREATION, CR_CREATION_TIMEOUT,
                 () -> {
                     try {
-                        ResourceManager.kubeClient().getClient().batch().jobs().inNamespace(kubeClient().getNamespace()).createOrReplace(kubernetesJob);
+                        ResourceManager.kubeClient().createJob(kubernetesJob, kubeClient().getNamespace());
                         return true;
                     } catch (KubernetesClientException e) {
                         if (e.getMessage().contains("object is being deleted")) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
@@ -70,7 +70,7 @@ public class KubernetesResource {
             TestUtils.waitFor("Job creation " + job.getMetadata().getName(), Constants.POLL_INTERVAL_FOR_RESOURCE_CREATION, CR_CREATION_TIMEOUT,
                 () -> {
                     try {
-                        ResourceManager.kubeClient().createJob(kubernetesJob, kubeClient().getNamespace());
+                        ResourceManager.kubeClient().createJob(kubernetesJob);
                         return true;
                     } catch (KubernetesClientException e) {
                         if (e.getMessage().contains("object is being deleted")) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -50,13 +50,13 @@ public class ClientUtils {
     public static void waitTillContinuousClientsFinish(String producerName, String consumerName, String namespace, int messageCount) {
         LOGGER.info("Waiting till producer {} and consumer {} finish", producerName, consumerName);
         TestUtils.waitFor("continuous clients finished", Constants.GLOBAL_POLL_INTERVAL, timeoutForClientFinishJob(messageCount),
-            () -> kubeClient().getJobStatus(producerName, namespace) && kubeClient().getJobStatus(consumerName, namespace));
+            () -> kubeClient().getJobStatus(producerName) && kubeClient().getJobStatus(consumerName));
     }
 
     public static void waitForClientSuccess(String jobName, String namespace, int messageCount) {
         LOGGER.info("Waiting for producer/consumer:{} will be finished", jobName);
         TestUtils.waitFor("job finished", Constants.GLOBAL_POLL_INTERVAL, timeoutForClientFinishJob(messageCount),
-            () -> kubeClient().getJobStatus(jobName, namespace));
+            () -> kubeClient().getJobStatus(jobName));
     }
 
     private static long timeoutForClientFinishJob(int messagesCount) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -13,7 +13,7 @@ import org.apache.logging.log4j.Logger;
 import java.time.Duration;
 import java.util.Random;
 
-import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 
 /**
  * ClientUtils class, which provides static methods for the all type clients
@@ -50,14 +50,13 @@ public class ClientUtils {
     public static void waitTillContinuousClientsFinish(String producerName, String consumerName, String namespace, int messageCount) {
         LOGGER.info("Waiting till producer {} and consumer {} finish", producerName, consumerName);
         TestUtils.waitFor("continuous clients finished", Constants.GLOBAL_POLL_INTERVAL, timeoutForClientFinishJob(messageCount),
-            () -> kubeClient().getClient().batch().jobs().inNamespace(namespace).withName(producerName).get().getStatus().getSucceeded().equals(1) &&
-                    kubeClient().getClient().batch().jobs().inNamespace(namespace).withName(consumerName).get().getStatus().getSucceeded().equals(1));
+            () -> kubeClient().getJobStatus(producerName, namespace) && kubeClient().getJobStatus(consumerName, namespace));
     }
 
     public static void waitForClientSuccess(String jobName, String namespace, int messageCount) {
         LOGGER.info("Waiting for producer/consumer:{} will be finished", jobName);
         TestUtils.waitFor("job finished", Constants.GLOBAL_POLL_INTERVAL, timeoutForClientFinishJob(messageCount),
-            () -> kubeClient().getClient().batch().jobs().inNamespace(namespace).withName(jobName).get().getStatus().getSucceeded().equals(1));
+            () -> kubeClient().getJobStatus(jobName, namespace));
     }
 
     private static long timeoutForClientFinishJob(int messagesCount) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
@@ -35,7 +35,7 @@ public class JobUtils {
      * @param name name of the job
      */
     public static void deleteJobWithWait(String namespace, String name) {
-        kubeClient().deleteJob(name, namespace);
+        kubeClient().deleteJob(name);
         waitForJobDeletion(name);
     }
 
@@ -48,6 +48,6 @@ public class JobUtils {
     public static void waitForJobFailure(String jobName, String namespace, long timeout) {
         LOGGER.info("Waiting for job: {} will be in error state", jobName);
         TestUtils.waitFor("job finished", Constants.GLOBAL_POLL_INTERVAL, timeout,
-            () -> !kubeClient().getJobStatus(jobName, namespace));
+            () -> !kubeClient().getJobStatus(jobName));
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
@@ -32,11 +32,10 @@ public class JobUtils {
 
     /**
      * Delete Job and wait for it's deletion
-     * @param namespace namespace where job is deployed
      * @param name name of the job
      */
-    public static void deleteJob(String namespace, String name) {
-        kubeClient().getClient().batch().jobs().inNamespace(namespace).withName(name).delete();
+    public static void deleteJobWithWait(String namespace, String name) {
+        kubeClient().deleteJob(name, namespace);
         waitForJobDeletion(name);
     }
 
@@ -49,6 +48,6 @@ public class JobUtils {
     public static void waitForJobFailure(String jobName, String namespace, long timeout) {
         LOGGER.info("Waiting for job: {} will be in error state", jobName);
         TestUtils.waitFor("job finished", Constants.GLOBAL_POLL_INTERVAL, timeout,
-            () -> kubeClient().getClient().batch().jobs().inNamespace(namespace).withName(jobName).get().getStatus().getSucceeded().equals(1));
+            () -> !kubeClient().getJobStatus(jobName, namespace));
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -78,7 +78,7 @@ public class OauthAbstractST extends AbstractST {
     @AfterEach
     void tearDown() {
 
-        for (Job job : kubeClient().getJobList(NAMESPACE).getItems()) {
+        for (Job job : kubeClient().getJobList().getItems()) {
             LOGGER.info("Deleting {} job", job.getMetadata().getName());
             JobUtils.deleteJobWithWait(NAMESPACE, job.getMetadata().getName());
         }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -78,9 +78,9 @@ public class OauthAbstractST extends AbstractST {
     @AfterEach
     void tearDown() {
 
-        for (Job job : kubeClient().getClient().batch().jobs().inNamespace(NAMESPACE).list().getItems()) {
+        for (Job job : kubeClient().getJobList(NAMESPACE).getItems()) {
             LOGGER.info("Deleting {} job", job.getMetadata().getName());
-            JobUtils.deleteJob(NAMESPACE, job.getMetadata().getName());
+            JobUtils.deleteJobWithWait(NAMESPACE, job.getMetadata().getName());
         }
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
@@ -85,7 +85,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
         teamAOauthClientJob = new KafkaOauthClientsResource(teamAOauthClientJob, TOPIC_NAME, "a-consumer_group");
         teamAOauthClientJob.producerStrimziOauthTls(CLUSTER_NAME).done();
         assertThrows(WaitException.class, () -> JobUtils.waitForJobFailure(TEAM_A_PRODUCER_NAME, NAMESPACE, 30_000));
-        JobUtils.deleteJob(NAMESPACE, TEAM_A_PRODUCER_NAME);
+        JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
 
         String topicXName = TOPIC_X + "-example-1";
         LOGGER.info("Sending {} messages to broker with topic name {}", MESSAGE_COUNT, topicXName);
@@ -93,13 +93,13 @@ public class OauthAuthorizationST extends OauthAbstractST {
         teamAOauthClientJob = new KafkaOauthClientsResource(teamAOauthClientJob, topicXName, "a-consumer_group");
         teamAOauthClientJob.producerStrimziOauthTls(CLUSTER_NAME).done();
         assertThrows(WaitException.class, () -> JobUtils.waitForJobFailure(TEAM_A_PRODUCER_NAME, NAMESPACE, 30_000));
-        JobUtils.deleteJob(NAMESPACE, TEAM_A_PRODUCER_NAME);
+        JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
 
         // Team A can not create topic starting with 'x-' only write to existing on
         KafkaTopicResource.topic(CLUSTER_NAME, topicXName).done();
         teamAOauthClientJob.producerStrimziOauthTls(CLUSTER_NAME).done();
         ClientUtils.waitForClientSuccess(TEAM_A_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJob(NAMESPACE, TEAM_A_PRODUCER_NAME);
+        JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
 
         LOGGER.info("Sending {} messages to broker with topic name {}", MESSAGE_COUNT, TOPIC_A);
         teamAOauthClientJob = new KafkaOauthClientsResource(teamAOauthClientJob, TOPIC_A, "a-consumer_group");
@@ -114,13 +114,13 @@ public class OauthAuthorizationST extends OauthAbstractST {
         LOGGER.info("Sending {} messages to broker with topic name {}", MESSAGE_COUNT, TOPIC_A);
         teamAOauthClientJob.producerStrimziOauthTls(CLUSTER_NAME).done();
         ClientUtils.waitForClientSuccess(TEAM_A_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJob(NAMESPACE, TEAM_A_PRODUCER_NAME);
+        JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
 
         // team A client shouldn't be able to consume messages with wrong consumer group
         teamAOauthClientJob = new KafkaOauthClientsResource(teamAOauthClientJob, TOPIC_A, "bad_consumer_group");
         teamAOauthClientJob.consumerStrimziOauthTls(CLUSTER_NAME).done();
         assertThrows(WaitException.class, () -> JobUtils.waitForJobFailure(TEAM_A_CONSUMER_NAME, NAMESPACE, 30_000));
-        JobUtils.deleteJob(NAMESPACE, TEAM_A_PRODUCER_NAME);
+        JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
 
         // team A client should be able to consume messages with correct consumer group
         teamAOauthClientJob = new KafkaOauthClientsResource(teamAOauthClientJob, TOPIC_A, "a-correct_consumer_group");
@@ -136,7 +136,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
         // Producer will not produce messages because authorization topic will failed. Team A can write only to topic starting with 'x-'
         teamBOauthClientJob.producerStrimziOauthTls(CLUSTER_NAME).done();
         assertThrows(WaitException.class, () -> JobUtils.waitForJobFailure(TEAM_B_PRODUCER_NAME, NAMESPACE, 30_000));
-        JobUtils.deleteJob(NAMESPACE, TEAM_B_PRODUCER_NAME);
+        JobUtils.deleteJobWithWait(NAMESPACE, TEAM_B_PRODUCER_NAME);
 
         LOGGER.info("Sending {} messages to broker with topic name {}", MESSAGE_COUNT, TOPIC_B);
         teamBOauthClientJob = new KafkaOauthClientsResource(teamBOauthClientJob, TOPIC_B, "x-consumer_group_b");
@@ -177,7 +177,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
 
         teamBOauthClientJob.producerStrimziOauthTls(CLUSTER_NAME).done();
         assertThrows(WaitException.class, () -> JobUtils.waitForJobFailure(TEAM_B_PRODUCER_NAME, NAMESPACE, 30_000));
-        JobUtils.deleteJob(NAMESPACE, TEAM_B_PRODUCER_NAME);
+        JobUtils.deleteJobWithWait(NAMESPACE, TEAM_B_PRODUCER_NAME);
 
         LOGGER.info("Verifying that team A is not able read to topic starting with 'x-' because in kafka cluster" +
                 "does not have super-users to break authorization rules");
@@ -187,7 +187,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
 
         teamAOauthClientJob.consumerStrimziOauthTls(CLUSTER_NAME).done();
         assertThrows(WaitException.class, () -> JobUtils.waitForJobFailure(TEAM_A_CONSUMER_NAME, NAMESPACE, 30_000));
-        JobUtils.deleteJob(NAMESPACE, TEAM_A_CONSUMER_NAME);
+        JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_CONSUMER_NAME);
 
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
@@ -186,7 +186,7 @@ public class OauthPlainST extends OauthAbstractST {
             Constants.GLOBAL_CLIENTS_POLL, Constants.TIMEOUT_FOR_MIRROR_MAKER_COPY_MESSAGES_BETWEEN_BROKERS,
             () -> {
                 LOGGER.info("Deleting the Job");
-                JobUtils.deleteJob(NAMESPACE, OAUTH_CONSUMER_NAME);
+                JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_CONSUMER_NAME);
 
                 LOGGER.info("Creating new client with new consumer-group and also to point on {} cluster", targetKafkaCluster);
                 KafkaOauthClientsResource kafkaOauthClientJob = new KafkaOauthClientsResource(OAUTH_PRODUCER_NAME, OAUTH_CONSUMER_NAME,
@@ -288,7 +288,7 @@ public class OauthPlainST extends OauthAbstractST {
             Duration.ofSeconds(30).toMillis(), Constants.TIMEOUT_FOR_MIRROR_MAKER_COPY_MESSAGES_BETWEEN_BROKERS,
             () -> {
                 LOGGER.info("Deleting the Job {}", OAUTH_CONSUMER_NAME);
-                JobUtils.deleteJob(NAMESPACE, OAUTH_CONSUMER_NAME);
+                JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_CONSUMER_NAME);
 
                 LOGGER.info("Creating new client with new consumer-group and also to point on {} cluster", kafkaTargetClusterName);
                 KafkaOauthClientsResource kafkaOauthClientJob = new KafkaOauthClientsResource(OAUTH_PRODUCER_NAME, OAUTH_CONSUMER_NAME,

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsST.java
@@ -288,7 +288,7 @@ public class OauthTlsST extends OauthAbstractST {
         KafkaUserResource.tlsUser(CLUSTER_NAME, USER_NAME).done();
         KafkaUserUtils.waitForKafkaUserCreation(USER_NAME);
 
-        JobUtils.deleteJob(NAMESPACE, OAUTH_PRODUCER_NAME);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_PRODUCER_NAME);
 
         LOGGER.info("Creating new client with new consumer-group and also to point on {} cluster", targetKafkaCluster);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/ClusterOperationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/ClusterOperationST.java
@@ -78,8 +78,8 @@ public class ClusterOperationST extends AbstractST {
         });
 
         producerNames.forEach(producerName -> ClientUtils.waitTillContinuousClientsFinish(producerName, consumerNames.get(producerName.indexOf(producerName)), NAMESPACE, continuousClientsMessageCount));
-        producerNames.forEach(producerName -> kubeClient().deleteJob(producerName, NAMESPACE));
-        consumerNames.forEach(consumerName -> kubeClient().deleteJob(consumerName, NAMESPACE));
+        producerNames.forEach(producerName -> kubeClient().deleteJob(producerName));
+        consumerNames.forEach(consumerName -> kubeClient().deleteJob(consumerName));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/ClusterOperationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/ClusterOperationST.java
@@ -78,8 +78,8 @@ public class ClusterOperationST extends AbstractST {
         });
 
         producerNames.forEach(producerName -> ClientUtils.waitTillContinuousClientsFinish(producerName, consumerNames.get(producerName.indexOf(producerName)), NAMESPACE, continuousClientsMessageCount));
-        producerNames.forEach(producerName -> kubeClient().getClient().batch().jobs().inNamespace(NAMESPACE).withName(producerName).delete());
-        consumerNames.forEach(consumerName -> kubeClient().getClient().batch().jobs().inNamespace(NAMESPACE).withName(consumerName).delete());
+        producerNames.forEach(producerName -> kubeClient().deleteJob(producerName, NAMESPACE));
+        consumerNames.forEach(consumerName -> kubeClient().deleteJob(consumerName, NAMESPACE));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -377,8 +377,8 @@ public class StrimziUpgradeST extends AbstractST {
             ClientUtils.waitTillContinuousClientsFinish(producerName, consumerName, NAMESPACE, continuousClientsMessageCount);
             // ##############################
             // Delete jobs to make same names available for next upgrade run during chain upgrade
-            kubeClient().deleteJob(producerName, NAMESPACE);
-            kubeClient().deleteJob(consumerName, NAMESPACE);
+            kubeClient().deleteJob(producerName);
+            kubeClient().deleteJob(consumerName);
         }
 
         // Check errors in CO log

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -377,8 +377,8 @@ public class StrimziUpgradeST extends AbstractST {
             ClientUtils.waitTillContinuousClientsFinish(producerName, consumerName, NAMESPACE, continuousClientsMessageCount);
             // ##############################
             // Delete jobs to make same names available for next upgrade run during chain upgrade
-            kubeClient().getClient().batch().jobs().inNamespace(NAMESPACE).withName(producerName).delete();
-            kubeClient().getClient().batch().jobs().inNamespace(NAMESPACE).withName(consumerName).delete();
+            kubeClient().deleteJob(producerName, NAMESPACE);
+            kubeClient().deleteJob(consumerName, NAMESPACE);
         }
 
         // Check errors in CO log

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -300,10 +300,6 @@ public class KubeClient {
         client.apps().statefulSets().inNamespace(getNamespace()).withName(statefulSetName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
 
-    public Deployment createOrReplaceDeployment(Deployment deployment) {
-        return client.apps().deployments().inNamespace(getNamespace()).createOrReplace(deployment);
-    }
-
     // ================================
     // ---------> DEPLOYMENT <---------
     // ================================
@@ -342,6 +338,10 @@ public class KubeClient {
 
     public void deleteDeployment(String deploymentName) {
         client.apps().deployments().inNamespace(getNamespace()).withName(deploymentName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+    }
+
+    public Deployment createOrReplaceDeployment(Deployment deployment) {
+        return client.apps().deployments().inNamespace(getNamespace()).createOrReplace(deployment);
     }
 
     // =======================================
@@ -423,56 +423,31 @@ public class KubeClient {
     }
 
     public Job createJob(Job job) {
-        return createJob(job, getNamespace());
+        return client.batch().jobs().inNamespace(getNamespace()).createOrReplace(job);
     }
-
-    public Job createJob(Job job, String namespace) {
-        return client.batch().jobs().inNamespace(namespace).createOrReplace(job);
-    }
-
 
     public Job replaceJob(Job job) {
-        return replaceJob(job, getNamespace());
-    }
-
-    public Job replaceJob(Job job, String namespace) {
-        return client.batch().jobs().inNamespace(namespace).createOrReplace(job);
+        return client.batch().jobs().inNamespace(getNamespace()).createOrReplace(job);
     }
 
     public Boolean deleteJob(String jobName) {
-        return deleteJob(jobName, getNamespace());
-    }
-
-    public Boolean deleteJob(String jobName, String namespace) {
-        return client.batch().jobs().inNamespace(namespace).withName(jobName).delete();
+        return client.batch().jobs().inNamespace(getNamespace()).withName(jobName).delete();
     }
 
     public Job getJob(String jobName) {
-        return getJob(jobName, getNamespace());
-    }
-
-    public Job getJob(String jobName, String namespace) {
-        return client.batch().jobs().inNamespace(namespace).withName(jobName).get();
+        return client.batch().jobs().inNamespace(getNamespace()).withName(jobName).get();
     }
 
     public Boolean getJobStatus(String jobName) {
-        return getJobStatus(jobName, getNamespace());
+        return client.batch().jobs().inNamespace(getNamespace()).withName(jobName).get().getStatus().getSucceeded().equals(1);
     }
 
-    public Boolean getJobStatus(String jobName, String namespace) {
-        return client.batch().jobs().inNamespace(namespace).withName(jobName).get().getStatus().getSucceeded().equals(1);
-    }
-
-    public JobList getJobList(String namespace) {
-        return client.batch().jobs().inNamespace(namespace).list();
+    public JobList getJobList() {
+        return client.batch().jobs().inNamespace(getNamespace()).list();
     }
 
     public List<Job> listJobs(String namePrefix) {
-        return listJobs(namePrefix, getNamespace());
-    }
-
-    public List<Job> listJobs(String namePrefix, String namespace) {
-        return client.batch().jobs().inNamespace(namespace).list().getItems().stream()
+        return client.batch().jobs().inNamespace(getNamespace()).list().getItems().stream()
             .filter(job -> job.getMetadata().getName().startsWith(namePrefix)).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In this PR I'm gonna add implementation of `jobClient()` to the code, so we don't have to do the `kubeClient().getClient().batch().jobs()` all the time. I also added some methods for current namespace, so we don't need  to always specify it in `inNamespace()` method.

### Checklist

- [x] Make sure all tests pass

