### PR TITLE
Improve the docs to make them less confusing

### DIFF
--- a/documentation/modules/deploying/con-deploy-product-downloads.adoc
+++ b/documentation/modules/deploying/con-deploy-product-downloads.adoc
@@ -16,8 +16,8 @@ endif::Downloading[]
 Strimzi release artifacts include sample YAML files to help you deploy the components of Strimzi to Kubernetes, perform common operations,
 and configure your Kafka cluster.
 
-Use `kubectl` to deploy the Strimzi Cluster Operator from the `install/cluster-operator` folder of the downloaded ZIP file.
-For more information about deploying and configuring the Cluster Operator see xref:cluster-operator-{context}[].
+Use `kubectl` to deploy the Cluster Operator from the `install/cluster-operator` folder of the downloaded ZIP file.
+For more information about deploying and configuring the Cluster Operator, see xref:cluster-operator-{context}[].
 
 In addition, if you want to use standalone installations of the Topic and User Operators with a Kafka cluster that is not managed by the Strimzi Cluster Operator, you can deploy them from the `install/topic-operator` and `install/user-operator` folders.
 

--- a/documentation/modules/deploying/con-deploy-product-downloads.adoc
+++ b/documentation/modules/deploying/con-deploy-product-downloads.adoc
@@ -16,8 +16,10 @@ endif::Downloading[]
 Strimzi release artifacts include sample YAML files to help you deploy the components of Strimzi to Kubernetes, perform common operations,
 and configure your Kafka cluster.
 
-Use `kubectl` to deploy Strimzi Cluster Operator from the `install/cluster-operator` folder from the downloaded zip file.
-In addition, if you want to use stand-alone installations of the Topic and User Operators with a Kafka cluster not managed by the Strimzi Cluster Operator, you can deploy them from the `install/topic-operator` and `install/user-operator` folders.
+Use `kubectl` to deploy the Strimzi Cluster Operator from the `install/cluster-operator` folder of the downloaded ZIP file.
+For more information about deploying and configuring the Cluster Operator see xref:cluster-operator-{context}[].
+
+In addition, if you want to use standalone installations of the Topic and User Operators with a Kafka cluster that is not managed by the Strimzi Cluster Operator, you can deploy them from the `install/topic-operator` and `install/user-operator` folders.
 
 NOTE: Additionally, Strimzi container images are available through the {DockerRepository}.
 However, we recommend that you use the YAML files provided to deploy Strimzi.

--- a/documentation/modules/deploying/con-deploy-product-downloads.adoc
+++ b/documentation/modules/deploying/con-deploy-product-downloads.adoc
@@ -16,7 +16,8 @@ endif::Downloading[]
 Strimzi release artifacts include sample YAML files to help you deploy the components of Strimzi to Kubernetes, perform common operations,
 and configure your Kafka cluster.
 
-You deploy Strimzi to a Kubernetes cluster using the `kubectl` command-line tool.
+Use `kubectl` to deploy Strimzi Cluster Operator from the `install/cluster-operator` folder from the downloaded zip file.
+In addition, if you want to use stand-alone installations of the Topic and User Operators with a Kafka cluster not managed by the Strimzi Cluster Operator, you can deploy them from the `install/topic-operator` and `install/user-operator` folders.
 
 NOTE: Additionally, Strimzi container images are available through the {DockerRepository}.
 However, we recommend that you use the YAML files provided to deploy Strimzi.


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

In #3745, a user pointed out this part of the documentation as confusing and as a reason why he installed the Co as well as the standalone TO and UO. This PR attempts to make it bit more clear and understandable.