### PR TITLE
[DOC] Used consistent .crt extension for PEM certificates

### DIFF
--- a/documentation/modules/security/proc-installing-certs-per-listener.adoc
+++ b/documentation/modules/security/proc-installing-certs-per-listener.adoc
@@ -71,7 +71,7 @@ listeners:
     configuration:
       brokerCertChainAndKey:
         secretName: my-secret
-        certificate: my-listener-certificate.pem
+        certificate: my-listener-certificate.crt
         key: my-listener-key.key
 # ...
 ----


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Trivial PR to use always `.crt` extension for PEM certificates instead of the `.pem` one.