### PR TITLE
Fixed wrong port peers list capacity

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1625,7 +1625,7 @@ public class KafkaCluster extends AbstractModel {
                     .endPodSelector()
                     .build();
 
-            List<NetworkPolicyPeer> clientsPortPeers = new ArrayList<>(4);
+            List<NetworkPolicyPeer> clientsPortPeers = new ArrayList<>(5);
             clientsPortPeers.add(clusterOperatorPeer);
             clientsPortPeers.add(kafkaClusterPeer);
             clientsPortPeers.add(entityOperatorPeer);


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Trivial PR to fix a wrong list initial capacity.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

