### PR TITLE
Improve the changes storage warning: Add resoruce info

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -483,9 +483,9 @@ public class KafkaCluster extends AbstractModel {
                         "adding volumes to Jbod storage or removing volumes from Jbod storage, " +
                         "changing overrides to nodes which do not exist yet" +
                         "and increasing size of persistent claim volumes (depending on the volume type and used storage class).");
-                log.warn("Your desired Kafka storage configuration contains changes which are not allowed. As a " +
+                log.warn("The desired Kafka storage configuration in the custom resource {}/{} contains changes which are not allowed. As a " +
                         "result, all storage changes will be ignored. Use DEBUG level logging for more information " +
-                        "about the detected changes.");
+                        "about the detected changes.", kafkaAssembly.getMetadata().getNamespace(), kafkaAssembly.getMetadata().getName());
 
                 Condition warning = StatusUtils.buildWarningCondition("KafkaStorage",
                         "The desired Kafka storage configuration contains changes which are not allowed. As a " +

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -248,9 +248,9 @@ public class ZookeeperCluster extends AbstractModel {
                         "changing the deleteClaim flag, " +
                         "changing overrides to nodes which do not exist yet " +
                         "and increasing size of persistent claim volumes (depending on the volume type and used storage class).");
-                log.warn("Your desired Zookeeper storage configuration contains changes which are not allowed. As " +
+                log.warn("The desired ZooKeeper storage configuration in the custom resource {}/{} contains changes which are not allowed. As " +
                         "a result, all storage changes will be ignored. Use DEBUG level logging for more information " +
-                        "about the detected changes.");
+                        "about the detected changes.", kafkaAssembly.getMetadata().getNamespace(), kafkaAssembly.getMetadata().getName());
 
                 Condition warning = StatusUtils.buildWarningCondition("ZooKeeperStorage",
                         "The desired ZooKeeper storage configuration contains changes which are not allowed. As a " +


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When storage configuration is illegally changed for existing cluster, we print some warnings and revert it. But when the operator manages many clusters, it is not clear from the warning which one has the issues. This PR improves the warning message to add the namespace and name of the cluster affected by this to make the log easier to read.

### Checklist

- [x] Make sure all tests pass