### PR TITLE
Fix errors when deploying example crds

### DIFF
--- a/examples/kafka/kafka-ephemeral-single.yaml
+++ b/examples/kafka/kafka-ephemeral-single.yaml
@@ -4,22 +4,16 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 2.6.0
+    version: 2.5.0
     replicas: 1
     listeners:
-      - name: plain
-        port: 9092
-        type: internal
-        tls: false
-      - name: tls
-        port: 9093
-        type: internal
-        tls: true
+      plain: {}
+      tls: {}
     config:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "2.6"
+      log.message.format.version: "2.5"
     storage:
       type: ephemeral
   zookeeper:

--- a/examples/kafka/kafka-ephemeral.yaml
+++ b/examples/kafka/kafka-ephemeral.yaml
@@ -4,22 +4,16 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 2.6.0
+    version: 2.5.0
     replicas: 3
     listeners:
-      - name: plain
-        port: 9092
-        type: internal
-        tls: false
-      - name: tls
-        port: 9093
-        type: internal
-        tls: true
+      plain: {}
+      tls: {}
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "2.6"
+      log.message.format.version: "2.5"
     storage:
       type: ephemeral
   zookeeper:

--- a/examples/kafka/kafka-jbod.yaml
+++ b/examples/kafka/kafka-jbod.yaml
@@ -4,22 +4,16 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 2.6.0
+    version: 2.5.0
     replicas: 3
     listeners:
-      - name: plain
-        port: 9092
-        type: internal
-        tls: false
-      - name: tls
-        port: 9093
-        type: internal
-        tls: true
+      plain: {}
+      tls: {}
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "2.6"
+      log.message.format.version: "2.5"
     storage:
       type: jbod
       volumes:

--- a/examples/kafka/kafka-persistent-single.yaml
+++ b/examples/kafka/kafka-persistent-single.yaml
@@ -4,22 +4,16 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 2.6.0
+    version: 2.5.0
     replicas: 1
     listeners:
-      - name: plain
-        port: 9092
-        type: internal
-        tls: false
-      - name: tls
-        port: 9093
-        type: internal
-        tls: true
+      plain: {}
+      tls: {}e
     config:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "2.6"
+      log.message.format.version: "2.5"
     storage:
       type: jbod
       volumes:

--- a/examples/kafka/kafka-persistent.yaml
+++ b/examples/kafka/kafka-persistent.yaml
@@ -4,22 +4,16 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 2.6.0
+    version: 2.5.0
     replicas: 3
     listeners:
-      - name: plain
-        port: 9092
-        type: internal
-        tls: false
-      - name: tls
-        port: 9093
-        type: internal
-        tls: true
+      plain: {}
+      tls: {}
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "2.6"
+      log.message.format.version: "2.5"
     storage:
       type: jbod
       volumes:


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Documentation

### Description
Got 2 errors when deploy kafka and topic crds

```yaml
cat <<EOF | kubectl apply -f -
apiVersion: kafka.strimzi.io/v1beta1
kind: Kafka
metadata:
  name: my-cluster
  namespace: default
spec:
  kafka:
    version: 2.6.0
    replicas: 3
    listeners:
      plain: {}
      tls: {}
    config:
      offsets.topic.replication.factor: 3
      transaction.state.log.replication.factor: 3
      transaction.state.log.min.isr: 2
      log.message.format.version: '2.6'
    storage:
      type: ephemeral
  zookeeper:
    replicas: 3
    storage:
      type: ephemeral
  entityOperator:
    topicOperator: {}
    userOperator: {}
---
apiVersion: kafka.strimzi.io/v1beta1
kind: KafkaTopic
metadata:
  name: my-topic
  namespace: default
  labels:
    strimzi.io/cluster: my-cluster
spec:
  partitions: 3
  replicas: 3
  config:
    retention.ms: 7200000
    segment.bytes: 1073741824
EOF
```

```bash
The Kafka "my-cluster" is invalid: spec.kafka.listeners: Invalid value: "array": spec.kafka.listeners in body must be of type object: "array"
```

In operator log:
```
2020-09-22 08:30:22 INFO  OperatorWatcher:40 - Reconciliation #2(watch) Kafka(default/my-cluster): Kafka my-cluster in namespace default was MODIFIED
2020-09-22 08:30:22 ERROR AbstractOperator:175 - Reconciliation #0(watch) Kafka(default/my-cluster): createOrUpdate failed
io.strimzi.operator.cluster.model.InvalidResourceException: Version 2.6.0 is not supported. Supported versions are: 2.4.0, 2.4.1, 2.5.0.
	at io.strimzi.operator.cluster.model.KafkaVersion$Lookup.asInvalidResourceException(KafkaVersion.java:280) ~[io.strimzi.cluster-operator-0.19.0.jar:0.19.0]
```
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x ] Update documentation
- [x ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

