### PR TITLE
[DOC] New replication policy config for MM2

### DIFF
--- a/documentation/modules/mirrormaker2/con-mirrormaker-replication.adoc
+++ b/documentation/modules/mirrormaker2/con-mirrormaker-replication.adoc
@@ -27,18 +27,20 @@ image::mirrormaker.png[MirrorMaker 2.0 replication]
 
 You can use MirrorMaker 2.0 in _active/passive_ or _active/active_ cluster configurations.
 
-* In an _active/passive_ configuration, the data from an active cluster is replicated in a passive cluster, which remains on standby, for example, for data recovery in the event of system failure.
 * In an _active/active_ configuration, both clusters are active and provide the same data simultaneously, which is useful if you want to make the same data available locally in different geographical locations.
+* In an _active/passive_ configuration, the data from an active cluster is replicated in a passive cluster, which remains on standby, for example, for data recovery in the event of system failure.
 
 The expectation is that producers and consumers connect to active clusters only.
 
-== Bidirectional replication
+A MirrorMaker 2.0 cluster is required at each target destination.
+
+== Bidirectional replication (active/active)
 
 The MirrorMaker 2.0 architecture supports bidirectional replication in an _active/active_ cluster configuration.
-A MirrorMaker 2.0 cluster is required at each target destination.
 
 Each cluster replicates the data of the other cluster using the concept of _source_ and _remote_ topics.
 As the same topics are stored in each cluster, remote topics are automatically renamed by MirrorMaker 2.0 to represent the source cluster.
+The name of the originating cluster is prepended to the name of the topic.
 
 .Topic renaming
 image::mirrormaker-renaming.png[MirrorMaker 2.0 bidirectional architecture]
@@ -47,6 +49,16 @@ By flagging the originating cluster, topics are not replicated back to that clus
 
 The concept of replication through _remote_ topics is useful when configuring an architecture that requires data aggregation.
 Consumers can subscribe to source and remote topics within the same cluster, without the need for a separate aggregation cluster.
+
+== Unidirectional replication (active/passive)
+
+The MirrorMaker 2.0 architecture supports unidirectional replication in an _active/passive_ cluster configuration.
+
+You can use an _active/passive_ cluster configuration to make backups or migrate data to another cluster.
+In this situation, you might not want automatic renaming of remote topics.
+
+You can override automatic renaming by adding `IdentityReplicationPolicy` to the source connector configuration of the `KafkaMirrorMaker2` resource.
+With this configuration applied, topics retain their original names.
 
 == Topic configuration synchronization
 

--- a/documentation/modules/mirrormaker2/proc-mirrormaker-replication.adoc
+++ b/documentation/modules/mirrormaker2/proc-mirrormaker-replication.adoc
@@ -111,36 +111,38 @@ spec:
         replication.factor: 1 <20>
         offset-syncs.topic.replication.factor: 1 <21>
         sync.topic.acls.enabled: "false" <22>
-    heartbeatConnector: <23>
+        replication.policy.separator: "" <23>
+        replication.policy.class: "io.strimzi.kafka.connect.mirror.IdentityReplicationPolicy" <24>
+    heartbeatConnector: <25>
       config:
-        heartbeats.topic.replication.factor: 1 <24>
-    checkpointConnector: <25>
+        heartbeats.topic.replication.factor: 1 <26>
+    checkpointConnector: <27>
       config:
-        checkpoints.topic.replication.factor: 1 <26>
-    topicsPattern: ".*" <27>
-    groupsPattern: "group1|group2|group3" <28>
-  resources: <29>
+        checkpoints.topic.replication.factor: 1 <28>
+    topicsPattern: ".*" <29>
+    groupsPattern: "group1|group2|group3" <30>
+  resources: <31>
     requests:
       cpu: "1"
       memory: 2Gi
     limits:
       cpu: "2"
       memory: 2Gi
-  logging: <30>
+  logging: <32>
     type: inline
     loggers:
       log4j.rootLogger: "INFO"
-  readinessProbe: <31>
+  readinessProbe: <33>
     initialDelaySeconds: 15
     timeoutSeconds: 5
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5
-  jvmOptions: <32>
+  jvmOptions: <34>
     "-Xmx": "1g"
     "-Xms": "1g"
-  image: my-org/my-image:latest <33>
-  template: <34>
+  image: my-org/my-image:latest <35>
+  template: <36>
     pod:
       affinity:
         podAntiAffinity:
@@ -153,7 +155,7 @@ spec:
                       - postgresql
                       - mongodb
               topologyKey: "kubernetes.io/hostname"
-    connectContainer: <35>
+    connectContainer: <37>
       env:
         - name: JAEGER_SERVICE_NAME
           value: my-jaeger-service
@@ -162,8 +164,8 @@ spec:
         - name: JAEGER_AGENT_PORT
           value: "6831"
   tracing:
-    type: jaeger <36>
-  externalConfiguration: <37>
+    type: jaeger <38>
+  externalConfiguration: <39>
     env:
       - name: AWS_ACCESS_KEY_ID
         valueFrom:
@@ -199,22 +201,24 @@ Standard Apache Kafka configuration may be provided, restricted to those propert
 <20> Replication factor for mirrored topics created at the target cluster.
 <21> Replication factor for the `MirrorSourceConnector` `offset-syncs` internal topic that maps the offsets of the source and target clusters.
 <22> When xref:con-mirrormaker-acls-{context}[ACL rules synchronization] is enabled, ACLs are applied to synchronized topics. The default is `true`.
-<23> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorHeartbeatConnector`] that performs connectivity checks. The `config` overrides the default configuration options.
-<24> Replication factor for the heartbeat topic created at the target cluster.
-<25> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorCheckpointConnector`] that tracks offsets. The `config` overrides the default configuration options.
-<26> Replication factor for the checkpoints topic created at the target cluster.
-<27> Topic replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request all topics.
-<28> Consumer group replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request three consumer groups by name.
+<23> Defines the separator used for the renaming of remote topics.
+<24> Adds a policy that overrides the automatic renaming of remote topics. Instead of prepending the name with the name of the source cluster, the topic retains its original name. Useful for active/passive backups and data migration.
+<25> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorHeartbeatConnector`] that performs connectivity checks. The `config` overrides the default configuration options.
+<26> Replication factor for the heartbeat topic created at the target cluster.
+<27> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorCheckpointConnector`] that tracks offsets. The `config` overrides the default configuration options.
+<28> Replication factor for the checkpoints topic created at the target cluster.
+<29> Topic replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request all topics.
+<30> Consumer group replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request three consumer groups by name.
 You can use comma-separated lists.
-<29> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
-<30> Specified xref:property-kafka-connect-logging-reference[Kafka Connect loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. Kafka Connect has a single logger called `log4j.rootLogger`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
-<31> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
-<32> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
-<33> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
-<34> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<35> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
-<36> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
-<37> xref:type-ExternalConfiguration-reference[External configuration] for a Kubernetes Secret mounted to Kafka MirrorMaker as an environment variable.
+<31> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
+<32> Specified xref:property-kafka-connect-logging-reference[Kafka Connect loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. Kafka Connect has a single logger called `log4j.rootLogger`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<33> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
+<34> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
+<35> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
+<36> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
+<37> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
+<38> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
+<39> xref:type-ExternalConfiguration-reference[External configuration] for a Kubernetes Secret mounted to Kafka MirrorMaker as an environment variable.
 
 . Create or update the resource:
 +

--- a/documentation/modules/overview/con-configuration-points-mirrormaker.adoc
+++ b/documentation/modules/overview/con-configuration-points-mirrormaker.adoc
@@ -22,6 +22,11 @@ MirrorMaker 2.0 uses:
 [discrete]
 === Cluster configuration
 
+You can use MirrorMaker 2.0 in _active/passive_ or _active/active_ cluster configurations.
+
+* In an _active/active_ configuration, both clusters are active and provide the same data simultaneously, which is useful if you want to make the same data available locally in different geographical locations.
+* In an _active/passive_ configuration, the data from an active cluster is replicated in a passive cluster, which remains on standby, for example, for data recovery in the event of system failure.
+
 You configure a `KafkaMirrorMaker2` custom resource to define the Kafka Connect deployment, including the connection details of the source and target clusters,
 and then run a set of MirrorMaker 2.0 connectors to make the connection.
 
@@ -51,8 +56,12 @@ image::mirrormaker.png[MirrorMaker 2.0 replication between a Kafka cluster in Re
 The MirrorMaker 2.0 architecture supports bidirectional replication in an _active/active_ cluster configuration,
 so both clusters are active and provide the same data simultaneously.
 A MirrorMaker 2.0 cluster is required at each target destination.
+
 Remote topics are distinguished by automatic renaming that prepends the name of cluster to the name of the topic.
 This is useful if you want to make the same data available locally in different geographical locations.
+
+However, if you want to backup or migrate data in an active/passive cluster configuration, you might want to keep the original names of the topics.
+If so, you can configure MirrorMaker 2.0 to turn off automatic renaming.
 
 .Bidirectional replication
 image::mirrormaker-renaming.png[MirrorMaker 2.0 bidirectional architecture]


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Changes to the _Overview_ and _Using_ guides to describe the new config for replication policy to turn off renaming of topics.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

