### PR TITLE
Default value of kafka logger

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
@@ -156,7 +156,7 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractResourceDiff {
      */
     private static void removeProperty(Collection<AlterConfigOp> alterConfigOps, String pathValueWithoutSlash, ConfigEntry entry) {
         if (!pathValueWithoutSlash.contains("log4j.appender") && !pathValueWithoutSlash.equals("root") && !"ERROR".equals(entry.value())) {
-            alterConfigOps.add(new AlterConfigOp(new ConfigEntry(pathValueWithoutSlash, "ERROR"), AlterConfigOp.OpType.SET));
+            alterConfigOps.add(new AlterConfigOp(new ConfigEntry(pathValueWithoutSlash, null), AlterConfigOp.OpType.DELETE));
             log.trace("{} not set in desired, setting to ERROR", entry.name());
         }
     }


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
When the logger from Kafka logging configuration was unset (not set at all or removed), it was set to level ERROR. It should be set to its default value instead.

### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

