### PR TITLE
Recreate watcher when closed with an exception

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
@@ -23,11 +23,11 @@ class K8sTopicWatcher implements Watcher<KafkaTopic> {
 
     private final static Logger LOGGER = LogManager.getLogger(K8sTopicWatcher.class);
     private final Future<Void> initReconcileFuture;
-    private final Runnable onHttpGoneTask;
+    private final Thread onHttpGoneTask;
 
     private TopicOperator topicOperator;
 
-    public K8sTopicWatcher(TopicOperator topicOperator, Future<Void> initReconcileFuture, Runnable onHttpGoneTask) {
+    public K8sTopicWatcher(TopicOperator topicOperator, Future<Void> initReconcileFuture, Thread onHttpGoneTask) {
         this.topicOperator = topicOperator;
         this.initReconcileFuture = initReconcileFuture;
         this.onHttpGoneTask = onHttpGoneTask;
@@ -82,6 +82,6 @@ class K8sTopicWatcher implements Watcher<KafkaTopic> {
                 .map(KubernetesClientException::getStatus)
                 .map(Status::getCode)
                 .filter(c -> c.equals(HttpURLConnection.HTTP_GONE))
-                .ifPresent(c -> onHttpGoneTask.run());
+                .ifPresent(c -> onHttpGoneTask.start());
     }
 }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
@@ -23,11 +23,11 @@ class K8sTopicWatcher implements Watcher<KafkaTopic> {
 
     private final static Logger LOGGER = LogManager.getLogger(K8sTopicWatcher.class);
     private final Future<Void> initReconcileFuture;
-    private final Thread onHttpGoneTask;
+    private final Runnable onHttpGoneTask;
 
     private TopicOperator topicOperator;
 
-    public K8sTopicWatcher(TopicOperator topicOperator, Future<Void> initReconcileFuture, Thread onHttpGoneTask) {
+    public K8sTopicWatcher(TopicOperator topicOperator, Future<Void> initReconcileFuture, Runnable onHttpGoneTask) {
         this.topicOperator = topicOperator;
         this.initReconcileFuture = initReconcileFuture;
         this.onHttpGoneTask = onHttpGoneTask;
@@ -76,12 +76,12 @@ class K8sTopicWatcher implements Watcher<KafkaTopic> {
         LOGGER.debug("Closing {}", this);
         Optional.ofNullable(exception)
                 .map(e -> {
-                    LOGGER.debug("Exception received during watch", e);
+                    LOGGER.info("Exception received during watch", e);
                     return exception;
                 })
                 .map(KubernetesClientException::getStatus)
                 .map(Status::getCode)
                 .filter(c -> c.equals(HttpURLConnection.HTTP_GONE))
-                .ifPresent(c -> onHttpGoneTask.start());
+                .ifPresent(c -> onHttpGoneTask.run());
     }
 }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -50,6 +50,7 @@ public class Session extends AbstractVerticle {
     /*test*/ TopicConfigsWatcher topicConfigsWatcher;
     /*test*/ ZkTopicWatcher topicWatcher;
     /*test*/ PrometheusMeterRegistry metricsRegistry;
+    K8sTopicWatcher watcher;
     /** The id of the periodic reconciliation timer. This is null during a periodic reconciliation. */
     private volatile Long timerId;
     private volatile boolean stopped = false;
@@ -189,7 +190,6 @@ public class Session extends AbstractVerticle {
 
                 Promise<Void> promise = Promise.promise();
                 Promise<Void> initReconcilePromise = Promise.promise();
-                K8sTopicWatcher watcher = new K8sTopicWatcher(topicOperator, initReconcilePromise.future());
                 Thread resourceThread = new Thread(() -> {
                     try {
                         LOGGER.debug("Watching KafkaTopics matching {}", labels.labels());
@@ -206,6 +206,8 @@ public class Session extends AbstractVerticle {
                     }
 
                 }, "resource-watcher");
+                watcher = new K8sTopicWatcher(topicOperator, initReconcilePromise.future(), resourceThread);
+
                 LOGGER.debug("Starting {}", resourceThread);
                 resourceThread.start();
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -139,7 +139,7 @@ public class TopicOperatorTest {
         KafkaTopic kafkaTopic = new KafkaTopicBuilder().withMetadata(new ObjectMetaBuilder().withName("non-topic").build()).build();
 
         Checkpoint async = context.checkpoint();
-        K8sTopicWatcher w = new K8sTopicWatcher(topicOperator, Future.succeededFuture(), () -> { });
+        K8sTopicWatcher w = new K8sTopicWatcher(topicOperator, Future.succeededFuture(), new Thread());
         w.eventReceived(ADDED, kafkaTopic);
         mockKafka.assertEmpty(context);
         mockTopicStore.assertEmpty(context);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -139,7 +139,7 @@ public class TopicOperatorTest {
         KafkaTopic kafkaTopic = new KafkaTopicBuilder().withMetadata(new ObjectMetaBuilder().withName("non-topic").build()).build();
 
         Checkpoint async = context.checkpoint();
-        K8sTopicWatcher w = new K8sTopicWatcher(topicOperator, Future.succeededFuture(), new Thread());
+        K8sTopicWatcher w = new K8sTopicWatcher(topicOperator, Future.succeededFuture(), () -> { });
         w.eventReceived(ADDED, kafkaTopic);
         mockKafka.assertEmpty(context);
         mockTopicStore.assertEmpty(context);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -139,7 +139,7 @@ public class TopicOperatorTest {
         KafkaTopic kafkaTopic = new KafkaTopicBuilder().withMetadata(new ObjectMetaBuilder().withName("non-topic").build()).build();
 
         Checkpoint async = context.checkpoint();
-        K8sTopicWatcher w = new K8sTopicWatcher(topicOperator, Future.succeededFuture());
+        K8sTopicWatcher w = new K8sTopicWatcher(topicOperator, Future.succeededFuture(), () -> { });
         w.eventReceived(ADDED, kafkaTopic);
         mockKafka.assertEmpty(context);
         mockTopicStore.assertEmpty(context);


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
When the TopicWatcher is closed with an exception, it should be recreated (reconnected). So if we get non-null exception, we run a thread which does exactly that. 

Please check this for thread-safety @tombentley 

Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/3771

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

