### PR TITLE
[systemtest] Fixes for listener's tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/ServiceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/ServiceUtils.java
@@ -98,7 +98,7 @@ public class ServiceUtils {
         TestUtils.waitFor("", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT,
             () -> {
                 try {
-                    InetAddress.getByName(kubeClient().getService("my-cluster-kafka-external-bootstrap").getStatus().getLoadBalancer().getIngress().get(0).getHostname());
+                    InetAddress.getByName(address);
                     return true;
                 } catch (IOException e) {
                     return false;

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/BackwardsCompatibleListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/BackwardsCompatibleListenersST.java
@@ -220,7 +220,7 @@ public class BackwardsCompatibleListenersST extends AbstractST {
         KafkaTopicResource.topic(CLUSTER_NAME, topicName).done();
         KafkaUserResource.tlsUser(CLUSTER_NAME, kafkaUsername).done();
 
-        ServiceUtils.waitUntilAddressIsReachable(KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getListeners().get(0).getBootstrapServers());
+        ServiceUtils.waitUntilAddressIsReachable(KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getListeners().get(0).getAddresses().get(0).getHost());
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
                 .withTopicName(topicName)

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/BackwardsCompatibleListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/BackwardsCompatibleListenersST.java
@@ -229,6 +229,7 @@ public class BackwardsCompatibleListenersST extends AbstractST {
                 .withMessageCount(MESSAGE_COUNT)
                 .withKafkaUsername(kafkaUsername)
                 .withSecurityProtocol(SecurityProtocol.SSL)
+                .withListenerName(Constants.EXTERNAL_LISTENER_DEFAULT_NAME)
                 .build();
 
         basicExternalKafkaClient.verifyProducedAndConsumedMessages(
@@ -268,6 +269,7 @@ public class BackwardsCompatibleListenersST extends AbstractST {
                 .withMessageCount(MESSAGE_COUNT)
                 .withKafkaUsername(kafkaUsername)
                 .withSecurityProtocol(SecurityProtocol.SSL)
+                .withListenerName(Constants.EXTERNAL_LISTENER_DEFAULT_NAME)
                 .build();
 
         basicExternalKafkaClient.verifyProducedAndConsumedMessages(

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/BackwardsCompatibleListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/BackwardsCompatibleListenersST.java
@@ -220,7 +220,7 @@ public class BackwardsCompatibleListenersST extends AbstractST {
         KafkaTopicResource.topic(CLUSTER_NAME, topicName).done();
         KafkaUserResource.tlsUser(CLUSTER_NAME, kafkaUsername).done();
 
-        ServiceUtils.waitUntilAddressIsReachable(kubeClient().getService(KafkaResources.externalBootstrapServiceName(CLUSTER_NAME)).getStatus().getLoadBalancer().getIngress().get(0).getHostname());
+        ServiceUtils.waitUntilAddressIsReachable(KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getListeners().get(0).getBootstrapServers());
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
                 .withTopicName(topicName)

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -1698,7 +1698,7 @@ public class ListenersST extends AbstractST {
             basicExternalKafkaClient.receiveMessagesTls()
         );
 
-        basicExternalKafkaClient = basicExternalKafkaClient.toBuilder()
+        internalKafkaClient = internalKafkaClient.toBuilder()
             .withConsumerGroupName("consumer-group-certs-92")
             .withMessageCount(MESSAGE_COUNT * 5)
             .build();

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -500,7 +500,7 @@ public class ListenersST extends AbstractST {
             .endSpec()
             .done();
 
-        ServiceUtils.waitUntilAddressIsReachable(kubeClient().getService(KafkaResources.externalBootstrapServiceName(CLUSTER_NAME)).getStatus().getLoadBalancer().getIngress().get(0).getIp());
+        ServiceUtils.waitUntilAddressIsReachable(KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getListeners().get(0).getBootstrapServers());
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(TOPIC_NAME)
@@ -540,7 +540,7 @@ public class ListenersST extends AbstractST {
 
         KafkaUserResource.tlsUser(CLUSTER_NAME, USER_NAME).done();
 
-        ServiceUtils.waitUntilAddressIsReachable(kubeClient().getService(KafkaResources.externalBootstrapServiceName(CLUSTER_NAME)).getStatus().getLoadBalancer().getIngress().get(0).getHostname());
+        ServiceUtils.waitUntilAddressIsReachable(KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getListeners().get(0).getBootstrapServers());
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(TOPIC_NAME)

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -500,7 +500,7 @@ public class ListenersST extends AbstractST {
             .endSpec()
             .done();
 
-        ServiceUtils.waitUntilAddressIsReachable(kubeClient().getService(KafkaResources.externalBootstrapServiceName(CLUSTER_NAME)).getStatus().getLoadBalancer().getIngress().get(0).getHostname());
+        ServiceUtils.waitUntilAddressIsReachable(kubeClient().getService(KafkaResources.externalBootstrapServiceName(CLUSTER_NAME)).getStatus().getLoadBalancer().getIngress().get(0).getIp());
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(TOPIC_NAME)

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -500,7 +500,7 @@ public class ListenersST extends AbstractST {
             .endSpec()
             .done();
 
-        ServiceUtils.waitUntilAddressIsReachable(KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getListeners().get(0).getBootstrapServers());
+        ServiceUtils.waitUntilAddressIsReachable(KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getListeners().get(0).getAddresses().get(0).getHost());
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(TOPIC_NAME)
@@ -540,7 +540,7 @@ public class ListenersST extends AbstractST {
 
         KafkaUserResource.tlsUser(CLUSTER_NAME, USER_NAME).done();
 
-        ServiceUtils.waitUntilAddressIsReachable(KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getListeners().get(0).getBootstrapServers());
+        ServiceUtils.waitUntilAddressIsReachable(KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getListeners().get(0).getAddresses().get(0).getHost());
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(TOPIC_NAME)

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
@@ -8,7 +8,6 @@ import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
-import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
@@ -46,7 +45,6 @@ public class MultipleListenersST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(MultipleListenersST.class);
     public static final String NAMESPACE = "multi-listener-namespace";
-    public final PasswordGenerator passwordGenerator = new PasswordGenerator(9, "a", "abcdefghilkfmnoprstwxyz");
 
     // only 4 type of listeners
     private Map<KafkaListenerType, List<GenericKafkaListener>> testCases = new HashMap<>(4);
@@ -279,7 +277,7 @@ public class MultipleListenersST extends AbstractST {
                         boolean stochasticCommunication = ThreadLocalRandom.current().nextInt(2) == 0;
 
                         testCaseListeners.add(new GenericKafkaListenerBuilder()
-                            .withName(passwordGenerator.generate())
+                            .withName(KafkaListenerType.NODEPORT.toValue() + j)
                             .withPort(10900 + j)
                             .withType(KafkaListenerType.NODEPORT)
                             .withTls(stochasticCommunication)
@@ -294,7 +292,7 @@ public class MultipleListenersST extends AbstractST {
                         boolean stochasticCommunication = ThreadLocalRandom.current().nextInt(2) == 0;
 
                         testCaseListeners.add(new GenericKafkaListenerBuilder()
-                            .withName(passwordGenerator.generate())
+                            .withName(KafkaListenerType.LOADBALANCER.toValue() + j)
                             .withPort(11900 + j)
                             .withType(KafkaListenerType.LOADBALANCER)
                             .withTls(stochasticCommunication)
@@ -304,7 +302,7 @@ public class MultipleListenersST extends AbstractST {
                 case ROUTE:
                     // TODO: bug with unique ports per listener which should be fixed now in Kafka 2.7.0
                     testCaseListeners.add(new GenericKafkaListenerBuilder()
-                        .withName(passwordGenerator.generate())
+                        .withName(KafkaListenerType.ROUTE.toValue())
                         .withPort(12091)
                         .withType(KafkaListenerType.ROUTE)
                         // Route or Ingress type listener and requires enabled TLS encryption
@@ -319,7 +317,7 @@ public class MultipleListenersST extends AbstractST {
                         boolean stochasticCommunication = ThreadLocalRandom.current().nextInt(2) == 0;
 
                         testCaseListeners.add(new GenericKafkaListenerBuilder()
-                            .withName(passwordGenerator.generate())
+                            .withName(KafkaListenerType.INTERNAL.toValue() + j)
                             .withPort(13900 + j)
                             .withType(KafkaListenerType.INTERNAL)
                             .withTls(stochasticCommunication)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -756,6 +756,7 @@ class SecurityST extends AbstractST {
             .withMessageCount(MESSAGE_COUNT)
             .withKafkaUsername(userName)
             .withSecurityProtocol(SecurityProtocol.PLAINTEXT)
+            .withListenerName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
             .build();
 
         internalKafkaClient.checkProducedAndConsumedMessages(
@@ -844,6 +845,7 @@ class SecurityST extends AbstractST {
             .withClusterName(CLUSTER_NAME)
             .withMessageCount(MESSAGE_COUNT)
             .withKafkaUsername(userName)
+            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
             .build();
 
         internalKafkaClient.checkProducedAndConsumedMessages(

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -154,6 +154,7 @@ public class SpecificST extends AbstractST {
             .withNamespaceName(NAMESPACE)
             .withClusterName(CLUSTER_NAME)
             .withMessageCount(MESSAGE_COUNT)
+            .withListenerName(Constants.EXTERNAL_LISTENER_DEFAULT_NAME)
             .build();
 
         basicExternalKafkaClient.verifyProducedAndConsumedMessages(

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -105,6 +105,7 @@ public class SpecificST extends AbstractST {
             .withNamespaceName(NAMESPACE)
             .withClusterName(CLUSTER_NAME)
             .withMessageCount(MESSAGE_COUNT)
+            .withListenerName(Constants.EXTERNAL_LISTENER_DEFAULT_NAME)
             .build();
 
         basicExternalKafkaClient.verifyProducedAndConsumedMessages(

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -224,6 +224,7 @@ public class SpecificST extends AbstractST {
             .withNamespaceName(NAMESPACE)
             .withClusterName(CLUSTER_NAME)
             .withMessageCount(MESSAGE_COUNT)
+            .withListenerName(Constants.EXTERNAL_LISTENER_DEFAULT_NAME)
             .build();
 
         basicExternalKafkaClient.verifyProducedAndConsumedMessages(


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes:
1) tests where listener's names weren't specified
2) changing the names of listeners in `MultipleListenersST` to be more "readable" so we can easily debug it
3) changing waits for service is reachable -> until now there was just one host on which we were waiting to be reachable

### Checklist

- [ ] Make sure all tests pass

