### PR TITLE
Fix upgrade from 0.19 when Kafka version is not specified in the CRD

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -918,7 +918,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             boolean shouldBePostponed = kafkaAssembly.getSpec().getKafka().getVersion() == null;
 
             if (versionChange == null)   {
-                log.debug("{}: Kafka versions are not known yet, upgrade iwll be skipped", reconciliation);
+                log.debug("{}: Kafka versions are not known yet, upgrade will be skipped", reconciliation);
                 return Future.succeededFuture(this);
             } else if (shouldBePostponed != postponedUpgrade) {
                 log.debug("{}: Upgrade should not be done in this phase", reconciliation);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -917,7 +917,10 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         Future<ReconciliationState> kafkaVersionChange(boolean postponedUpgrade) {
             boolean shouldBePostponed = kafkaAssembly.getSpec().getKafka().getVersion() == null;
 
-            if (shouldBePostponed != postponedUpgrade) {
+            if (versionChange == null)   {
+                log.debug("{}: Kafka versions are not known yet, upgrade iwll be skipped", reconciliation);
+                return Future.succeededFuture(this);
+            } else if (shouldBePostponed != postponedUpgrade) {
                 log.debug("{}: Upgrade should not be done in this phase", reconciliation);
                 return Future.succeededFuture(this);
             } else if (versionChange.isNoop()) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
@@ -216,7 +216,9 @@ public class KafkaUpdateTest {
                         }
                     }
                 }
-                .kafkaVersionChange();
+                .kafkaVersionChangeCheck()
+                .compose(res -> res.kafkaVersionChange(false));
+
         AtomicReference<UpgradeException> ex = new AtomicReference<>();
         future.onComplete(ar -> {
             if (ar.failed()) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -188,7 +188,6 @@ public class StrimziUpgradeST extends AbstractST {
 
         coDir = new File(dir, "strimzi-" + strimziReleaseWithOlderKafkaVersion + "/install/cluster-operator/");
 
-        //String previousKafkaVersion = getValueForLastKafkaVersionInFile(previousKafkaVersionsYaml, "version");
         String latestKafkaVersion = getValueForLastKafkaVersionInFile(latestKafkaVersionsYaml, "version");
 
         // Modify + apply installation files


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Kafka upgrade can currently happen in two ways:

1) The regular one when `.spec.kafka.version` is specified happens separately from the operator upgrade. In that case the operator does first a regular rolling update (in this case for example from Strimzi 0.19.0/2.5.0 to Strimzi 0.20.0/2.5.0) and only in later phase it upgrades the Kafka to 2.6.0 when user changes the version. This means that when the Kafka upgrade happens, all the other Kubernetes resources are already updated to the new version of the operator. We want to do the upgrade as soon as possible to make sure it does just the upgrade and ideally doesn't mix in any other changes.

2) The second upgrade type happens when `.spec.kafka.version` is not specified. In that case the upgrade is done in one go - both operator upgrade as well as Kafka upgrade ((in this case for example from Strimzi 0.19.0/2.5.0 to Strimzi 0.20.0/2.6.0). This is problematic, because we start with all the services, config maps and stateful sets not updated. So ideally we want to first let the operator update all the Kube resources and only as the last thing do the upgrade roll of the Kafka pods. This means we have different requirements here from the regular Kafka upgrade.

In this PR I split the version change into 3 parts:
* The upgrade check on the beginning just checks if versions changed and upgrade is needed.
* The first upgrade call does the regular upgrade with the old statefulset and config maps from previous reconciliation. This is used only for the regular upgrade. This runs early in the reconciliation.
* The second upgrade call does the all-in-one upgrade without specified Kafka version. I called this _postponed_ and it runs only as the last part before the regular rolling update.

This should make it much easier to handle both kinds of upgrades even when there were major changes to the way the pods are configured such as happened in relation to the listener change which caused the latest issue here.

This should close #3685.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging