### PR TITLE
ExampleTest.java: fix the "illegal reflective access" warning

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
@@ -115,7 +115,7 @@ public class ExamplesTest {
         }
     }
 
-    private void checkForJsonAnyGetter(Stack<String> path, Object resource, Class<?> cls, Method method) throws IllegalAccessException, InvocationTargetException {
+    protected void checkForJsonAnyGetter(Stack<String> path, Object resource, Class<?> cls, Method method) throws IllegalAccessException, InvocationTargetException {
         if (method.isAnnotationPresent(JsonAnyGetter.class)) {
             Map additionalProperties = (Map) method.invoke(resource);
             if (CustomResourceDefinitionSpec.class.equals(cls)) {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This is a temporary fix to suppress the "WARNING: An illegal reflective access operation has occurred". The origin of the warning is `method.setAccessible(true);` (See reference). Though this fixes the warning, we should try to avoid `setAccessible()` to be future-proof.

Reference: https://github.com/jknack/handlebars.java/issues/667
Closes: https://github.com/strimzi/strimzi-kafka-operator/issues/3595
Signed-off-by: Allen Bai <carpe.diem.allen@gmail.com>


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Make sure all tests pass

