### PR TITLE
Make it clear that StorageClass overrides can be used even with Zoo

### DIFF
--- a/documentation/modules/ref-storage-persistent.adoc
+++ b/documentation/modules/ref-storage-persistent.adoc
@@ -74,7 +74,7 @@ storage:
 
 == Storage class overrides
 
-You can specify a different storage class for one or more Kafka brokers, instead of using the default storage class.
+You can specify a different storage class for one or more Kafka brokers or ZooKeeper nodes, instead of using the default storage class.
 This is useful if, for example, storage classes are restricted to different availability zones or data centers.
 You can use the `overrides` field for this purpose.
 
@@ -107,10 +107,28 @@ spec:
         - broker: 2
           class: my-storage-class-zone-1c
   # ...
+  zookeeper:
+    replicas: 3
+    storage:
+      deleteClaim: true
+      size: 100Gi
+      type: persistent-claim
+      class: my-storage-class
+      overrides:
+        - broker: 0
+          class: my-storage-class-zone-1a
+        - broker: 1
+          class: my-storage-class-zone-1b
+        - broker: 2
+          class: my-storage-class-zone-1c
+  # ...
 ----
 
-As a result of the configured `overrides` property, the broker volumes use the following storage classes:
+As a result of the configured `overrides` property, the volumes use the following storage classes:
 
+* The persistent volumes of ZooKeeper node 0 will use `my-storage-class-zone-1a`.
+* The persistent volumes of ZooKeeper node 1 will use `my-storage-class-zone-1b`.
+* The persistent volumes of ZooKeeepr node 2 will use `my-storage-class-zone-1c`.
 * The persistent volumes of broker 0 will use `my-storage-class-zone-1a`.
 * The persistent volumes of broker 1 will use `my-storage-class-zone-1b`.
 * The persistent volumes of broker 2 will use `my-storage-class-zone-1c`.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

From the documentation it is not completely clear that the StorageClass overrides can work not just with Kafka brokers but also with Zookeeper nodes (and that for Zookeeper nodes, the node is still called `broker`). This Pr tries to improve the docs by adding example and making it a bit more clear.

This should close issue #3782.