### PR TITLE
Install tini only once

### DIFF
--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -4,3 +4,12 @@ ARG JAVA_VERSION=11
 RUN yum -y update \
     && yum -y install java-${JAVA_VERSION}-openjdk-headless openssl \
     && yum -y clean all
+
+#####
+# Add Tini
+#####
+ENV TINI_VERSION v0.18.0
+ENV TINI_SHA256=12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
+RUN echo "${TINI_SHA256} */usr/bin/tini" | sha256sum -c \
+    && chmod +x /usr/bin/tini

--- a/docker-images/jmxtrans/Dockerfile
+++ b/docker-images/jmxtrans/Dockerfile
@@ -30,15 +30,6 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 COPY jmxtrans_readiness_check.sh /opt/jmx/
 
 #####
-# Add Tini
-#####
-ENV TINI_VERSION v0.18.0
-ENV TINI_SHA256=12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
-RUN echo "${TINI_SHA256} */usr/bin/tini" | sha256sum -c \
-    && chmod +x /usr/bin/tini
-
-#####
 # Add NC
 #####
 RUN yum install -y nc

--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -70,15 +70,6 @@ COPY ./stunnel-scripts/ $STUNNEL_HOME
 ENV S2I_HOME=/opt/kafka/s2i
 COPY ./s2i-scripts $S2I_HOME
 
-#####
-# Add Tini
-#####
-ENV TINI_VERSION v0.18.0
-ENV TINI_SHA256=12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
-RUN echo "${TINI_SHA256} */usr/bin/tini" | sha256sum -c \
-    && chmod +x /usr/bin/tini
-
 WORKDIR $KAFKA_HOME
 
 USER 1001

--- a/docker-images/operator/Dockerfile
+++ b/docker-images/operator/Dockerfile
@@ -14,13 +14,4 @@ COPY scripts/ tmp/bin/ bin/
 
 COPY tmp/lib/ lib/
 
-#####
-# Add Tini
-#####
-ENV TINI_VERSION v0.18.0
-ENV TINI_SHA256=12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
-RUN echo "${TINI_SHA256} */usr/bin/tini" | sha256sum -c \
-    && chmod +x /usr/bin/tini
-
 USER 1001


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Currently, the `tini` installation is done several times for each image instead of doing it only once in the base image. This PR moves it to the base image so that it is done only once. That should make the build faster and also have it only in one place when it needs to be changed.