### PR TITLE
Add support for HostAliases to Pod template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@
 * Add support for `client.rack` property for Kafka Connect to use `fetch from closest replica` feature. 
 * Refactored operators Grafana dashboard
   * Fixed bug on maximum reconcile time graph
-  * Removed the avarage reconsile time graph
+  * Removed the avarage reconcile time graph
   * Rearranged graphs
-* Make `listeners` configurable as an array and add support for more different listeners in single cluster 
+* Make `listeners` configurable as an array and add support for more different listeners in single cluster
+* Add support for configuring `hostAliases` in Pod templates 
 
 ### Deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
@@ -34,8 +34,8 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({
-        "metadata", "imagePullSecrets", "securityContext", "terminationGracePeriodSeconds"})
+@JsonPropertyOrder({"metadata", "imagePullSecrets", "securityContext", "terminationGracePeriodSeconds", "affinity",
+        "tolerations", "priorityClassName", "schedulerName", "hostAliases"})
 @EqualsAndHashCode
 @DescriptionFile
 public class PodTemplate implements Serializable, UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model.template;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.Affinity;
+import io.fabric8.kubernetes.api.model.HostAlias;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.PodSecurityContext;
 import io.fabric8.kubernetes.api.model.Toleration;
@@ -48,6 +49,7 @@ public class PodTemplate implements Serializable, UnknownPropertyPreserving {
     private List<Toleration> tolerations;
     private String priorityClassName;
     private String schedulerName;
+    private List<HostAlias> hostAliases;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Metadata applied to the resource.")
@@ -142,6 +144,18 @@ public class PodTemplate implements Serializable, UnknownPropertyPreserving {
 
     public void setSchedulerName(String schedulerName) {
         this.schedulerName = schedulerName;
+    }
+
+    @Description("The pod's HostAliases. " +
+            "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.")
+    @KubeLink(group = "core", version = "v1", kind = "HostAlias")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<HostAlias> getHostAliases() {
+        return hostAliases;
+    }
+
+    public void setHostAliases(List<HostAlias> hostAliases) {
+        this.hostAliases = hostAliases;
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -15,6 +15,7 @@ import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.EnvVarSource;
 import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.HostAlias;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
@@ -249,6 +250,7 @@ public abstract class AbstractModel {
     protected int templatePodDisruptionBudgetMaxUnavailable = 1;
     protected String templatePodPriorityClassName;
     protected String templatePodSchedulerName;
+    protected List<HostAlias> templatePodHostAliases;
     protected PodManagementPolicy templatePodManagementPolicy = PodManagementPolicy.PARALLEL;
 
     protected List<Condition> warningConditions = new ArrayList<>(0);
@@ -907,6 +909,7 @@ public abstract class AbstractModel {
                             .withSecurityContext(securityContext)
                             .withPriorityClassName(templatePodPriorityClassName)
                             .withSchedulerName(templatePodSchedulerName != null ? templatePodSchedulerName : "default-scheduler")
+                            .withHostAliases(templatePodHostAliases)
                         .endSpec()
                     .endTemplate()
                     .withVolumeClaimTemplates(volumeClaims)
@@ -955,6 +958,7 @@ public abstract class AbstractModel {
                             .withSecurityContext(templateSecurityContext)
                             .withPriorityClassName(templatePodPriorityClassName)
                             .withSchedulerName(templatePodSchedulerName)
+                            .withHostAliases(templatePodHostAliases)
                         .endSpec()
                     .endTemplate()
                 .endSpec()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -140,6 +140,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                             .withSecurityContext(templateSecurityContext)
                             .withPriorityClassName(templatePodPriorityClassName)
                             .withSchedulerName(templatePodSchedulerName)
+                            .withHostAliases(templatePodHostAliases)
                         .endSpec()
                     .endTemplate()
                     .withTriggers(configChangeTrigger, imageChangeTrigger)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -255,6 +255,7 @@ public class ModelUtils {
             model.templateSecurityContext = pod.getSecurityContext();
             model.templatePodPriorityClassName = pod.getPriorityClassName();
             model.templatePodSchedulerName = pod.getSchedulerName();
+            model.templatePodHostAliases = pod.getHostAliases();
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -11,6 +11,8 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.HostAlias;
+import io.fabric8.kubernetes.api.model.HostAliasBuilder;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.OwnerReference;
@@ -71,6 +73,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -515,6 +518,15 @@ public class KafkaConnectClusterTest {
         Map<String, String> pdbLabels = TestUtils.map("l7", "v7", "l8", "v8");
         Map<String, String> pdbAnots = TestUtils.map("a7", "v7", "a8", "v8");
 
+        HostAlias hostAlias1 = new HostAliasBuilder()
+                .withHostnames("my-host-1", "my-host-2")
+                .withIp("192.168.1.86")
+                .build();
+        HostAlias hostAlias2 = new HostAliasBuilder()
+                .withHostnames("my-host-3")
+                .withIp("192.168.1.87")
+                .build();
+
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .editSpec()
                     .withNewTemplate()
@@ -531,6 +543,7 @@ public class KafkaConnectClusterTest {
                             .endMetadata()
                             .withNewPriorityClassName("top-priority")
                             .withNewSchedulerName("my-scheduler")
+                            .withHostAliases(hostAlias1, hostAlias2)
                         .endPod()
                         .withNewApiService()
                             .withNewMetadata()
@@ -559,6 +572,7 @@ public class KafkaConnectClusterTest {
         assertThat(dep.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()), is(true));
         assertThat(dep.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnots.entrySet()), is(true));
         assertThat(dep.getSpec().getTemplate().getSpec().getSchedulerName(), is("my-scheduler"));
+        assertThat(dep.getSpec().getTemplate().getSpec().getHostAliases(), containsInAnyOrder(hostAlias1, hostAlias2));
 
         // Check Service
         Service svc = kc.generateService();

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1185,6 +1185,10 @@ include::../api/io.strimzi.api.kafka.model.template.PodTemplate.adoc[leveloffset
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core[Affinity]
+|hostAliases                    1.2+<.<|The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#HostAlias-v1-core[core/v1 HostAlias].
+
+
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#HostAlias-v1-core[HostAlias] array
 |priorityClassName              1.2+<.<|The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
 |string
 |schedulerName                  1.2+<.<|The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1185,18 +1185,18 @@ include::../api/io.strimzi.api.kafka.model.template.PodTemplate.adoc[leveloffset
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core[Affinity]
-|hostAliases                    1.2+<.<|The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#HostAlias-v1-core[core/v1 HostAlias].
-
-
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#HostAlias-v1-core[HostAlias] array
-|priorityClassName              1.2+<.<|The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-|string
-|schedulerName                  1.2+<.<|The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
-|string
 |tolerations                    1.2+<.<|The pod's tolerations. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core[core/v1 toleration].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core[Toleration] array
+|priorityClassName              1.2+<.<|The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+|string
+|schedulerName                  1.2+<.<|The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+|string
+|hostAliases                    1.2+<.<|The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#HostAlias-v1-core[core/v1 HostAlias].
+
+
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#HostAlias-v1-core[HostAlias] array
 |====
 
 [id='type-ResourceTemplate-{context}']

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -1826,24 +1826,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -1860,6 +1842,24 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                       description: Template for Kafka `Pods`.
                     bootstrapService:
                       type: object
@@ -2918,24 +2918,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -2952,6 +2934,24 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                       description: Template for ZooKeeper `Pods`.
                     clientService:
                       type: object
@@ -4446,24 +4446,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -4480,6 +4462,24 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                       description: Template for Entity Operator `Pods`.
                     tlsSidecarContainer:
                       type: object
@@ -5191,24 +5191,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -5225,6 +5207,24 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                       description: Template for Cruise Control `Pods`.
                     apiService:
                       type: object
@@ -5784,24 +5784,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -5818,6 +5800,24 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                       description: Template for JmxTrans `Pods`.
                     container:
                       type: object
@@ -6213,24 +6213,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -6247,6 +6229,24 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                       description: Template for Kafka Exporter `Pods`.
                     service:
                       type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -1826,6 +1826,18 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
@@ -2906,6 +2918,18 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
@@ -4422,6 +4446,18 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
@@ -5155,6 +5191,18 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
@@ -5736,6 +5784,18 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
@@ -6153,6 +6213,18 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -835,6 +835,18 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                     priorityClassName:
                       type: string
                       description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -835,24 +835,6 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
-                    hostAliases:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          hostnames:
-                            type: array
-                            items:
-                              type: string
-                          ip:
-                            type: string
-                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                    priorityClassName:
-                      type: string
-                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                    schedulerName:
-                      type: string
-                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -869,6 +851,24 @@ spec:
                           value:
                             type: string
                       description: The pod's tolerations.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -661,6 +661,18 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                     priorityClassName:
                       type: string
                       description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -661,24 +661,6 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
-                    hostAliases:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          hostnames:
-                            type: array
-                            items:
-                              type: string
-                          ip:
-                            type: string
-                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                    priorityClassName:
-                      type: string
-                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                    schedulerName:
-                      type: string
-                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -695,6 +677,24 @@ spec:
                           value:
                             type: string
                       description: The pod's tolerations.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -974,24 +974,6 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
-                    hostAliases:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          hostnames:
-                            type: array
-                            items:
-                              type: string
-                          ip:
-                            type: string
-                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                    priorityClassName:
-                      type: string
-                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                    schedulerName:
-                      type: string
-                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -1008,6 +990,24 @@ spec:
                           value:
                             type: string
                       description: The pod's tolerations.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                   description: Template for Kafka MirrorMaker `Pods`.
                 mirrorMakerContainer:
                   type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -974,6 +974,18 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                     priorityClassName:
                       type: string
                       description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -635,24 +635,6 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
-                    hostAliases:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          hostnames:
-                            type: array
-                            items:
-                              type: string
-                          ip:
-                            type: string
-                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                    priorityClassName:
-                      type: string
-                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                    schedulerName:
-                      type: string
-                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -669,6 +651,24 @@ spec:
                           value:
                             type: string
                       description: The pod's tolerations.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                   description: Template for Kafka Bridge `Pods`.
                 apiService:
                   type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -635,6 +635,18 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                     priorityClassName:
                       type: string
                       description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -917,24 +917,6 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
-                    hostAliases:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          hostnames:
-                            type: array
-                            items:
-                              type: string
-                          ip:
-                            type: string
-                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                    priorityClassName:
-                      type: string
-                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                    schedulerName:
-                      type: string
-                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -951,6 +933,24 @@ spec:
                           value:
                             type: string
                       description: The pod's tolerations.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -917,6 +917,18 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                     priorityClassName:
                       type: string
                       description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1822,24 +1822,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -1856,6 +1838,24 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                       description: Template for Kafka `Pods`.
                     bootstrapService:
                       type: object
@@ -2914,24 +2914,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -2948,6 +2930,24 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                       description: Template for ZooKeeper `Pods`.
                     clientService:
                       type: object
@@ -4442,24 +4442,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -4476,6 +4458,24 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                       description: Template for Entity Operator `Pods`.
                     tlsSidecarContainer:
                       type: object
@@ -5187,24 +5187,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -5221,6 +5203,24 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                       description: Template for Cruise Control `Pods`.
                     apiService:
                       type: object
@@ -5780,24 +5780,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -5814,6 +5796,24 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                       description: Template for JmxTrans `Pods`.
                     container:
                       type: object
@@ -6209,24 +6209,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                         tolerations:
                           type: array
                           items:
@@ -6243,6 +6225,24 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                       description: Template for Kafka Exporter `Pods`.
                     service:
                       type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1822,6 +1822,18 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
@@ -2902,6 +2914,18 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
@@ -4418,6 +4442,18 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
@@ -5151,6 +5187,18 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
@@ -5732,6 +5780,18 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
@@ -6149,6 +6209,18 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -831,6 +831,18 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                     priorityClassName:
                       type: string
                       description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -831,24 +831,6 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
-                    hostAliases:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          hostnames:
-                            type: array
-                            items:
-                              type: string
-                          ip:
-                            type: string
-                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                    priorityClassName:
-                      type: string
-                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                    schedulerName:
-                      type: string
-                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -865,6 +847,24 @@ spec:
                           value:
                             type: string
                       description: The pod's tolerations.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -657,6 +657,18 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                     priorityClassName:
                       type: string
                       description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -657,24 +657,6 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
-                    hostAliases:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          hostnames:
-                            type: array
-                            items:
-                              type: string
-                          ip:
-                            type: string
-                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                    priorityClassName:
-                      type: string
-                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                    schedulerName:
-                      type: string
-                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -691,6 +673,24 @@ spec:
                           value:
                             type: string
                       description: The pod's tolerations.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -970,24 +970,6 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
-                    hostAliases:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          hostnames:
-                            type: array
-                            items:
-                              type: string
-                          ip:
-                            type: string
-                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                    priorityClassName:
-                      type: string
-                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                    schedulerName:
-                      type: string
-                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -1004,6 +986,24 @@ spec:
                           value:
                             type: string
                       description: The pod's tolerations.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                   description: Template for Kafka MirrorMaker `Pods`.
                 mirrorMakerContainer:
                   type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -970,6 +970,18 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                     priorityClassName:
                       type: string
                       description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -631,6 +631,18 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                     priorityClassName:
                       type: string
                       description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -631,24 +631,6 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
-                    hostAliases:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          hostnames:
-                            type: array
-                            items:
-                              type: string
-                          ip:
-                            type: string
-                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                    priorityClassName:
-                      type: string
-                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                    schedulerName:
-                      type: string
-                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -665,6 +647,24 @@ spec:
                           value:
                             type: string
                       description: The pod's tolerations.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                   description: Template for Kafka Bridge `Pods`.
                 apiService:
                   type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -913,6 +913,18 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                     priorityClassName:
                       type: string
                       description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -913,24 +913,6 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
-                    hostAliases:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          hostnames:
-                            type: array
-                            items:
-                              type: string
-                          ip:
-                            type: string
-                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-                    priorityClassName:
-                      type: string
-                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
-                    schedulerName:
-                      type: string
-                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -947,6 +929,24 @@ spec:
                           value:
                             type: string
                       description: The pod's tolerations.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -2355,6 +2355,20 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional
+                            list of hosts and IPs that will be injected into the pod's
+                            hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign
@@ -3580,6 +3594,20 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional
+                            list of hosts and IPs that will be injected into the pod's
+                            hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign
@@ -5237,6 +5265,20 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional
+                            list of hosts and IPs that will be injected into the pod's
+                            hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign
@@ -6053,6 +6095,20 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional
+                            list of hosts and IPs that will be injected into the pod's
+                            hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign
@@ -6714,6 +6770,20 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional
+                            list of hosts and IPs that will be injected into the pod's
+                            hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign
@@ -7168,6 +7238,20 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional
+                            list of hosts and IPs that will be injected into the pod's
+                            hosts file if specified.
                         priorityClassName:
                           type: string
                           description: The name of the priority class used to assign

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -2355,30 +2355,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional
-                            list of hosts and IPs that will be injected into the pod's
-                            hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign
-                            priority to the pods. For more information about priority
-                            classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
                         tolerations:
                           type: array
                           items:
@@ -2395,6 +2371,30 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign
+                            priority to the pods. For more information about priority
+                            classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional
+                            list of hosts and IPs that will be injected into the pod's
+                            hosts file if specified.
                       description: Template for Kafka `Pods`.
                     bootstrapService:
                       type: object
@@ -3594,30 +3594,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional
-                            list of hosts and IPs that will be injected into the pod's
-                            hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign
-                            priority to the pods. For more information about priority
-                            classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
                         tolerations:
                           type: array
                           items:
@@ -3634,6 +3610,30 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign
+                            priority to the pods. For more information about priority
+                            classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional
+                            list of hosts and IPs that will be injected into the pod's
+                            hosts file if specified.
                       description: Template for ZooKeeper `Pods`.
                     clientService:
                       type: object
@@ -5265,30 +5265,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional
-                            list of hosts and IPs that will be injected into the pod's
-                            hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign
-                            priority to the pods. For more information about priority
-                            classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
                         tolerations:
                           type: array
                           items:
@@ -5305,6 +5281,30 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign
+                            priority to the pods. For more information about priority
+                            classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional
+                            list of hosts and IPs that will be injected into the pod's
+                            hosts file if specified.
                       description: Template for Entity Operator `Pods`.
                     tlsSidecarContainer:
                       type: object
@@ -6095,30 +6095,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional
-                            list of hosts and IPs that will be injected into the pod's
-                            hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign
-                            priority to the pods. For more information about priority
-                            classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
                         tolerations:
                           type: array
                           items:
@@ -6135,6 +6111,30 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign
+                            priority to the pods. For more information about priority
+                            classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional
+                            list of hosts and IPs that will be injected into the pod's
+                            hosts file if specified.
                       description: Template for Cruise Control `Pods`.
                     apiService:
                       type: object
@@ -6770,30 +6770,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional
-                            list of hosts and IPs that will be injected into the pod's
-                            hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign
-                            priority to the pods. For more information about priority
-                            classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
                         tolerations:
                           type: array
                           items:
@@ -6810,6 +6786,30 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign
+                            priority to the pods. For more information about priority
+                            classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional
+                            list of hosts and IPs that will be injected into the pod's
+                            hosts file if specified.
                       description: Template for JmxTrans `Pods`.
                     container:
                       type: object
@@ -7238,30 +7238,6 @@ spec:
                                       topologyKey:
                                         type: string
                           description: The pod's affinity rules.
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional
-                            list of hosts and IPs that will be injected into the pod's
-                            hosts file if specified.
-                        priorityClassName:
-                          type: string
-                          description: The name of the priority class used to assign
-                            priority to the pods. For more information about priority
-                            classes, see {K8sPriorityClass}.
-                        schedulerName:
-                          type: string
-                          description: The name of the scheduler used to dispatch
-                            this `Pod`. If not specified, the default scheduler will
-                            be used.
                         tolerations:
                           type: array
                           items:
@@ -7278,6 +7254,30 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign
+                            priority to the pods. For more information about priority
+                            classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional
+                            list of hosts and IPs that will be injected into the pod's
+                            hosts file if specified.
                       description: Template for Kafka Exporter `Pods`.
                     service:
                       type: object

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -907,29 +907,6 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
-                    hostAliases:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          hostnames:
-                            type: array
-                            items:
-                              type: string
-                          ip:
-                            type: string
-                      description: The pod's HostAliases. HostAliases is an optional
-                        list of hosts and IPs that will be injected into the pod's
-                        hosts file if specified.
-                    priorityClassName:
-                      type: string
-                      description: The name of the priority class used to assign priority
-                        to the pods. For more information about priority classes,
-                        see {K8sPriorityClass}.
-                    schedulerName:
-                      type: string
-                      description: The name of the scheduler used to dispatch this
-                        `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -946,6 +923,29 @@ spec:
                           value:
                             type: string
                       description: The pod's tolerations.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority
+                        to the pods. For more information about priority classes,
+                        see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional
+                        list of hosts and IPs that will be injected into the pod's
+                        hosts file if specified.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -907,6 +907,20 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional
+                        list of hosts and IPs that will be injected into the pod's
+                        hosts file if specified.
                     priorityClassName:
                       type: string
                       description: The name of the priority class used to assign priority

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -695,29 +695,6 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
-                    hostAliases:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          hostnames:
-                            type: array
-                            items:
-                              type: string
-                          ip:
-                            type: string
-                      description: The pod's HostAliases. HostAliases is an optional
-                        list of hosts and IPs that will be injected into the pod's
-                        hosts file if specified.
-                    priorityClassName:
-                      type: string
-                      description: The name of the priority class used to assign priority
-                        to the pods. For more information about priority classes,
-                        see {K8sPriorityClass}.
-                    schedulerName:
-                      type: string
-                      description: The name of the scheduler used to dispatch this
-                        `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -734,6 +711,29 @@ spec:
                           value:
                             type: string
                       description: The pod's tolerations.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority
+                        to the pods. For more information about priority classes,
+                        see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional
+                        list of hosts and IPs that will be injected into the pod's
+                        hosts file if specified.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -695,6 +695,20 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional
+                        list of hosts and IPs that will be injected into the pod's
+                        hosts file if specified.
                     priorityClassName:
                       type: string
                       description: The name of the priority class used to assign priority

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -1079,29 +1079,6 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
-                    hostAliases:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          hostnames:
-                            type: array
-                            items:
-                              type: string
-                          ip:
-                            type: string
-                      description: The pod's HostAliases. HostAliases is an optional
-                        list of hosts and IPs that will be injected into the pod's
-                        hosts file if specified.
-                    priorityClassName:
-                      type: string
-                      description: The name of the priority class used to assign priority
-                        to the pods. For more information about priority classes,
-                        see {K8sPriorityClass}.
-                    schedulerName:
-                      type: string
-                      description: The name of the scheduler used to dispatch this
-                        `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -1118,6 +1095,29 @@ spec:
                           value:
                             type: string
                       description: The pod's tolerations.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority
+                        to the pods. For more information about priority classes,
+                        see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional
+                        list of hosts and IPs that will be injected into the pod's
+                        hosts file if specified.
                   description: Template for Kafka MirrorMaker `Pods`.
                 mirrorMakerContainer:
                   type: object

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -1079,6 +1079,20 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional
+                        list of hosts and IPs that will be injected into the pod's
+                        hosts file if specified.
                     priorityClassName:
                       type: string
                       description: The name of the priority class used to assign priority

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -707,29 +707,6 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
-                    hostAliases:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          hostnames:
-                            type: array
-                            items:
-                              type: string
-                          ip:
-                            type: string
-                      description: The pod's HostAliases. HostAliases is an optional
-                        list of hosts and IPs that will be injected into the pod's
-                        hosts file if specified.
-                    priorityClassName:
-                      type: string
-                      description: The name of the priority class used to assign priority
-                        to the pods. For more information about priority classes,
-                        see {K8sPriorityClass}.
-                    schedulerName:
-                      type: string
-                      description: The name of the scheduler used to dispatch this
-                        `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -746,6 +723,29 @@ spec:
                           value:
                             type: string
                       description: The pod's tolerations.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority
+                        to the pods. For more information about priority classes,
+                        see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional
+                        list of hosts and IPs that will be injected into the pod's
+                        hosts file if specified.
                   description: Template for Kafka Bridge `Pods`.
                 apiService:
                   type: object

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -707,6 +707,20 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional
+                        list of hosts and IPs that will be injected into the pod's
+                        hosts file if specified.
                     priorityClassName:
                       type: string
                       description: The name of the priority class used to assign priority

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1013,29 +1013,6 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
-                    hostAliases:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          hostnames:
-                            type: array
-                            items:
-                              type: string
-                          ip:
-                            type: string
-                      description: The pod's HostAliases. HostAliases is an optional
-                        list of hosts and IPs that will be injected into the pod's
-                        hosts file if specified.
-                    priorityClassName:
-                      type: string
-                      description: The name of the priority class used to assign priority
-                        to the pods. For more information about priority classes,
-                        see {K8sPriorityClass}.
-                    schedulerName:
-                      type: string
-                      description: The name of the scheduler used to dispatch this
-                        `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -1052,6 +1029,29 @@ spec:
                           value:
                             type: string
                       description: The pod's tolerations.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority
+                        to the pods. For more information about priority classes,
+                        see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional
+                        list of hosts and IPs that will be injected into the pod's
+                        hosts file if specified.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1013,6 +1013,20 @@ spec:
                                   topologyKey:
                                     type: string
                       description: The pod's affinity rules.
+                    hostAliases:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostnames:
+                            type: array
+                            items:
+                              type: string
+                          ip:
+                            type: string
+                      description: The pod's HostAliases. HostAliases is an optional
+                        list of hosts and IPs that will be injected into the pod's
+                        hosts file if specified.
                     priorityClassName:
                       type: string
                       description: The name of the priority class used to assign priority


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Kubernetes offers the ability to add records to the `/etc/hosts` file using the `hostAliases` field in Pod template spec. This can be useful especially in Kafka Connect or Mirror Maker which are connecting also somewhere outside of the cluster and was requested by users. This PR adds it to the pod template so that it can be configured in our pods.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md
