### PR TITLE
Let the new listeners use only ports 9092 and higher

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListener.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListener.java
@@ -64,11 +64,10 @@ public class GenericKafkaListener implements UnknownPropertyPreserving, Serializ
         this.name = name;
     }
 
-    @Description("Port number used by the listener. " +
+    @Description("Port number used by the listener inside Kafka. " +
             "The port number has to be unique within a given Kafka cluster. " +
-            "The port number will be used for the listener inside Kafka. " +
-            "Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999 which are already used for Prometheus and JMX. " +
-            "Depending on the listener type, it might not be the port number where the Kafka clients connect.")
+            "Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. " +
+            "Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.")
     @JsonProperty(required = true)
     @Minimum(9092)
     public int getPort() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListener.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListener.java
@@ -14,6 +14,7 @@ import io.strimzi.api.kafka.model.listener.KafkaListenerAuthentication;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.KubeLink;
+import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.Pattern;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -66,8 +67,10 @@ public class GenericKafkaListener implements UnknownPropertyPreserving, Serializ
     @Description("Port number used by the listener. " +
             "The port number has to be unique within a given Kafka cluster. " +
             "The port number will be used for the listener inside Kafka. " +
+            "Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999 which are already used for Prometheus and JMX. " +
             "Depending on the listener type, it might not be the port number where the Kafka clients connect.")
     @JsonProperty(required = true)
+    @Minimum(9092)
     public int getPort() {
         return port;
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
@@ -29,7 +29,7 @@ public class KafkaClusterOAuthValidationTest {
     private List<GenericKafkaListener> getListeners(KafkaListenerAuthenticationOAuth auth)   {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
-                .withPort(9000)
+                .withPort(9900)
                 .withType(KafkaListenerType.INTERNAL)
                 .withAuth(auth)
                 .build();
@@ -56,7 +56,7 @@ public class KafkaClusterOAuthValidationTest {
     public void testOAuthAuthnAuthz() {
         List<GenericKafkaListener> listeners = asList(new GenericKafkaListenerBuilder()
                 .withName("listener1")
-                .withPort(9000)
+                .withPort(9900)
                 .withType(KafkaListenerType.INTERNAL)
                 .withAuth(new KafkaListenerAuthenticationOAuthBuilder()
                         .withClientId("my-client-id")
@@ -108,7 +108,7 @@ public class KafkaClusterOAuthValidationTest {
         assertThrows(InvalidResourceException.class, () -> {
             List<GenericKafkaListener> listeners = asList(new GenericKafkaListenerBuilder()
                     .withName("listener1")
-                    .withPort(9000)
+                    .withPort(9900)
                     .withType(KafkaListenerType.INTERNAL)
                     .withAuth(new KafkaListenerAuthenticationScramSha512Builder()
                             .build())

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
@@ -50,7 +50,7 @@ public class ListenersUtilsTest {
 
     private GenericKafkaListener newPlain = new GenericKafkaListenerBuilder()
             .withName("plain2")
-            .withPort(9000)
+            .withPort(9900)
             .withType(KafkaListenerType.INTERNAL)
             .withTls(false)
             .withNewConfiguration()
@@ -70,7 +70,7 @@ public class ListenersUtilsTest {
 
     private GenericKafkaListener newTls = new GenericKafkaListenerBuilder()
             .withName("tls2")
-            .withPort(9001)
+            .withPort(9901)
             .withType(KafkaListenerType.INTERNAL)
             .withTls(true)
             .withNewConfiguration()
@@ -98,7 +98,7 @@ public class ListenersUtilsTest {
 
     private GenericKafkaListener newRoute = new GenericKafkaListenerBuilder()
             .withName("route")
-            .withPort(9002)
+            .withPort(9902)
             .withType(KafkaListenerType.ROUTE)
             .withTls(true)
             .withNewConfiguration()
@@ -126,7 +126,7 @@ public class ListenersUtilsTest {
 
     private GenericKafkaListener newNodePort = new GenericKafkaListenerBuilder()
             .withName("np1")
-            .withPort(9003)
+            .withPort(9903)
             .withType(KafkaListenerType.NODEPORT)
             .withTls(true)
             .withNewConfiguration()
@@ -135,7 +135,7 @@ public class ListenersUtilsTest {
 
     private GenericKafkaListener newNodePort2 = new GenericKafkaListenerBuilder()
             .withName("np2")
-            .withPort(9004)
+            .withPort(9904)
             .withType(KafkaListenerType.NODEPORT)
             .withTls(true)
             .withNewConfiguration()
@@ -165,7 +165,7 @@ public class ListenersUtilsTest {
 
     private GenericKafkaListener newLoadBalancer = new GenericKafkaListenerBuilder()
             .withName("lb1")
-            .withPort(9005)
+            .withPort(9905)
             .withType(KafkaListenerType.LOADBALANCER)
             .withTls(true)
             .withNewConfiguration()
@@ -179,7 +179,7 @@ public class ListenersUtilsTest {
 
     private GenericKafkaListener newLoadBalancer2 = new GenericKafkaListenerBuilder()
             .withName("lb2")
-            .withPort(9006)
+            .withPort(9906)
             .withType(KafkaListenerType.LOADBALANCER)
             .withTls(true)
             .withNewConfiguration()
@@ -209,7 +209,7 @@ public class ListenersUtilsTest {
 
     private GenericKafkaListener newIngress = new GenericKafkaListenerBuilder()
             .withName("ing1")
-            .withPort(9007)
+            .withPort(9907)
             .withType(KafkaListenerType.INGRESS)
             .withTls(true)
             .withNewConfiguration()
@@ -229,7 +229,7 @@ public class ListenersUtilsTest {
 
     private GenericKafkaListener newIngress2 = new GenericKafkaListenerBuilder()
             .withName("ing2")
-            .withPort(9008)
+            .withPort(9908)
             .withType(KafkaListenerType.INGRESS)
             .withTls(true)
             .withNewConfiguration()
@@ -258,7 +258,7 @@ public class ListenersUtilsTest {
 
     private GenericKafkaListener newNodePort3 = new GenericKafkaListenerBuilder()
             .withName("np3")
-            .withPort(9009)
+            .withPort(9909)
             .withType(KafkaListenerType.NODEPORT)
             .withTls(true)
             .withNewConfiguration()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -56,13 +56,13 @@ public class ListenersValidatorTest {
     public void testValidateNewListeners() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
-                .withPort(9000)
+                .withPort(9900)
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
         GenericKafkaListener listener2 = new GenericKafkaListenerBuilder()
                 .withName("listener2")
-                .withPort(9001)
+                .withPort(9901)
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
@@ -74,13 +74,13 @@ public class ListenersValidatorTest {
     public void testValidateThrowsException() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
-                .withPort(9000)
+                .withPort(9900)
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
         GenericKafkaListener listener2 = new GenericKafkaListenerBuilder()
                 .withName("listener2")
-                .withPort(9000)
+                .withPort(9900)
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
@@ -94,19 +94,19 @@ public class ListenersValidatorTest {
     public void testValidateDuplicatePorts() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
-                .withPort(9000)
+                .withPort(9900)
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
         GenericKafkaListener listener2 = new GenericKafkaListenerBuilder()
                 .withName("listener2")
-                .withPort(9001)
+                .withPort(9901)
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
         GenericKafkaListener listener3 = new GenericKafkaListenerBuilder()
                 .withName("listener3")
-                .withPort(9001)
+                .withPort(9901)
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
@@ -118,31 +118,31 @@ public class ListenersValidatorTest {
     public void testValidateForbiddenPorts() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
-                .withPort(9091)
+                .withPort(9000)
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
         List<GenericKafkaListener> listeners = asList(listener1);
-        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("ports [9090, 9091, 9404, 9999] are forbidden and cannot be used"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("port 9000 is forbidden and cannot be used"));
     }
 
     @Test
     public void testValidateDuplicateNames() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
-                .withPort(9000)
+                .withPort(9900)
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
         GenericKafkaListener listener2 = new GenericKafkaListenerBuilder()
                 .withName("listener2")
-                .withPort(9001)
+                .withPort(9901)
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
         GenericKafkaListener listener3 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
-                .withPort(9002)
+                .withPort(9902)
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
@@ -154,19 +154,19 @@ public class ListenersValidatorTest {
     public void testInvalidNames() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener 1")
-                .withPort(9000)
+                .withPort(9900)
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
         GenericKafkaListener listener2 = new GenericKafkaListenerBuilder()
                 .withName("LISTENER2")
-                .withPort(9001)
+                .withPort(9901)
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
         GenericKafkaListener listener3 = new GenericKafkaListenerBuilder()
                 .withName("listener12345678901234567890")
-                .withPort(9002)
+                .withPort(9902)
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
@@ -625,7 +625,7 @@ public class ListenersValidatorTest {
     public void testValidateOauth() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
-                .withPort(9000)
+                .withPort(9900)
                 .withType(KafkaListenerType.INTERNAL)
                 .withAuth(new KafkaListenerAuthenticationOAuthBuilder().build())
                 .build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -115,7 +115,7 @@ public class ListenersValidatorTest {
     }
 
     @Test
-    public void testValidateForbiddenPorts() {
+    public void testValidateForbiddenPortByRange() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
                 .withPort(9000)
@@ -124,6 +124,18 @@ public class ListenersValidatorTest {
 
         List<GenericKafkaListener> listeners = asList(listener1);
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("port 9000 is forbidden and cannot be used"));
+    }
+
+    @Test
+    public void testValidateForbiddenPortByException() {
+        GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
+                .withName("listener1")
+                .withPort(9404)
+                .withType(KafkaListenerType.INTERNAL)
+                .build();
+
+        List<GenericKafkaListener> listeners = asList(listener1);
+        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("port 9404 is forbidden and cannot be used"));
     }
 
     @Test

--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
@@ -63,7 +63,7 @@ listeners:
 
 The name and port must be unique within the Kafka cluster.
 The name can be up to 25 characters long, comprising lower-case letters and numbers.
-Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999 which are already used for Prometheus and JMX.
+Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX.
 
 By specifying a unique name and port for each listener,
 you can configure multiple listeners.

--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
@@ -63,6 +63,7 @@ listeners:
 
 The name and port must be unique within the Kafka cluster.
 The name can be up to 25 characters long, comprising lower-case letters and numbers.
+Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999 which are already used for Prometheus and JMX.
 
 By specifying a unique name and port for each listener,
 you can configure multiple listeners.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -193,7 +193,7 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |Property                   |Description
 |name                1.2+<.<|Name of the listener. The name will be used to identify the listener and the related Kubernetes objects. The name has to be unique within given a Kafka cluster. The name can consist of lowercase characters and numbers and be up to 11 characters long.
 |string
-|port                1.2+<.<|Port number used by the listener. The port number has to be unique within a given Kafka cluster. The port number will be used for the listener inside Kafka. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999 which are already used for Prometheus and JMX. Depending on the listener type, it might not be the port number where the Kafka clients connect.
+|port                1.2+<.<|Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
 |integer
 |type                1.2+<.<|Type of the listener. Currently the supported types are `internal`, `route`, `loadbalancer`, `nodeport` and `ingress`. 
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -193,7 +193,7 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |Property                   |Description
 |name                1.2+<.<|Name of the listener. The name will be used to identify the listener and the related Kubernetes objects. The name has to be unique within given a Kafka cluster. The name can consist of lowercase characters and numbers and be up to 11 characters long.
 |string
-|port                1.2+<.<|Port number used by the listener. The port number has to be unique within a given Kafka cluster. The port number will be used for the listener inside Kafka. Depending on the listener type, it might not be the port number where the Kafka clients connect.
+|port                1.2+<.<|Port number used by the listener. The port number has to be unique within a given Kafka cluster. The port number will be used for the listener inside Kafka. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999 which are already used for Prometheus and JMX. Depending on the listener type, it might not be the port number where the Kafka clients connect.
 |integer
 |type                1.2+<.<|Type of the listener. Currently the supported types are `internal`, `route`, `loadbalancer`, `nodeport` and `ingress`. 
 

--- a/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
+++ b/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
@@ -93,7 +93,7 @@ spec:
 ----
 <1> Configuration options for enabling external listeners are described in the link:{BookURLUsing}#type-GenericKafkaListener-reference[Generic Kafka listener schema reference^].
 <2> Name to identify the listener. Must be unique within the Kafka cluster.
-<3> Port number for the listener. Must be unique within the Kafka cluster. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
+<3> Port number for the listener. Must be unique within the Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999 which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
 <4> External listener type specified as `route`, `loadbalancer`, `nodeport` or `ingress`. An internal listener is specified as `internal`.
 <5> Enables TLS encryption on the listener. Default is `false`. TLS encryption is not required for `route` listeners.
 <6> Authentication specified as `tls`.

--- a/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
+++ b/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
@@ -93,7 +93,7 @@ spec:
 ----
 <1> Configuration options for enabling external listeners are described in the link:{BookURLUsing}#type-GenericKafkaListener-reference[Generic Kafka listener schema reference^].
 <2> Name to identify the listener. Must be unique within the Kafka cluster.
-<3> Port number for the listener. Must be unique within the Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999 which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
+<3> Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
 <4> External listener type specified as `route`, `loadbalancer`, `nodeport` or `ingress`. An internal listener is specified as `internal`.
 <5> Enables TLS encryption on the listener. Default is `false`. TLS encryption is not required for `route` listeners.
 <6> Authentication specified as `tls`.

--- a/documentation/modules/ref-sample-kafka-resource-config.adoc
+++ b/documentation/modules/ref-sample-kafka-resource-config.adoc
@@ -132,7 +132,7 @@ spec:
 <5> JVM options can xref:ref-jvm-options-{context}[specify the minimum (`-Xms`) and maximum (`-Xmx`) memory allocation for JVM].
 <6> Listeners configure how clients connect to the Kafka cluster via bootstrap addresses. Listeners are xref:assembly-securing-kafka-brokers-str[configured as _internal_ or _external_ listeners for connection inside or outside the Kubernetes cluster].
 <7> Name to identify the listener. Must be unique within the Kafka cluster.
-<8> Port number for the listener. Must be unique within the Kafka cluster. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
+<8> Port number for the listener. Must be unique within the Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999 which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
 <9> Listener type specified as `internal`, or for external listeners, as `route`, `loadbalancer`, `nodeport` or `ingress`.
 <10> Enables TLS encryption for each listener. Default is `false`. TLS encryption is not required for `route` listeners.
 <11> Defines whether the fully-qualified DNS names including the cluster service suffix (usually `.cluster.local`) are assigned.

--- a/documentation/modules/ref-sample-kafka-resource-config.adoc
+++ b/documentation/modules/ref-sample-kafka-resource-config.adoc
@@ -132,7 +132,7 @@ spec:
 <5> JVM options can xref:ref-jvm-options-{context}[specify the minimum (`-Xms`) and maximum (`-Xmx`) memory allocation for JVM].
 <6> Listeners configure how clients connect to the Kafka cluster via bootstrap addresses. Listeners are xref:assembly-securing-kafka-brokers-str[configured as _internal_ or _external_ listeners for connection inside or outside the Kubernetes cluster].
 <7> Name to identify the listener. Must be unique within the Kafka cluster.
-<8> Port number for the listener. Must be unique within the Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999 which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
+<8> Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
 <9> Listener type specified as `internal`, or for external listeners, as `route`, `loadbalancer`, `nodeport` or `ingress`.
 <10> Enables TLS encryption for each listener. Default is `false`. TLS encryption is not required for `route` listeners.
 <11> Defines whether the fully-qualified DNS names including the cluster service suffix (usually `.cluster.local`) are assigned.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -160,7 +160,8 @@ spec:
                             description: Name of the listener. The name will be used to identify the listener and the related Kubernetes objects. The name has to be unique within given a Kafka cluster. The name can consist of lowercase characters and numbers and be up to 11 characters long.
                           port:
                             type: integer
-                            description: Port number used by the listener. The port number has to be unique within a given Kafka cluster. The port number will be used for the listener inside Kafka. Depending on the listener type, it might not be the port number where the Kafka clients connect.
+                            minimum: 9092
+                            description: Port number used by the listener. The port number has to be unique within a given Kafka cluster. The port number will be used for the listener inside Kafka. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999 which are already used for Prometheus and JMX. Depending on the listener type, it might not be the port number where the Kafka clients connect.
                           type:
                             type: string
                             enum:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -161,7 +161,7 @@ spec:
                           port:
                             type: integer
                             minimum: 9092
-                            description: Port number used by the listener. The port number has to be unique within a given Kafka cluster. The port number will be used for the listener inside Kafka. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999 which are already used for Prometheus and JMX. Depending on the listener type, it might not be the port number where the Kafka clients connect.
+                            description: Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
                           type:
                             type: string
                             enum:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -157,7 +157,7 @@ spec:
                           port:
                             type: integer
                             minimum: 9092
-                            description: Port number used by the listener. The port number has to be unique within a given Kafka cluster. The port number will be used for the listener inside Kafka. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999 which are already used for Prometheus and JMX. Depending on the listener type, it might not be the port number where the Kafka clients connect.
+                            description: Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
                           type:
                             type: string
                             enum:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -156,7 +156,8 @@ spec:
                             description: Name of the listener. The name will be used to identify the listener and the related Kubernetes objects. The name has to be unique within given a Kafka cluster. The name can consist of lowercase characters and numbers and be up to 11 characters long.
                           port:
                             type: integer
-                            description: Port number used by the listener. The port number has to be unique within a given Kafka cluster. The port number will be used for the listener inside Kafka. Depending on the listener type, it might not be the port number where the Kafka clients connect.
+                            minimum: 9092
+                            description: Port number used by the listener. The port number has to be unique within a given Kafka cluster. The port number will be used for the listener inside Kafka. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999 which are already used for Prometheus and JMX. Depending on the listener type, it might not be the port number where the Kafka clients connect.
                           type:
                             type: string
                             enum:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -186,11 +186,14 @@ spec:
                             and be up to 11 characters long.
                         port:
                           type: integer
+                          minimum: 9092
                           description: Port number used by the listener. The port
                             number has to be unique within a given Kafka cluster.
                             The port number will be used for the listener inside Kafka.
-                            Depending on the listener type, it might not be the port
-                            number where the Kafka clients connect.
+                            Allowed port numbers are 9092 and higher with the exception
+                            of ports 9404 and 9999 which are already used for Prometheus
+                            and JMX. Depending on the listener type, it might not
+                            be the port number where the Kafka clients connect.
                         type:
                           type: string
                           enum:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -187,13 +187,13 @@ spec:
                         port:
                           type: integer
                           minimum: 9092
-                          description: Port number used by the listener. The port
-                            number has to be unique within a given Kafka cluster.
-                            The port number will be used for the listener inside Kafka.
-                            Allowed port numbers are 9092 and higher with the exception
-                            of ports 9404 and 9999 which are already used for Prometheus
-                            and JMX. Depending on the listener type, it might not
-                            be the port number where the Kafka clients connect.
+                          description: Port number used by the listener inside Kafka.
+                            The port number has to be unique within a given Kafka
+                            cluster. Allowed port numbers are 9092 and higher with
+                            the exception of ports 9404 and 9999, which are already
+                            used for Prometheus and JMX. Depending on the listener
+                            type, the port number might not be the same as the port
+                            number that connects Kafka clients.
                         type:
                           type: string
                           enum:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The new listeners currently allow to use any port apart from 9090, 9091, 9404 and 9999. This is not enough since in the future we might need to have more internal ports and there is _no way back_ once we allow people to use any port numbers ... since we will never know if someone isn't already using this port.

This PR allows to use only ports 9092 or higher (with the exception of 9404 and 9999). That means that everything below 9091 is reserved. We can see the feedback from the users any allow more ports in the future. Blocking anything below 9092 also allows us to use the validation when creating / updating CRs.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally