### PR TITLE
Fix memory parsing when millibytes are used

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/Quantities.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/Quantities.java
@@ -18,6 +18,7 @@ class Quantities {
     public static long parseMemory(String memory) {
         boolean seenDot = false;
         boolean seenE = false;
+        boolean seenm = false;
         long factor = 1L;
         int end = memory.length();
         for (int i = 0; i < memory.length(); i++) {
@@ -26,6 +27,10 @@ class Quantities {
                 seenE = true;
             } else if (ch == '.') {
                 seenDot = true;
+            } else if (ch == 'm') {
+                seenm = true;
+                end = i;
+                break;
             } else if (ch < '0' || '9' < ch) {
                 end = i;
                 factor = memoryFactor(memory.substring(i));
@@ -36,6 +41,8 @@ class Quantities {
         String numberPart = memory.substring(0, end);
         if (seenDot || seenE) {
             result = (long) (Double.parseDouble(numberPart) * factor);
+        } else if (seenm)   {
+            result = (long) Math.floor(Double.parseDouble(numberPart) / 1000);
         } else {
             result = Long.parseLong(numberPart) * factor;
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/QuantitiesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/QuantitiesTest.java
@@ -26,6 +26,8 @@ public class QuantitiesTest {
         assertThat(parseMemory("1Ki"), is(1024L));
         assertThat(parseMemory("512Ki"), is(512 * 1024L));
         assertThat(parseMemory("1e6"), is(1_000_000L));
+        assertThat(parseMemory("3060164198400m"), is(parseMemory("2.85Gi")));
+        assertThat(parseMemory("3081639034880m"), is(parseMemory("2.87Gi")));
 
         assertThat(parseMemory("0"), is(0L));
         assertThat(parseMemory("0K"), is(0L));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Sometimes it happens that users use memory request or limits such as `2.85Gi` or `2.87Gi`. The problem with them is that they do not translate to whole bytes Kubernetes translates it to _millibytes_ ... e.g. `3060164198400m` or `3081639034880m` (do not ask me how does the pod use 0.4 bytes 🤯). This cause the operator to fail reconciling the pods because it does not understand the _millibytes_ unit:

```
2020-09-30 20:19:12 WARN  AbstractOperator:470 - Reconciliation #19(timer) Kafka(myproject/my-cluster): Failed to reconcile
java.lang.IllegalArgumentException: Invalid memory suffix: m
	at io.strimzi.operator.cluster.operator.resource.Quantities.memoryFactor(Quantities.java:79) ~[io.strimzi.cluster-operator-0.20.0-SNAPSHOT.jar:0.20.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.resource.Quantities.parseMemory(Quantities.java:31) ~[io.strimzi.cluster-operator-0.20.0-SNAPSHOT.jar:0.20.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.resource.StatefulSetDiff.compareMemoryAndCpuResources(StatefulSetDiff.java:148) ~[io.strimzi.cluster-operator-0.20.0-SNAPSHOT.jar:0.20.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.resource.StatefulSetDiff.<init>(StatefulSetDiff.java:92) ~[io.strimzi.cluster-operator-0.20.0-SNAPSHOT.jar:0.20.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.resource.StatefulSetOperator.internalPatch(StatefulSetOperator.java:292) ~[io.strimzi.cluster-operator-0.20.0-SNAPSHOT.jar:0.20.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.resource.StatefulSetOperator.internalPatch(StatefulSetOperator.java:45) ~[io.strimzi.cluster-operator-0.20.0-SNAPSHOT.jar:0.20.0-SNAPSHOT]
	at io.strimzi.operator.common.operator.resource.AbstractResourceOperator.lambda$reconcile$0(AbstractResourceOperator.java:104) ~[io.strimzi.operator-common-0.20.0-SNAPSHOT.jar:0.20.0-SNAPSHOT]
	at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$2(ContextImpl.java:313) ~[io.vertx.vertx-core-3.9.1.jar:3.9.1]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty.netty-common-4.1.50.Final.jar:4.1.50.Final]
	at java.lang.Thread.run(Thread.java:834) [?:?]
```

This PR improves the handling to properly compare the _millibyte_ values if we get them.

This was raised here: https://github.com/strimzi/strimzi-kafka-operator/issues/1435#issuecomment-676213958

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging