### PR TITLE
[DOC] Kafka Bridge - document message format including Kafka headers 

### DIFF
--- a/documentation/assemblies/assembly-kafka-bridge-concepts.adoc
+++ b/documentation/assemblies/assembly-kafka-bridge-concepts.adoc
@@ -5,7 +5,13 @@
 [id='kafka-bridge-concepts-{context}']
 = Kafka Bridge
 
-This chapter provides an overview of the Strimzi Kafka Bridge and helps you get started using its REST API to interact with Strimzi. To try out the Kafka Bridge in your local environment, see the xref:assembly-kafka-bridge-quickstart-{context}[] later in this chapter.
+This chapter provides an overview of the Strimzi Kafka Bridge and helps you get started using its REST API to interact with Strimzi.
+
+* To try out the Kafka Bridge in your local environment, see the xref:assembly-kafka-bridge-quickstart-{context}[] later in this chapter.
+
+* For detailed configuration steps, see xref:assembly-deployment-configuration-kafka-bridge-{context}[]. 
+
+* To view the API documentation, see the {LatestBridgeAPIDocs}.
 
 include::assembly-kafka-bridge-overview.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/assembly-kafka-bridge-overview.adoc
+++ b/documentation/assemblies/assembly-kafka-bridge-overview.adoc
@@ -10,7 +10,7 @@
 
 [id='assembly-kafka-bridge-overview-{context}']
 = Kafka Bridge overview
-You can use the Kafka Bridge as an interface to make specific types of request to the Kafka cluster.
+You can use the Strimzi Kafka Bridge as an interface to make specific types of HTTP requests to the Kafka cluster.
 
 :context: kafka-bridge-overview
 

--- a/documentation/modules/con-requests-kafka-bridge.adoc
+++ b/documentation/modules/con-requests-kafka-bridge.adoc
@@ -76,7 +76,7 @@ Producer requests must also provide a `Content-Type` header that corresponds to 
 
 == Message format
 
-When sending messages using the `/topics/` endpoint, you enter the message payload in the `records` parameter in the request body.
+When sending messages using the `/topics` endpoint, you enter the message payload in the request body, in the `records` parameter.
 
 The `records` parameter can contain any of these optional fields:
 
@@ -85,7 +85,7 @@ The `records` parameter can contain any of these optional fields:
 * Message `value`
 * Destination `partition`
 
-.Example `POST` request
+.Example `POST` request to /topics
 [source,curl,subs=attributes+]
 ----
 curl -X POST \
@@ -100,13 +100,14 @@ curl -X POST \
             "headers": [
               {
                 "key": "key1",
-                "value": "value1"
+                "value": "QXBhY2hlIEthZmthIGlzIHRoZSBib21iIQ==" <1>
               }
             ]
         },
     ]
 }'
 ----
+<1> The header value in binary format and encoded as Base64.
 
 == Accept headers
 

--- a/documentation/modules/con-requests-kafka-bridge.adoc
+++ b/documentation/modules/con-requests-kafka-bridge.adoc
@@ -18,7 +18,7 @@ API request and response bodies are always encoded as JSON.
 Content-Type: application/vnd.kafka.v2+json
 ----
 
-* When performing producer operations, `POST` requests must provide `Content-Type` headers specifying the desired _embedded data format_ of the messages produced. This can be either `json` or `binary`.
+* When performing producer operations, `POST` requests must provide `Content-Type` headers specifying the _embedded data format_ of the messages produced. This can be either `json` or `binary`.
 +
 [cols="35,65",options="header",stripes="none",separator=¦]
 |===

--- a/documentation/modules/con-requests-kafka-bridge.adoc
+++ b/documentation/modules/con-requests-kafka-bridge.adoc
@@ -18,9 +18,9 @@ API request and response bodies are always encoded as JSON.
 Content-Type: application/vnd.kafka.v2+json
 ----
 
-* When performing producer operations, `POST` requests must provide `Content-Type` headers specifying the desired _embedded data format_, either `json` or `binary`, as shown in the following table.
+* When performing producer operations, `POST` requests must provide `Content-Type` headers specifying the desired _embedded data format_ of the messages produced. This can be either `json` or `binary`.
 +
-[%autowidth,cols="2*",options="header",stripes="none",separator=¦]
+[cols="35,65",options="header",stripes="none",separator=¦]
 |===
 
 ¦Embedded data format
@@ -34,9 +34,9 @@ m¦Content-Type: application/vnd.kafka.binary.v2+json
 
 |===
 
-You set the embedded data format when creating a consumer using the `consumers/_groupid_` endpoint--for more information, see the next section.
+The embedded data format is set per consumer, as described in the next section.
 
-The `Content-Type` must not be set if the `POST` request has an empty body.
+The `Content-Type` must _not_ be set if the `POST` request has an empty body.
 An empty body can be used to create a consumer with the default values.
 
 == Embedded data format
@@ -74,16 +74,50 @@ If you choose to specify a binary embedded data format, subsequent producer requ
 
 Producer requests must also provide a `Content-Type` header that corresponds to the embedded data format, for example, `Content-Type: application/vnd.kafka.binary.v2+json`.
 
+== Message format
+
+When sending messages using the `/topics/` endpoint, you enter the message payload in the `records` parameter in the request body.
+
+The `records` parameter can contain any of these optional fields:
+
+* Message `headers`
+* Message `key`
+* Message `value`
+* Destination `partition`
+
+.Example `POST` request
+[source,curl,subs=attributes+]
+----
+curl -X POST \
+  http://localhost:8080/topics/my-topic \
+  -H 'content-type: application/vnd.kafka.json.v2+json' \
+  -d '{
+    "records": [
+        {
+            "key": "my-key",
+            "value": "sales-lead-0001"
+            "partition": 2
+            "headers": [
+              {
+                "key": "key1",
+                "value": "value1"
+              }
+            ]
+        },
+    ]
+}'
+----
+
 == Accept headers
 
 After creating a consumer, all subsequent GET requests must provide an `Accept` header in the following format:
 
 [source,http,subs=+quotes]
 ----
-Accept: application/vnd.kafka._embedded-data-format_.v2+json
+Accept: application/vnd.kafka._EMBEDDED-DATA-FORMAT_.v2+json
 ----
 
-The `embedded-data-format` is either `json` or `binary`.
+The `EMBEDDED-DATA-FORMAT` is either `json` or `binary`.
 
 For example, when retrieving records for a subscribed consumer using an embedded data format of JSON, include this Accept header:
 

--- a/documentation/modules/overview/con-overview-components-kafka-bridge.adoc
+++ b/documentation/modules/overview/con-overview-components-kafka-bridge.adoc
@@ -5,8 +5,8 @@
 [id="overview-components-kafka-bridge_{context}"]
 = Kafka Bridge interface
 
-Strimzi Kafka Bridge provides a RESTful interface that allows HTTP-based clients to interact with a Kafka cluster. 
-Kafka Bridge offers the advantages of a web API connection to Strimzi, without the need for client applications to interpret the Kafka protocol.
+The Kafka Bridge provides a RESTful interface that allows HTTP-based clients to interact with a Kafka cluster. 
+It offers the advantages of a web API connection to Strimzi, without the need for client applications to interpret the Kafka protocol.
 
 The API has two main resources — `consumers` and `topics` — that are exposed and made accessible through endpoints to interact with consumers and producers in your Kafka cluster. The resources relate only to the Kafka Bridge, not the consumers and producers connected directly to Kafka.
 
@@ -15,6 +15,7 @@ The Kafka Bridge supports HTTP requests to a Kafka cluster, with methods to:
 
 * Send messages to a topic.
 * Retrieve messages from topics.
+* Retrieve a list of partitions for a topic.
 * Create and delete consumers.
 * Subscribe consumers to topics, so that they start receiving messages from those topics.
 * Retrieve a list of topics that a consumer is subscribed to.
@@ -29,4 +30,4 @@ Messages can be sent in JSON or binary formats.
 Clients can produce and consume messages without the requirement to use the native Kafka protocol.
 
 .Additional resources
-* To view the API documentation, including example requests and responses, see the {LatestBridgeAPIDocs} on the Strimzi website.
+* To view the API documentation, including example requests and responses, see the {LatestBridgeAPIDocs}.

--- a/documentation/modules/ref-api-resources-kafka-bridge.adoc
+++ b/documentation/modules/ref-api-resources-kafka-bridge.adoc
@@ -5,4 +5,4 @@
 [id='ref-api-resources-kafka-bridge-{context}']
 = Kafka Bridge API resources
 
-For the full list of REST API endpoints and descriptions, including example requests and responses, see the {LatestBridgeAPIDocs} on the Strimzi website.
+For the full list of REST API endpoints and descriptions, including example requests and responses, see the {LatestBridgeAPIDocs}.


### PR DESCRIPTION
Signed-off-by: Daniel Laing <dlaing@redhat.com>

### Type of change

- Documentation

### Description

**Guides affected:** 

_Using Strimzi_
* Kafka Bridge
  * Kafka Bridge overview

Adds a new sub-section on the format of messages sent using the `topics` endpoint. It includes details on the `headers` field that was added in #413.

Also adds a one-line change describing the method to retrieve all partitions on a topic. This method was added in #427.

Also makes a few unrelated changes:

* Trying to simplify the explanation of the embedded data format for consumers
* Improve the signposting at the start of the chapter by adding cross-references to other locations

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging 
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

