### PR TITLE
Fix detection and application of logging changes

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -106,6 +106,10 @@
             <artifactId>vertx-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>certificate-manager</artifactId>
         </dependency>
@@ -139,6 +143,10 @@
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-oauth-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>kafka-oauth-common</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
@@ -5,7 +5,6 @@
 
 package io.strimzi.operator.cluster.operator.resource;
 
-import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.operator.common.operator.resource.AbstractResourceDiff;
 import org.apache.kafka.clients.admin.AlterConfigOp;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
@@ -119,18 +119,17 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractResourceDiff {
             }
 
             int e = name.length();
-            int b = e;
-            while (b > -1) {
-                b = name.lastIndexOf('.', e);
-                if (b == -1) {
+            while (e > -1) {
+                e = name.lastIndexOf('.', e);
+                if (e == -1) {
                     level = config.get("root");
                 } else {
-                    level = config.get(name.substring(0, b));
+                    level = config.get(name.substring(0, e));
                 }
                 if (level != null) {
                     return LoggingLevel.valueOf(level.split(",")[0]);
                 }
-                e = b - 1;
+                e -= 1;
             }
             // still here? Not even root logger defined?
             return LoggingLevel.INFO;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
@@ -70,7 +70,14 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractResourceDiff {
         LoggingLevelResolver levelResolver = new LoggingLevelResolver(desiredMap);
 
         for (ConfigEntry entry: brokerConfigs.entries()) {
-            LoggingLevel desiredLevel = levelResolver.resolveLevel(entry.name());
+            LoggingLevel desiredLevel;
+            try {
+                desiredLevel = levelResolver.resolveLevel(entry.name());
+            } catch (IllegalArgumentException e) {
+                log.warn("Skipping {} - it is configured with an unsupported value (\"{}\")", entry.name(), e.getMessage());
+                continue;
+            }
+
             if (!desiredLevel.name().equals(entry.value())) {
                 updatedCE.add(new AlterConfigOp(new ConfigEntry(entry.name(), desiredLevel.name()), AlterConfigOp.OpType.SET));
                 log.trace("{} has a deprecated value. Setting to {}", entry.name(), desiredLevel.name());
@@ -143,7 +150,6 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractResourceDiff {
         WARN,
         INFO,
         DEBUG,
-        TRACE,
-        OFF
+        TRACE
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiffTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static java.util.Collections.emptyList;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiffTest.java
@@ -5,12 +5,14 @@
 
 package io.strimzi.operator.cluster.operator.resource;
 
+import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -52,5 +54,90 @@ public class KafkaBrokerLoggingConfigurationDiffTest {
     public void testReplaceRootLogger() {
         KafkaBrokerLoggingConfigurationDiff klcd = new KafkaBrokerLoggingConfigurationDiff(getCurrentConfiguration(emptyList()), getDesiredConfiguration(emptyList()), brokerId);
         assertThat(klcd.getDiffSize(), is(0));
+    }
+
+    @Test
+    public void testDiffUsingLoggerInheritance() {
+        // Prepare desiredConfig
+        String desiredConfig = getRealisticDesiredConfig();
+
+        // Prepare currentConfig
+        Config currentConfig = getRealisticConfig();
+
+        KafkaBrokerLoggingConfigurationDiff diff = new KafkaBrokerLoggingConfigurationDiff(currentConfig, desiredConfig, brokerId);
+        assertThat(diff.getLoggingDiff(), is(getRealisticConfigDiff()));
+    }
+
+    Config getRealisticConfig() {
+        return new Config(Arrays.asList(
+            new ConfigEntry("org.apache.zookeeper.CreateMode", "INFO"),
+            new ConfigEntry("io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler", "INFO"),
+            new ConfigEntry("io.netty.util.concurrent.PromiseNotifier", "INFO"),
+            new ConfigEntry("kafka.server.DynamicConfigManager", "INFO"),
+            new ConfigEntry("org.apache.kafka.common.utils.AppInfoParser", "INFO"),
+            new ConfigEntry("kafka.utils.KafkaScheduler", "INFO"),
+            new ConfigEntry("io.netty.util.internal.PlatformDependent0", "INFO"),
+            new ConfigEntry("org.apache.kafka.clients.ClientUtils", "INFO"),
+            new ConfigEntry("org.apache.kafka", "DEBUG"),
+            new ConfigEntry("state.change.logger", "TRACE"),
+            new ConfigEntry("org.apache.kafka.common.security.authenticator.LoginManager", "INFO"),
+            new ConfigEntry("io.strimzi.kafka.oauth.common.HttpUtil", "INFO"),
+            new ConfigEntry("org.apache.zookeeper.ZooKeeper", "INFO"),
+            new ConfigEntry("io.netty.util.internal.CleanerJava9", "INFO"),
+            new ConfigEntry("org.apache.zookeeper.ClientCnxnSocket", "INFO"),
+            new ConfigEntry("io.strimzi", "TRACE"),
+            new ConfigEntry("kafka", "DEBUG"),
+            new ConfigEntry("org.apache.zookeeper", "INFO"),
+            new ConfigEntry("root", "INFO")));
+    }
+
+    String getRealisticDesiredConfig() {
+        return "# Do not change this generated file. Logging can be configured in the corresponding Kubernetes resource.\n" +
+                "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
+                "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
+                "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n" +
+                "log4j.rootLogger=INFO, CONSOLE\n" +
+                "log4j.logger.org.I0Itec.zkclient.ZkClient=INFO\n" +
+                "log4j.logger.org.apache.zookeeper=INFO\n" +
+                "log4j.logger.kafka=DEBUG\n" +
+                "log4j.logger.org.apache.kafka=DEBUG\n" +
+                "log4j.logger.kafka.request.logger=WARN, CONSOLE\n" +
+                "log4j.logger.kafka.network.Processor=OFF\n" +
+                "log4j.logger.kafka.server.KafkaApis=OFF\n" +
+                "log4j.logger.kafka.network.RequestChannel$=WARN\n" +
+                "log4j.logger.kafka.controller=TRACE\n" +
+                "log4j.logger.kafka.log.LogCleaner=INFO\n" +
+                "log4j.logger.state.change.logger=TRACE\n" +
+                "log4j.logger.kafka.authorizer.logger=INFO\n" +
+                "log4j.logger.io.strimzi=TRACE\n" +
+                "log4j.logger.some.category=ALL\n" +
+                "log4j.logger.another.category=FINE\n" +
+                "log4j.logger.another.category.sub=TRACE";
+    }
+
+    List<AlterConfigOp> getRealisticConfigDiff() {
+        return Arrays.asList(
+            newAlterConfigOp("io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler", "TRACE"),
+            newAlterConfigOp("kafka.server.DynamicConfigManager", "DEBUG"),
+            newAlterConfigOp("org.apache.kafka.common.utils.AppInfoParser", "DEBUG"),
+            newAlterConfigOp("kafka.utils.KafkaScheduler", "DEBUG"),
+            newAlterConfigOp("org.apache.kafka.clients.ClientUtils", "DEBUG"),
+            newAlterConfigOp("org.apache.kafka.common.security.authenticator.LoginManager", "DEBUG"),
+            newAlterConfigOp("io.strimzi.kafka.oauth.common.HttpUtil", "TRACE"),
+            newAlterConfigOp("org.I0Itec.zkclient.ZkClient", "INFO"),
+            newAlterConfigOp("kafka.request.logger", "WARN"),
+            newAlterConfigOp("kafka.network.Processor", "FATAL"),
+            newAlterConfigOp("kafka.server.KafkaApis", "FATAL"),
+            newAlterConfigOp("kafka.network.RequestChannel$", "WARN"),
+            newAlterConfigOp("kafka.controller", "TRACE"),
+            newAlterConfigOp("kafka.log.LogCleaner", "INFO"),
+            newAlterConfigOp("kafka.authorizer.logger", "INFO"),
+            newAlterConfigOp("some.category", "TRACE"),
+            newAlterConfigOp("another.category", "WARN"),
+            newAlterConfigOp("another.category.sub", "TRACE"));
+    }
+
+    AlterConfigOp newAlterConfigOp(String category, String level) {
+        return new AlterConfigOp(new ConfigEntry(category, level), AlterConfigOp.OpType.SET);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -646,6 +646,11 @@
             </dependency>
             <dependency>
                 <groupId>io.strimzi</groupId>
+                <artifactId>kafka-oauth-common</artifactId>
+                <version>${strimzi-oauth.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.strimzi</groupId>
                 <artifactId>kafka-oauth-keycloak-authorizer</artifactId>
                 <version>${strimzi-oauth.version}</version>
             </dependency>


### PR DESCRIPTION
Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>

### Type of change

This PR attempts to address the issue of synchronizing Kafka CR logging section with dynamic Kafka Broker configuration.
Apparently Kafka Broker iterates the Log4j loggers, and calls getLevel() on them. And if getLevel() returns null it communicates it as INFO, which is wrong as it masks the actual state of things with regards to logging level inheritance. This part should be addressed in Apache Kafka code base, however, such erroneous behaviour is mandated by [KIP-412](https://cwiki.apache.org/confluence/display/KAFKA/KIP-412%3A+Extend+Admin+API+to+support+dynamic+application+log+levels).

Typically the list of loggers returned by using CLI tool:
```
bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --entity-type broker-loggers --entity-name 0
```
is 100+ because all loggers with null level are also returned (as having INFO level), whereas Kafka CR logging configuration (plus defaults) only contains levels for maybe 10 categories.

In order to prevent detecting a difference every single time during configuration synchronisation, and updating the config every single time with updates that result in no apparent effect, the only way to currently address this seems to be to properly calculate logging levels of all the loggers based on Kafka CR logging configuration and setting them on the loggers - overriding the inheritance mechanism.


_Select the type of your PR_

- Bugfix

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

