### PR TITLE
Docs after ver expansion in dyn. logging

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -447,7 +447,8 @@ public abstract class AbstractModel {
                     newSettings.addMapPairs(inlineLogging.getLoggers());
 
                     if (newRootLogger != null && !rootAppenderName.isEmpty() && !newRootLogger.contains(",")) {
-                        log.warn("Newly set rootLogger does not contain appender. Setting appender to {}.", rootAppenderName);
+                        // this should never happen as appender name is added in default configuration
+                        log.debug("Newly set rootLogger does not contain appender. Setting appender to {}.", rootAppenderName);
                         String level = newSettings.asMap().get("log4j.rootLogger");
                         newSettings.addPair("log4j.rootLogger", level + ", " + rootAppenderName);
                     }

--- a/cluster-operator/src/main/resources/kafkaConnectDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/kafkaConnectDefaultLoggingProperties
@@ -1,7 +1,8 @@
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n
-log4j.rootLogger=INFO, CONSOLE
+connect.root.logger.level=INFO
+log4j.rootLogger=${connect.root.logger.level}, CONSOLE
 log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.I0Itec.zkclient=ERROR
 log4j.logger.org.reflections=ERROR

--- a/cluster-operator/src/main/resources/kafkaDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/kafkaDefaultLoggingProperties
@@ -1,7 +1,8 @@
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n
-log4j.rootLogger=INFO, CONSOLE
+kafka.root.logger.level=INFO
+log4j.rootLogger=${kafka.root.logger.level}, CONSOLE
 log4j.logger.org.I0Itec.zkclient.ZkClient=INFO
 log4j.logger.org.apache.zookeeper=INFO
 log4j.logger.kafka=INFO

--- a/cluster-operator/src/main/resources/kafkaMirrorMaker2DefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/kafkaMirrorMaker2DefaultLoggingProperties
@@ -1,7 +1,8 @@
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n
-log4j.rootLogger=INFO, CONSOLE
+connect.root.logger.level=INFO
+log4j.rootLogger=${connect.root.logger.level}, CONSOLE
 log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.I0Itec.zkclient=ERROR
 log4j.logger.org.reflections=ERROR

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -146,7 +146,7 @@ public class KafkaAssemblyOperatorTest {
     static {
         LOG_KAFKA_CONFIG.setLoggers(singletonMap("kafka.root.logger.level", "INFO"));
         LOG_ZOOKEEPER_CONFIG.setLoggers(singletonMap("zookeeper.root.logger", "INFO"));
-        LOG_CONNECT_CONFIG.setLoggers(singletonMap("log4j.rootLogger", "INFO"));
+        LOG_CONNECT_CONFIG.setLoggers(singletonMap("connect.root.logger.level", "INFO"));
     }
 
     private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_9;

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc
@@ -4,7 +4,7 @@ Configures a Kafka Connect cluster.
 === `logging`
 Kafka Connect has its own configurable loggers:
 
-* `log4j.rootLogger`
+* `connect.root.logger.level`
 * `log4j.logger.org.reflections`
 
 Further loggers are added depending on the Kafka Connect plugins running.
@@ -36,7 +36,7 @@ spec:
   logging:
     type: inline
     loggers:
-      log4j.rootLogger: "INFO"
+      connect.root.logger.level: "INFO"
   # ...
 ----
 

--- a/documentation/assemblies/assembly-external-logging.adoc
+++ b/documentation/assemblies/assembly-external-logging.adoc
@@ -14,7 +14,7 @@ spec:
   logging:
     type: inline
     loggers:
-      log4j.logger.kafka: "INFO"
+      kafka.root.logger.level: "INFO"
 ----
 
 Or you can specify _external_ logging:

--- a/documentation/modules/con-kafka-connect-s2i-logging.adoc
+++ b/documentation/modules/con-kafka-connect-s2i-logging.adoc
@@ -7,7 +7,7 @@
 
 Kafka Connect with Source2Image support has its own configurable loggers:
 
-* `log4j.rootLogger`
+* `connect.root.logger.level`
 * `log4j.logger.org.reflections`
 
 Kafka Connect uses the Apache `log4j` logger implementation.
@@ -29,7 +29,7 @@ spec:
   logging:
     type: inline
     loggers:
-      log4j.rootLogger: "INFO"
+      connect.root.logger.level: "INFO"
   # ...
 ----
 

--- a/documentation/modules/con-kafka-logging.adoc
+++ b/documentation/modules/con-kafka-logging.adoc
@@ -48,7 +48,7 @@ spec:
     logging:
       type: inline
       loggers:
-        log4j.logger.kafka: "INFO"
+        kafka.root.logger.level: "INFO"
   # ...
   zookeeper:
     # ...

--- a/documentation/modules/mirrormaker2/proc-mirrormaker-replication.adoc
+++ b/documentation/modules/mirrormaker2/proc-mirrormaker-replication.adoc
@@ -131,7 +131,7 @@ spec:
   logging: <32>
     type: inline
     loggers:
-      log4j.rootLogger: "INFO"
+      connect.root.logger.level: "INFO"
   readinessProbe: <33>
     initialDelaySeconds: 15
     timeoutSeconds: 5
@@ -211,7 +211,7 @@ Standard Apache Kafka configuration may be provided, restricted to those propert
 <30> Consumer group replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request three consumer groups by name.
 You can use comma-separated lists.
 <31> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
-<32> Specified xref:property-kafka-connect-logging-reference[Kafka Connect loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. Kafka Connect has a single logger called `log4j.rootLogger`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<32> Specified xref:property-kafka-connect-logging-reference[Kafka Connect loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. Kafka Connect has a single logger called `connect.root.logger.level`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
 <33> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
 <34> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
 <35> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.

--- a/documentation/modules/overview/con-configuration-points-common.adoc
+++ b/documentation/modules/overview/con-configuration-points-common.adoc
@@ -42,7 +42,7 @@ spec:
   logging:
     type: inline
     loggers:
-      log4j.rootLogger: "INFO"
+      connect.root.logger.level: "INFO"
   readinessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5

--- a/documentation/modules/proc-creating-configmap.adoc
+++ b/documentation/modules/proc-creating-configmap.adoc
@@ -32,7 +32,7 @@ metadata:
   name: logging-configmap
 data:
   log4j.properties:
-    log4j.logger.kafka="INFO"
+    kafka.root.logger.level="INFO"
 ----
 +
 From the command line, using a properties file:
@@ -47,7 +47,7 @@ The properties file defines the logging configuration:
 [source,text]
 ----
 # Define the logger
-log4j.logger.kafka="INFO"
+kafka.root.logger.level="INFO"
 # ...
 ----
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -77,7 +77,7 @@ public class KafkaConnectResource {
                 .addToConfig("config.storage.topic", KafkaConnectResources.metricsAndLogConfigMapName(kafkaClusterName))
                 .addToConfig("status.storage.topic", KafkaConnectResources.configStorageTopicStatus(kafkaClusterName))
                 .withNewInlineLogging()
-                    .addToLoggers("log4j.rootLogger", "DEBUG")
+                    .addToLoggers("connect.root.logger.level", "DEBUG")
                 .endInlineLogging()
             .endSpec();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
@@ -61,7 +61,7 @@ public class KafkaConnectS2IResource {
                 .endTls()
                 .withInsecureSourceRepository(true)
                 .withNewInlineLogging()
-                    .addToLoggers("log4j.rootLogger", "DEBUG")
+                    .addToLoggers("connect.root.logger.level", "DEBUG")
                 .endInlineLogging()
             .endSpec();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
@@ -97,7 +97,7 @@ public class KafkaMirrorMaker2Resource {
                     .withTargetCluster(kafkaTargetClusterName)
                 .endMirror()
                 .withNewInlineLogging()
-                    .addToLoggers("log4j.rootLogger", "DEBUG")
+                    .addToLoggers("connect.root.logger.level", "DEBUG")
                 .endInlineLogging()
             .endSpec();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -171,7 +171,7 @@ public class KafkaResource {
                         .endGenericKafkaListener()
                     .endListeners()
                     .withNewInlineLogging()
-                        .addToLoggers("log4j.rootLogger", "DEBUG")
+                        .addToLoggers("kafka.root.logger.level", "DEBUG")
                     .endInlineLogging()
                 .endKafka()
                 .editZookeeper()

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -574,7 +574,7 @@ class LoggingChangeST extends AbstractST {
     void testDynamicallySetConnectLoggingLevels() {
         InlineLogging ilOff = new InlineLogging();
         Map<String, String> loggers = new HashMap<>();
-        loggers.put("log4j.rootLogger", "OFF");
+        loggers.put("connect.root.logger.level", "OFF");
         ilOff.setLoggers(loggers);
 
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
@@ -593,7 +593,7 @@ class LoggingChangeST extends AbstractST {
 
         LOGGER.info("Changing rootLogger level to DEBUG with inline logging");
         InlineLogging ilDebug = new InlineLogging();
-        loggers.put("log4j.rootLogger", "DEBUG");
+        loggers.put("connect.root.logger.level", "DEBUG");
         ilDebug.setLoggers(loggers);
 
         KafkaConnectResource.replaceKafkaConnectResource(CLUSTER_NAME, conn -> {
@@ -653,11 +653,11 @@ class LoggingChangeST extends AbstractST {
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaName);
 
         InlineLogging ilOff = new InlineLogging();
-        ilOff.setLoggers(Collections.singletonMap("log4j.rootLogger", "INFO"));
+        ilOff.setLoggers(Collections.singletonMap("kafka.root.logger.level", "INFO"));
 
         LOGGER.info("Changing rootLogger level to DEBUG with inline logging");
         InlineLogging ilDebug = new InlineLogging();
-        ilDebug.setLoggers(Collections.singletonMap("log4j.rootLogger", "DEBUG"));
+        ilDebug.setLoggers(Collections.singletonMap("kafka.root.logger.level", "DEBUG"));
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, k -> {
             k.getSpec().getKafka().setLogging(ilDebug);
         });
@@ -740,7 +740,7 @@ class LoggingChangeST extends AbstractST {
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaName);
 
         InlineLogging il = new InlineLogging();
-        il.setLoggers(Collections.singletonMap("log4j.rootLogger", "PAPRIKA"));
+        il.setLoggers(Collections.singletonMap("kafka.root.logger.level", "PAPRIKA"));
 
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, k -> {
             k.getSpec().getKafka().setLogging(il);
@@ -860,7 +860,7 @@ class LoggingChangeST extends AbstractST {
     void testDynamicallySetMM2LoggingLevels() {
         InlineLogging ilOff = new InlineLogging();
         Map<String, String> loggers = new HashMap<>();
-        loggers.put("log4j.rootLogger", "OFF");
+        loggers.put("connect.root.logger.level", "OFF");
         ilOff.setLoggers(loggers);
 
         KafkaResource.kafkaEphemeral(CLUSTER_NAME + "-source", 3).done();
@@ -874,7 +874,7 @@ class LoggingChangeST extends AbstractST {
 
         LOGGER.info("Changing rootLogger level to DEBUG with inline logging");
         InlineLogging ilDebug = new InlineLogging();
-        loggers.put("log4j.rootLogger", "DEBUG");
+        loggers.put("connect.root.logger.level", "DEBUG");
         ilDebug.setLoggers(loggers);
 
         KafkaMirrorMaker2Resource.replaceKafkaMirrorMaker2Resource(CLUSTER_NAME, mm2 -> {


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Documentation

### Description
After Marko implemented var expansion in logging configuration, it is possible to revert docs to not break backward compatibility.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

