### PR TITLE
issues##3769 Update Documentation for Forbidden configuration prefixes

### DIFF
--- a/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
+++ b/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
@@ -17,22 +17,25 @@ You can specify and configure all the options listed in the "Configurations" sec
 Specifically, you *cannot* modify configuration options with keys equal to or starting with one of the following strings:
 
 * `bootstrap.servers`
+* `client.id`
 * `zookeeper.`
-* `ssl.`
+* `network.`
 * `security.`
 * `failed.brokers.zk.path`
-* `webserver.http.port`
-* `webserver.http.address`
+* `webserver.http.`
 * `webserver.api.urlprefix`
+* `webserver.session.path`
+* `webserver.accesslog.`
+* `two.step.`
+* `request.reason.required`
 * `metric.reporter.sampler.bootstrap.servers`
 * `metric.reporter.topic`
-* `metric.reporter.topic.pattern`
 * `partition.metric.sample.store.topic`
 * `broker.metric.sample.store.topic`
 * `capacity.config.file`
-* `skip.sample.store.topic.rack.awareness.check`
-* `cruise.control.metrics.topic`
-* `sasl.`
+* `self.healing.`
+* `anomaly.detection.`
+* `ssl.`
 
 If restricted options are specified, they are ignored and a warning message is printed to the Cluster Operator log file.
 All the supported options are passed to Cruise Control.

--- a/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
+++ b/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
@@ -14,28 +14,7 @@ The `config` property in `Kafka.spec.cruiseControl` contains configuration optio
 NOTE: Strings that look like JSON or YAML will need to be explicitly quoted.
 
 You can specify and configure all the options listed in the "Configurations" section of the {CruiseControlConfigDocs}, apart from those managed directly by Strimzi.
-Specifically, you *cannot* modify configuration options with keys equal to or starting with one of the following strings:
-
-* `bootstrap.servers`
-* `client.id`
-* `zookeeper.`
-* `network.`
-* `security.`
-* `failed.brokers.zk.path`
-* `webserver.http.`
-* `webserver.api.urlprefix`
-* `webserver.session.path`
-* `webserver.accesslog.`
-* `two.step.`
-* `request.reason.required`
-* `metric.reporter.sampler.bootstrap.servers`
-* `metric.reporter.topic`
-* `partition.metric.sample.store.topic`
-* `broker.metric.sample.store.topic`
-* `capacity.config.file`
-* `self.healing.`
-* `anomaly.detection.`
-* `ssl.`
+Specifically, you *cannot* modify configuration options with keys equal to or starting with one of the keys mentioned https://strimzi.io/docs/operators/latest/using.html#type-CruiseControlSpec-reference[here.]
 
 If restricted options are specified, they are ignored and a warning message is printed to the Cluster Operator log file.
 All the supported options are passed to Cruise Control.

--- a/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
+++ b/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
@@ -14,7 +14,7 @@ The `config` property in `Kafka.spec.cruiseControl` contains configuration optio
 NOTE: Strings that look like JSON or YAML will need to be explicitly quoted.
 
 You can specify and configure all the options listed in the "Configurations" section of the {CruiseControlConfigDocs}, apart from those managed directly by Strimzi.
-Specifically, you *cannot* modify configuration options with keys equal to or starting with one of the keys mentioned https://strimzi.io/docs/operators/latest/using.html#type-CruiseControlSpec-reference[here.]
+Specifically, you *cannot* modify configuration options with keys equal to or starting with one of the keys mentioned xref:type-CruiseControlSpec-reference[here].
 
 If restricted options are specified, they are ignored and a warning message is printed to the Cluster Operator log file.
 All the supported options are passed to Cruise Control.


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

Forbidden configuration prefixes missing from Cruise Control configuration documentation

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

