### PR TITLE
ST: Fix upgrade dependencies

### DIFF
--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -138,6 +138,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>${javax.json.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes dependencies for upgrade system tests which caused failures during loading `StrimziUpgrade.json`. It was caused by https://github.com/strimzi/strimzi-kafka-operator/pull/3651.

This should be cherry-picked to `release-0.20.x`

### Checklist

- [x] Make sure all tests pass


