### PR TITLE
Move test for introspection endpoint to make it valuable

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -46,7 +46,7 @@ public class KafkaResource {
     }
 
     public static DoneableKafka kafkaEphemeral(String name, int kafkaReplicas) {
-        return kafkaEphemeral(name, kafkaReplicas, 3);
+        return kafkaEphemeral(name, kafkaReplicas, Math.min(kafkaReplicas, 3));
     }
 
     public static DoneableKafka kafkaEphemeral(String name, int kafkaReplicas, int zookeeperReplicas) {
@@ -55,7 +55,7 @@ public class KafkaResource {
     }
 
     public static DoneableKafka kafkaPersistent(String name, int kafkaReplicas) {
-        return kafkaPersistent(name, kafkaReplicas, 3);
+        return kafkaPersistent(name, kafkaReplicas, Math.min(kafkaReplicas, 3));
     }
 
     public static DoneableKafka kafkaPersistent(String name, int kafkaReplicas, int zookeeperReplicas) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
@@ -377,61 +377,6 @@ public class OauthPlainST extends OauthAbstractST {
         ClientUtils.waitForClientSuccess(producerName, NAMESPACE, MESSAGE_COUNT);
     }
 
-    @Test
-    void testIntrospectionEndpointWithPlainCommunication() {
-        LOGGER.info("Deploying kafka...");
-
-        keycloakInstance.setIntrospectionEndpointUri("http://" + keycloakInstance.getHttpUri() + "/auth/realms/internal/protocol/openid-connect/token/introspect");
-        String introspectionKafka = CLUSTER_NAME + "-intro";
-
-        KafkaResource.kafkaEphemeral(introspectionKafka, 1)
-            .editSpec()
-                .editKafka()
-                    .withNewListeners()
-                        .addNewGenericKafkaListener()
-                            .withName("tls")
-                            .withPort(9093)
-                            .withType(KafkaListenerType.INTERNAL)
-                            .withTls(true)
-                            .withNewKafkaListenerAuthenticationOAuth()
-                                .withClientId(OAUTH_KAFKA_CLIENT_NAME)
-                                .withNewClientSecret()
-                                    .withSecretName(OAUTH_KAFKA_CLIENT_SECRET)
-                                    .withKey(OAUTH_KEY)
-                                .endClientSecret()
-                                .withAccessTokenIsJwt(false)
-                                .withValidIssuerUri(keycloakInstance.getValidIssuerUri())
-                                .withIntrospectionEndpointUri(keycloakInstance.getIntrospectionEndpointUri())
-                            .endKafkaListenerAuthenticationOAuth()
-                        .endGenericKafkaListener()
-                        .addNewGenericKafkaListener()
-                            .withName("external")
-                            .withPort(9094)
-                            .withType(KafkaListenerType.NODEPORT)
-                            .withTls(false)
-                            .withNewKafkaListenerAuthenticationOAuth()
-                                .withClientId(OAUTH_KAFKA_CLIENT_NAME)
-                                .withNewClientSecret()
-                                    .withSecretName(OAUTH_KAFKA_CLIENT_SECRET)
-                                    .withKey(OAUTH_KEY)
-                                .endClientSecret()
-                                .withAccessTokenIsJwt(false)
-                                .withValidIssuerUri(keycloakInstance.getValidIssuerUri())
-                                .withIntrospectionEndpointUri(keycloakInstance.getIntrospectionEndpointUri())
-                            .endKafkaListenerAuthenticationOAuth()
-                        .endGenericKafkaListener()
-                    .endListeners()
-                .endKafka()
-            .endSpec()
-            .done();
-
-        oauthInternalClientJob.producerStrimziOauthPlain().done();
-        ClientUtils.waitForClientSuccess(OAUTH_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
-
-        oauthInternalClientJob.consumerStrimziOauthPlain().done();
-        ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
-    }
-
     @BeforeAll
     void setUp() {
         keycloakInstance.setRealm("internal", false);


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

Test for introspection endpoint was useles, because it didn't the clients didn't use the tls listener where it was configured. This PR fix this issue and it also covers https://github.com/strimzi/strimzi-kafka-operator/pull/3704.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass


