### PR TITLE
Fix custom, oauth and authz-keycloak related P12 truststore are not built correctly

### DIFF
--- a/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -75,12 +75,11 @@ echo "Preparing keystore for replication and clienttls listener is complete"
 regex="^\/opt\/kafka\/certificates\/(custom|oauth)-([a-z0-9]{1,11})-([0-9]+)-certs$"
 for CERT_DIR in /opt/kafka/certificates/*; do
   if [[ $CERT_DIR =~ $regex ]]; then
-    echo "Preparing store for ${BASH_REMATCH[1]} ${BASH_REMATCH[2]} listener"
+    echo "Preparing store for ${BASH_REMATCH[1]}-${BASH_REMATCH[2]}-${BASH_REMATCH[3]} listener"
     if [[ ${BASH_REMATCH[1]} == "custom"  ]]; then
       echo /tmp/kafka/"${BASH_REMATCH[1]}"-"${BASH_REMATCH[2]}"-"${BASH_REMATCH[3]}".keystore.p12
       create_keystore_without_ca_file /tmp/kafka/"${BASH_REMATCH[1]}"-"${BASH_REMATCH[2]}"-"${BASH_REMATCH[3]}".keystore.p12 "$CERTS_STORE_PASSWORD" "${CERT_DIR}/tls.crt" "${CERT_DIR}/tls.key" custom-key
-    fi
-    if [[ ${BASH_REMATCH[1]} == "oauth"  ]]; then
+    elif [[ ${BASH_REMATCH[1]} == "oauth"  ]]; then
       OAUTH_STORE="/tmp/kafka/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}-${BASH_REMATCH[3]}.truststore.p12"
       # Add each certificate to the trust store
       declare -i INDEX=0
@@ -95,7 +94,7 @@ for CERT_DIR in /opt/kafka/certificates/*; do
   fi
 done
 
-echo "Preparing truststore for clienttls listener"
+echo "Preparing truststore for client authentication"
 # Add each certificate to the trust store
 STORE=/tmp/kafka/clients.truststore.p12
 for CRT in /opt/kafka/client-ca-certs/*.crt; do
@@ -103,7 +102,7 @@ for CRT in /opt/kafka/client-ca-certs/*.crt; do
   echo "Adding $CRT to truststore $STORE with alias $ALIAS"
   create_truststore "$STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
 done
-echo "Preparing truststore for clienttls listener is complete"
+echo "Preparing truststore for client authentication is complete"
 
 AUTHZ_KEYCLOAK_DIR="/opt/kafka/certificates/authz-keycloak-certs"
 AUTHZ_KEYCLOAK_STORE="/tmp/kafka/authz-keycloak.truststore.p12"

--- a/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -72,17 +72,40 @@ create_keystore /tmp/kafka/cluster.keystore.p12 "$CERTS_STORE_PASSWORD" \
     "$HOSTNAME"
 echo "Preparing keystore for replication and clienttls listener is complete"
 
-regex="^\/opt\/kafka\/certificates\/custom-([a-z0-9]{1,11})-([0-9]+)-certs$"
-for CUSTOM_CERT_DIR in /opt/kafka/certificates/custom-*; do
-    echo "dir=$CUSTOM_CERT_DIR"
-    if [[ $CUSTOM_CERT_DIR =~ $regex ]];
-    then
-      echo "listener=${BASH_REMATCH[1]}:${BASH_REMATCH[2]}"
-      echo "Preparing custom keystore for ${BASH_REMATCH[1]} listener"
-      create_keystore_without_ca_file /tmp/kafka/custom-${BASH_REMATCH[1]}-${BASH_REMATCH[2]}.keystore.p12 "$CERTS_STORE_PASSWORD" "${CUSTOM_CERT_DIR}/tls.crt" "${CUSTOM_CERT_DIR}/tls.key" custom-key
-      echo "Preparing custom keystore for ${BASH_REMATCH[1]} listener is complete"  
+regex="^\/opt\/kafka\/certificates\/(custom|oauth)-([a-z0-9]{1,11})-([0-9]+)-certs$"
+for CERT_DIR in /opt/kafka/certificates/*; do
+  if [[ $CERT_DIR =~ $regex ]]; then
+    echo "Preparing store for ${BASH_REMATCH[1]} ${BASH_REMATCH[2]} listener"
+    if [[ ${BASH_REMATCH[1]} == "custom"  ]]; then
+      echo /tmp/kafka/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}-${BASH_REMATCH[3]}.keystore.p12
+      create_keystore_without_ca_file /tmp/kafka/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}-${BASH_REMATCH[3]}.keystore.p12 "$CERTS_STORE_PASSWORD" "${CERT_DIR}/tls.crt" "${CERT_DIR}/tls.key" custom-key
     fi
+    if [[ ${BASH_REMATCH[1]} == "oauth"  ]]; then
+      OAUTH_STORE="/tmp/kafka/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}-${BASH_REMATCH[3]}.truststore.p12"
+      # Add each certificate to the trust store
+      declare -i INDEX=0
+      for CRT in "$CERT_DIR"/**/*; do
+        ALIAS="oauth-${INDEX}"
+        echo "Adding $CRT to truststore $OAUTH_STORE with alias $ALIAS"
+        create_truststore "$OAUTH_STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
+        INDEX+=1
+      done
+    fi
+    echo "Preparing store for ${BASH_REMATCH[1]} ${BASH_REMATCH[2]} listener is complete"  
+  fi
 done
+
+#regex="^\/opt\/kafka\/certificates\/custom-([a-z0-9]{1,11})-([0-9]+)-certs$"
+#for CUSTOM_CERT_DIR in /opt/kafka/certificates/custom-*; do
+#    echo "dir=$CUSTOM_CERT_DIR"
+#    if [[ $CUSTOM_CERT_DIR =~ $regex ]];
+#    then
+#      echo "listener=${BASH_REMATCH[1]}:${BASH_REMATCH[2]}"
+#      echo "Preparing custom keystore for ${BASH_REMATCH[1]} listener"
+#      create_keystore_without_ca_file /tmp/kafka/custom-${BASH_REMATCH[1]}-${BASH_REMATCH[2]}.keystore.p12 "$CERTS_STORE_PASSWORD" "${CUSTOM_CERT_DIR}/tls.crt" "${CUSTOM_CERT_DIR}/tls.key" custom-key
+#      echo "Preparing custom keystore for ${BASH_REMATCH[1]} listener is complete"  
+#    fi
+#done
 
 #CUSTOM_CERT_DIR="/opt/kafka/certificates/custom-tls-9093-certs"
 #if [ -d "$CUSTOM_CERT_DIR" ]; then
@@ -108,53 +131,53 @@ for CRT in /opt/kafka/client-ca-certs/*.crt; do
 done
 echo "Preparing truststore for clienttls listener is complete"
 
-OAUTH_CERT_DIR="/opt/kafka/certificates/oauth-plain-9092-certs"
-OAUTH_STORE="/tmp/kafka/oauth-plain-9092.truststore.p12"
-if [ -d "$OAUTH_CERT_DIR" ]; then
-  echo "Preparing truststore for OAuth on PLAIN listener"
+#OAUTH_CERT_DIR="/opt/kafka/certificates/oauth-plain-9092-certs"
+#OAUTH_STORE="/tmp/kafka/oauth-plain-9092.truststore.p12"
+#if [ -d "$OAUTH_CERT_DIR" ]; then
+  #echo "Preparing truststore for OAuth on PLAIN listener"
 
   # Add each certificate to the trust store
-  declare -i INDEX=0
-  for CRT in "$OAUTH_CERT_DIR"/**/*; do
-    ALIAS="oauth-${INDEX}"
-    echo "Adding $CRT to truststore $OAUTH_STORE with alias $ALIAS"
-    create_truststore "$OAUTH_STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
-    INDEX+=1
-  done
-  echo "Preparing truststore for OAuth on PLAIN listener is complete"
-fi
+  #declare -i INDEX=0
+  #for CRT in "$OAUTH_CERT_DIR"/**/*; do
+    #ALIAS="oauth-${INDEX}"
+    #echo "Adding $CRT to truststore $OAUTH_STORE with alias $ALIAS"
+    #create_truststore "$OAUTH_STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
+    #INDEX+=1
+  #done
+  #echo "Preparing truststore for OAuth on PLAIN listener is complete"
+#fi
 
-OAUTH_CERT_DIR="/opt/kafka/certificates/oauth-tls-9093-certs"
-OAUTH_STORE="/tmp/kafka/oauth-tls-9093.truststore.p12"
-if [ -d "$OAUTH_CERT_DIR" ]; then
-  echo "Preparing truststore for OAuth on TLS listener"
-
-  # Add each certificate to the trust store
-  declare -i INDEX=0
-  for CRT in "$OAUTH_CERT_DIR"/**/*; do
-    ALIAS="oauth-${INDEX}"
-    echo "Adding $CRT to truststore $OAUTH_STORE with alias $ALIAS"
-    create_truststore "$OAUTH_STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
-    INDEX+=1
-  done
-  echo "Preparing truststore for OAuth on TLS listener is complete"
-fi
-
-OAUTH_CERT_DIR="/opt/kafka/certificates/oauth-external-9094-certs"
-OAUTH_STORE="/tmp/kafka/oauth-external-9094.truststore.p12"
-if [ -d "$OAUTH_CERT_DIR" ]; then
-  echo "Preparing truststore for OAuth on external listener"
+#OAUTH_CERT_DIR="/opt/kafka/certificates/oauth-tls-9093-certs"
+#OAUTH_STORE="/tmp/kafka/oauth-tls-9093.truststore.p12"
+#if [ -d "$OAUTH_CERT_DIR" ]; then
+  #echo "Preparing truststore for OAuth on TLS listener"
 
   # Add each certificate to the trust store
-  declare -i INDEX=0
-  for CRT in "$OAUTH_CERT_DIR"/**/*; do
-    ALIAS="oauth-${INDEX}"
-    echo "Adding $CRT to truststore $OAUTH_STORE with alias $ALIAS"
-    create_truststore "$OAUTH_STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
-    INDEX+=1
-  done
-  echo "Preparing truststore for OAuth on external listener is complete"
-fi
+  #declare -i INDEX=0
+  #for CRT in "$OAUTH_CERT_DIR"/**/*; do
+    #ALIAS="oauth-${INDEX}"
+    #echo "Adding $CRT to truststore $OAUTH_STORE with alias $ALIAS"
+    #create_truststore "$OAUTH_STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
+    #INDEX+=1
+  #done
+  #echo "Preparing truststore for OAuth on TLS listener is complete"
+#fi
+
+#OAUTH_CERT_DIR="/opt/kafka/certificates/oauth-external-9094-certs"
+#OAUTH_STORE="/tmp/kafka/oauth-external-9094.truststore.p12"
+#if [ -d "$OAUTH_CERT_DIR" ]; then
+  #echo "Preparing truststore for OAuth on external listener"
+
+  # Add each certificate to the trust store
+  #declare -i INDEX=0
+  #for CRT in "$OAUTH_CERT_DIR"/**/*; do
+    #ALIAS="oauth-${INDEX}"
+    #echo "Adding $CRT to truststore $OAUTH_STORE with alias $ALIAS"
+    #create_truststore "$OAUTH_STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
+    #INDEX+=1
+  #done
+  #echo "Preparing truststore for OAuth on external listener is complete"
+#fi
 
 AUTHZ_KEYCLOAK_DIR="/opt/kafka/certificates/authz-keycloak-certs"
 AUTHZ_KEYCLOAK_STORE="/tmp/kafka/authz-keycloak.truststore.p12"

--- a/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -77,8 +77,8 @@ for CERT_DIR in /opt/kafka/certificates/*; do
   if [[ $CERT_DIR =~ $regex ]]; then
     echo "Preparing store for ${BASH_REMATCH[1]} ${BASH_REMATCH[2]} listener"
     if [[ ${BASH_REMATCH[1]} == "custom"  ]]; then
-      echo /tmp/kafka/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}-${BASH_REMATCH[3]}.keystore.p12
-      create_keystore_without_ca_file /tmp/kafka/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}-${BASH_REMATCH[3]}.keystore.p12 "$CERTS_STORE_PASSWORD" "${CERT_DIR}/tls.crt" "${CERT_DIR}/tls.key" custom-key
+      echo /tmp/kafka/"${BASH_REMATCH[1]}"-"${BASH_REMATCH[2]}"-"${BASH_REMATCH[3]}".keystore.p12
+      create_keystore_without_ca_file /tmp/kafka/"${BASH_REMATCH[1]}"-"${BASH_REMATCH[2]}"-"${BASH_REMATCH[3]}".keystore.p12 "$CERTS_STORE_PASSWORD" "${CERT_DIR}/tls.crt" "${CERT_DIR}/tls.key" custom-key
     fi
     if [[ ${BASH_REMATCH[1]} == "oauth"  ]]; then
       OAUTH_STORE="/tmp/kafka/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}-${BASH_REMATCH[3]}.truststore.p12"

--- a/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -95,32 +95,6 @@ for CERT_DIR in /opt/kafka/certificates/*; do
   fi
 done
 
-#regex="^\/opt\/kafka\/certificates\/custom-([a-z0-9]{1,11})-([0-9]+)-certs$"
-#for CUSTOM_CERT_DIR in /opt/kafka/certificates/custom-*; do
-#    echo "dir=$CUSTOM_CERT_DIR"
-#    if [[ $CUSTOM_CERT_DIR =~ $regex ]];
-#    then
-#      echo "listener=${BASH_REMATCH[1]}:${BASH_REMATCH[2]}"
-#      echo "Preparing custom keystore for ${BASH_REMATCH[1]} listener"
-#      create_keystore_without_ca_file /tmp/kafka/custom-${BASH_REMATCH[1]}-${BASH_REMATCH[2]}.keystore.p12 "$CERTS_STORE_PASSWORD" "${CUSTOM_CERT_DIR}/tls.crt" "${CUSTOM_CERT_DIR}/tls.key" custom-key
-#      echo "Preparing custom keystore for ${BASH_REMATCH[1]} listener is complete"  
-#    fi
-#done
-
-#CUSTOM_CERT_DIR="/opt/kafka/certificates/custom-tls-9093-certs"
-#if [ -d "$CUSTOM_CERT_DIR" ]; then
-#    echo "Preparing custom keystore for tls listener"
-#    create_keystore_without_ca_file /tmp/kafka/custom-tls-9093.keystore.p12 "$CERTS_STORE_PASSWORD" "${CUSTOM_CERT_DIR}/tls.crt" "${CUSTOM_CERT_DIR}/tls.key" custom-key
-#    echo "Preparing custom keystore for tls listener is complete"
-#fi
-
-#CUSTOM_CERT_DIR="/opt/kafka/certificates/custom-external-9094-certs"
-#if [ -d "$CUSTOM_CERT_DIR" ]; then
-#    echo "Preparing custom keystore for external listener"
-#    create_keystore_without_ca_file /tmp/kafka/custom-external-9094.keystore.p12 "$CERTS_STORE_PASSWORD" "${CUSTOM_CERT_DIR}/tls.crt" "${CUSTOM_CERT_DIR}/tls.key" custom-key
-#    echo "Preparing custom keystore for external listener is complete"
-#fi
-
 echo "Preparing truststore for clienttls listener"
 # Add each certificate to the trust store
 STORE=/tmp/kafka/clients.truststore.p12
@@ -130,54 +104,6 @@ for CRT in /opt/kafka/client-ca-certs/*.crt; do
   create_truststore "$STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
 done
 echo "Preparing truststore for clienttls listener is complete"
-
-#OAUTH_CERT_DIR="/opt/kafka/certificates/oauth-plain-9092-certs"
-#OAUTH_STORE="/tmp/kafka/oauth-plain-9092.truststore.p12"
-#if [ -d "$OAUTH_CERT_DIR" ]; then
-  #echo "Preparing truststore for OAuth on PLAIN listener"
-
-  # Add each certificate to the trust store
-  #declare -i INDEX=0
-  #for CRT in "$OAUTH_CERT_DIR"/**/*; do
-    #ALIAS="oauth-${INDEX}"
-    #echo "Adding $CRT to truststore $OAUTH_STORE with alias $ALIAS"
-    #create_truststore "$OAUTH_STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
-    #INDEX+=1
-  #done
-  #echo "Preparing truststore for OAuth on PLAIN listener is complete"
-#fi
-
-#OAUTH_CERT_DIR="/opt/kafka/certificates/oauth-tls-9093-certs"
-#OAUTH_STORE="/tmp/kafka/oauth-tls-9093.truststore.p12"
-#if [ -d "$OAUTH_CERT_DIR" ]; then
-  #echo "Preparing truststore for OAuth on TLS listener"
-
-  # Add each certificate to the trust store
-  #declare -i INDEX=0
-  #for CRT in "$OAUTH_CERT_DIR"/**/*; do
-    #ALIAS="oauth-${INDEX}"
-    #echo "Adding $CRT to truststore $OAUTH_STORE with alias $ALIAS"
-    #create_truststore "$OAUTH_STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
-    #INDEX+=1
-  #done
-  #echo "Preparing truststore for OAuth on TLS listener is complete"
-#fi
-
-#OAUTH_CERT_DIR="/opt/kafka/certificates/oauth-external-9094-certs"
-#OAUTH_STORE="/tmp/kafka/oauth-external-9094.truststore.p12"
-#if [ -d "$OAUTH_CERT_DIR" ]; then
-  #echo "Preparing truststore for OAuth on external listener"
-
-  # Add each certificate to the trust store
-  #declare -i INDEX=0
-  #for CRT in "$OAUTH_CERT_DIR"/**/*; do
-    #ALIAS="oauth-${INDEX}"
-    #echo "Adding $CRT to truststore $OAUTH_STORE with alias $ALIAS"
-    #create_truststore "$OAUTH_STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
-    #INDEX+=1
-  #done
-  #echo "Preparing truststore for OAuth on external listener is complete"
-#fi
 
 AUTHZ_KEYCLOAK_DIR="/opt/kafka/certificates/authz-keycloak-certs"
 AUTHZ_KEYCLOAK_STORE="/tmp/kafka/authz-keycloak.truststore.p12"

--- a/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -72,19 +72,31 @@ create_keystore /tmp/kafka/cluster.keystore.p12 "$CERTS_STORE_PASSWORD" \
     "$HOSTNAME"
 echo "Preparing keystore for replication and clienttls listener is complete"
 
-CUSTOM_CERT_DIR="/opt/kafka/certificates/custom-tls-9093-certs"
-if [ -d "$CUSTOM_CERT_DIR" ]; then
-    echo "Preparing custom keystore for tls listener"
-    create_keystore_without_ca_file /tmp/kafka/custom-tls-9093.keystore.p12 "$CERTS_STORE_PASSWORD" "${CUSTOM_CERT_DIR}/tls.crt" "${CUSTOM_CERT_DIR}/tls.key" custom-key
-    echo "Preparing custom keystore for tls listener is complete"
-fi
+regex="^\/opt\/kafka\/certificates\/custom-([a-z0-9]{1,11})-([0-9]+)-certs$"
+for CUSTOM_CERT_DIR in /opt/kafka/certificates/custom-*; do
+    echo "dir=$CUSTOM_CERT_DIR"
+    if [[ $CUSTOM_CERT_DIR =~ $regex ]];
+    then
+      echo "listener=${BASH_REMATCH[1]}:${BASH_REMATCH[2]}"
+      echo "Preparing custom keystore for ${BASH_REMATCH[1]} listener"
+      create_keystore_without_ca_file /tmp/kafka/custom-${BASH_REMATCH[1]}-${BASH_REMATCH[2]}.keystore.p12 "$CERTS_STORE_PASSWORD" "${CUSTOM_CERT_DIR}/tls.crt" "${CUSTOM_CERT_DIR}/tls.key" custom-key
+      echo "Preparing custom keystore for ${BASH_REMATCH[1]} listener is complete"  
+    fi
+done
 
-CUSTOM_CERT_DIR="/opt/kafka/certificates/custom-external-9094-certs"
-if [ -d "$CUSTOM_CERT_DIR" ]; then
-    echo "Preparing custom keystore for external listener"
-    create_keystore_without_ca_file /tmp/kafka/custom-external-9094.keystore.p12 "$CERTS_STORE_PASSWORD" "${CUSTOM_CERT_DIR}/tls.crt" "${CUSTOM_CERT_DIR}/tls.key" custom-key
-    echo "Preparing custom keystore for external listener is complete"
-fi
+#CUSTOM_CERT_DIR="/opt/kafka/certificates/custom-tls-9093-certs"
+#if [ -d "$CUSTOM_CERT_DIR" ]; then
+#    echo "Preparing custom keystore for tls listener"
+#    create_keystore_without_ca_file /tmp/kafka/custom-tls-9093.keystore.p12 "$CERTS_STORE_PASSWORD" "${CUSTOM_CERT_DIR}/tls.crt" "${CUSTOM_CERT_DIR}/tls.key" custom-key
+#    echo "Preparing custom keystore for tls listener is complete"
+#fi
+
+#CUSTOM_CERT_DIR="/opt/kafka/certificates/custom-external-9094-certs"
+#if [ -d "$CUSTOM_CERT_DIR" ]; then
+#    echo "Preparing custom keystore for external listener"
+#    create_keystore_without_ca_file /tmp/kafka/custom-external-9094.keystore.p12 "$CERTS_STORE_PASSWORD" "${CUSTOM_CERT_DIR}/tls.crt" "${CUSTOM_CERT_DIR}/tls.key" custom-key
+#    echo "Preparing custom keystore for external listener is complete"
+#fi
 
 echo "Preparing truststore for clienttls listener"
 # Add each certificate to the trust store

--- a/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -72,15 +72,16 @@ create_keystore /tmp/kafka/cluster.keystore.p12 "$CERTS_STORE_PASSWORD" \
     "$HOSTNAME"
 echo "Preparing keystore for replication and clienttls listener is complete"
 
-regex="^\/opt\/kafka\/certificates\/(custom|oauth)-([a-z0-9]{1,11})-([0-9]+)-certs$"
+regex="^\/opt\/kafka\/certificates\/(custom|oauth)-(.+)-(.+)-certs$"
 for CERT_DIR in /opt/kafka/certificates/*; do
   if [[ $CERT_DIR =~ $regex ]]; then
-    echo "Preparing store for ${BASH_REMATCH[1]}-${BASH_REMATCH[2]}-${BASH_REMATCH[3]} listener"
+    listener=${BASH_REMATCH[1]}-${BASH_REMATCH[2]}-${BASH_REMATCH[3]}
+    echo "Preparing store for $listener listener"
     if [[ ${BASH_REMATCH[1]} == "custom"  ]]; then
-      echo /tmp/kafka/"${BASH_REMATCH[1]}"-"${BASH_REMATCH[2]}"-"${BASH_REMATCH[3]}".keystore.p12
-      create_keystore_without_ca_file /tmp/kafka/"${BASH_REMATCH[1]}"-"${BASH_REMATCH[2]}"-"${BASH_REMATCH[3]}".keystore.p12 "$CERTS_STORE_PASSWORD" "${CERT_DIR}/tls.crt" "${CERT_DIR}/tls.key" custom-key
+      echo "Creating keystore /tmp/kafka/$listener.keystore.p12"
+      create_keystore_without_ca_file /tmp/kafka/"$listener".keystore.p12 "$CERTS_STORE_PASSWORD" "${CERT_DIR}/tls.crt" "${CERT_DIR}/tls.key" custom-key
     elif [[ ${BASH_REMATCH[1]} == "oauth"  ]]; then
-      OAUTH_STORE="/tmp/kafka/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}-${BASH_REMATCH[3]}.truststore.p12"
+      OAUTH_STORE="/tmp/kafka/$listener.truststore.p12"
       # Add each certificate to the trust store
       declare -i INDEX=0
       for CRT in "$CERT_DIR"/**/*; do


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #3823. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

