### PR TITLE
[systemtest] Change deprecated --zookeeper option to --bootstrap-server in tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/cli/KafkaCmdClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/cli/KafkaCmdClient.java
@@ -18,20 +18,20 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class KafkaCmdClient {
 
-    private static final int PORT = 12181;
+    private static final int PORT = 9092;
 
     public KafkaCmdClient() { }
 
-    public static List<String> listTopicsUsingPodCli(String clusterName, int zkPodId) {
-        String podName = KafkaResources.zookeeperPodName(clusterName, zkPodId);
+    public static List<String> listTopicsUsingPodCli(String clusterName, int kafkaPodId) {
+        String podName = KafkaResources.kafkaPodName(clusterName, kafkaPodId);
         return Arrays.asList(cmdKubeClient().execInPod(podName, "/bin/bash", "-c",
-            "bin/kafka-topics.sh --list --zookeeper localhost:" + PORT).out().split("\\s+"));
+            "bin/kafka-topics.sh --list --bootstrap-server localhost:" + PORT).out().split("\\s+"));
     }
 
-    public static String createTopicUsingPodCli(String clusterName, int zkPodId, String topic, int replicationFactor, int partitions) {
-        String podName = KafkaResources.zookeeperPodName(clusterName, zkPodId);
+    public static String createTopicUsingPodCli(String clusterName, int kafkaPodId, String topic, int replicationFactor, int partitions) {
+        String podName = KafkaResources.kafkaPodName(clusterName, kafkaPodId);
         String response = cmdKubeClient().execInPod(podName, "/bin/bash", "-c",
-            "bin/kafka-topics.sh --zookeeper localhost:" + PORT + " --create " + " --topic " + topic +
+            "bin/kafka-topics.sh --bootstrap-server localhost:" + PORT + " --create " + " --topic " + topic +
                 " --replication-factor " + replicationFactor + " --partitions " + partitions).out();
 
         KafkaTopicUtils.waitForKafkaTopicCreation(topic);
@@ -42,21 +42,21 @@ public class KafkaCmdClient {
         return response;
     }
 
-    public static String deleteTopicUsingPodCli(String clusterName, int zkPodId, String topic) {
-        String podName = KafkaResources.zookeeperPodName(clusterName, zkPodId);
+    public static String deleteTopicUsingPodCli(String clusterName, int kafkaPodId, String topic) {
+        String podName = KafkaResources.kafkaPodName(clusterName, kafkaPodId);
         return cmdKubeClient().execInPod(podName, "/bin/bash", "-c",
-            "bin/kafka-topics.sh --zookeeper localhost:" + PORT + " --delete --topic " + topic).out();
+            "bin/kafka-topics.sh --bootstrap-server localhost:" + PORT + " --delete --topic " + topic).out();
     }
 
-    public static List<String> describeTopicUsingPodCli(String clusterName, int zkPodId, String topic) {
-        String podName = KafkaResources.zookeeperPodName(clusterName, zkPodId);
+    public static List<String> describeTopicUsingPodCli(String clusterName, int kafkaPodId, String topic) {
+        String podName = KafkaResources.kafkaPodName(clusterName, kafkaPodId);
         return Arrays.asList(cmdKubeClient().execInPod(podName, "/bin/bash", "-c",
-            "bin/kafka-topics.sh --zookeeper localhost:" + PORT + " --describe --topic " + topic).out().replace(": ", ":").split("\\s+"));
+            "bin/kafka-topics.sh --bootstrap-server localhost:" + PORT + " --describe --topic " + topic).out().replace(": ", ":").split("\\s+"));
     }
 
-    public static String updateTopicPartitionsCountUsingPodCli(String clusterName, int zkPodId, String topic, int partitions) {
-        String podName = KafkaResources.zookeeperPodName(clusterName, zkPodId);
+    public static String updateTopicPartitionsCountUsingPodCli(String clusterName, int kafkaPodId, String topic, int partitions) {
+        String podName = KafkaResources.kafkaPodName(clusterName, kafkaPodId);
         return cmdKubeClient().execInPod(podName, "/bin/bash", "-c",
-            "bin/kafka-topics.sh --zookeeper localhost:" + PORT + " --alter --topic " + topic + " --partitions " + partitions).out();
+            "bin/kafka-topics.sh --bootstrap-server localhost:" + PORT + " --alter --topic " + topic + " --partitions " + partitions).out();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -179,10 +179,10 @@ class UserST extends AbstractST {
         // Create user with correct name
         KafkaUserResource.userWithQuota(user, prodRate, consRate, reqPerc).done();
 
-        String command = "sh bin/kafka-configs.sh --zookeeper localhost:12181 --describe --entity-type users";
+        String command = "bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --entity-type users";
         LOGGER.debug("Command for kafka-configs.sh {}", command);
 
-        ExecResult result = cmdKubeClient().execInPod(KafkaResources.zookeeperPodName(CLUSTER_NAME, 0), "/bin/bash", "-c", command);
+        ExecResult result = cmdKubeClient().execInPod(KafkaResources.kafkaPodName(CLUSTER_NAME, 0), "/bin/bash", "-c", command);
         assertThat(result.out().contains("Configs for user-principal '" + userName + "' are"), is(true));
         assertThat(result.out().contains("request_percentage=" + reqPerc), is(true));
         assertThat(result.out().contains("producer_byte_rate=" + prodRate), is(true));
@@ -203,7 +203,7 @@ class UserST extends AbstractST {
         KafkaUserResource.kafkaUserClient().inNamespace(NAMESPACE).withName(user.getMetadata().getName()).delete();
         KafkaUserUtils.waitForKafkaUserDeletion(user.getMetadata().getName());
 
-        ExecResult resultAfterDelete = cmdKubeClient().execInPod(KafkaResources.zookeeperPodName(CLUSTER_NAME, 0), "/bin/bash", "-c", command);
+        ExecResult resultAfterDelete = cmdKubeClient().execInPod(KafkaResources.kafkaPodName(CLUSTER_NAME, 0), "/bin/bash", "-c", command);
         assertThat(resultAfterDelete.out(), not(containsString(userName)));
 
         TestUtils.waitFor("user " + userName + " will be deleted from Zookeeper", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT, () -> {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- "Bugfix"

### Description

This PR gonna change deprecated option `--zookeeper` in tests and `KafkaCmdClient` to `--bootstrap-server`, also changing the pods where the command should be executed from zookeeper pod to kafka pod.

### Checklist

- [x] Make sure all tests pass
