### PR TITLE
AZP: fix typo in test path, move tests a little

### DIFF
--- a/.azure/regression-pipeline.yaml
+++ b/.azure/regression-pipeline.yaml
@@ -7,13 +7,13 @@ pr:
     include:
       - '*'
       -
-# Regression tests are split into 5 jobs because of timeout set to 360 minutes for each job
+# Regression tests are split into 6 jobs because of timeout set to 360 minutes for each job
 jobs:
   - template: 'templates/system_test_general.yaml'
     parameters:
       name: 'regression_kafka'
       display_name: 'regression-bundle I. - kafka'
-      test_case: 'kafka/**/*ST,!kafka.dynamicconfiguration/**/*ST'
+      test_case: 'kafka/**/*ST,!kafka/dynamicconfiguration/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -30,8 +30,8 @@ jobs:
   - template: 'templates/system_test_general.yaml'
     parameters:
       name: 'regression_connect_tracing'
-      display_name: 'regression-bundle III. - connect + tracing'
-      test_case: 'connect/**/*ST,tracing/**/*ST'
+      display_name: 'regression-bundle III. - connect + tracing + watcher'
+      test_case: 'connect/**/*ST,tracing/**/*ST,watcher/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -39,8 +39,8 @@ jobs:
   - template: 'templates/system_test_general.yaml'
     parameters:
       name: 'regression_operators_rollingupdate_watcher'
-      display_name: 'regression-bundle IV. - operator + rollingupdate + watcher'
-      test_case: 'operators/**/*ST,rollingupdate/**/*ST,watcher/**/*ST'
+      display_name: 'regression-bundle IV. - operators + rollingupdate'
+      test_case: 'operators/**/*ST,rollingupdate/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -48,8 +48,8 @@ jobs:
   - template: 'templates/system_test_general.yaml'
     parameters:
       name: 'regression_mirrormaker'
-      display_name: 'regression-bundle V. - mirrormaker'
-      test_case: 'mirrormaker/**/*ST,kafka.dynamicconfiguration/**/*ST'
+      display_name: 'regression-bundle V. - mirrormaker + dynamicconfiguration'
+      test_case: 'mirrormaker/**/*ST,kafka/dynamicconfiguration/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

After discussion with @see-quick  we decided to move a few tests to different jobs to prevent timeouts. This PR also includes fix for typo in path for dynamic configuration tests.

### Checklist

- [x] Make sure all tests pass


