### PR TITLE
Fix OAuth substition

### DIFF
--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -63,7 +63,7 @@ for LISTENER in $LISTENERS ; do
 
   # If OAuth is used, add the environment variables to the list for the envsubst command
   VAR_NAME="STRIMZI_${LISTENER}_OAUTH_CLIENT_SECRET"
-  if [ -z "${!VAR_NAME}" ]; then
+  if [ -n "${!VAR_NAME}" ]; then
     SUBSTITUTIONS="$SUBSTITUTIONS,\${STRIMZI_${LISTENER}_OAUTH_CLIENT_SECRET}"
   fi
 done


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
It seems that if statement used wrong option to compare if the variable is *not* empty.
This PR fixes #3699 

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

