### PR TITLE
ST: Small changes for KafkaRoller ST to remove redundant checks

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
@@ -27,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -150,11 +150,10 @@ class KafkaRollerST extends AbstractST {
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka ->
                 kafka.getSpec().getKafka().getJvmOptions().setXx(Collections.emptyMap()));
 
-        long startTime = System.currentTimeMillis();
+        // kafka should get back ready in some reasonable time frame.
+        // Current timeout for wait is set to 14 minutes, which should be enough.
+        // No additional checks are needed, because in case of wait failure, the test will not continue.
         KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
-        long endTime = System.currentTimeMillis();
-
-        assertThat(Duration.ofMillis(endTime - startTime).toMinutes(), is(lessThan(20L)));
     }
 
     @Test
@@ -167,13 +166,12 @@ class KafkaRollerST extends AbstractST {
         KafkaUtils.waitForKafkaNotReady(CLUSTER_NAME);
 
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka ->
-                kafka.getSpec().getKafka().setImage("strimzi/kafka:latest-kafka-2.6.0"));
+                kafka.getSpec().getKafka().setImage("strimzi/kafka:latest-kafka-" + Environment.ST_KAFKA_VERSION));
 
-        long startTime = System.currentTimeMillis();
+        // kafka should get back ready in some reasonable time frame.
+        // Current timeout for wait is set to 14 minutes, which should be enough.
+        // No additional checks are needed, because in case of wait failure, the test will not continue.
         KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
-        long endTime = System.currentTimeMillis();
-
-        assertThat(Duration.ofMillis(endTime - startTime).toMinutes(), is(lessThan(20L)));
     }
 
     @Test
@@ -190,7 +188,7 @@ class KafkaRollerST extends AbstractST {
                 .done();
 
         Map<String, Quantity> requests = new HashMap<>(2);
-        requests.put("cpu", new Quantity("10"));
+        requests.put("cpu", new Quantity("10000"));
         requests.put("memory", new Quantity("512Mi"));
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka ->
                 kafka.getSpec().getKafka().getResources().setRequests(requests));
@@ -202,11 +200,10 @@ class KafkaRollerST extends AbstractST {
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka ->
                 kafka.getSpec().getKafka().getResources().setRequests(requests));
 
-        long startTime = System.currentTimeMillis();
+        // kafka should get back ready in some reasonable time frame.
+        // Current timeout for wait is set to 14 minutes, which should be enough.
+        // No additional checks are needed, because in case of wait failure, the test will not continue.
         KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
-        long endTime = System.currentTimeMillis();
-
-        assertThat(Duration.ofMillis(endTime - startTime).toMinutes(), is(lessThan(20L)));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -187,7 +187,7 @@ class KafkaRollerST extends AbstractST {
                 .done();
 
         Map<String, Quantity> requests = new HashMap<>(2);
-        requests.put("cpu", new Quantity("10000"));
+        requests.put("cpu", new Quantity("123456"));
         requests.put("memory", new Quantity("512Mi"));
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka ->
                 kafka.getSpec().getKafka().getResources().setRequests(requests));

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -45,7 +45,6 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag(REGRESSION)


### PR DESCRIPTION

Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Refactoring

### Description

Tests added in https://github.com/strimzi/strimzi-kafka-operator/pull/3721 contained redundant check for time which was needed for "repair" Kafka pods. Currently, the timeout for Kafka readines is set for 14 minutes (as it was), but additional check for time was removed. 

### Checklist

- [x] Make sure all tests pass

