### PR TITLE
Fix regex for max port name length

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListener.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListener.java
@@ -37,7 +37,8 @@ import java.util.Map;
 public class GenericKafkaListener implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 
-    public final static String LISTENER_NAME_REGEX = "^[a-z0-9]{1,25}$";
+    // maximal port name length is 15. The prefix of generic port name is 'tcp-'
+    public final static String LISTENER_NAME_REGEX = "^[a-z0-9]{1,11}$";
 
     private String name;
     private int port;
@@ -51,7 +52,7 @@ public class GenericKafkaListener implements UnknownPropertyPreserving, Serializ
     @Description("Name of the listener. " +
             "The name will be used to identify the listener and the related Kubernetes objects. " +
             "The name has to be unique within given a Kafka cluster. " +
-            "The name can consist of lowercase characters and numbers and be up to 25 characters long.")
+            "The name can consist of lowercase characters and numbers and be up to 11 characters long.")
     @JsonProperty(required = true)
     @Pattern(LISTENER_NAME_REGEX)
     public String getName() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -171,7 +171,7 @@ public class ListenersValidatorTest {
                 .build();
 
         List<GenericKafkaListener> listeners = asList(listener1, listener2, listener3);
-        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("listener names [listener 1, LISTENER2, listener12345678901234567890] are invalid and do not match the pattern ^[a-z0-9]{1,25}$"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("listener names [listener 1, LISTENER2, listener12345678901234567890] are invalid and do not match the pattern ^[a-z0-9]{1,11}$"));
     }
 
     @Test

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -191,7 +191,7 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 [options="header"]
 |====
 |Property                   |Description
-|name                1.2+<.<|Name of the listener. The name will be used to identify the listener and the related Kubernetes objects. The name has to be unique within given a Kafka cluster. The name can consist of lowercase characters and numbers and be up to 25 characters long.
+|name                1.2+<.<|Name of the listener. The name will be used to identify the listener and the related Kubernetes objects. The name has to be unique within given a Kafka cluster. The name can consist of lowercase characters and numbers and be up to 11 characters long.
 |string
 |port                1.2+<.<|Port number used by the listener. The port number has to be unique within a given Kafka cluster. The port number will be used for the listener inside Kafka. Depending on the listener type, it might not be the port number where the Kafka clients connect.
 |integer

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -156,8 +156,8 @@ spec:
                         properties:
                           name:
                             type: string
-                            pattern: ^[a-z0-9]{1,25}$
-                            description: Name of the listener. The name will be used to identify the listener and the related Kubernetes objects. The name has to be unique within given a Kafka cluster. The name can consist of lowercase characters and numbers and be up to 25 characters long.
+                            pattern: ^[a-z0-9]{1,11}$
+                            description: Name of the listener. The name will be used to identify the listener and the related Kubernetes objects. The name has to be unique within given a Kafka cluster. The name can consist of lowercase characters and numbers and be up to 11 characters long.
                           port:
                             type: integer
                             description: Port number used by the listener. The port number has to be unique within a given Kafka cluster. The port number will be used for the listener inside Kafka. Depending on the listener type, it might not be the port number where the Kafka clients connect.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -152,8 +152,8 @@ spec:
                         properties:
                           name:
                             type: string
-                            pattern: ^[a-z0-9]{1,25}$
-                            description: Name of the listener. The name will be used to identify the listener and the related Kubernetes objects. The name has to be unique within given a Kafka cluster. The name can consist of lowercase characters and numbers and be up to 25 characters long.
+                            pattern: ^[a-z0-9]{1,11}$
+                            description: Name of the listener. The name will be used to identify the listener and the related Kubernetes objects. The name has to be unique within given a Kafka cluster. The name can consist of lowercase characters and numbers and be up to 11 characters long.
                           port:
                             type: integer
                             description: Port number used by the listener. The port number has to be unique within a given Kafka cluster. The port number will be used for the listener inside Kafka. Depending on the listener type, it might not be the port number where the Kafka clients connect.

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -178,12 +178,12 @@ spec:
                       properties:
                         name:
                           type: string
-                          pattern: ^[a-z0-9]{1,25}$
+                          pattern: ^[a-z0-9]{1,11}$
                           description: Name of the listener. The name will be used
                             to identify the listener and the related Kubernetes objects.
                             The name has to be unique within given a Kafka cluster.
                             The name can consist of lowercase characters and numbers
-                            and be up to 25 characters long.
+                            and be up to 11 characters long.
                         port:
                           type: integer
                           description: Port number used by the listener. The port


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
The maximal port name length is 15. (https://github.com/kubernetes/kubernetes/blob/d407129cf7a87ad9834fe86543e115dacac43df4/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L329). Thus we need to adjust our validation for max port name length. And because we add `tcp-` prefix to the listener name(https://github.com/strimzi/strimzi-kafka-operator/blob/e786ce9a12117b506ef56c23fe6a314f6d9eb27b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java#L233), the maximal length of user supplied port name can be 15-4=11.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

