### PR TITLE
[DOC] Improve Kafka Connect deployment docs

### DIFF
--- a/documentation/modules/deploying/proc-deploy-kafka-connect.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect.adoc
@@ -23,10 +23,13 @@ See the _Using Strimzi_ guide for more information about configuring the `KafkaC
 .Prerequisites
 
 * xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
+* xref:deploying-kafka-cluster-str[Running Kafka cluster.]
 
 .Procedure
 
 . Deploy Kafka Connect to your Kubernetes cluster.
+For a Kafka cluster with 3 or more brokers, `examples/connect/kafka-connect.yaml`.
+For a Kafka cluster with less nodes, please use `examples/connect/kafka-connect-single-node-kafka.yaml` instead of `examples/connect/kafka-connect.yaml`.
 +
 [source,shell,subs="attributes+"]
 ----

--- a/documentation/modules/deploying/proc-deploy-kafka-connect.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect.adoc
@@ -28,8 +28,8 @@ See the _Using Strimzi_ guide for more information about configuring the `KafkaC
 .Procedure
 
 . Deploy Kafka Connect to your Kubernetes cluster.
-For a Kafka cluster with 3 or more brokers, `examples/connect/kafka-connect.yaml`.
-For a Kafka cluster with less nodes, please use `examples/connect/kafka-connect-single-node-kafka.yaml` instead of `examples/connect/kafka-connect.yaml`.
+For a Kafka cluster with 3 or more brokers, use the `examples/connect/kafka-connect.yaml` file.
+For a Kafka cluster with less than 3 brokers, use the `examples/connect/kafka-connect-single-node-kafka.yaml` file.
 +
 [source,shell,subs="attributes+"]
 ----


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The Connect deployment procedure is missing running Kafka cluster in prerequisites. It is also isn't clear enough that 3 nodes Kafka cluster is needed for the default example file. This PR tries to improve it

This should address issue #3780.