### PR TITLE
Diff Pod Disruption Budgets before patching them to not recreate them on every reconciliation

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetDiff.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetDiff.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
+import io.fabric8.zjsonpatch.JsonDiff;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.regex.Pattern;
+
+import static io.fabric8.kubernetes.client.internal.PatchUtils.patchMapper;
+
+class PodDisruptionBudgetDiff extends AbstractResourceDiff  {
+    private static final Logger log = LogManager.getLogger(PodDisruptionBudgetDiff.class.getName());
+
+    private final boolean isEmpty;
+
+    private static final Pattern IGNORABLE_PATHS = Pattern.compile(
+            "^(/metadata/managedFields" +
+                    "|/status)$");
+
+    public PodDisruptionBudgetDiff(PodDisruptionBudget current, PodDisruptionBudget desired) {
+        JsonNode source = patchMapper().valueToTree(current == null ? "{}" : current);
+        JsonNode target = patchMapper().valueToTree(desired == null ? "{}" : desired);
+        JsonNode diff = JsonDiff.asJson(source, target);
+
+        int num = 0;
+
+        for (JsonNode d : diff) {
+            String pathValue = d.get("path").asText();
+
+            if (IGNORABLE_PATHS.matcher(pathValue).matches()) {
+                log.debug("Ignoring PodDisruptionBudget diff {}", d);
+                continue;
+            }
+
+            if (log.isDebugEnabled()) {
+                log.debug("PodDisruptionBudget differs: {}", d);
+                log.debug("Current PodDisruptionBudget path {} has value {}", pathValue, lookupPath(source, pathValue));
+                log.debug("Desired PodDisruptionBudget path {} has value {}", pathValue, lookupPath(target, pathValue));
+            }
+
+            num++;
+            break;
+        }
+
+        this.isEmpty = num == 0;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return isEmpty;
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperator.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudgetList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 public class PodDisruptionBudgetOperator extends AbstractResourceOperator<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, DoneablePodDisruptionBudget, Resource<PodDisruptionBudget, DoneablePodDisruptionBudget>> {
@@ -18,9 +19,20 @@ public class PodDisruptionBudgetOperator extends AbstractResourceOperator<Kubern
         super(vertx, client, "PodDisruptionBudget");
 
     }
+
     @Override
     protected MixedOperation<PodDisruptionBudget, PodDisruptionBudgetList, DoneablePodDisruptionBudget, Resource<PodDisruptionBudget, DoneablePodDisruptionBudget>> operation() {
         return client.policy().podDisruptionBudget();
     }
 
+    @Override
+    protected Future<ReconcileResult<PodDisruptionBudget>> internalPatch(String namespace, String name, PodDisruptionBudget current, PodDisruptionBudget desired, boolean cascading) {
+        PodDisruptionBudgetDiff diff = new PodDisruptionBudgetDiff(current, desired);
+
+        if (!diff.isEmpty())    {
+            return super.internalPatch(namespace, name, current, desired, cascading);
+        } else {
+            return Future.succeededFuture(ReconcileResult.noop(desired));
+        }
+    }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetDiffTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetDiffTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource;
+
+import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
+import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudgetBuilder;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class PodDisruptionBudgetDiffTest  {
+    @Test
+    public void testNoDiff()    {
+        PodDisruptionBudget pdb1 = new PodDisruptionBudgetBuilder()
+                .withNewMetadata()
+                    .withName("my-pdb")
+                    .withNamespace("my-ns")
+                    .withLabels(singletonMap("foo", "bar"))
+                .endMetadata()
+                .withNewSpec()
+                    .withNewMaxUnavailable(1)
+                .endSpec()
+                .build();
+
+        PodDisruptionBudget pdb2 = new PodDisruptionBudgetBuilder()
+                .withNewMetadata()
+                    .withName("my-pdb")
+                    .withNamespace("my-ns")
+                    .withLabels(singletonMap("foo", "bar"))
+                .endMetadata()
+                .withNewSpec()
+                    .withNewMaxUnavailable(1)
+                .endSpec()
+                .build();
+
+        assertThat((new PodDisruptionBudgetDiff(pdb1, pdb2)).isEmpty(), is(true));
+    }
+
+    @Test
+    public void testMaxUnavailableDiff()    {
+        PodDisruptionBudget pdb1 = new PodDisruptionBudgetBuilder()
+                .withNewMetadata()
+                    .withName("my-pdb")
+                    .withNamespace("my-ns")
+                    .withLabels(singletonMap("foo", "bar"))
+                .endMetadata()
+                .withNewSpec()
+                    .withNewMaxUnavailable(1)
+                .endSpec()
+                .build();
+
+        PodDisruptionBudget pdb2 = new PodDisruptionBudgetBuilder()
+                .withNewMetadata()
+                    .withName("my-pdb")
+                    .withNamespace("my-ns")
+                    .withLabels(singletonMap("foo", "bar"))
+                .endMetadata()
+                .withNewSpec()
+                    .withNewMaxUnavailable(2)
+                .endSpec()
+                .build();
+
+        assertThat((new PodDisruptionBudgetDiff(pdb1, pdb2)).isEmpty(), is(false));
+    }
+
+    @Test
+    public void testMetadataDiff()    {
+        PodDisruptionBudget pdb1 = new PodDisruptionBudgetBuilder()
+                .withNewMetadata()
+                    .withName("my-pdb")
+                    .withNamespace("my-ns")
+                    .withLabels(singletonMap("foo", "bar"))
+                .endMetadata()
+                .withNewSpec()
+                    .withNewMaxUnavailable(1)
+                .endSpec()
+                .build();
+
+        PodDisruptionBudget pdb2 = new PodDisruptionBudgetBuilder()
+                .withNewMetadata()
+                    .withName("my-pdb")
+                    .withNamespace("my-ns")
+                    .withLabels(singletonMap("foo", "bar2"))
+                .endMetadata()
+                .withNewSpec()
+                    .withNewMaxUnavailable(1)
+                .endSpec()
+                .build();
+
+        assertThat((new PodDisruptionBudgetDiff(pdb1, pdb2)).isEmpty(), is(false));
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperatorTest.java
@@ -4,18 +4,28 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.policy.DoneablePodDisruptionBudget;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudgetBuilder;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudgetList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PolicyAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.singletonMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class PodDisruptionBudgetOperatorTest extends AbstractResourceOperatorTest<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, DoneablePodDisruptionBudget, Resource<PodDisruptionBudget, DoneablePodDisruptionBudget>> {
@@ -56,4 +66,66 @@ public class PodDisruptionBudgetOperatorTest extends AbstractResourceOperatorTes
                 .build();
     }
 
+    @Test
+    public void testCreateWhenExistsIsAPatch(VertxTestContext context) {
+        PodDisruptionBudget existingResource = resource();
+        PodDisruptionBudget desiredResource = resource();
+        desiredResource.getSpec().setMaxUnavailable(new IntOrString(2));
+
+        Resource mockResource = mock(resourceType());
+        when(mockResource.get()).thenReturn(existingResource);
+        when(mockResource.withPropagationPolicy(DeletionPropagation.FOREGROUND)).thenReturn(mockResource);
+        when(mockResource.patch(any())).thenReturn(existingResource);
+
+        NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(existingResource.getMetadata().getName()))).thenReturn(mockResource);
+
+        MixedOperation mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(existingResource.getMetadata().getNamespace()))).thenReturn(mockNameable);
+
+        KubernetesClient mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+
+        Checkpoint async = context.checkpoint();
+        createResourceOperations(vertx, mockClient).createOrUpdate(desiredResource).onComplete(context.succeeding(rr -> context.verify(() -> {
+            verify(mockResource).get();
+            verify(mockResource).patch(any());
+            verify(mockResource, never()).create(any());
+            verify(mockResource, never()).createNew();
+            verify(mockResource, never()).createOrReplace(any());
+            verify(mockCms, never()).createOrReplace(any());
+            async.flag();
+        })));
+    }
+
+    @Test
+    public void testCreateWhenExistsAndNoDiffIsNotAPatch(VertxTestContext context) {
+        PodDisruptionBudget existingResource = resource();
+        PodDisruptionBudget desiredResource = resource();
+
+        Resource mockResource = mock(resourceType());
+        when(mockResource.get()).thenReturn(existingResource);
+        when(mockResource.withPropagationPolicy(DeletionPropagation.FOREGROUND)).thenReturn(mockResource);
+        when(mockResource.patch(any())).thenReturn(existingResource);
+
+        NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(existingResource.getMetadata().getName()))).thenReturn(mockResource);
+
+        MixedOperation mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(existingResource.getMetadata().getNamespace()))).thenReturn(mockNameable);
+
+        KubernetesClient mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+
+        Checkpoint async = context.checkpoint();
+        createResourceOperations(vertx, mockClient).createOrUpdate(desiredResource).onComplete(context.succeeding(rr -> context.verify(() -> {
+            verify(mockResource).get();
+            verify(mockResource, never()).patch(any());
+            verify(mockResource, never()).create(any());
+            verify(mockResource, never()).createNew();
+            verify(mockResource, never()).createOrReplace(any());
+            verify(mockCms, never()).createOrReplace(any());
+            async.flag();
+        })));
+    }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

As described in #2993, in every reconciliation when we patch the PodDisruptionBudgets, they will get recreated. This created unnecessary load on the Kubernetes API server and triggers some alarms in user monitoring systems. This PR introduces a new diffing mechanism for PodDisruptionBudgets which check if something really changed before patching it and solves the issue.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging