### PR TITLE
Fix wrong tls config for route in docs

### DIFF
--- a/documentation/modules/ref-sample-kafka-resource-config.adoc
+++ b/documentation/modules/ref-sample-kafka-resource-config.adoc
@@ -52,7 +52,7 @@ spec:
       - name: external <13>
         port: 9094
         type: route
-        tls: false
+        tls: true
         configuration:
           brokerCertChainAndKey: <14>
             secretName: my-secret


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix
- Documentation

### Description

`tls:false` is not a valid config for route and I think it's not intended to have it as an invalid example.

### Checklist

- [x] Update documentation


