### PR TITLE
Change Netty logging level to INFO by default

### DIFF
--- a/helm-charts/helm2/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -28,4 +28,6 @@ data:
     logger.zookeepertrustmanager.additivity = false
 
     # Keeps separate level for Netty logging -> to not be changed by the root logger
-    io.netty = INFO
+    logger.netty.name = io.netty
+    logger.netty.level = INFO
+    logger.netty.additivity = false

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -26,3 +26,6 @@ data:
     logger.zookeepertrustmanager.name = org.apache.zookeeper
     logger.zookeepertrustmanager.level = WARN
     logger.zookeepertrustmanager.additivity = false
+
+    # Netty is by default on DEBUG level, which returns not related exceptions and errors -> we set it to INFO
+    io.netty = INFO

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -27,5 +27,5 @@ data:
     logger.zookeepertrustmanager.level = WARN
     logger.zookeepertrustmanager.additivity = false
 
-    # Netty is by default on DEBUG level, which returns not related exceptions and errors -> we set it to INFO
+    # Keeps separate level for Netty logging -> to not be changed by the root logger
     io.netty = INFO

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -29,5 +29,5 @@ data:
     logger.zookeepertrustmanager.level = WARN
     logger.zookeepertrustmanager.additivity = false
 
-    # Netty is by default on DEBUG level, which returns not related exceptions and errors -> we set it to INFO
+    # Keeps separate level for Netty logging -> to not be changed by the root logger
     io.netty = INFO

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -28,3 +28,6 @@ data:
     logger.zookeepertrustmanager.name = org.apache.zookeeper
     logger.zookeepertrustmanager.level = WARN
     logger.zookeepertrustmanager.additivity = false
+
+    # Netty is by default on DEBUG level, which returns not related exceptions and errors -> we set it to INFO
+    io.netty = INFO

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -30,4 +30,6 @@ data:
     logger.zookeepertrustmanager.additivity = false
 
     # Keeps separate level for Netty logging -> to not be changed by the root logger
-    io.netty = INFO
+    logger.netty.name = io.netty
+    logger.netty.level = INFO
+    logger.netty.additivity = false

--- a/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -29,5 +29,5 @@ data:
     logger.zookeepertrustmanager.level = WARN
     logger.zookeepertrustmanager.additivity = false
 
-    # Netty is by default on DEBUG level, which returns not related exceptions and errors -> we set it to INFO
+    # Keeps separate level for Netty logging -> to not be changed by the root logger
     io.netty = INFO

--- a/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -28,3 +28,6 @@ data:
     logger.zookeepertrustmanager.name = org.apache.zookeeper
     logger.zookeepertrustmanager.level = WARN
     logger.zookeepertrustmanager.additivity = false
+
+    # Netty is by default on DEBUG level, which returns not related exceptions and errors -> we set it to INFO
+    io.netty = INFO

--- a/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -30,4 +30,6 @@ data:
     logger.zookeepertrustmanager.additivity = false
 
     # Keeps separate level for Netty logging -> to not be changed by the root logger
-    io.netty = INFO
+    logger.netty.name = io.netty
+    logger.netty.level = INFO
+    logger.netty.additivity = false


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

In our tests we can see that in CO log sometimes appear some "errors" and "exceptions" that are not really the errors and exceptions which we should take a care about -> that's because the logging level of netty is set by default to DEBUG. This PR gonna add to all `050-ConfigMap-strimzi-cluster-operator.yaml` setting for the Netty logging level.

### Checklist

- [ ] Make sure all tests pass


