### PR TITLE
Make information about dropping Kube 1.11-1.15 support more clear and more visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.20.0
 
-* Please note: This is the last version of Strimzi that will support Kubernetes 1.11-1.15. Future versions will support Kubernetes 1.16+.
+**Note: This is the last version of Strimzi that will support Kubernetes 1.11 and higher. Future versions will drop support for Kubernetes 1.11-1.15 and support only Kubernetes 1.16 and higher.**
+
 * Add support for Kafka 2.5.1 and 2.6.0. Remove support for 2.4.0 and 2.4.1
 * Remove TLS sidecars from Kafka pods => Kafka now uses native TLS to connect to ZooKeeper
 * Updated to Cruise Control 2.5.11, which adds Kafka 2.6.0 support and fixes a previous issue with CPU utilization statistics for containers. As a result, the CPUCapacityGoal has now been enabled.


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The information about the plan to drop support for Kube 1.11-1.15 seems to be a bit confusing as it is not clear what other versions we support. It is also a bit lost given how important it is. This PR tries to make it more clear and more visible.