### PR TITLE
Fix yq version check in prerequisites script

### DIFF
--- a/prerequisites-check.sh
+++ b/prerequisites-check.sh
@@ -23,12 +23,16 @@ yq_array=($(echo "$YQ_VERSION" | tr '.' '\n'))
 yq_err_msg="${RED}yq version is ${YQ_VERSION}, version must be 3.3.1 or above. Please download the latest version from https://github.com/mikefarah/yq/releases${NO_COLOUR}"
 
 if [[ yq_array[0] -lt 3  ]]; then
-  echo -e $yq_err_msg
+  echo -e "$yq_err_msg"
   exit 1
-elif [[ yq_array[1] -lt 3 ]]; then
-  echo -e $yq_err_msg
+fi
+
+if [[ yq_array[0] -eq 3  ]] && [[ yq_array[1] -lt 3 ]]; then
+  echo -e "$yq_err_msg"
   exit 1
-elif [[ yq_array[2] -lt 1 ]]; then
-  echo -e $yq_err_msg
+fi
+
+if [[ yq_array[0] -eq 3  ]] && [[ yq_array[1] -eq 3 ]] && [[ yq_array[2] -lt 1 ]]; then
+  echo -e "$yq_err_msg"
   exit 1 
 fi


### PR DESCRIPTION
### Type of change

Bugfix

### Description

The code which checks the `yq` version is above 3.3.1 was wrong and fails when a user updates to 3.4.0, whoever wrote that code should have been more careful [_looks sheepish_]. 

This PR should make the checks work as intended. I have tried it with various version strings to make sure it works properly.