### PR TITLE
[DOC] note on naming of route listeners

### DIFF
--- a/documentation/assemblies/security/assembly-security.adoc
+++ b/documentation/assemblies/security/assembly-security.adoc
@@ -3,7 +3,7 @@
 // master.adoc
 
 [id='security-{context}']
-= Security
+= Managing TLS certificates for secure communication
 
 Strimzi supports encrypted communication between the Kafka and Strimzi components using the TLS protocol.
 Communication between Kafka brokers (interbroker communication), between ZooKeeper nodes (internodal communication), and between these and the Strimzi operators is always encrypted.
@@ -17,7 +17,7 @@ Certificates provided by users are not renewed.
 You can provide your own server certificates, called _Kafka listener certificates_, for TLS listeners or external listeners which have TLS encryption enabled.
 For more information, see xref:kafka-listener-certificates-str[].
 
-.Example architecture diagram of the communication secured by TLS.
+.Example architecture of the communication secured by TLS
 image::secure_communication.png[Secure Communication]
 
 include::modules/con-certificate-authorities.adoc[leveloffset=+1]

--- a/documentation/assemblies/security/assembly-security.adoc
+++ b/documentation/assemblies/security/assembly-security.adoc
@@ -3,7 +3,7 @@
 // master.adoc
 
 [id='security-{context}']
-= Managing TLS certificates for secure communication
+= Managing TLS certificates
 
 Strimzi supports encrypted communication between the Kafka and Strimzi components using the TLS protocol.
 Communication between Kafka brokers (interbroker communication), between ZooKeeper nodes (internodal communication), and between these and the Strimzi operators is always encrypted.

--- a/documentation/modules/metrics/ref_metrics-config-files.adoc
+++ b/documentation/modules/metrics/ref_metrics-config-files.adoc
@@ -7,7 +7,7 @@
 
 = Example metrics files
 
-You can find example Grafana dashboards and other metrics configuration files in the `examples/metrics` directory.
+You can find example Grafana dashboards and other metrics configuration files in the {ExampleMetrics}[`examples/metrics` directory^].
 
 .Example metrics files provided with Strimzi
 [source]

--- a/documentation/modules/mirrormaker2/proc-mirrormaker-replication.adoc
+++ b/documentation/modules/mirrormaker2/proc-mirrormaker-replication.adoc
@@ -202,7 +202,7 @@ Standard Apache Kafka configuration may be provided, restricted to those propert
 <21> Replication factor for the `MirrorSourceConnector` `offset-syncs` internal topic that maps the offsets of the source and target clusters.
 <22> When xref:con-mirrormaker-acls-{context}[ACL rules synchronization] is enabled, ACLs are applied to synchronized topics. The default is `true`.
 <23> Defines the separator used for the renaming of remote topics.
-<24> Adds a policy that overrides the automatic renaming of remote topics. Instead of prepending the name with the name of the source cluster, the topic retains its original name. Useful for active/passive backups and data migration.
+<24> Adds a policy that overrides the automatic renaming of remote topics. Instead of prepending the name with the name of the source cluster, the topic retains its original name. This optional setting is useful for active/passive backups and data migration.
 <25> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorHeartbeatConnector`] that performs connectivity checks. The `config` overrides the default configuration options.
 <26> Replication factor for the heartbeat topic created at the target cluster.
 <27> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorCheckpointConnector`] that tracks offsets. The `config` overrides the default configuration options.

--- a/documentation/modules/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-routes.adoc
@@ -27,6 +27,11 @@ For example:
 ----
 apiVersion: {KafkaApiVersion}
 kind: Kafka
+metadata:
+  labels:
+    app: my-cluster
+  name: my-cluster
+  namespace: myproject
 spec:
   kafka:
     # ...
@@ -41,7 +46,8 @@ spec:
     # ...
 ----
 +
-WARNING: Make sure that the name of the listener does not exceed 63 characters.
+WARNING: An OpenShift Route address comprises the name of the Kafka cluster, the name of the listener, and the name of the namespace it is created in.
+For example, `my-cluster-external-myproject`. Be careful with naming as the whole length of the address must not exceed 63 characters, with an 11-character limit for the listener name.
 
 . Create or update the resource.
 +

--- a/documentation/modules/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-routes.adoc
@@ -40,6 +40,8 @@ spec:
   zookeeper:
     # ...
 ----
++
+WARNING: Make sure that the name of the listener does not exceed 63 characters.
 
 . Create or update the resource.
 +

--- a/documentation/modules/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-routes.adoc
@@ -36,7 +36,7 @@ spec:
   kafka:
     # ...
     listeners:
-      - name: external
+      - name: listener1
         port: 9094
         type: route
         tls: true
@@ -47,7 +47,7 @@ spec:
 ----
 +
 WARNING: An OpenShift Route address comprises the name of the Kafka cluster, the name of the listener, and the name of the namespace it is created in.
-For example, `my-cluster-external-myproject`. Be careful with naming as the whole length of the address must not exceed 63 characters, with an 11-character limit for the listener name.
+For example, `my-cluster-kafka-listener1-bootstrap-myproject` (_CLUSTER-NAME_-kafka-_LISTENER-NAME_-bootstrap-_NAMESPACE_). Be careful that the whole length of the address does not exceed a maximum limit of 63 characters.
 
 . Create or update the resource.
 +

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -29,6 +29,7 @@
 :ReleaseDownload: https://github.com/strimzi/strimzi-kafka-operator/releases[GitHub^]
 
 //Monitoring links
+:ExampleMetrics: link:https://github.com/strimzi/strimzi-kafka-operator/tree/master/examples/metrics/
 :GrafanaHome: link:https://grafana.com/[Grafana Labs^]
 :JMXExporter: link:https://github.com/prometheus/jmx_exporter[JMX Exporter documentation^]
 :PrometheusHome: link:https://github.com/prometheus[Prometheus^]


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Updated the _Using Guide_ to include a warning note about name length in the _Accessing Kafka using OpenShift routes_ procedure

Also made a few minor updates, mostly related to community feedback:

* Changed the name of the _Security_ chapter to _= Managing TLS certificates for secure communication_
* Added a link to the example metrics files form the _Introducing Monitoring_ chapter
* Clarified that MM renaming policy is optional

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

