### PR TITLE
Fix the Azure Pipelines build script to properly handle tags

### DIFF
--- a/.azure/scripts/build.sh
+++ b/.azure/scripts/build.sh
@@ -55,7 +55,7 @@ fi
 # Push artifatcs (Docker containers, JARs, docs)
 if [ "$BUILD_REASON" == "PullRequest" ] ; then
     echo "Building Pull Request - nothing to push"
-elif [ "$BRANCH" != "refs/tags/*" ] && [ "$BRANCH" != "refs/heads/master" ]; then
+elif [[ "$BRANCH" != "refs/tags/"* ]] && [ "$BRANCH" != "refs/heads/master" ]; then
     echo "Not in master branch and not in release tag - nothing to push"
 else
     if [ "${MAIN_BUILD}" == "TRUE" ] ; then


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Azure Pipelines build script currently badly evaluates the builds in tags. That means it. does not handle releases well. I already fixed it for the 0.20 release branch during the 0.20.0-rc1 release. But we need to fix this in master to preserve it for next releases as well. No need to cherry-pick.