### PR TITLE
Improve confusing log message when reconciling custom resources

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -214,7 +214,7 @@ public abstract class AbstractOperator<
 
                 Set<Condition> unknownAndDeprecatedConditions = validate(cr);
 
-                log.info("{}: {} {} should be created or updated", reconciliation, kind, name);
+                log.info("{}: {} {} should be checked for creation or update", reconciliation, kind, name);
 
                 createOrUpdate(reconciliation, cr)
                         .onComplete(res -> {

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -214,7 +214,7 @@ public abstract class AbstractOperator<
 
                 Set<Condition> unknownAndDeprecatedConditions = validate(cr);
 
-                log.info("{}: {} {} should be checked for creation or update", reconciliation, kind, name);
+                log.info("{}: {} {} will be checked for creation or modification", reconciliation, kind, name);
 
                 createOrUpdate(reconciliation, cr)
                         .onComplete(res -> {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When reconciling custom resources, we always print a message like this: `Kafka my-cluster should be created or updated`. This seems to be confusing to users (who are then asking about it in chat) since it suggests that something changed and we are going to do something while in reality it just means we will check it and decide if anything is needed.

This PR changes this message to something like `Kafka my-cluster should be checked for creation or update` which should be hopefully more clear to users and less confusing.
