### PR TITLE
Fixed rebalance example with goals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Add support for Kafka 2.5.1 and 2.6.0. Remove support for 2.4.0 and 2.4.1
 * Remove TLS sidecars from Kafka pods => Kafka now uses native TLS to connect to ZooKeeper
-* Updated to Cruise Control 2.5.11, which adds Kafka 2.6.0 support and fixes a previous issue with CPU utilization statistics for containers. As a result, the CPUCapacityGoal has now been enabled.
+* Updated to Cruise Control 2.5.11, which adds Kafka 2.6.0 support and fixes a previous issue with CPU utilization statistics for containers. As a result, the CpuCapacityGoal has now been enabled.
 * Cruise Control metrics integration:
   * Enable metrics JMX exporter configuration in the `cruiseControl` property of the Kafka custom resource
   * New Grafana dashboard for the Cruise Control metrics

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -59,7 +59,7 @@ Cruise Control will ignore this goal if doing so enables all the configured hard
 In Cruise Control, the following xref:master-goals[master optimization goals] are preset as hard goals:
 
 [source]
-RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CPUCapacityGoal
+RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CpuCapacityGoal
 
 You configure hard goals in the Cruise Control deployment configuration, by editing the `hard.goals` property in `Kafka.spec.cruiseControl.config`.
 
@@ -108,7 +108,7 @@ Goals that are not listed in the master optimization goals are not available for
 Unless you change the Cruise Control xref:proc-deploying-cruise-control-{context}[deployment configuration], Strimzi will inherit the following master optimization goals from Cruise Control, in descending priority order:
 
 [source]
-RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CPUCapacityGoal; ReplicaDistributionGoal; PotentialNwOutGoal; DiskUsageDistributionGoal; NetworkInboundUsageDistributionGoal; NetworkOutboundUsageDistributionGoal; CpuUsageDistributionGoal; TopicReplicaDistributionGoal; LeaderReplicaDistributionGoal; LeaderBytesInDistributionGoal; PreferredLeaderElectionGoal
+RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CpuCapacityGoal; ReplicaDistributionGoal; PotentialNwOutGoal; DiskUsageDistributionGoal; NetworkInboundUsageDistributionGoal; NetworkOutboundUsageDistributionGoal; CpuUsageDistributionGoal; TopicReplicaDistributionGoal; LeaderReplicaDistributionGoal; LeaderBytesInDistributionGoal; PreferredLeaderElectionGoal
 
 Six of these goals are preset as xref:hard-soft-goals[hard goals].
 

--- a/examples/cruise-control/kafka-rebalance-with-goals.yaml
+++ b/examples/cruise-control/kafka-rebalance-with-goals.yaml
@@ -6,7 +6,7 @@ metadata:
     strimzi.io/cluster: my-cluster
 spec:
   goals:
-    - CPUCapacityGoal
+    - CpuCapacityGoal
     - NetworkInboundCapacityGoal
     - DiskCapacityGoal
     - RackAwareGoal


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This trivial PR just fixes a typo in the `CpuCapacityGoal` in the rebalance with goals example.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
