### PR TITLE
Fixed Kafka deployments with Cruise Control and JMXTrans using the new listeners syntax

### DIFF
--- a/examples/cruise-control/kafka-cruise-control.yaml
+++ b/examples/cruise-control/kafka-cruise-control.yaml
@@ -7,8 +7,14 @@ spec:
     version: 2.6.0
     replicas: 3
     listeners:
-      plain: {}
-      tls: {}
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3

--- a/examples/metrics/jmxtrans/jmxtrans.yaml
+++ b/examples/metrics/jmxtrans/jmxtrans.yaml
@@ -7,8 +7,14 @@ spec:
     version: 2.6.0
     replicas: 2
     listeners:
-      plain: {}
-      tls: {}
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
     config:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1

--- a/examples/metrics/kafka-cruise-control-metrics.yaml
+++ b/examples/metrics/kafka-cruise-control-metrics.yaml
@@ -7,8 +7,14 @@ spec:
     version: 2.6.0
     replicas: 3
     listeners:
-      plain: {}
-      tls: {}
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This trivial PR just fixed the `Kafka` custom resource example with Cruise Control and JMX Trans to use the latest `listeners` syntax.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally