### PR TITLE
Allow downgrade with message version older than the version we are downgrading to

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1157,7 +1157,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
             // Force the user to explicitly set log.message.format.version
             // (Controller shouldn't break clients)
-            if (oldMessageFormat == null || !oldMessageFormat.equals(versionChange.to().messageVersion())) {
+            if (oldMessageFormat == null || compareDottedVersions(oldMessageFormat, versionChange.to().messageVersion()) > 0) {
                 return Future.failedFuture(new KafkaUpgradeException(
                         String.format("Cannot downgrade Kafka cluster %s in namespace %s to version %s " +
                                         "because the current cluster is configured with %s=%s. " +

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
@@ -570,6 +570,12 @@ public class KafkaUpdateTest {
     }
 
     @Test
+    public void downgradeLatestToPrevWithEarlierThenPrevMessageFormatConfig(VertxTestContext context) throws IOException {
+        testDowngradeLatestToPrevMessageFormatConfig(context, singletonMap(LOG_MESSAGE_FORMAT_VERSION,
+                "2.0"), true);
+    }
+
+    @Test
     public void downgradeLatestToPrevWithLatestProtocolVersion(VertxTestContext context) throws IOException {
         testDowngradeLatestToPrevMessageFormatConfig(context,
                 (Map) map(LOG_MESSAGE_FORMAT_VERSION, KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When downgrading the Kafka version, the operator currently checks that the message format version has to be the same as the broker version which we are downgrading to. This is too strict -> it should check for the version being equal or older than the version we are downgrading to. E.g., when downgrading from 2.6 to 2.5, we should allow the downgrade if the message version is set to 2.4.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally