### PR TITLE
ST: Add strimzi_resources_state metric check to MetricsST

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -5,8 +5,16 @@
 package io.strimzi.systemtest.metrics;
 
 import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridgeResources;
+import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaConnectS2I;
+import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaExporterResources;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
+import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
@@ -228,33 +236,30 @@ public class MetricsST extends AbstractST {
             assertCoMetricNotNull("strimzi_reconciliations_failed_total", resource, clusterOperatorMetricsData);
         }
 
-        Pattern connectResponse = Pattern.compile("strimzi_resources\\{kind=\"Kafka\",} ([\\d.][^\\n]+)");
-        ArrayList<Double> values = MetricsUtils.collectSpecificMetric(connectResponse, clusterOperatorMetricsData);
-        assertThat(values.stream().mapToDouble(i -> i).sum(), is((double) 2));
+        assertCoMetricResources(Kafka.RESOURCE_KIND, 2);
+        assertCoMetricResourceState(Kafka.RESOURCE_KIND, CLUSTER_NAME, 1);
+        assertCoMetricResourceState(Kafka.RESOURCE_KIND, SECOND_CLUSTER, 1);
 
-        connectResponse = Pattern.compile("strimzi_resources\\{kind=\"KafkaBridge\",} ([\\d.][^\\n]+)");
-        values = MetricsUtils.collectSpecificMetric(connectResponse, clusterOperatorMetricsData);
-        assertThat(values.stream().mapToDouble(i -> i).sum(), is((double) 1));
+        assertCoMetricResources(KafkaBridge.RESOURCE_KIND, 1);
+        assertCoMetricResourceState(KafkaBridge.RESOURCE_KIND, BRIDGE_CLUSTER, 1);
 
-        connectResponse = Pattern.compile("strimzi_resources\\{kind=\"KafkaConnect\",} ([\\d.][^\\n]+)");
-        values = MetricsUtils.collectSpecificMetric(connectResponse, clusterOperatorMetricsData);
-        assertThat(values.stream().mapToDouble(i -> i).sum(), is((double) 1));
+        assertCoMetricResources(KafkaConnect.RESOURCE_KIND, 1);
+        assertCoMetricResourceState(KafkaConnect.RESOURCE_KIND, CLUSTER_NAME, 1);
 
-        connectResponse = Pattern.compile("strimzi_resources\\{kind=\"KafkaConnectS2I\",} ([\\d.][^\\n]+)");
-        values = MetricsUtils.collectSpecificMetric(connectResponse, clusterOperatorMetricsData);
-        assertThat(values.stream().mapToDouble(i -> i).sum(), is((double) 0));
+        assertCoMetricResources(KafkaConnectS2I.RESOURCE_KIND, 0);
+        assertCoMetricResourceState(KafkaConnectS2I.RESOURCE_KIND, CLUSTER_NAME, 0);
 
-        connectResponse = Pattern.compile("strimzi_resources\\{kind=\"KafkaMirrorMaker\",} ([\\d.][^\\n]+)");
-        values = MetricsUtils.collectSpecificMetric(connectResponse, clusterOperatorMetricsData);
-        assertThat(values.stream().mapToDouble(i -> i).sum(), is((double) 0));
+        assertCoMetricResources(KafkaMirrorMaker.RESOURCE_KIND, 0);
+        assertCoMetricResourceState(KafkaMirrorMaker.RESOURCE_KIND, CLUSTER_NAME, 0);
 
-        connectResponse = Pattern.compile("strimzi_resources\\{kind=\"KafkaMirrorMaker2\",} ([\\d.][^\\n]+)");
-        values = MetricsUtils.collectSpecificMetric(connectResponse, clusterOperatorMetricsData);
-        assertThat(values.stream().mapToDouble(i -> i).sum(), is((double) 1));
+        assertCoMetricResources(KafkaMirrorMaker2.RESOURCE_KIND, 1);
+        assertCoMetricResourceState(KafkaMirrorMaker2.RESOURCE_KIND, MIRROR_MAKER_CLUSTER, 1);
 
-        connectResponse = Pattern.compile("strimzi_resources\\{kind=\"KafkaConnector\",} ([\\d.][^\\n]+)");
-        values = MetricsUtils.collectSpecificMetric(connectResponse, clusterOperatorMetricsData);
-        assertThat(values.stream().mapToDouble(i -> i).sum(), is((double) 0));
+        assertCoMetricResources(KafkaConnector.RESOURCE_KIND, 0);
+        assertCoMetricResourceState(KafkaConnector.RESOURCE_KIND, CLUSTER_NAME, 0);
+
+        assertCoMetricResources(KafkaRebalance.RESOURCE_KIND, 0);
+        assertCoMetricResourceState(KafkaRebalance.RESOURCE_KIND, CLUSTER_NAME, 0);
     }
 
     @Test
@@ -392,6 +397,18 @@ public class MetricsST extends AbstractST {
         Pattern connectResponse = Pattern.compile(metric + "\\{kind=\"" + kind + "\",} ([\\d.][^\\n]+)");
         ArrayList<Double> values = MetricsUtils.collectSpecificMetric(connectResponse, data);
         assertThat(values.stream().mapToDouble(i -> i).count(), notNullValue());
+    }
+
+    private void assertCoMetricResourceState(String kind, String name, int value) {
+        Pattern pattern = Pattern.compile("strimzi_resource_state\\{kind=\"" + kind + "\",name=\"" + name + "\",resource_namespace=\"" + NAMESPACE + "\",} ([\\d.][^\\n]+)");
+        ArrayList<Double> values = MetricsUtils.collectSpecificMetric(pattern, clusterOperatorMetricsData);
+        assertThat("strimzi_resource_state for " + kind + " is not " + value, values.stream().mapToDouble(i -> i).sum(), is((double) value));
+    }
+
+    private void assertCoMetricResources(String kind, int value) {
+        Pattern pattern = Pattern.compile("strimzi_resources\\{kind=\"" + kind + "\",} ([\\d.][^\\n]+)");
+        ArrayList<Double> values = MetricsUtils.collectSpecificMetric(pattern, clusterOperatorMetricsData);
+        assertThat("strimzi_resources for " + kind + " is not " + value, values.stream().mapToDouble(i -> i).sum(), is((double) value));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -20,6 +20,7 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
 import io.strimzi.systemtest.resources.crd.KafkaBridgeResource;
+import io.strimzi.systemtest.resources.crd.KafkaConnectS2IResource;
 import io.strimzi.systemtest.resources.crd.KafkaMirrorMaker2Resource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.resources.crd.kafkaclients.KafkaBridgeClientsResource;
@@ -223,7 +224,10 @@ public class MetricsST extends AbstractST {
     @Test
     void testClusterOperatorMetrics() {
         clusterOperatorMetricsData = MetricsUtils.collectClusterOperatorPodMetrics();
-        List<String> resourcesList = Arrays.asList("Kafka", "KafkaBridge", "KafkaConnect", "KafkaConnectS2I", "KafkaConnector", "KafkaMirrorMaker", "KafkaMirrorMaker2");
+        List<String> resourcesList = Arrays.asList("Kafka", "KafkaBridge", "KafkaConnect", "KafkaConnectS2I", "KafkaConnector", "KafkaMirrorMaker", "KafkaMirrorMaker2", "KafkaRebalance");
+
+        // Create some resource which will have state 0. S2I will not be ready, because there is KafkaConnect cluster with same name.
+        KafkaConnectS2IResource.kafkaConnectS2IWithoutWait(KafkaConnectS2IResource.defaultKafkaConnectS2I(CLUSTER_NAME, CLUSTER_NAME, 1).build());
 
         for (String resource : resourcesList) {
             assertCoMetricNotNull("strimzi_reconciliations_periodical_total", resource, clusterOperatorMetricsData);
@@ -250,16 +254,16 @@ public class MetricsST extends AbstractST {
         assertCoMetricResourceState(KafkaConnectS2I.RESOURCE_KIND, CLUSTER_NAME, 0);
 
         assertCoMetricResources(KafkaMirrorMaker.RESOURCE_KIND, 0);
-        assertCoMetricResourceState(KafkaMirrorMaker.RESOURCE_KIND, CLUSTER_NAME, 0);
+        AssertCoMetricResourceStateNotExists(KafkaMirrorMaker.RESOURCE_KIND, CLUSTER_NAME);
 
         assertCoMetricResources(KafkaMirrorMaker2.RESOURCE_KIND, 1);
         assertCoMetricResourceState(KafkaMirrorMaker2.RESOURCE_KIND, MIRROR_MAKER_CLUSTER, 1);
 
         assertCoMetricResources(KafkaConnector.RESOURCE_KIND, 0);
-        assertCoMetricResourceState(KafkaConnector.RESOURCE_KIND, CLUSTER_NAME, 0);
+        AssertCoMetricResourceStateNotExists(KafkaConnector.RESOURCE_KIND, CLUSTER_NAME);
 
         assertCoMetricResources(KafkaRebalance.RESOURCE_KIND, 0);
-        assertCoMetricResourceState(KafkaRebalance.RESOURCE_KIND, CLUSTER_NAME, 0);
+        AssertCoMetricResourceStateNotExists(KafkaRebalance.RESOURCE_KIND, CLUSTER_NAME);
     }
 
     @Test
@@ -397,6 +401,12 @@ public class MetricsST extends AbstractST {
         Pattern connectResponse = Pattern.compile(metric + "\\{kind=\"" + kind + "\",} ([\\d.][^\\n]+)");
         ArrayList<Double> values = MetricsUtils.collectSpecificMetric(connectResponse, data);
         assertThat(values.stream().mapToDouble(i -> i).count(), notNullValue());
+    }
+
+    private void AssertCoMetricResourceStateNotExists(String kind, String name) {
+        Pattern pattern = Pattern.compile("strimzi_resource_state\\{kind=\"" + kind + "\",name=\"" + name + "\",resource_namespace=\"" + NAMESPACE + "\",} ([\\d.][^\\n]+)");
+        ArrayList<Double> values = MetricsUtils.collectSpecificMetric(pattern, clusterOperatorMetricsData);
+        assertThat(values.isEmpty(), is(true));
     }
 
     private void assertCoMetricResourceState(String kind, String name, int value) {


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Enhancement / new feature


### Description

This PR adds checks into MetricsST to cover changes delivered in https://github.com/strimzi/strimzi-kafka-operator/pull/3652 .

### Checklist


- [x] Make sure all tests pass


