### PR TITLE
Set systemtest/target as default dir for st debug log

### DIFF
--- a/systemtest/src/main/resources/log4j2.properties
+++ b/systemtest/src/main/resources/log4j2.properties
@@ -7,8 +7,8 @@ appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} %highlight{%-5p} 
 
 appender.rolling.type = RollingFile
 appender.rolling.name = RollingFile
-appender.rolling.fileName = ${env:TEST_LOG_DIR:-target/logs}/strimzi-debug.log
-appender.rolling.filePattern = ${env:TEST_LOG_DIR:-target/logs}/strimzi-debug-%d{yyyy-MM-dd-HH-mm-ss}-%i.log.gz
+appender.rolling.fileName = ${env:TEST_LOG_DIR:-systemtest/target/logs}/strimzi-debug.log
+appender.rolling.filePattern = ${env:TEST_LOG_DIR:-systemtest/target/logs}/strimzi-debug-%d{yyyy-MM-dd-HH-mm-ss}-%i.log.gz
 appender.rolling.policies.type = Policies
 appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
 appender.rolling.policies.size.size=100MB


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

When you execute system tests, `strimzi-debug.log` is generated by default and contains debug log from STs. This file is stored in `target/logs/` instead of `systemtest/target/logs` as rest of the collect logs. This PR fix the path.

### Checklist

- [x] Make sure all tests pass

