### PR TITLE
[systemtest] Fixes for nightlies

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -431,14 +431,14 @@ public abstract class AbstractST implements TestSeparator {
         String kafkaServiceName = clusterName + "-kafka";
         String zookeeperServiceName = clusterName + "-zookeeper";
 
-        Map<String, String> servicesList = new HashMap<>();
-        servicesList.put(kafkaServiceName + "-bootstrap", kafkaServiceName);
-        servicesList.put(kafkaServiceName + "-brokers", kafkaServiceName);
+        Map<String, String> servicesMap = new HashMap<>();
+        servicesMap.put(kafkaServiceName + "-bootstrap", kafkaServiceName);
+        servicesMap.put(kafkaServiceName + "-brokers", kafkaServiceName);
 
-        servicesList.put(zookeeperServiceName + "-nodes", zookeeperServiceName);
-        servicesList.put(zookeeperServiceName + "-client", zookeeperServiceName + "-client");
+        servicesMap.put(zookeeperServiceName + "-nodes", zookeeperServiceName);
+        servicesMap.put(zookeeperServiceName + "-client", zookeeperServiceName + "-client");
 
-        for (String serviceName : servicesList.keySet()) {
+        for (String serviceName : servicesMap.keySet()) {
             kubeClient().listServices().stream()
                 .filter(service -> service.getMetadata().getName().equals(serviceName))
                 .forEach(service -> {
@@ -446,7 +446,7 @@ public abstract class AbstractST implements TestSeparator {
                     assertThat(service.getMetadata().getLabels().get("app"), is(appName));
                     assertThat(service.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is(clusterName));
                     assertThat(service.getMetadata().getLabels().get(Labels.STRIMZI_KIND_LABEL), is("Kafka"));
-                    assertThat(service.getMetadata().getLabels().get(Labels.STRIMZI_NAME_LABEL), is(servicesList.get(serviceName)));
+                    assertThat(service.getMetadata().getLabels().get(Labels.STRIMZI_NAME_LABEL), is(servicesMap.get(serviceName)));
                 });
         }
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -428,13 +428,17 @@ public abstract class AbstractST implements TestSeparator {
 
     void verifyLabelsForKafkaAndZKServices(String clusterName, String appName) {
         LOGGER.info("Verifying labels for Services");
-        List<String> servicesList = new ArrayList<>();
-        servicesList.add(clusterName + "-kafka-bootstrap");
-        servicesList.add(clusterName + "-kafka-brokers");
-        servicesList.add(clusterName + "-zookeeper-nodes");
-        servicesList.add(clusterName + "-zookeeper-client");
+        String kafkaServiceName = clusterName + "-kafka";
+        String zookeeperServiceName = clusterName + "-zookeeper";
 
-        for (String serviceName : servicesList) {
+        Map<String, String> servicesList = new HashMap<>();
+        servicesList.put(kafkaServiceName + "-bootstrap", kafkaServiceName);
+        servicesList.put(kafkaServiceName + "-brokers", kafkaServiceName);
+
+        servicesList.put(zookeeperServiceName + "-nodes", zookeeperServiceName);
+        servicesList.put(zookeeperServiceName + "-client", zookeeperServiceName + "-client");
+
+        for (String serviceName : servicesList.keySet()) {
             kubeClient().listServices().stream()
                 .filter(service -> service.getMetadata().getName().equals(serviceName))
                 .forEach(service -> {
@@ -442,7 +446,7 @@ public abstract class AbstractST implements TestSeparator {
                     assertThat(service.getMetadata().getLabels().get("app"), is(appName));
                     assertThat(service.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is(clusterName));
                     assertThat(service.getMetadata().getLabels().get(Labels.STRIMZI_KIND_LABEL), is("Kafka"));
-                    assertThat(service.getMetadata().getLabels().get(Labels.STRIMZI_NAME_LABEL), is(serviceName));
+                    assertThat(service.getMetadata().getLabels().get(Labels.STRIMZI_NAME_LABEL), is(servicesList.get(serviceName)));
                 });
         }
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -126,7 +126,7 @@ class KafkaST extends AbstractST {
         cmdKubeClient().deleteByName("Kafka", OPENSHIFT_CLUSTER_NAME);
 
         //Wait for kafka deletion
-        cmdKubeClient().waitForResourceDeletion("Kafka", OPENSHIFT_CLUSTER_NAME);
+        cmdKubeClient().waitForResourceDeletion(Kafka.RESOURCE_KIND, OPENSHIFT_CLUSTER_NAME);
         kubeClient().listPods().stream()
             .filter(p -> p.getMetadata().getName().startsWith(OPENSHIFT_CLUSTER_NAME))
             .forEach(p -> PodUtils.deletePodWithWait(p.getMetadata().getName()));
@@ -992,7 +992,7 @@ class KafkaST extends AbstractST {
                     new GenericKafkaListenerBuilder()
                             .withName("external")
                             .withPort(9094)
-                            .withType(KafkaListenerType.NODEPORT)
+                            .withType(KafkaListenerType.LOADBALANCER)
                             .withTls(true)
                             .build()
             ), null);
@@ -1664,6 +1664,8 @@ class KafkaST extends AbstractST {
         if (cluster.getListOfDeployedResources().contains(TEMPLATE_PATH)) {
             cluster.deleteCustomResources(TEMPLATE_PATH);
         }
+
+        cmdKubeClient().deleteByName(Kafka.RESOURCE_KIND, OPENSHIFT_CLUSTER_NAME);
 
         kubeClient().listPods().stream()
             .filter(p -> p.getMetadata().getName().startsWith(OPENSHIFT_CLUSTER_NAME))

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -1665,7 +1665,9 @@ class KafkaST extends AbstractST {
             cluster.deleteCustomResources(TEMPLATE_PATH);
         }
 
-        cmdKubeClient().deleteByName(Kafka.RESOURCE_KIND, OPENSHIFT_CLUSTER_NAME);
+        if (KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(OPENSHIFT_CLUSTER_NAME).get() != null) {
+            cmdKubeClient().deleteByName(Kafka.RESOURCE_KIND, OPENSHIFT_CLUSTER_NAME);
+        }
 
         kubeClient().listPods().stream()
             .filter(p -> p.getMetadata().getName().startsWith(OPENSHIFT_CLUSTER_NAME))

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
@@ -484,7 +484,7 @@ public class ListenersST extends AbstractST {
                         .addNewGenericKafkaListener()
                             .withName("external")
                             .withPort(9094)
-                            .withType(KafkaListenerType.NODEPORT)
+                            .withType(KafkaListenerType.LOADBALANCER)
                             .withTls(false)
                         .endGenericKafkaListener()
                     .endListeners()

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
@@ -14,6 +14,7 @@ import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.api.kafka.model.status.Condition;
@@ -80,6 +81,7 @@ import static io.strimzi.systemtest.enums.CustomResourceStatus.NotReady;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
 import static io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils.getKafkaSecretCertificates;
 import static io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils.getKafkaStatusCertificates;
+import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
@@ -166,6 +168,7 @@ class CustomResourceStatusST extends AbstractST {
         LOGGER.info("KafkaUser {} is in desired state: {}", userName, kafkaCondition.getType());
 
         KafkaUserResource.kafkaUserClient().inNamespace(NAMESPACE).withName(userName).delete();
+        KafkaUserUtils.waitForKafkaUserDeletion(userName);
     }
 
     @Test
@@ -319,6 +322,7 @@ class CustomResourceStatusST extends AbstractST {
         KafkaConnectorUtils.waitForConnectorNotReady(CLUSTER_NAME);
 
         KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+        KafkaConnectorUtils.waitForConnectorDeletion(CLUSTER_NAME);
     }
 
     @Test
@@ -333,6 +337,9 @@ class CustomResourceStatusST extends AbstractST {
         KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME, topicName, 1, 10, 10).build());
         KafkaTopicUtils.waitForKafkaTopicNotReady(topicName);
         assertKafkaTopicStatus(1, topicName);
+
+        cmdKubeClient().deleteByName(KafkaTopic.RESOURCE_KIND, topicName);
+        KafkaTopicUtils.waitForKafkaTopicDeletion(topicName);
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -11,7 +11,6 @@ import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
-import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
@@ -764,26 +763,7 @@ public class TracingST extends AbstractST {
     @Tag(CONNECT_COMPONENTS)
     void testConnectS2IService() {
 
-        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
-                .editSpec()
-                    .editKafka()
-                        .withNewListeners()
-                            .addNewGenericKafkaListener()
-                                .withName("tls")
-                                .withPort(9093)
-                                .withType(KafkaListenerType.INTERNAL)
-                                .withTls(true)
-                            .endGenericKafkaListener()
-                            .addNewGenericKafkaListener()
-                                .withName("external")
-                                .withPort(9094)
-                                .withType(KafkaListenerType.NODEPORT)
-                                .withTls(false)
-                            .endGenericKafkaListener()
-                        .endListeners()
-                    .endKafka()
-                .endSpec()
-                .done();
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1).done();
 
         kafkaTracingClient.producerWithTracing().done();
         kafkaTracingClient.consumerWithTracing().done();


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Tests fixes

### Description

After some PRs and new features it seems that some tests are failing.

-> naming of services was changed for Kafka and Zookeeper in `strimzi.io/name`
-> some listeners was switch: NODEPORT -> LOADBALANCER
-> removed the listeners from resource where was already set in the `defaultKafka` method in `KafkaResource`

### Checklist

- [x] Make sure all tests pass


