### PR TITLE
Removed ZooKeeper JMX exporter config for Standalone mode

### DIFF
--- a/examples/metrics/kafka-metrics.yaml
+++ b/examples/metrics/kafka-metrics.yaml
@@ -202,13 +202,6 @@ spec:
         labels:
           replicaId: "$2"
           memberType: "$3"
-      # standalone Zookeeper
-      - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+)><>(\\w+)"
-        type: GAUGE
-        name: "zookeeper_$2"
-      - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+), name1=InMemoryDataTree><>(\\w+)"
-        type: GAUGE
-        name: "zookeeper_$2"
   entityOperator:
     topicOperator: {}
     userOperator: {}


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Our current ZooKeeper deployment is always created with `standaloneEnabled = false` even when there is just 1 node; it's because, in this way it is possible to scale up the cluster. We are always running ZooKeeper in distributed mode (even when 1 node).
For this reason, the JMX metrics mbean related to StandaloneServer are never exposed and for this reason is useless to filter them in the current JMX exporter configuration (even because it means that the exporter goes through more pattern for matching something that won't be never there).
This PR removes those filtering rules.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

