### PR TITLE
Split regresison AZP to don't hit timeouts

### DIFF
--- a/.azure/regression-pipeline.yaml
+++ b/.azure/regression-pipeline.yaml
@@ -13,7 +13,7 @@ jobs:
     parameters:
       name: 'regression_kafka'
       display_name: 'regression-bundle I. - kafka'
-      test_case: 'kafka.**ST'
+      test_case: 'kafka/**/*ST,!kafka.dynamicconfiguration/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -22,7 +22,7 @@ jobs:
     parameters:
       name: 'regression_security'
       display_name: 'regression-bundle II. - security'
-      test_case: 'security.**ST'
+      test_case: 'security/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -31,7 +31,7 @@ jobs:
     parameters:
       name: 'regression_connect_tracing'
       display_name: 'regression-bundle III. - connect + tracing'
-      test_case: 'connect.**ST,tracing.**ST'
+      test_case: 'connect/**/*ST,tracing/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -40,7 +40,7 @@ jobs:
     parameters:
       name: 'regression_operators_rollingupdate_watcher'
       display_name: 'regression-bundle IV. - operator + rollingupdate + watcher'
-      test_case: 'operators.**ST,rollingupdate.**ST,watcher.**ST'
+      test_case: 'operators/**/*ST,rollingupdate/**/*ST,watcher/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -49,7 +49,7 @@ jobs:
     parameters:
       name: 'regression_mirrormaker'
       display_name: 'regression-bundle V. - mirrormaker'
-      test_case: 'mirrormaker.**ST'
+      test_case: 'mirrormaker/**/*ST,kafka.dynamicconfiguration/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -59,7 +59,7 @@ jobs:
       name: 'regression_all_remaining'
       display_name: 'regression-bundle VI. - remaining system tests'
       # !LoggingChangeST is skipped because it can be flaky on Azure
-      test_case: '!kafka.**ST,!mirrormaker.**ST,!connect.**ST,!security.**ST,!LoggingChangeST,!operators.**ST,!rollingupdate.**ST,!watcher.**ST,!tracing.**ST'
+      test_case: '!kafka/**/*ST,!mirrormaker/**/*ST,!connect/**/*ST,!security/**/*ST,!LoggingChangeST,!operators/**/*ST,!rollingupdate/**/*ST,!watcher/**/*ST,!tracing/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360

--- a/.azure/regression-pipeline.yaml
+++ b/.azure/regression-pipeline.yaml
@@ -13,16 +13,25 @@ jobs:
     parameters:
       name: 'regression_kafka'
       display_name: 'regression-bundle I. - kafka'
-      test_case: 'kafka.*ST'
+      test_case: 'kafka.**ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 
   - template: 'templates/system_test_general.yaml'
     parameters:
-      name: 'regression_connect_security'
-      display_name: 'regression-bundle II. - connect + security'
-      test_case: 'connect.*ST,security.*ST'
+      name: 'regression_security'
+      display_name: 'regression-bundle II. - security'
+      test_case: 'security.**ST'
+      groups: 'regression'
+      cluster_operator_install_type: 'bundle'
+      timeout: 360
+
+  - template: 'templates/system_test_general.yaml'
+    parameters:
+      name: 'regression_connect_tracing'
+      display_name: 'regression-bundle III. - connect + tracing'
+      test_case: 'connect.**ST,tracing.**ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -30,8 +39,8 @@ jobs:
   - template: 'templates/system_test_general.yaml'
     parameters:
       name: 'regression_operators_rollingupdate_watcher'
-      display_name: 'regression-bundle III. - operator + rollingupdate + watcher'
-      test_case: 'operators.*ST,rollingupdate.*ST,watcher.*ST'
+      display_name: 'regression-bundle IV. - operator + rollingupdate + watcher'
+      test_case: 'operators.**ST,rollingupdate.**ST,watcher.**ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -39,8 +48,8 @@ jobs:
   - template: 'templates/system_test_general.yaml'
     parameters:
       name: 'regression_mirrormaker'
-      display_name: 'regression-bundle IV. - mirrormaker'
-      test_case: 'mirrormaker.*ST'
+      display_name: 'regression-bundle V. - mirrormaker'
+      test_case: 'mirrormaker.**ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -48,9 +57,9 @@ jobs:
   - template: 'templates/system_test_general.yaml'
     parameters:
       name: 'regression_all_remaining'
-      display_name: 'regression-bundle V. - remaining system tests'
+      display_name: 'regression-bundle VI. - remaining system tests'
       # !LoggingChangeST is skipped because it can be flaky on Azure
-      test_case: '!kafka.*ST,!mirrormaker.*ST,!connect.*ST,!security.*ST,!LoggingChangeST,!operators.*ST,!rollingupdate.*ST,!watcher.*ST'
+      test_case: '!kafka.**ST,!mirrormaker.**ST,!connect.**ST,!security.**ST,!LoggingChangeST,!operators.**ST,!rollingupdate.**ST,!watcher.**ST,!tracing.**ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix
- Refactoring

### Description
This PR split AZP regression pipeline into more pieces to avoid hitting the hard timeout of AZP. I also changed patterns for maven to include/excluded tests properly. `.*` doesn't count with another packages in specific dir, but `.**` does.

### Checklist

- [ ] Make sure all tests pass


