### PR TITLE
[systemtest] Fixes and improvements to the suites

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -35,6 +35,8 @@ import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.status.HasStatus;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.ConfigMapUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentConfigUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
@@ -182,6 +184,28 @@ public class ResourceManager {
                             .withPropagationPolicy(DeletionPropagation.FOREGROUND)
                             .delete();
                     waitForDeletion((KafkaBridge) resource);
+                });
+                break;
+            case KafkaTopic.RESOURCE_KIND:
+                pointerResources.add(() -> {
+                    LOGGER.info("Deleting {} {} in namespace {}",
+                        resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
+                    operation.inNamespace(resource.getMetadata().getNamespace())
+                        .withName(resource.getMetadata().getName())
+                        .withPropagationPolicy(DeletionPropagation.FOREGROUND)
+                        .delete();
+                    KafkaTopicUtils.waitForKafkaTopicDeletion(resource.getMetadata().getName());
+                });
+                break;
+            case KafkaUser.RESOURCE_KIND:
+                pointerResources.add(() -> {
+                    LOGGER.info("Deleting {} {} in namespace {}",
+                        resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
+                    operation.inNamespace(resource.getMetadata().getNamespace())
+                        .withName(resource.getMetadata().getName())
+                        .withPropagationPolicy(DeletionPropagation.FOREGROUND)
+                        .delete();
+                    KafkaUserUtils.waitForKafkaUserDeletion(resource.getMetadata().getName());
                 });
                 break;
             case DEPLOYMENT:

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
@@ -18,6 +18,7 @@ import java.util.Random;
 
 import static io.strimzi.systemtest.enums.CustomResourceStatus.NotReady;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
+import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class KafkaUserUtils {
@@ -50,7 +51,15 @@ public class KafkaUserUtils {
     public static void waitForKafkaUserDeletion(String userName) {
         LOGGER.info("Waiting for KafkaUser deletion {}", userName);
         TestUtils.waitFor("KafkaUser deletion " + userName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, DELETION_TIMEOUT,
-            () -> KafkaUserResource.kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName).get() == null,
+            () -> {
+                if (KafkaUserResource.kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName) == null) {
+                    return true;
+                } else {
+                    LOGGER.warn("KafkaUser {} is not deleted yet! Triggering force delete by cmd client!", userName);
+                    cmdKubeClient().deleteByName(KafkaUser.RESOURCE_KIND, userName);
+                    return false;
+                }
+            },
             () -> LOGGER.info(KafkaUserResource.kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName).get())
         );
         LOGGER.info("KafkaUser {} deleted", userName);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
@@ -52,7 +52,7 @@ public class KafkaUserUtils {
         LOGGER.info("Waiting for KafkaUser deletion {}", userName);
         TestUtils.waitFor("KafkaUser deletion " + userName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, DELETION_TIMEOUT,
             () -> {
-                if (KafkaUserResource.kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName) == null) {
+                if (KafkaUserResource.kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName).get() == null) {
                     return true;
                 } else {
                     LOGGER.warn("KafkaUser {} is not deleted yet! Triggering force delete by cmd client!", userName);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
@@ -50,7 +50,7 @@ public class CruiseControlUtils {
     public static String callApi(SupportedHttpMethods method, CruiseControlEndpoints endpoint) {
         String ccPodName = PodUtils.getFirstPodNameContaining(CONTAINER_NAME);
 
-        return cmdKubeClient().execInPodContainer(ccPodName, CONTAINER_NAME, "/bin/bash", "-c",
+        return cmdKubeClient().execInPodContainer(false, ccPodName, CONTAINER_NAME, "/bin/bash", "-c",
             "curl -X" + method.name() + " localhost:" + CRUISE_CONTROL_DEFAULT_PORT + endpoint.toString()).out();
     }
 
@@ -59,7 +59,7 @@ public class CruiseControlUtils {
     public static String callApi(SupportedHttpMethods method, String endpoint) {
         String ccPodName = PodUtils.getFirstPodNameContaining(CONTAINER_NAME);
 
-        return cmdKubeClient().execInPodContainer(ccPodName, CONTAINER_NAME, "/bin/bash", "-c",
+        return cmdKubeClient().execInPodContainer(false, ccPodName, CONTAINER_NAME, "/bin/bash", "-c",
             "curl -X" + method.name() + " localhost:" + CRUISE_CONTROL_METRICS_PORT + endpoint).out();
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -20,7 +20,6 @@ import io.strimzi.systemtest.resources.operator.BundleResource;
 import io.strimzi.systemtest.resources.operator.HelmResource;
 import io.strimzi.systemtest.resources.operator.OlmResource;
 import io.strimzi.systemtest.resources.ResourceManager;
-import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
@@ -95,13 +94,12 @@ public abstract class AbstractST implements TestSeparator {
 
     public static final int MESSAGE_COUNT = 100;
 
-    public static final String TOPIC_NAME = KafkaTopicUtils.generateRandomNameOfTopic();
     public static final String EXAMPLE_TOPIC_NAME = "my-topic";
     public static final String AVAILABILITY_TOPIC_SOURCE_NAME = "availability-topic-source-" + rng.nextInt(Integer.MAX_VALUE);
     public static final String AVAILABILITY_TOPIC_TARGET_NAME = "availability-topic-target-" + rng.nextInt(Integer.MAX_VALUE);
-    public static final String USER_NAME = KafkaUserUtils.generateRandomNameOfKafkaUser();
 
-    public static final String CONSUMER_GROUP_NAME = ClientUtils.generateRandomConsumerGroup();
+    public static final String USER_NAME = KafkaUserUtils.generateRandomNameOfKafkaUser();
+    public static final String TOPIC_NAME = KafkaTopicUtils.generateRandomNameOfTopic();
 
     /**
      * This method install Strimzi Cluster Operator based on environment variable configuration.

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
@@ -201,6 +201,7 @@ class ConnectS2IST extends AbstractST {
         final String userName = KafkaUserUtils.generateRandomNameOfKafkaUser();
         final String kafkaConnectS2IName = "kafka-connect-s2i-name-2";
 
+        KafkaTopicResource.topic(CLUSTER_NAME, CONNECT_S2I_TOPIC_NAME).done();
         KafkaUser user = KafkaUserResource.scramShaUser(CLUSTER_NAME, userName).done();
 
         KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-tls-" + Constants.KAFKA_CLIENTS, user).done();
@@ -227,8 +228,6 @@ class ConnectS2IST extends AbstractST {
                     .endKafkaClientAuthenticationScramSha512()
                 .endSpec()
                 .done();
-
-        KafkaTopicResource.topic(CLUSTER_NAME, CONNECT_S2I_TOPIC_NAME).done();
 
         final String tlsKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(CLUSTER_NAME + "-tls-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -773,6 +773,7 @@ class ConnectST extends AbstractST {
                 .endSpec()
                 .done();
 
+        KafkaTopicResource.topic(CLUSTER_NAME, TOPIC_NAME).done();
         KafkaUserResource.tlsUser(CLUSTER_NAME, weirdUserName).done();
 
         KafkaConnectResource.kafkaConnect(CLUSTER_NAME, 1)
@@ -835,6 +836,7 @@ class ConnectST extends AbstractST {
                 .endSpec()
                 .done();
 
+        KafkaTopicResource.topic(CLUSTER_NAME, TOPIC_NAME).done();
         KafkaUserResource.scramShaUser(CLUSTER_NAME, weirdUserName).done();
 
         KafkaConnectResource.kafkaConnect(CLUSTER_NAME, 1)
@@ -867,7 +869,6 @@ class ConnectST extends AbstractST {
     }
 
     void testConnectAuthorizationWithWeirdUserName(String userName, SecurityProtocol securityProtocol) {
-        KafkaTopicResource.topic(CLUSTER_NAME, TOPIC_NAME).done();
         String connectorPodName = kubeClient().listPodsByPrefixInName(CLUSTER_NAME + "-connect").get(0).getMetadata().getName();
 
         KafkaConnectorResource.kafkaConnector(CLUSTER_NAME)

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -14,7 +14,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -37,10 +36,11 @@ public class CruiseControlApiST extends AbstractST {
 
     private static final String CRUISE_CONTROL_NAME = "Cruise Control";
 
-    @Order(1)
     @Tag(ACCEPTANCE)
     @Test
-    void testCruiseControlDeploymentStateEndpoint()  {
+    void testCruiseControlBasicAPIRequests()  {
+        LOGGER.info("----> CRUISE CONTROL DEPLOYMENT STATE ENDPOINT <----");
+
         String response = CruiseControlUtils.callApi(CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.STATE);
 
         assertThat(response, is("Unrecognized endpoint in request '/state'\n" +
@@ -55,12 +55,10 @@ public class CruiseControlApiST extends AbstractST {
         assertThat(response, containsString("NO_TASK_IN_PROGRESS"));
 
         CruiseControlUtils.verifyThatCruiseControlTopicsArePresent();
-    }
 
-    @Order(2)
-    @Test
-    void testRebalance() {
-        String response = CruiseControlUtils.callApi(CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.REBALANCE);
+        LOGGER.info("----> KAFKA REBALANCE <----");
+
+        response = CruiseControlUtils.callApi(CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.REBALANCE);
 
         assertThat(response, is("Unrecognized endpoint in request '/rebalance'\n" +
             "Supported GET endpoints: [BOOTSTRAP, TRAIN, LOAD, PARTITION_LOAD, PROPOSALS, STATE, KAFKA_CLUSTER_STATE, USER_TASKS, REVIEW_BOARD]\n"));
@@ -88,12 +86,10 @@ public class CruiseControlApiST extends AbstractST {
         assertThat(response, containsString("PreferredLeaderElectionGoal"));
 
         assertThat(response, containsString("Cluster load after rebalance"));
-    }
 
-    @Order(3)
-    @Test
-    void testStopProposalExecution() {
-        String response = CruiseControlUtils.callApi(CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.STOP);
+        LOGGER.info("----> EXECUTION OF STOP PROPOSAL <----");
+
+        response = CruiseControlUtils.callApi(CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.STOP);
 
         assertThat(response, is("Unrecognized endpoint in request '/stop_proposal_execution'\n" +
             "Supported GET endpoints: [BOOTSTRAP, TRAIN, LOAD, PARTITION_LOAD, PROPOSALS, STATE, KAFKA_CLUSTER_STATE, USER_TASKS, REVIEW_BOARD]\n"));
@@ -101,12 +97,10 @@ public class CruiseControlApiST extends AbstractST {
         response = CruiseControlUtils.callApi(CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.STOP);
 
         assertThat(response, containsString("Proposal execution stopped."));
-    }
 
-    @Order(4)
-    @Test
-    void testUserTasks() {
-        String response = CruiseControlUtils.callApi(CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.USER_TASKS);
+        LOGGER.info("----> USER TASKS <----");
+
+        response = CruiseControlUtils.callApi(CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.USER_TASKS);
 
         assertThat(response, is("Unrecognized endpoint in request '/user_tasks'\n" +
             "Supported POST endpoints: [ADD_BROKER, REMOVE_BROKER, FIX_OFFLINE_REPLICAS, REBALANCE, STOP_PROPOSAL_EXECUTION, PAUSE_SAMPLING, RESUME_SAMPLING, DEMOTE_BROKER, ADMIN, REVIEW, TOPIC_CONFIGURATION]\n"));

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -152,6 +152,7 @@ class MirrorMaker2ST extends AbstractST {
                     .endMirror()
                 .endSpec()
                 .done();
+
         LOGGER.info("Looks like the mirrormaker2 cluster my-cluster deployed OK");
 
         String podName = PodUtils.getPodNameByPrefix(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME));

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.mirrormaker;
 
+import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.CertSecretSource;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpec;
@@ -39,6 +40,7 @@ import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -766,5 +768,18 @@ class MirrorMaker2ST extends AbstractST {
     void setup() throws Exception {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT);
+    }
+
+    @AfterEach
+    void removeResourcesAndTopics() {
+        // force deletion of MM2 (all) components, after that remove other KafkaTopics
+        // else they will/might be incorrectly recreated by MM2 component (TopicOperator)
+        ResourceManager.deleteMethodResources();
+        KafkaTopicList kafkaTopicList = KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).list();
+        kafkaTopicList.getItems().forEach(kafkaTopic -> {
+            KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).delete(kafkaTopic);
+            LOGGER.info("Topic {} deleted", kafkaTopic.getMetadata().getName());
+            KafkaTopicUtils.waitForKafkaTopicDeletion(kafkaTopic.getMetadata().getName());
+        });
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest.mirrormaker;
 
-import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.CertSecretSource;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpec;
@@ -40,7 +39,6 @@ import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -768,18 +766,5 @@ class MirrorMaker2ST extends AbstractST {
     void setup() throws Exception {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT);
-    }
-
-    @AfterEach
-    void removeResourcesAndTopics() {
-        // force deletion of MM2 (all) components, after that remove other KafkaTopics
-        // else they will/might be incorrectly recreated by MM2 component (TopicOperator)
-        ResourceManager.deleteMethodResources();
-        KafkaTopicList kafkaTopicList = KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).list();
-        kafkaTopicList.getItems().forEach(kafkaTopic -> {
-            KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).delete(kafkaTopic);
-            LOGGER.info("Topic {} deleted", kafkaTopic.getMetadata().getName());
-            KafkaTopicUtils.waitForKafkaTopicDeletion(kafkaTopic.getMetadata().getName());
-        });
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
@@ -342,6 +342,9 @@ public class MirrorMakerST extends AbstractST {
                 .endKafka()
             .endSpec().done();
 
+        // Deploy topic
+        KafkaTopicResource.topic(kafkaClusterSourceName, TOPIC_NAME).done();
+
         // Create Kafka user for source cluster
         KafkaUser userSource = KafkaUserResource.scramShaUser(kafkaClusterSourceName, kafkaUserSource).done();
 
@@ -420,9 +423,6 @@ public class MirrorMakerST extends AbstractST {
                     .endTls()
                 .endProducer()
             .endSpec().done();
-
-        // Deploy topic
-        KafkaTopicResource.topic(kafkaClusterSourceName, TOPIC_NAME).done();
 
         internalKafkaClient.setTopicName(TOPIC_NAME);
         internalKafkaClient.setClusterName(kafkaClusterSourceName);


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix
- Enhancement

### Description

This PR should deal with several problems in our STs:

1) I added all tests that we had in `CruiseControlApiST` to one big test - problem is that when we have ordering in suite, the reruns are not working if the test fails -> if we want to delete ordering in `CruiseControlApiST`, several tests will not work.

2) Another problem is with deletion of topics/users if the test pass -> problem is that when the topic is connected to some component and we delete it, the topic will be recreated. I added deletion handler to `ResourceManager` for `KafkaUser` and `KafkaTopic` as we had only deletion without any wait or triggering force delete by `cmdKubeClient()`. I guess this is also connected to the deletion of MM2 topics, where the new cascade style of deletion doesn't work, as the topic is connected to the MM2.
 
### Checklist

- [x] Make sure all tests pass


