### PR TITLE
Update the OAuth library to 0.6.1

### DIFF
--- a/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.6.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.6.1</strimzi-oauth.version>
         <cruise-control.version>2.5.11</cruise-control.version>
         <opa-authorizer.version>0.4.1</opa-authorizer.version>
     </properties>
@@ -25,6 +25,10 @@
         <repository>
             <id>jcenter</id>
             <url>https://jcenter.bintray.com/</url>
+        </repository>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1078</url>
         </repository>
     </repositories>
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
@@ -26,10 +26,6 @@
             <id>jcenter</id>
             <url>https://jcenter.bintray.com/</url>
         </repository>
-        <repository>
-            <id>staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1078</url>
-        </repository>
     </repositories>
 
     <dependencies>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.6.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.6.1</strimzi-oauth.version>
         <cruise-control.version>2.5.11</cruise-control.version>
         <opa-authorizer.version>0.4.1</opa-authorizer.version>
     </properties>
@@ -25,6 +25,10 @@
         <repository>
             <id>jcenter</id>
             <url>https://jcenter.bintray.com/</url>
+        </repository>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1078</url>
         </repository>
     </repositories>
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
@@ -26,10 +26,6 @@
             <id>jcenter</id>
             <url>https://jcenter.bintray.com/</url>
         </repository>
-        <repository>
-            <id>staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1078</url>
-        </repository>
     </repositories>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -131,13 +131,6 @@
         <skip.surefire.tests>${skipTests}</skip.surefire.tests>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1078</url>
-        </repository>
-    </repositories>
-
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <jaeger.version>1.3.2</jaeger.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
-        <strimzi-oauth.version>0.6.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.6.1</strimzi-oauth.version>
 
         <test-containers.version>1.14.0</test-containers.version>
         <javax.json-api.version>1.1.4</javax.json-api.version>
@@ -130,6 +130,13 @@
         <!--suppress UnresolvedMavenProperty -->
         <skip.surefire.tests>${skipTests}</skip.surefire.tests>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1078</url>
+        </repository>
+    </repositories>
 
     <distributionManagement>
         <snapshotRepository>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR updates the Strimzi OAuth library to 0.6.1 which contains some updated dependencies to address CVEs.