### PR TITLE
More fixes for dynamic logging diff

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -419,6 +419,16 @@ public abstract class AbstractModel {
         this.logging = logging;
     }
 
+
+    /**
+     * Regarding to used implementation we may need to patch an appender.
+     * If the user does not provide the appender in tuple logger: level, it should be added and warn message printed.
+     * @return true if patching needs to be done due to dynamic configuration, otherwise false
+     */
+    protected boolean shouldPatchLoggerAppender() {
+        return false;
+    }
+
     /**
      * @param logging The Logging to parse.
      * @param externalCm The external ConfigMap, used if Logging is an instance of ExternalLogging
@@ -431,7 +441,19 @@ public abstract class AbstractModel {
 
             if (inlineLogging.getLoggers() != null) {
                 // Inline logging as specified and some loggers are configured
-                newSettings.addMapPairs(inlineLogging.getLoggers());
+                if (shouldPatchLoggerAppender()) {
+                    String rootAppenderName = getRootAppenderNamesFromDefaultLoggingConfig(newSettings);
+                    String newRootLogger = inlineLogging.getLoggers().get("log4j.rootLogger");
+                    newSettings.addMapPairs(inlineLogging.getLoggers());
+
+                    if (!rootAppenderName.isEmpty() && !newRootLogger.contains(",")) {
+                        log.warn("Newly set rootLogger does not contain appender. Setting appender to {}.", rootAppenderName);
+                        String level = newSettings.asMap().get("log4j.rootLogger");
+                        newSettings.addPair("log4j.rootLogger", level + ", " + rootAppenderName);
+                    }
+                } else {
+                    newSettings.addMapPairs(inlineLogging.getLoggers());
+                }
             }
 
             return createLog4jProperties(newSettings);
@@ -449,6 +471,22 @@ public abstract class AbstractModel {
             log.debug("logging is not set, using default loggers");
             return createLog4jProperties(getDefaultLogConfig());
         }
+    }
+
+    private String getRootAppenderNamesFromDefaultLoggingConfig(OrderedProperties newSettings) {
+        String logger = newSettings.asMap().get("log4j.rootLogger");
+        String appenderName = "";
+        if (logger != null) {
+            String[] tmp = logger.trim().split(",", 2);
+            if (tmp.length == 2) {
+                appenderName = tmp[1].trim();
+            } else {
+                log.warn("Logging configuration for root logger does not contain appender.");
+            }
+        } else {
+            log.warn("Logger log4j.rootLogger not set.");
+        }
+        return appenderName;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -446,7 +446,7 @@ public abstract class AbstractModel {
                     String newRootLogger = inlineLogging.getLoggers().get("log4j.rootLogger");
                     newSettings.addMapPairs(inlineLogging.getLoggers());
 
-                    if (!rootAppenderName.isEmpty() && !newRootLogger.contains(",")) {
+                    if (newRootLogger != null && !rootAppenderName.isEmpty() && !newRootLogger.contains(",")) {
                         log.warn("Newly set rootLogger does not contain appender. Setting appender to {}.", rootAppenderName);
                         String level = newSettings.asMap().get("log4j.rootLogger");
                         newSettings.addPair("log4j.rootLogger", level + ", " + rootAppenderName);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -361,7 +361,7 @@ public abstract class AbstractModel {
     /**
      * @return OrderedProperties map with all available loggers for current pod and default values.
      */
-    protected OrderedProperties getDefaultLogConfig() {
+    public OrderedProperties getDefaultLogConfig() {
         String logConfigFileName = getDefaultLogConfigFileName();
         if (logConfigFileName == null || logConfigFileName.isEmpty()) {
             return new OrderedProperties();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1891,4 +1891,9 @@ public class KafkaCluster extends AbstractModel {
     public KafkaVersion getKafkaVersion() {
         return this.kafkaVersion;
     }
+
+    @Override
+    protected boolean shouldPatchLoggerAppender() {
+        return true;
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -817,4 +817,9 @@ public class KafkaConnectCluster extends AbstractModel {
 
         return getClusterRoleBinding(subject, roleRef);
     }
+
+    @Override
+    protected boolean shouldPatchLoggerAppender() {
+        return true;
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -493,4 +493,9 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
     protected String getServiceAccountName() {
         return KafkaMirrorMakerResources.serviceAccountName(cluster);
     }
+
+    @Override
+    protected boolean shouldPatchLoggerAppender() {
+        return true;
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -56,6 +56,7 @@ import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
@@ -173,7 +174,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
      * Create a watch on {@code KafkaConnector} in the given {@code namespace}.
      * The watcher will:
      * <ul>
-     * <li>{@linkplain #reconcileConnectors(Reconciliation, CustomResource, KafkaConnectStatus, boolean, String)} on the KafkaConnect or KafkaConnectS2I
+     * <li>{@linkplain #reconcileConnectors(Reconciliation, CustomResource, KafkaConnectStatus, boolean, String, OrderedProperties)} on the KafkaConnect or KafkaConnectS2I
      * identified by {@code KafkaConnector.metadata.labels[strimzi.io/cluster]}.</li>
      * <li>If there is a Connect and ConnectS2I cluster with the given name then the plain Connect one is used
      * (and an error is logged about the ambiguity).</li>
@@ -327,7 +328,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
      * @param scaledToZero  Indicated whether the related Connect cluster is currently scaled to 0 replicas
      * @return A future, failed if any of the connectors' statuses could not be updated.
      */
-    protected Future<Void> reconcileConnectors(Reconciliation reconciliation, T connect, S connectStatus, boolean scaledToZero, String desiredLogging) {
+    protected Future<Void> reconcileConnectors(Reconciliation reconciliation, T connect, S connectStatus, boolean scaledToZero, String desiredLogging, OrderedProperties defaultLogging) {
         String connectName = connect.getMetadata().getName();
         String namespace = connect.getMetadata().getNamespace();
         String host = KafkaConnectResources.qualifiedServiceName(connectName, namespace);
@@ -351,7 +352,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                 apiClient.list(host, port),
                 connectorOperator.listAsync(namespace, Optional.of(new LabelSelectorBuilder().addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName).build())),
                 apiClient.listConnectorPlugins(host, port),
-                apiClient.updateConnectLoggers(host, port, desiredLogging)
+                apiClient.updateConnectLoggers(host, port, desiredLogging, defaultLogging)
         ).compose(cf -> {
             List<String> runningConnectorNames = cf.resultAt(0);
             List<KafkaConnector> desiredConnectors = cf.resultAt(1);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.operator.common.BackOff;
+import io.strimzi.operator.common.model.OrderedProperties;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.json.JsonObject;
@@ -120,11 +121,11 @@ public interface KafkaConnectApi {
      * @param host The host to make the request to.
      * @param port The port to make the request to.
      * @param desiredLogging Desired logging.
+     * @param defaultLogging Default logging.
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the list of connector loggers.
      */
-    Future<Void> updateConnectLoggers(String host, int port, String desiredLogging);
-
+    Future<Void> updateConnectLoggers(String host, int port, String desiredLogging, OrderedProperties defaultLogging);
 
     /**
      * Make a {@code GET} request to {@code /admin/loggers}.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -459,7 +459,6 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
 
     @Override
     public Future<Void> updateConnectLoggers(String host, int port, String desiredLogging, OrderedProperties defaultLogging) {
-        log.info("proc se mi toto deje?");
         return listConnectLoggers(host, port).compose(fetchedLoggers -> updateLoggers(host, port, desiredLogging, fetchedLoggers, defaultLogging));
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.operator.common.BackOff;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -408,6 +409,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     private Future<Void> updateLoggers(String host, int port, String desiredLogging, Map<String, Map<String, String>> fetchedLoggers) {
+        desiredLogging = Util.expandVars(desiredLogging);
         Map<String, String> updateLoggers = new LinkedHashMap<>();
         fetchedLoggers.entrySet().forEach(entry -> {
             // set all logger levels to OFF

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -146,7 +146,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                 .compose(i -> deploymentOperations.scaleUp(namespace, connect.getName(), connect.getReplicas()))
                 .compose(i -> deploymentOperations.waitForObserved(namespace, connect.getName(), 1_000, operationTimeoutMs))
                 .compose(i -> connectHasZeroReplicas ? Future.succeededFuture() : deploymentOperations.readiness(namespace, connect.getName(), 1_000, operationTimeoutMs))
-                .compose(i -> reconcileConnectors(reconciliation, kafkaConnect, kafkaConnectStatus, connectHasZeroReplicas, desiredLogging))
+                .compose(i -> reconcileConnectors(reconciliation, kafkaConnect, kafkaConnectStatus, connectHasZeroReplicas, desiredLogging, connect.getDefaultLogConfig()))
                 .onComplete(reconciliationResult -> {
                     StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnect, kafkaConnectStatus, reconciliationResult);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -157,7 +157,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<Ope
                 .compose(i -> deploymentConfigOperations.scaleUp(namespace, connect.getName(), connect.getReplicas()))
                 .compose(i -> deploymentConfigOperations.waitForObserved(namespace, connect.getName(), 1_000, operationTimeoutMs))
                 .compose(i -> connectHasZeroReplicas ? Future.succeededFuture() : deploymentConfigOperations.readiness(namespace, connect.getName(), 1_000, operationTimeoutMs))
-                .compose(i -> reconcileConnectors(reconciliation, kafkaConnectS2I, kafkaConnectS2Istatus, connectHasZeroReplicas, desiredLogging))
+                .compose(i -> reconcileConnectors(reconciliation, kafkaConnectS2I, kafkaConnectS2Istatus, connectHasZeroReplicas, desiredLogging, connect.getDefaultLogConfig()))
                 .onComplete(reconciliationResult -> {
                     StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnectS2I, kafkaConnectS2Istatus, reconciliationResult);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -261,7 +261,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                         return reconcileMirrorMaker2Connector(reconciliation, mirrorMaker2, apiClient, host, connectorName, connectorSpec, mirrorMaker2Status);
                     })                            
                     .collect(Collectors.toList()))
-                    .map((Void) null).compose(i -> apiClient.updateConnectLoggers(host, KafkaConnectCluster.REST_API_PORT, desiredLogging));
+                    .map((Void) null).compose(i -> apiClient.updateConnectLoggers(host, KafkaConnectCluster.REST_API_PORT, desiredLogging, mirrorMaker2Cluster.getDefaultLogConfig()));
     }
 
     private static void prepareMirrorMaker2ConnectorConfig(KafkaMirrorMaker2MirrorSpec mirror, KafkaMirrorMaker2ClusterSpec sourceCluster, KafkaMirrorMaker2ClusterSpec targetCluster, KafkaConnectorSpec connectorSpec, KafkaMirrorMaker2Cluster mirrorMaker2Cluster) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
@@ -98,6 +98,8 @@ public class KafkaBrokerConfigurationDiff extends AbstractResourceDiff {
         for (AlterConfigOp entry : diff) {
             if (isEntryReadOnly(entry.configEntry())) {
                 result = false;
+                log.debug("Configuration can't be updated dynamically due to: {}", entry);
+                break;
             }
         }
         return result;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
@@ -126,14 +126,14 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractResourceDiff {
                 // we ignore appenders (log4j.appender.*)
                 // and only handle loggers (log4j.logger.*)
                 if (line.startsWith("log4j.logger.")) {
-                    int startat = "log4j.logger.".length();
-                    int p = line.indexOf("=", startat);
-                    if (p == -1) {
+                    int startIdx = "log4j.logger.".length();
+                    int endIdx = line.indexOf("=", startIdx);
+                    if (endIdx == -1) {
                         log.debug("Skipping log4j.logger.* declaration without level: {}", line);
                         continue;
                     }
-                    String name = line.substring(startat, p).trim();
-                    String value = line.substring(p + 1).trim();
+                    String name = line.substring(startIdx, endIdx).trim();
+                    String value = line.substring(endIdx + 1).trim();
 
                     value = Util.expandVar(value, env);
                     parsed.put(name, value);
@@ -209,19 +209,19 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractResourceDiff {
                 return result != null ? result : LoggingLevel.WARN;
             }
 
-            int e = name.length();
-            while (e > -1) {
-                e = name.lastIndexOf('.', e);
-                if (e == -1) {
+            int endIdx = name.length();
+            while (endIdx > -1) {
+                endIdx = name.lastIndexOf('.', endIdx);
+                if (endIdx == -1) {
                     level = config.get("root");
                 } else {
-                    level = config.get(name.substring(0, e));
+                    level = config.get(name.substring(0, endIdx));
                 }
                 if (level != null) {
                     LoggingLevel result = LoggingLevel.ofLog4jConfig(level);
                     return result != null ? result : LoggingLevel.WARN;
                 }
-                e -= 1;
+                endIdx -= 1;
             }
             // still here? Not even root logger defined?
             return LoggingLevel.WARN;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
@@ -5,6 +5,7 @@
 
 package io.strimzi.operator.cluster.operator.resource;
 
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.operator.resource.AbstractResourceDiff;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.Config;
@@ -133,11 +134,11 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractResourceDiff {
                     String name = line.substring(13, p).trim();
                     String value = line.substring(p + 1).trim();
 
-                    value = expandVars(value, env);
+                    value = Util.expandVar(value, env);
                     parsed.put(name, value);
 
                 } else if (line.startsWith("log4j.rootLogger=")) {
-                    parsed.put("root", expandVars(line.substring(17).trim(), env));
+                    parsed.put("root", Util.expandVar(line.substring(17).trim(), env));
 
                 } else {
                     log.debug("Skipping log4j line: {}", line);
@@ -148,25 +149,6 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractResourceDiff {
             return Collections.emptyMap();
         }
         return parsed;
-    }
-
-    private static String expandVars(String value, Map<String, String> env) {
-        StringBuilder sb = new StringBuilder();
-        int e = -1;
-        int b;
-        while ((b = value.indexOf("${", e + 1)) != -1) {
-            sb.append(value.substring(e + 1, b));
-            e = value.indexOf("}", b + 2);
-            if (e != -1) {
-                String key = value.substring(b + 2, e);
-                String r = env.get(key);
-                sb.append(r != null ? r : "");
-            } else {
-                break;
-            }
-        }
-        sb.append(value.substring(e + 1));
-        return sb.toString();
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
@@ -113,9 +113,9 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractResourceDiff {
 
                 // everything that does not start with 'log4j.' is a variable definition
                 if (!line.startsWith("log4j.")) {
-                    int p = line.indexOf("=");
-                    if (p >= 0) {
-                        env.put(line.substring(0, p).trim(), line.substring(p + 1).trim());
+                    int foundIdx = line.indexOf("=");
+                    if (foundIdx >= 0) {
+                        env.put(line.substring(0, foundIdx).trim(), line.substring(foundIdx + 1).trim());
                     } else {
                         env.put(line.trim(), "");
                     }
@@ -139,8 +139,8 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractResourceDiff {
                     parsed.put(name, value);
 
                 } else if (line.startsWith("log4j.rootLogger=")) {
-                    int startat = "log4j.rootLogger=".length();
-                    parsed.put("root", Util.expandVar(line.substring(startat).trim(), env));
+                    int startIdx = "log4j.rootLogger=".length();
+                    parsed.put("root", Util.expandVar(line.substring(startIdx).trim(), env));
 
                 } else {
                     log.debug("Skipping log4j line: {}", line);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
@@ -119,6 +119,7 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractResourceDiff {
                         env.put(line.trim(), "");
                     }
                     log.debug("Treating the line as ENV var declaration: {}", line);
+                    continue;
                 }
 
                 // we ignore appenders (log4j.appender.*)
@@ -139,7 +140,7 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractResourceDiff {
                     parsed.put("root", expandVars(line.substring(17).trim(), env));
 
                 } else {
-                    log.debug("Skipping log4j.* declaration: {}", line);
+                    log.debug("Skipping log4j line: {}", line);
                 }
             }
         } catch (Exception e) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
@@ -126,19 +126,21 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractResourceDiff {
                 // we ignore appenders (log4j.appender.*)
                 // and only handle loggers (log4j.logger.*)
                 if (line.startsWith("log4j.logger.")) {
-                    int p = line.indexOf("=", 13);
+                    int startat = "log4j.logger.".length();
+                    int p = line.indexOf("=", startat);
                     if (p == -1) {
                         log.debug("Skipping log4j.logger.* declaration without level: {}", line);
                         continue;
                     }
-                    String name = line.substring(13, p).trim();
+                    String name = line.substring(startat, p).trim();
                     String value = line.substring(p + 1).trim();
 
                     value = Util.expandVar(value, env);
                     parsed.put(name, value);
 
                 } else if (line.startsWith("log4j.rootLogger=")) {
-                    parsed.put("root", Util.expandVar(line.substring(17).trim(), env));
+                    int startat = "log4j.rootLogger=".length();
+                    parsed.put("root", Util.expandVar(line.substring(startat).trim(), env));
 
                 } else {
                     log.debug("Skipping log4j line: {}", line);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -37,6 +37,7 @@ import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube.MockKube;
@@ -172,7 +173,7 @@ public class ConnectorMockTest {
                     .build();
             return Future.succeededFuture(Collections.singletonList(connectorPlugin));
         });
-        when(api.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(api.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
         when(api.getConnectorConfig(any(), any(), anyInt(), any())).thenAnswer(invocation -> {
             String host = invocation.getArgument(1);
             String connectorName = invocation.getArgument(3);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.debezium.kafka.KafkaCluster;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.operator.common.BackOff;
+import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.test.TestUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -262,7 +263,10 @@ public class KafkaConnectApiTest {
         KafkaConnectApi client = new KafkaConnectApiImpl(vertx);
         Checkpoint async = context.checkpoint();
 
-        client.updateConnectLoggers("localhost", PORT, desired)
+        OrderedProperties ops = new OrderedProperties();
+        ops.addStringPairs(desired);
+
+        client.updateConnectLoggers("localhost", PORT, desired, ops)
                 .onComplete(context.succeeding())
                 .compose(a -> client.listConnectLoggers("localhost", PORT)
                         .onComplete(context.succeeding(map -> context.verify(() -> {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -275,7 +275,7 @@ public class KafkaConnectApiTest {
                             assertThat(map.get("org.reflections").get("level"), is("FATAL"));
                             assertThat(map.get("org.reflections.Reflection").get("level"), is("INFO"));
                             assertThat(map.get("root").get("level"), is("INFO"));
-                            assertThat(map.get("io.debezium").get("level"), is("OFF"));
+                            assertThat(map.get("io.debezium").get("level"), is("INFO"));
                             assertThat(map.get("unknown"), is(nullValue()));
                             async.flag();
                         }))));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -32,6 +32,7 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
@@ -148,7 +149,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 .withVersion("1.0.0")
                 .build();
         when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
@@ -292,7 +293,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 .withVersion("1.0.0")
                 .build();
         when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
@@ -410,7 +411,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 .withVersion("1.0.0")
                 .build();
         when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
@@ -568,7 +569,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 .withVersion("1.0.0")
                 .build();
         when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
@@ -636,7 +637,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 .withVersion("1.0.0")
                 .build();
         when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
@@ -816,7 +817,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 .withVersion("1.0.0")
                 .build();
         when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -34,6 +34,7 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.operator.common.operator.resource.BuildConfigOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
@@ -159,7 +160,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 .withVersion("1.0.0")
                 .build();
         when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
 
@@ -340,7 +341,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 .withVersion("1.0.0")
                 .build();
         when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
@@ -477,7 +478,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 .withVersion("1.0.0")
                 .build();
         when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
@@ -675,7 +676,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 .withVersion("1.0.0")
                 .build();
         when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
@@ -752,7 +753,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 .withVersion("1.0.0")
                 .build();
         when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
@@ -938,7 +939,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 .withVersion("1.0.0")
                 .build();
         when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -24,6 +24,7 @@ import io.strimzi.operator.cluster.operator.resource.ZookeeperLeaderFinder;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube.MockKube;
@@ -47,6 +48,7 @@ import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -147,7 +149,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
             .build());
         KafkaConnectApi mock = mock(KafkaConnectApi.class);
         when(mock.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mock.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mock.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         Checkpoint async = context.checkpoint();
         createMirrorMaker2Cluster(context, mock)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
@@ -25,6 +25,7 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
@@ -129,7 +130,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
         when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
@@ -226,7 +227,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
         when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
@@ -334,7 +335,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
         when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
@@ -479,7 +480,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
         when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
@@ -536,7 +537,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
         when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
@@ -689,7 +690,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
         when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString())).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.updateConnectLoggers(anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiffTest.java
@@ -95,7 +95,8 @@ public class KafkaBrokerLoggingConfigurationDiffTest {
                 "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
                 "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
                 "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n" +
-                "log4j.rootLogger=INFO, CONSOLE\n" +
+                "root.logger.level=INFO\n " +
+                "log4j.rootLogger=${root.logger.level}, CONSOLE\n" +
                 "log4j.logger.org.I0Itec.zkclient.ZkClient=INFO\n" +
                 "log4j.logger.org.apache.zookeeper=INFO\n" +
                 "log4j.logger.kafka=DEBUG\n" +

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -497,12 +497,15 @@ public class KafkaRollerTest {
             }
         })
             .onComplete(testContext.failing(e -> testContext.verify(() -> {
-                assertThat(e.getClass() + " is not a subclass of " + exception.getName(), e, instanceOf(exception));
-                assertThat("The exception message was not as expected", e.getMessage(), is(message));
-                assertThat("The restarted pods were not as expected", restarted(), is(expectedRestart));
-                assertNoUnclosedAdminClient(testContext, kafkaRoller);
-                testContext.completeNow();
-                async.countDown();
+                try {
+                    assertThat(e.getClass() + " is not a subclass of " + exception.getName(), e, instanceOf(exception));
+                    assertThat("The exception message was not as expected", e.getMessage(), is(message));
+                    assertThat("The restarted pods were not as expected", restarted(), is(expectedRestart));
+                    assertNoUnclosedAdminClient(testContext, kafkaRoller);
+                    testContext.completeNow();
+                } finally {
+                    async.countDown();
+                }
             })));
         async.await();
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -411,4 +411,34 @@ public class Util {
         return result.toString();
     }
 
+    public static String expandVars(String env) {
+        OrderedProperties ops = new OrderedProperties();
+        ops.addStringPairs(env);
+        Map<String, String> map = ops.asMap();
+        StringBuilder resultBuilder = new StringBuilder();
+        for (Map.Entry<String, String> entry: map.entrySet()) {
+            resultBuilder.append(entry.getKey() + "=" + expandVar(entry.getValue(), ops.asMap()) + "\n");
+        }
+        return resultBuilder.toString();
+    }
+
+    public static String expandVar(String value, Map<String, String> env) {
+        StringBuilder sb = new StringBuilder();
+        int e = -1;
+        int b;
+        while ((b = value.indexOf("${", e + 1)) != -1) {
+            sb.append(value.substring(e + 1, b));
+            e = value.indexOf("}", b + 2);
+            if (e != -1) {
+                String key = value.substring(b + 2, e);
+                String r = env.get(key);
+                sb.append(r != null ? r : "");
+            } else {
+                break;
+            }
+        }
+        sb.append(value.substring(e + 1));
+        return sb.toString();
+    }
+
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -411,6 +411,13 @@ public class Util {
         return result.toString();
     }
 
+    /**
+     * Load the properties and expand any variables of format ${NAME} inside values with resolved values.
+     * Variables are resolved by looking up the property names only within the loaded map.
+     *
+     * @param env Multiline properties file as String
+     * @return Multiline properties file as String with variables resolved
+     */
     public static String expandVars(String env) {
         OrderedProperties ops = new OrderedProperties();
         ops.addStringPairs(env);
@@ -422,22 +429,31 @@ public class Util {
         return resultBuilder.toString();
     }
 
+    /**
+     * Search for occurrences of ${NAME} in the 'value' parameter and replace them with
+     * the value for the NAME key in the 'env' map.
+     *
+     * @param value String value possibly containing variables of format: ${NAME}
+     * @param env Var map with name:value pairs
+     * @return Input string with variable references resolved
+     */
     public static String expandVar(String value, Map<String, String> env) {
         StringBuilder sb = new StringBuilder();
-        int e = -1;
-        int b;
-        while ((b = value.indexOf("${", e + 1)) != -1) {
-            sb.append(value.substring(e + 1, b));
-            e = value.indexOf("}", b + 2);
-            if (e != -1) {
-                String key = value.substring(b + 2, e);
-                String r = env.get(key);
-                sb.append(r != null ? r : "");
+        int endIdx = -1;
+        int startIdx;
+        int prefixLen = "${".length();
+        while ((startIdx = value.indexOf("${", endIdx + 1)) != -1) {
+            sb.append(value.substring(endIdx + 1, startIdx));
+            endIdx = value.indexOf("}", startIdx + prefixLen);
+            if (endIdx != -1) {
+                String key = value.substring(startIdx + prefixLen, endIdx);
+                String resolved = env.get(key);
+                sb.append(resolved != null ? resolved : "");
             } else {
                 break;
             }
         }
-        sb.append(value.substring(e + 1));
+        sb.append(value.substring(endIdx + 1));
         return sb.toString();
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
+import java.util.TreeMap;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -402,8 +403,8 @@ public class Util {
         OrderedProperties ops = new OrderedProperties();
         ops.addStringPairs(loggingConfiguration);
         StringBuilder result = new StringBuilder();
-        for (Map.Entry<String, String> entry: ops.asMap().entrySet()) {
-            if (!entry.getKey().startsWith("log4j.logger.") && !entry.getKey().equals("log4j.rootLogger") && !entry.getKey().equals("monitorInterval")) {
+        for (Map.Entry<String, String> entry: new TreeMap<>(ops.asMap()).entrySet()) {
+            if (entry.getKey().startsWith("log4j.appender.") && !entry.getKey().equals("monitorInterval")) {
                 result.append(entry.getKey()).append("=").append(entry.getValue());
             }
         }

--- a/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
@@ -119,4 +119,21 @@ public class UtilTest {
         assertThat(Util.mergeLabelsOrAnnotations(null, overrides2), is(overrides2));
         assertThrows(InvalidResourceException.class, () -> Util.mergeLabelsOrAnnotations(base, forbiddenOverrides));
     }
+
+    @Test
+    public void testVarExpansion() {
+        String input = "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
+                "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
+                "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n" +
+                "mirrormaker.root.logger=INFO\n" +
+                "log4j.rootLogger=${mirrormaker.root.logger}, CONSOLE";
+
+        String expectedOutput = "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
+                "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
+                "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n" +
+                "mirrormaker.root.logger=INFO\n" +
+                "log4j.rootLogger=INFO, CONSOLE\n";
+        String result = Util.expandVars(input);
+        assertThat(result, is(expectedOutput));
+    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -540,7 +540,6 @@ class RollingUpdateST extends AbstractST {
         zkPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME), 3, zkPods);
         kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaPods);
 
-        configMapLoggers.getData().put("log4j.properties", loggersConfig.replace("INFO", "DEBUG"));
         configMapLoggers.getData().put("log4j.properties", loggersConfig.replace("%p %m (%c) [%t]", "%p %m (%c) [%t]%n"));
         configMapLoggers.getData().put("log4j2.properties", loggersConfig.replace("INFO", "DEBUG"));
         kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMapLoggers);

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -501,7 +501,7 @@ class RollingUpdateST extends AbstractST {
 
         String loggersConfig = "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
                 "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
-                "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n" +
+                "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]\n" +
                 "kafka.root.logger.level=INFO\n" +
                 "log4j.rootLogger=${kafka.root.logger.level}, CONSOLE\n" +
                 "log4j.logger.org.I0Itec.zkclient.ZkClient=INFO\n" +
@@ -541,6 +541,7 @@ class RollingUpdateST extends AbstractST {
         kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaPods);
 
         configMapLoggers.getData().put("log4j.properties", loggersConfig.replace("INFO", "DEBUG"));
+        configMapLoggers.getData().put("log4j.properties", loggersConfig.replace("%p %m (%c) [%t]", "%p %m (%c) [%t]%n"));
         configMapLoggers.getData().put("log4j2.properties", loggersConfig.replace("INFO", "DEBUG"));
         kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMapLoggers);
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Previous fixes to dynamic logging left a few problems:
- Some system tests were failing due to the lack of the proper handling of variable expansion and variable definitions in (log4j) logging configuration.
- We realised that we also broke backwards compatibility due to removing variable declarations from template log4j.properties files.
- Fixed a buggy KafkaRollerTest that kept hanging
- Added support for automatically adding an appender to log4j.rootLogger declaration without one
- Added same fixes also to kafkaconnect, and mirrormaker2 logging config, where before the logger levels were all first set to OFF and then they didn't inherit the proper level, but now the default root logger level from the log4j file is used



### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

