### PR TITLE
Fix patching of immutable ipFamily field in Service spec

### DIFF
--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
@@ -135,4 +135,83 @@ public class ServiceOperatorTest extends AbstractResourceOperatorTest<Kubernetes
 
         assertThat(current.getSpec().getHealthCheckNodePort(), is(desired.getSpec().getHealthCheckNodePort()));
     }
+
+    @Test
+    public void testIpFamilyPatching()  {
+        KubernetesClient client = mock(KubernetesClient.class);
+
+        Service current = new ServiceBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(RESOURCE_NAME)
+                .endMetadata()
+                .withNewSpec()
+                    .withType("ClusterIp")
+                    .withPorts(
+                            new ServicePortBuilder()
+                                    .withName("port1")
+                                    .withPort(1234)
+                                    .withTargetPort(new IntOrString(1234))
+                                    .build(),
+                            new ServicePortBuilder()
+                                    .withName("port2")
+                                    .withPort(5678)
+                                    .withTargetPort(new IntOrString(5678))
+                                    .build()
+                    )
+                    .withNewIpFamily("IPv6")
+                .endSpec()
+                .build();
+
+        Service current2 = new ServiceBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(RESOURCE_NAME)
+                .endMetadata()
+                .withNewSpec()
+                    .withType("ClusterIp")
+                    .withPorts(
+                            new ServicePortBuilder()
+                                    .withName("port1")
+                                    .withPort(1234)
+                                    .withTargetPort(new IntOrString(1234))
+                                    .build(),
+                            new ServicePortBuilder()
+                                    .withName("port2")
+                                    .withPort(5678)
+                                    .withTargetPort(new IntOrString(5678))
+                                    .build()
+                    )
+                    .withNewIpFamily("IPv6")
+                .endSpec()
+                .build();
+
+        Service desired = new ServiceBuilder()
+                .withNewMetadata()
+                .withNamespace(NAMESPACE)
+                .withName(RESOURCE_NAME)
+                .endMetadata()
+                .withNewSpec()
+                .withType("NodePort")
+                .withPorts(
+                        new ServicePortBuilder()
+                                .withName("port2")
+                                .withPort(5678)
+                                .withTargetPort(new IntOrString(5678))
+                                .build(),
+                        new ServicePortBuilder()
+                                .withName("port1")
+                                .withPort(1234)
+                                .withTargetPort(new IntOrString(1234))
+                                .build()
+                )
+                .endSpec()
+                .build();
+
+        ServiceOperator op = new ServiceOperator(vertx, client);
+        op.patchIpFamily(current, desired);
+
+        assertThat(current.getSpec().getIpFamily(), is(desired.getSpec().getIpFamily()));
+        assertThat(current2.getSpec().getIpFamily(), is(desired.getSpec().getIpFamily()));
+    }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `ipFamily` is a new field in the Service spec which is immutable. It is used on dual stack Kube clusters which use both IPv4 and IPv6. This field is immutable, so when patching the service, we take the field from the current service and pass it to the desired service.

This should fix #3747

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging