### PR TITLE
Add reconcile resource state metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
   * Removed the avarage reconcile time graph
   * Rearranged graphs
 * Make `listeners` configurable as an array and add support for more different listeners in single cluster
-* Add support for configuring `hostAliases` in Pod templates 
+* Add support for configuring `hostAliases` in Pod templates
+* Add new resource state metric in the operators for reflecting the reconcile result on a specific resource 
 
 ### Deprecations and removals
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -12,6 +12,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.Meter;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.common.model.NamespaceAndName;
 import io.strimzi.operator.common.model.ResourceVisitor;
@@ -26,6 +27,8 @@ import io.vertx.core.shareddata.Lock;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -27,11 +27,11 @@ import io.vertx.core.shareddata.Lock;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -115,7 +115,7 @@ public abstract class AbstractOperator<
                 "The time the reconciliation takes to complete",
                 metricTags);
 
-        resourcesStateCounter = new HashMap<>();
+        resourcesStateCounter = new ConcurrentHashMap<>();
     }
 
     @Override


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR fixes #3642.
It adds a new metric exposed by operators and defined as:

`strimzi_resource_state{kind="Kafka", name="my-cluster", resource-namespace="my-kafka-namespace"}`

providing the information on the latest reconcile state so a kind of information if the Kafka cluster was created and ready at the end of reconciling something failed (more info to check in the status of the custom resource). The possible values are just 1.0 and 0.0.
Of course, it's not just about Kafka but even the other resources.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
