### PR TITLE
Fix helm3 install error

### DIFF
--- a/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -56,7 +56,7 @@ $ helm repo add strimzi https://strimzi.io/charts/
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install --name my-release strimzi/strimzi-kafka-operator
+$ helm install my-release strimzi/strimzi-kafka-operator
 ```
 
 The command deploys the Strimzi Cluster Operator on the Kubernetes cluster with the default configuration.


### PR DESCRIPTION
Signed-off-by: Benjamin <benjamin@yunify.com>

### Type of change

- Bugfix
- Documentation

### Description
Got error like below when I ran `helm install --name kafka-operator strimzi/strimzi-kafka-operator`
```bash
Error: unknown flag: --name
```