### PR TITLE
Add minItems validation to listeners array

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/ArrayOrObjectKafkaListeners.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/ArrayOrObjectKafkaListeners.java
@@ -20,6 +20,7 @@ import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.listener.KafkaListeners;
 import io.strimzi.crdgenerator.annotations.Alternation;
 import io.strimzi.crdgenerator.annotations.Alternative;
+import io.strimzi.crdgenerator.annotations.MinimumItems;
 import io.sundr.builder.annotations.Buildable;
 
 import java.io.IOException;
@@ -45,6 +46,7 @@ public class ArrayOrObjectKafkaListeners implements Serializable {
     }
 
     @Alternative()
+    @MinimumItems(1)
     public List<GenericKafkaListener> getGenericKafkaListeners() {
         return genericKafkaListeners;
     }

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -96,11 +96,6 @@ import static java.util.Collections.emptyMap;
  *     This gets added to the {@code maximum}
  *     of {@code property}s within the corresponding Schema Object.</dd>
  *
- *     <dt>@{@link MinimumItems}</dt>
- *     <dd>A inclusive minimum for size of the array.
- *     This gets added to the {@code minItems}
- *     of {@code property}s within the corresponding Schema Object.</dd>
- *
  *     <dt>{@code @Deprecated}</dt>
  *     <dd>When present on a JavaBean property this marks the property as being deprecated within
  *     the corresponding Schema Object.

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/MinimumItems.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/MinimumItems.java
@@ -9,6 +9,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**    {@link MinimumItems}
+ *     A inclusive minimum for size of the array.
+ *     This gets added to the {@code minItems}
+ *     of {@code property}s within the corresponding Schema Object.
+ */
+
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})
 public @interface MinimumItems {

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/MinimumItems.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/MinimumItems.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.crdgenerator.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface MinimumItems {
+    int value();
+}

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -15,6 +15,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Example;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.Minimum;
+import io.strimzi.crdgenerator.annotations.MinimumItems;
 import io.strimzi.crdgenerator.annotations.OneOf;
 import io.strimzi.crdgenerator.annotations.Pattern;
 
@@ -68,6 +69,7 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
     @Description("Example of field property.")
     public String fieldProperty;
 
+    @MinimumItems(1)
     public String[] arrayProperty;
 
     public String[][] arrayProperty2;

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -272,6 +272,7 @@ spec:
             properties: {}
         arrayProperty:
           type: "array"
+          minItems: 1
           items:
             type: "string"
         arrayProperty2:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -278,6 +278,7 @@ spec:
             properties: {}
         arrayProperty:
           type: "array"
+          minItems: 1
           items:
             type: "string"
         arrayProperty2:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -151,6 +151,7 @@ spec:
                 listeners:
                   oneOf:
                     - type: array
+                      minItems: 1
                       items:
                         type: object
                         properties:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -147,6 +147,7 @@ spec:
                 listeners:
                   oneOf:
                     - type: array
+                      minItems: 1
                       items:
                         type: object
                         properties:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -173,6 +173,7 @@ spec:
                 listeners:
                   oneOf:
                   - type: array
+                    minItems: 1
                     items:
                       type: object
                       properties:


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement / new feature

### Description
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/3675
Listeners array should have at least one item. We can perform validation using `minItems`.

### Checklist
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

