### PR TITLE
Run ConnectS2I with tini

### DIFF
--- a/docker-images/kafka/s2i-scripts/run
+++ b/docker-images/kafka/s2i-scripts/run
@@ -11,6 +11,7 @@ then
 fi
 
 export KAFKA_CONNECT_PLUGIN_PATH=/tmp/kafka-plugins
-export KAFKA_CONNECT_S2I=true
 echo "Starting Kafka Connect with custom plugin directory $KAFKA_CONNECT_PLUGIN_PATH"
-exec /usr/bin/tini -w -e 143 -- /opt/kafka/kafka_connect_run.sh
+# shellcheck source=/opt/kafka/kafka_connect_run.sh
+# shellcheck disable=SC1091
+source /opt/kafka/kafka_connect_run.sh

--- a/docker-images/kafka/s2i-scripts/run
+++ b/docker-images/kafka/s2i-scripts/run
@@ -11,5 +11,6 @@ then
 fi
 
 export KAFKA_CONNECT_PLUGIN_PATH=/tmp/kafka-plugins
+export KAFKA_CONNECT_S2I=true
 echo "Starting Kafka Connect with custom plugin directory $KAFKA_CONNECT_PLUGIN_PATH"
-/opt/kafka/kafka_connect_run.sh
+exec /usr/bin/tini -w -e 143 -- /opt/kafka/kafka_connect_run.sh

--- a/docker-images/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka/scripts/kafka_connect_run.sh
@@ -69,4 +69,10 @@ fi
 . ./set_kafka_gc_options.sh
 
 # starting Kafka server with final configuration
-exec /usr/bin/tini -w -e 143 -- "${KAFKA_HOME}/bin/connect-distributed.sh" /tmp/strimzi-connect.properties
+
+if [ "$KAFKA_CONNECT_S2I" = "true" ]; then
+    # this script already run via tini
+    "${KAFKA_HOME}/bin/connect-distributed.sh" /tmp/strimzi-connect.properties
+  else
+    exec /usr/bin/tini -w -e 143 -- "${KAFKA_HOME}/bin/connect-distributed.sh" /tmp/strimzi-connect.properties
+fi

--- a/docker-images/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka/scripts/kafka_connect_run.sh
@@ -69,10 +69,4 @@ fi
 . ./set_kafka_gc_options.sh
 
 # starting Kafka server with final configuration
-
-if [ "$KAFKA_CONNECT_S2I" = "true" ]; then
-    # this script already run via tini
-    "${KAFKA_HOME}/bin/connect-distributed.sh" /tmp/strimzi-connect.properties
-  else
-    exec /usr/bin/tini -w -e 143 -- "${KAFKA_HOME}/bin/connect-distributed.sh" /tmp/strimzi-connect.properties
-fi
+exec /usr/bin/tini -w -e 143 -- "${KAFKA_HOME}/bin/connect-distributed.sh" /tmp/strimzi-connect.properties

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
@@ -353,7 +353,7 @@ class LogSettingST extends AbstractST {
 
         for (Pod pod : kubeClient().listPods()) {
             String podName = pod.getMetadata().getName();
-            if (!podName.contains("build") && !podName.contains("deploy") && !podName.contains("kafka-clients") && !podName.contains(CONNECTS2I_NAME)) {
+            if (!podName.contains("build") && !podName.contains("deploy") && !podName.contains("kafka-clients")) {
                 for (Container container : pod.getSpec().getContainers()) {
                     LOGGER.info("Checking tini process for pod {} with container {}", pod, container);
                     boolean isPresent = cmdKubeClient().execInPodContainer(false, podName, container.getName(), "/bin/bash", "-c", command).out().trim().equals("1");


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
The ConnectS2I deployment is not run with `tini` as PID 1. It is caused by the composition of scripts. Connect S2I is run by `/docker-images/kafka/s2i-scripts/run` which runs `/opt/kafka/kafka_connect_run.sh` which runs `tini`. So first process in Connect is `tini`, but in ConnectS2I it is `bash`.

After the change:
```
[sknot@localhost productizedf8]$ oc exec -ti my-s2i-connect-cluster-connect-1-7wllq -- ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
1000150+     1  0.0  0.0   4360   360 ?        Ss   10:00   0:00 /usr/bin/tini -w -e 
1000150+    31 47.0  3.5 8166700 578940 ?      Sl   10:00   0:34 java -Xms128M -serve
1000150+   511  0.0  0.0  51756  1656 ?        Rs+  10:01   0:00 ps aux

```

One question for @im-konge : Why is test `testCheckContainersHaveProcessOneAsTini` in LogSettingST class? It does not test any logging or?


Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/3282
### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

