### PR TITLE
[oauth] Test for maxSecondsWithoutReauthentication

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/KeycloakUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/KeycloakUtils.java
@@ -7,8 +7,13 @@ package io.strimzi.systemtest.utils.specific;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.test.executor.Exec;
 import io.strimzi.test.executor.ExecResult;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import static io.strimzi.systemtest.resources.ResourceManager.cmdKubeClient;
+import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 
 public class KeycloakUtils {
 
@@ -35,5 +40,102 @@ public class KeycloakUtils {
     public static void deleteKeycloak(String namespace) {
         LOGGER.info("Teardown Keycloak in namespace: {}", namespace);
         Exec.exec(true, "/bin/bash", PATH_TO_KEYCLOAK_TEARDOWN_SCRIPT, namespace);
+    }
+
+    public static String getToken(String baseURI, String userName, String password) {
+        String coPodName = kubeClient().getClusterOperatorPodName();
+        return new JsonObject(
+            cmdKubeClient().execInPod(
+                coPodName,
+                "curl",
+                "-v",
+                "--insecure",
+                "-X",
+                "POST",
+                "-d", "client_id=admin-cli&client_secret=aGVsbG8td29ybGQtcHJvZHVjZXItc2VjcmV0&grant_type=password&username=" + userName + "&password=" + password,
+                baseURI + "/auth/realms/master/protocol/openid-connect/token"
+            ).out()).getString("access_token");
+    }
+
+    public static JsonObject getKeycloakRealm(String baseURI, String token, String desiredRealm) {
+        String coPodName = kubeClient().getClusterOperatorPodName();
+        return new JsonObject(cmdKubeClient().execInPod(
+            coPodName,
+            "curl",
+            "-v",
+            "--insecure",
+            "-X",
+            "GET",
+            baseURI + "/auth/admin/realms/" + desiredRealm,
+            "-H", "Authorization: Bearer " + token
+        ).out());
+    }
+
+    public static JsonArray getKeycloakRealmClients(String baseURI, String token, String desiredRealm) {
+        String coPodName = kubeClient().getClusterOperatorPodName();
+        return new JsonArray(cmdKubeClient().execInPod(
+            coPodName,
+            "curl",
+            "-v",
+            "--insecure",
+            "-X",
+            "GET",
+            baseURI + "/auth/admin/realms/" + desiredRealm + "/clients",
+            "-H", "Authorization: Bearer " + token
+        ).out());
+    }
+
+    public static JsonArray getResourcesFromRealmClient(String baseUri, String token, String desiredRealm, String clientId) {
+        return getConfigFromResourceServerOfRealm(baseUri, token, desiredRealm, clientId, "resource");
+    }
+
+    public static JsonArray getPoliciesFromRealmClient(String baseUri, String token, String desiredRealm, String clientId) {
+        return getConfigFromResourceServerOfRealm(baseUri, token, desiredRealm, clientId, "policy");
+    }
+
+    private static JsonArray getConfigFromResourceServerOfRealm(String baseUri, String token, String desiredRealm, String clientId, String endpoint) {
+        String coPodName = kubeClient().getClusterOperatorPodName();
+        return new JsonArray(cmdKubeClient().execInPod(
+            coPodName,
+            "curl",
+            "-v",
+            "--insecure",
+            "-X",
+            "GET",
+            baseUri + "/auth/admin/realms/" + desiredRealm + "/clients/" + clientId + "/authz/resource-server/" + endpoint,
+            "-H", "Authorization: Bearer " + token
+        ).out());
+    }
+
+    public static String putConfigurationToRealm(String baseUri, String token, JsonObject config, String desiredRealm) {
+        String coPodName = kubeClient().getClusterOperatorPodName();
+        return cmdKubeClient().execInPod(
+            coPodName,
+            "curl",
+            "-v",
+            "--insecure",
+            "-X",
+            "PUT",
+            baseUri + "/auth/admin/realms/" + desiredRealm,
+            "-H", "Authorization: Bearer " + token,
+            "-d", config.toString(),
+            "-H", "Content-Type: application/json"
+        ).out();
+    }
+
+    public static String updatePolicyOfRealmClient(String baseUri, String token, JsonObject policy, String desiredRealm, String clientId) {
+        String coPodName = kubeClient().getClusterOperatorPodName();
+        return cmdKubeClient().execInPod(
+            coPodName,
+            "curl",
+            "-v",
+            "--insecure",
+            "-X",
+            "PUT",
+            baseUri + "/auth/admin/realms/" + desiredRealm + "/clients/" + clientId + "/authz/resource-server/policy" + policy.getValue("id"),
+            "-H", "Authorization: Bearer " + token,
+            "-d", policy.toString(),
+            "-H", "Content-Type: application/json"
+        ).out();
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/KeycloakUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/KeycloakUtils.java
@@ -132,7 +132,7 @@ public class KeycloakUtils {
             "--insecure",
             "-X",
             "PUT",
-            baseUri + "/auth/admin/realms/" + desiredRealm + "/clients/" + clientId + "/authz/resource-server/policy" + policy.getValue("id"),
+            baseUri + "/auth/admin/realms/" + desiredRealm + "/clients/" + clientId + "/authz/resource-server/policy/" + policy.getValue("id"),
             "-H", "Authorization: Bearer " + token,
             "-d", policy.toString(),
             "-H", "Content-Type: application/json"

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
@@ -374,12 +374,17 @@ public class OauthAuthorizationST extends OauthAbstractST {
         LOGGER.info("Changing the Dev Team A policy for topics starting with x- and checking that job will not be successful");
         KeycloakUtils.updatePolicyOfRealmClient(baseUri, token, newDevAPolicy, TEST_REALM, kafkaClientId);
         assertThrows(WaitException.class, () -> ClientUtils.waitForClientSuccess(TEAM_A_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT));
+
         JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
 
         LOGGER.info("Changing back to the original settings and checking, if the producer will be successful");
-        KeycloakUtils.updatePolicyOfRealmClient(baseUri, token, devAPolicy, TEST_REALM, kafkaClientId);
+
+        config.put("scopes", "[\"Describe\",\"Write\"]");
+        newDevAPolicy.put("config", config);
+
+        KeycloakUtils.updatePolicyOfRealmClient(baseUri, token, newDevAPolicy, TEST_REALM, kafkaClientId);
         teamAOauthClientJob = teamAOauthClientJob.toBuilder()
-            .withDelayMs(0)
+            .withDelayMs(1000)
             .build();
 
         teamAOauthClientJob.producerStrimziOauthTls(CLUSTER_NAME).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
@@ -292,24 +292,24 @@ public class OauthAuthorizationST extends OauthAbstractST {
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka -> {
             kafka.getSpec().getKafka().setListeners(new ArrayOrObjectKafkaListenersBuilder()
                 .addNewGenericKafkaListener()
-                .withName("tls")
-                .withPort(9093)
-                .withType(KafkaListenerType.INTERNAL)
-                .withTls(true)
-                .withNewKafkaListenerAuthenticationOAuth()
-                    .withValidIssuerUri(keycloakInstance.getValidIssuerUri())
-                    .withJwksExpirySeconds(keycloakInstance.getJwksExpireSeconds())
-                    .withJwksRefreshSeconds(keycloakInstance.getJwksRefreshSeconds())
-                    .withJwksEndpointUri(keycloakInstance.getJwksEndpointUri())
-                    .withUserNameClaim(keycloakInstance.getUserNameClaim())
-                    .withTlsTrustedCertificates(
-                        new CertSecretSourceBuilder()
-                            .withSecretName(KeycloakInstance.KEYCLOAK_SECRET_NAME)
-                            .withCertificate(KeycloakInstance.KEYCLOAK_SECRET_CERT)
-                            .build())
-                    .withDisableTlsHostnameVerification(true)
-                    .withMaxSecondsWithoutReauthentication(30)
-                .endKafkaListenerAuthenticationOAuth()
+                    .withName("tls")
+                    .withPort(9093)
+                    .withType(KafkaListenerType.INTERNAL)
+                    .withTls(true)
+                    .withNewKafkaListenerAuthenticationOAuth()
+                        .withValidIssuerUri(keycloakInstance.getValidIssuerUri())
+                        .withJwksExpirySeconds(keycloakInstance.getJwksExpireSeconds())
+                        .withJwksRefreshSeconds(keycloakInstance.getJwksRefreshSeconds())
+                        .withJwksEndpointUri(keycloakInstance.getJwksEndpointUri())
+                        .withUserNameClaim(keycloakInstance.getUserNameClaim())
+                        .withTlsTrustedCertificates(
+                            new CertSecretSourceBuilder()
+                                .withSecretName(KeycloakInstance.KEYCLOAK_SECRET_NAME)
+                                .withCertificate(KeycloakInstance.KEYCLOAK_SECRET_CERT)
+                                .build())
+                        .withDisableTlsHostnameVerification(true)
+                        .withMaxSecondsWithoutReauthentication(30)
+                    .endKafkaListenerAuthenticationOAuth()
                 .endGenericKafkaListener()
                 .build());
         });
@@ -385,6 +385,33 @@ public class OauthAuthorizationST extends OauthAbstractST {
         teamAOauthClientJob.producerStrimziOauthTls(CLUSTER_NAME).done();
         ClientUtils.waitForClientSuccess(TEAM_A_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
         JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
+
+        LOGGER.info("Changing configuration of Kafka back to it's original form");
+        KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka -> {
+            kafka.getSpec().getKafka().setListeners(new ArrayOrObjectKafkaListenersBuilder()
+                .addNewGenericKafkaListener()
+                    .withName("tls")
+                    .withPort(9093)
+                    .withType(KafkaListenerType.INTERNAL)
+                    .withTls(true)
+                    .withNewKafkaListenerAuthenticationOAuth()
+                        .withValidIssuerUri(keycloakInstance.getValidIssuerUri())
+                        .withJwksExpirySeconds(keycloakInstance.getJwksExpireSeconds())
+                        .withJwksRefreshSeconds(keycloakInstance.getJwksRefreshSeconds())
+                        .withJwksEndpointUri(keycloakInstance.getJwksEndpointUri())
+                        .withUserNameClaim(keycloakInstance.getUserNameClaim())
+                        .withTlsTrustedCertificates(
+                            new CertSecretSourceBuilder()
+                                .withSecretName(KeycloakInstance.KEYCLOAK_SECRET_NAME)
+                                .withCertificate(KeycloakInstance.KEYCLOAK_SECRET_CERT)
+                                .build())
+                        .withDisableTlsHostnameVerification(true)
+                    .endKafkaListenerAuthenticationOAuth()
+                .endGenericKafkaListener()
+                .build());
+        });
+
+        KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
     }
 
     @Disabled("Will be implemented in next PR")

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
@@ -4,18 +4,13 @@
  */
 package io.strimzi.systemtest.security.oauth;
 
-import io.fabric8.kubernetes.api.model.Service;
 import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.KafkaAuthorizationKeycloak;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.listener.arraylistener.ArrayOrObjectKafkaListenersBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.kafkaclients.clientproperties.ProducerProperties;
-import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
-import io.strimzi.systemtest.kafkaclients.externalClients.OauthExternalKafkaClient;
 import io.strimzi.systemtest.keycloak.KeycloakInstance;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
@@ -24,13 +19,11 @@ import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
-import io.strimzi.systemtest.utils.kubeUtils.objects.ServiceUtils;
 import io.strimzi.systemtest.utils.specific.KeycloakUtils;
 import io.strimzi.test.WaitException;
 import io.vertx.core.cli.annotations.Description;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -294,6 +287,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
      */
     @Test
     @Order(7)
+    @SuppressWarnings({"checkstyle:MethodLength"})
     void testSessionReAuthentication() {
         String topicXName = TOPIC_X + "-example-topic";
         String topicAName = TOPIC_A + "-example-topic";

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.security.oauth;
 import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.KafkaAuthorizationKeycloak;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.listener.arraylistener.ArrayOrObjectKafkaListenersBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.keycloak.KeycloakInstance;
@@ -15,10 +16,14 @@ import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.resources.crd.kafkaclients.KafkaOauthExampleClients;
 import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
+import io.strimzi.systemtest.utils.specific.KeycloakUtils;
 import io.strimzi.test.WaitException;
 import io.vertx.core.cli.annotations.Description;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -30,12 +35,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.OAUTH;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag(OAUTH)
@@ -63,6 +71,8 @@ public class OauthAuthorizationST extends OauthAbstractST {
     private static final String TEAM_A_CONSUMER_NAME = TEAM_A_CLIENT + "-consumer";
     private static final String TEAM_B_PRODUCER_NAME = TEAM_B_CLIENT + "-producer";
     private static final String TEAM_B_CONSUMER_NAME = TEAM_B_CLIENT + "-consumer";
+
+    private static final String TEST_REALM = "kafka-authz";
 
     @Description("As a member of team A, I should be able to read and write to all topics starting with a-")
     @Test
@@ -261,23 +271,139 @@ public class OauthAuthorizationST extends OauthAbstractST {
         ClientUtils.waitForClientSuccess(TEAM_A_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
     }
 
-    @Disabled("Will be implemented in next PR")
     @Test
     @Order(7)
+    void testSessionReAuthentication() {
+        String topicName = TOPIC_X + "-example-topic";
+        LOGGER.info("Verifying that team A producer is able to send messages to the {} topic -> the topic starting with 'x'", topicName);
+
+        KafkaTopicResource.topic(CLUSTER_NAME, topicName).done();
+
+        teamAOauthClientJob = teamAOauthClientJob.toBuilder()
+            .withTopicName(topicName)
+            .withMessageCount(MESSAGE_COUNT)
+            .build();
+
+        teamAOauthClientJob.producerStrimziOauthTls(CLUSTER_NAME).done();
+        ClientUtils.waitForClientSuccess(TEAM_A_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
+
+        LOGGER.info("Adding the maxSecondsWithoutReauthentication to Kafka listener with OAuth authentication");
+        KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka -> {
+            kafka.getSpec().getKafka().setListeners(new ArrayOrObjectKafkaListenersBuilder()
+                .addNewGenericKafkaListener()
+                .withName("tls")
+                .withPort(9093)
+                .withType(KafkaListenerType.INTERNAL)
+                .withTls(true)
+                .withNewKafkaListenerAuthenticationOAuth()
+                    .withValidIssuerUri(keycloakInstance.getValidIssuerUri())
+                    .withJwksExpirySeconds(keycloakInstance.getJwksExpireSeconds())
+                    .withJwksRefreshSeconds(keycloakInstance.getJwksRefreshSeconds())
+                    .withJwksEndpointUri(keycloakInstance.getJwksEndpointUri())
+                    .withUserNameClaim(keycloakInstance.getUserNameClaim())
+                    .withTlsTrustedCertificates(
+                        new CertSecretSourceBuilder()
+                            .withSecretName(KeycloakInstance.KEYCLOAK_SECRET_NAME)
+                            .withCertificate(KeycloakInstance.KEYCLOAK_SECRET_CERT)
+                            .build())
+                    .withDisableTlsHostnameVerification(true)
+                    .withMaxSecondsWithoutReauthentication(30)
+                .endKafkaListenerAuthenticationOAuth()
+                .endGenericKafkaListener()
+                .build());
+        });
+
+        KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
+
+        String baseUri = "https://" + keycloakInstance.getHttpsUri();
+
+        LOGGER.info("Setting the master realm token's lifespan to 3600s");
+
+        // get admin token for all operation on realms
+        String userName =  new String(Base64.getDecoder().decode(kubeClient().getSecret("credential-example-keycloak").getData().get("ADMIN_USERNAME").getBytes()));
+        String password = new String(Base64.getDecoder().decode(kubeClient().getSecret("credential-example-keycloak").getData().get("ADMIN_PASSWORD").getBytes()));
+        String token = KeycloakUtils.getToken(baseUri, userName, password);
+
+        // firstly we will increase token lifespan
+        JsonObject masterRealm = KeycloakUtils.getKeycloakRealm(baseUri, token, "master");
+        masterRealm.put("accessTokenLifespan", "3600");
+        KeycloakUtils.putConfigurationToRealm(baseUri, token, masterRealm, "master");
+
+        // now we need to get the token with new lifespan
+        token = KeycloakUtils.getToken(baseUri, userName, password);
+
+        LOGGER.info("Getting the {} kafka client for obtaining the Dev A Team policy for the x topics", TEST_REALM);
+        // we need to get clients for kafka-authz realm to access auth policies in kafka client
+        JsonArray kafkaAuthzRealm = KeycloakUtils.getKeycloakRealmClients(baseUri, token, TEST_REALM);
+
+        String kafkaClientId = "";
+        for (Object client : kafkaAuthzRealm) {
+            JsonObject clientObject = new JsonObject(client.toString());
+            if (clientObject.getString("clientId").equals("kafka")) {
+                kafkaClientId = clientObject.getString("id");
+            }
+        }
+
+        teamAOauthClientJob = teamAOauthClientJob.toBuilder()
+            .withDelayMs(1000)
+            .build();
+
+        LOGGER.info("Deploying the Team A producer");
+        teamAOauthClientJob.producerStrimziOauthTls(CLUSTER_NAME).done();
+
+        JsonArray kafkaAuthzRealmPolicies = KeycloakUtils.getPoliciesFromRealmClient(baseUri, token, TEST_REALM, kafkaClientId);
+
+        JsonObject devAPolicy = new JsonObject();
+        for (Object resource : kafkaAuthzRealmPolicies) {
+            JsonObject resourceObject = new JsonObject(resource.toString());
+            if (resourceObject.getValue("name").toString().contains("Dev Team A can write to topics that start with x- on any cluster")) {
+                devAPolicy = resourceObject;
+            }
+        }
+
+        JsonObject newDevAPolicy = devAPolicy;
+
+        Map<String, String> config = new HashMap<>();
+        config.put("resources", "[\"Topic:x-*\"]");
+        config.put("scopes", "[\"Describe\"]");
+        config.put("applyPolicies", "[\"Dev Team A\"]");
+
+        newDevAPolicy.put("config", config);
+
+        LOGGER.info("Changing the Dev Team A policy for topics starting with x- and checking that job will not be successful");
+        KeycloakUtils.updatePolicyOfRealmClient(baseUri, token, newDevAPolicy, TEST_REALM, kafkaClientId);
+        assertThrows(WaitException.class, () -> ClientUtils.waitForClientSuccess(TEAM_A_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT));
+        JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
+
+        LOGGER.info("Changing back to the original settings and checking, if the producer will be successful");
+        KeycloakUtils.updatePolicyOfRealmClient(baseUri, token, devAPolicy, TEST_REALM, kafkaClientId);
+        teamAOauthClientJob = teamAOauthClientJob.toBuilder()
+            .withDelayMs(0)
+            .build();
+
+        teamAOauthClientJob.producerStrimziOauthTls(CLUSTER_NAME).done();
+        ClientUtils.waitForClientSuccess(TEAM_A_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
+    }
+
+    @Disabled("Will be implemented in next PR")
+    @Test
+    @Order(8)
     void testListTopics() {
         // TODO: in the new PR add AdminClient support with operations listTopics(), etc.
     }
 
     @Disabled("Will be implemented in next PR")
     @Test
-    @Order(8)
+    @Order(9)
     void testClusterVerification() {
         // TODO: create more examples via cluster wide stuff
     }
 
     @BeforeAll
     void setUp()  {
-        keycloakInstance.setRealm("kafka-authz", true);
+        keycloakInstance.setRealm(TEST_REALM, true);
 
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
             .editSpec()

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
@@ -271,6 +271,19 @@ public class OauthAuthorizationST extends OauthAbstractST {
         ClientUtils.waitForClientSuccess(TEAM_A_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
     }
 
+    /**
+     * 1) Try to send messages to topic starting with `x-` with producer from Dev Team A
+     * 2) Change the Oauth listener configuration -> add the maxSecondsWithoutReauthentication set to 30s
+     * 3) Try to send messages with delay of 1000ms (in the meantime, the permissions configuration will be changed)
+     * 4) Get all configuration from the Keycloak (realms, policies) and change the policy so the Dev Team A producer should not be able to send messages to the topic
+     *      starting with `x-` -> updating the policy through the Keycloak API
+     * 5) Wait for the WaitException to appear -> as the producer doesn't have permission for sending messages, the
+     *      job will be in error state
+     * 6) Change the permissions back and check that the messages are correctly set
+     *
+     *
+     * The re-authentication can be seen in the log of team-a-producer pod.
+     */
     @Test
     @Order(7)
     void testSessionReAuthentication() {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New tests

### Description

This PR gonna add test for the `maxSecondsWithoutReauthentication` option added to the Oauth authorization. Firstly, I'm sending the messages with `Dev Team A` to the topic that starts with `x-` -> this should pass, as the `Dev Team A` have permissions to write into the topics that starts with the `x-`. After that, I'm changing the permissions of the `Dev Team A` to have only the `Describe` option, so the producer job will fail after the re-auth happen. At the end I'm changing the permissions back to it's original form and asserting that the messages will be correctly sent.

### Checklist

- [x] Write tests
- [ ] Make sure all tests pass

