### PR TITLE
Enable CORS configuration for Cruise Control

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
@@ -38,7 +38,8 @@ public class CruiseControlSpec implements UnknownPropertyPreserving, Serializabl
         + "webserver.http., webserver.api.urlprefix, webserver.session.path, webserver.accesslog., two.step., request.reason.required,"
         + "metric.reporter.sampler.bootstrap.servers, metric.reporter.topic, partition.metric.sample.store.topic, broker.metric.sample.store.topic,"
         + "capacity.config.file, self.healing., anomaly.detection., ssl.";
-    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, webserver.http.cors.enabled" +
+            "webserver.http.cors.origin, webserver.http.cors.exposeheaders";
 
     private String image;
     private TlsSidecar tlsSidecar;

--- a/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
@@ -38,7 +38,7 @@ public class CruiseControlSpec implements UnknownPropertyPreserving, Serializabl
         + "webserver.http., webserver.api.urlprefix, webserver.session.path, webserver.accesslog., two.step., request.reason.required,"
         + "metric.reporter.sampler.bootstrap.servers, metric.reporter.topic, partition.metric.sample.store.topic, broker.metric.sample.store.topic,"
         + "capacity.config.file, self.healing., anomaly.detection., ssl.";
-    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, webserver.http.cors.enabled" +
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, webserver.http.cors.enabled," +
             "webserver.http.cors.origin, webserver.http.cors.exposeheaders";
 
     private String image;

--- a/docker-images/kafka/cruise-control-scripts/cruise_control_config_generator.sh
+++ b/docker-images/kafka/cruise-control-scripts/cruise_control_config_generator.sh
@@ -42,6 +42,7 @@ capacity.config.file=$CC_CAPACITY_FILE
 cluster.configs.file=$CC_CLUSTER_CONFIG_FILE
 webserver.accesslog.path=$CC_ACCESS_LOG
 webserver.http.address=0.0.0.0
+webserver.http.cors.allowmethods=OPTIONS,GET
 security.protocol=SSL
 ssl.keystore.type=PKCS12
 ssl.keystore.location=/tmp/cruise-control/replication.keystore.p12


### PR DESCRIPTION
### Type of change

- Enhancement / new feature


### Description

Enable CORS configuration for Cruise Control. See: #3809

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

