### PR TITLE
ST: Skip log collecting for tests which are skipped by assumptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
         <jupiter.version>5.6.2</jupiter.version>
         <junit.platform.version>1.6.2</junit.platform.version>
         <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
+        <opentest4j.version>1.2.0</opentest4j.version>
         <gson.version>2.8.2</gson.version>
         <vertx.kafka.client>3.9.1</vertx.kafka.client>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -140,6 +140,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.opentest4j</groupId>
+            <artifactId>opentest4j</artifactId>
+            <version>${opentest4j.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.json</groupId>
             <artifactId>javax.json-api</artifactId>
             <version>${javax.json-api.version}</version>

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.LifecycleMethodExecutionExceptionHandler;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+import org.opentest4j.TestAbortedException;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
@@ -25,24 +26,30 @@ public class TestExecutionWatcher implements TestExecutionExceptionHandler, Life
 
     @Override
     public void handleTestExecutionException(ExtensionContext extensionContext, Throwable throwable) throws Throwable {
-        String testClass = extensionContext.getRequiredTestClass().getName();
-        String testMethod = extensionContext.getRequiredTestMethod().getName();
-        collectLogs(testClass, testMethod);
+        if (!(throwable instanceof TestAbortedException)) {
+            String testClass = extensionContext.getRequiredTestClass().getName();
+            String testMethod = extensionContext.getRequiredTestMethod().getName();
+            collectLogs(testClass, testMethod);
+        }
         throw throwable;
     }
 
     @Override
     public void handleBeforeAllMethodExecutionException(ExtensionContext extensionContext, Throwable throwable) throws Throwable {
-        String testClass = extensionContext.getRequiredTestClass().getName();
-        collectLogs(testClass, testClass);
+        if (!(throwable instanceof TestAbortedException)) {
+            String testClass = extensionContext.getRequiredTestClass().getName();
+            collectLogs(testClass, testClass);
+        }
         throw throwable;
     }
 
     @Override
     public void handleBeforeEachMethodExecutionException(ExtensionContext extensionContext, Throwable throwable) throws Throwable {
-        String testClass = extensionContext.getRequiredTestClass().getName();
-        String testMethod = extensionContext.getRequiredTestMethod().getName();
-        collectLogs(testClass, testMethod);
+        if (!(throwable instanceof TestAbortedException)) {
+            String testClass = extensionContext.getRequiredTestClass().getName();
+            String testMethod = extensionContext.getRequiredTestMethod().getName();
+            collectLogs(testClass, testMethod);
+        }
         throw throwable;
     }
 


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

This PR skip log collection for tests, which are skipped/aborted by assumptions. For example tests in `watcher` package are skipped for runs where CO is installed via OLM/hem.

### Checklist


- [x] Make sure all tests pass


