### PR TITLE
Remove JVM options not supported anymore on Java 11 from examples

### DIFF
--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -364,7 +364,6 @@ jvmOptions:
     "MaxGCPauseMillis": 20
     "InitiatingHeapOccupancyPercent": 35
     "ExplicitGCInvokesConcurrent": true
-    "UseParNewGC": false
 ----
 
 The example configuration above will result in the following JVM options:


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The `UseParNewGC` option we have in our `jvmOptions` examples is not supported anymore in the OpenJDK11 and when someone copies it it causes the pods to to fail because Java rejects the `UseParNewGC` option. This PR removes it from the examples.