### PR TITLE
ST: OLM specific tests changes

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/AllNamespacesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/AllNamespacesST.java
@@ -69,6 +69,11 @@ public class AllNamespacesST extends OlmAbstractST {
         doTestDeployExampleKafkaMirrorMaker2();
     }
 
+    @Test
+    @Order(9)
+    void testDeployExampleKafkaRebalance() {
+        doTestDeployExampleKafkaRebalance();
+    }
 
     @BeforeAll
     void setup() throws Exception {

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAbstractST.java
@@ -10,15 +10,19 @@ import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
+import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
+import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
 import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.operator.OlmResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaBridgeUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectS2IUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaMirrorMaker2Utils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaMirrorMakerUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaRebalanceUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
@@ -41,6 +45,15 @@ public class OlmAbstractST extends AbstractST {
     }
 
     void doTestDeployExampleKafkaUser() {
+        // KafkaUser example needs Kafka with authorization
+        KafkaResource.kafkaEphemeral("user-kafka", 1, 1)
+            .editSpec()
+                .editKafka()
+                    .withNewKafkaAuthorizationSimple()
+                    .endKafkaAuthorizationSimple()
+                .endKafka()
+            .endSpec()
+            .done();
         JsonObject kafkaUserResource = OlmResource.getExampleResources().get(KafkaUser.RESOURCE_KIND);
         cmdKubeClient().applyContent(kafkaUserResource.toString());
         KafkaUserUtils.waitForKafkaUserCreation(kafkaUserResource.getJsonObject("metadata").getString("name"));
@@ -91,8 +104,15 @@ public class OlmAbstractST extends AbstractST {
         KafkaMirrorMaker2Utils.waitForKafkaMirrorMaker2Ready(kafkaMirrorMaker2Resource.getJsonObject("metadata").getString("name"));
     }
 
+    void doTestDeployExampleKafkaRebalance() {
+        JsonObject kafkaRebalanceResource = OlmResource.getExampleResources().get(KafkaRebalance.RESOURCE_KIND);
+        cmdKubeClient().applyContent(kafkaRebalanceResource.toString());
+        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(CLUSTER_NAME, KafkaRebalanceState.PendingProposal);
+    }
+
     @AfterAll
     void teardown() {
+        cmdKubeClient().deleteContent(OlmResource.getExampleResources().get(KafkaRebalance.RESOURCE_KIND).toString());
         cmdKubeClient().deleteContent(OlmResource.getExampleResources().get(KafkaMirrorMaker2.RESOURCE_KIND).toString());
         cmdKubeClient().deleteContent(OlmResource.getExampleResources().get(KafkaMirrorMaker.RESOURCE_KIND).toString());
         cmdKubeClient().deleteContent(OlmResource.getExampleResources().get(KafkaBridge.RESOURCE_KIND).toString());

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/SingleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/SingleNamespaceST.java
@@ -73,6 +73,12 @@ public class SingleNamespaceST extends OlmAbstractST {
         doTestDeployExampleKafkaMirrorMaker2();
     }
 
+    @Test
+    @Order(9)
+    void testDeployExampleKafkaRebalance() {
+        doTestDeployExampleKafkaRebalance();
+    }
+
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();


### PR DESCRIPTION
### Type of change

- Bugfix
- Refactoring

### Description

This PR fixes the issue with KafkaUser example in OLM manifests. Currently, the Kafka installed via OLM doesn't have authorization part, which is needed by KU.

I also added tests for KafkaRebalance example. Verified manually with latest images.

```
...
[INFO] Results:
[INFO]
[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
```

### Checklist

- [x] Make sure all tests pass


