### PR TITLE
ST: Break infinite loop for producers in tests

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/KafkaListenerType.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/KafkaListenerType.java
@@ -40,7 +40,7 @@ public enum KafkaListenerType {
             case ROUTE:
                 return "route";
             case LOADBALANCER:
-                return "lb";
+                return "loadbalancer";
             case NODEPORT:
                 return "nodeport";
             case INGRESS:

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/KafkaListenerType.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/KafkaListenerType.java
@@ -40,7 +40,7 @@ public enum KafkaListenerType {
             case ROUTE:
                 return "route";
             case LOADBALANCER:
-                return "loadbalancer";
+                return "lb";
             case NODEPORT:
                 return "nodeport";
             case INGRESS:

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/Producer.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/Producer.java
@@ -100,6 +100,10 @@ public class Producer extends ClientHandlerBase<Integer> implements AutoCloseabl
                         sendNext(topic);
                     }
                 } else {
+                    // Stop recursion in case the vertx is closed
+                    if (vertx == null || done.cause() instanceof IllegalStateException) {
+                        return;
+                    }
                     LOGGER.debug("Producer cannot connect to topic {}: {}", topic, done.cause().toString());
                     sendNext(topic);
                 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
@@ -44,7 +44,7 @@ import static io.strimzi.systemtest.Constants.REGRESSION;
 public class MultipleListenersST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(MultipleListenersST.class);
-    public static final String NAMESPACE = "multi-listener-namespace";
+    public static final String NAMESPACE = "multi-listener";
 
     // only 4 type of listeners
     private Map<KafkaListenerType, List<GenericKafkaListener>> testCases = new HashMap<>(4);

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
@@ -292,7 +292,7 @@ public class MultipleListenersST extends AbstractST {
                         boolean stochasticCommunication = ThreadLocalRandom.current().nextInt(2) == 0;
 
                         testCaseListeners.add(new GenericKafkaListenerBuilder()
-                            .withName(KafkaListenerType.LOADBALANCER.toValue() + j)
+                            .withName(KafkaListenerType.LOADBALANCER.toValue().substring(0, 5) + j)
                             .withPort(11900 + j)
                             .withType(KafkaListenerType.LOADBALANCER)
                             .withTls(stochasticCommunication)


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

This PR adds a break for our implementation of Kafka producer. Before this, the producer were running in memory until end of the test plan and generate tons of useles debug log.

This should be cherry-picked to `release-0.20.x`

### Checklist

- [] Make sure all tests pass

