### PR TITLE
Fix camelCase in the upgrade chapter for alternativeNames

### DIFF
--- a/documentation/modules/upgrading/con-upgrade-listeners.adoc
+++ b/documentation/modules/upgrading/con-upgrade-listeners.adoc
@@ -68,7 +68,7 @@ Changes introduced to the listener `configuration`:
 * `overrides` is merged with the `configuration` section
 * `dnsAnnotations` has been renamed `annotations`
 * `preferredAddressType` has been renamed `preferredNodePortAddressType`
-* `address` has been renamed `alternativenames`
+* `address` has been renamed `alternativeNames`
 * `loadBalancerSourceRanges` and `externalTrafficPolicy` move to the listener configuration from the now deprecated `template`
 
 For example, this configuration:


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The docs section about the listeners upgrade mentions `alternativeNames` all in lower case as `alternativenames`. That does not work. This PR fixes it. It seems to be ok in other places.