### PR TITLE
[report.sh] Another fix for the report script - correct obtaining of original secret

### DIFF
--- a/tools/report.sh
+++ b/tools/report.sh
@@ -104,11 +104,12 @@ fi
 
 get_masked_secrets() {
 	mkdir -p $direct/reports/"$1"
+	echo "$1"
 	resources=$($platform get $1 -l strimzi.io/cluster=$cluster -o name -n $namespace)
 	for line in $resources; do
 		filename=`echo $line | cut -f 2 -d "/"`
 		echo "   "$line
-		original_data=`oc get $line -o=jsonpath='{.data}' | cut -c5-`
+		original_data=`oc get $line -o=jsonpath='{.data}' -n $namespace | cut -c5-`
 		SAVEIFS=$IFS
     IFS=$'\n'
     original_data=($original_data)


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

After I tested the script with more namespaces up, I found out that the script is trying to obtain original secret from the namespace, that is not specified and it finishes with error, that desired secret is not present in different namespace that specified by user.

This PR fixes it, so the secret will be obtained just from the specified namespace -> `--namespace=xxx`

### Checklist

- [x] Make sure everything works