### PR TITLE
Remove undesired labels from the Topic Operator service account

### DIFF
--- a/install/topic-operator/01-ServiceAccount-strimzi-topic-operator.yaml
+++ b/install/topic-operator/01-ServiceAccount-strimzi-topic-operator.yaml
@@ -4,7 +4,3 @@ metadata:
   name: strimzi-topic-operator
   labels:
     app: strimzi
-    chart: strimzi-kafka-operator-0.1.0
-    component: kafka-service-account
-    release: RELEASE-NAME
-    heritage: Tiller


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In the Topic Operator installation files, the Service Account seems ot have some left-over labels from the Helm Chart which should not be there. This PR removes them. The labels should not be there. This was raised in #3744.