### PR TITLE
[report.sh] Change of used bash

### DIFF
--- a/tools/report.sh
+++ b/tools/report.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 oc_installed=false
 kubectl_installed=false


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Description

When the `report.sh` is used in different shell then `sh`, it shows some errors, like when I used the zsh:

```
./report.sh --namespace=kafka-listener-cluster-test --cluster=my-cluster                                                                                                                                                                                                                

./report.sh: 22: [[: not found
./report.sh: 85: Syntax error: "(" unexpected
```

This PR fixes this problem, as the correct `sh` will be used for executing the script.

### Checklist

- [x] Make sure everything works
