### PR TITLE
feat: Namespace RBAC scope deployment option

### DIFF
--- a/.azure/namespace-rbac-scope-acceptance-pipeline.yaml
+++ b/.azure/namespace-rbac-scope-acceptance-pipeline.yaml
@@ -1,0 +1,21 @@
+# Triggers
+# This pipeline will be triggered manually for a release or by github comment
+trigger: none
+pr:
+  autoCancel: false
+  branches:
+    include:
+      - '*'
+
+jobs:
+  - template: 'templates/system_test_general.yaml'
+    parameters:
+      name: 'namespace_rbac_scope_acceptance'
+      display_name: 'namespace-rbac-scope-acceptance'
+      test_case: '.*ST'
+      groups: 'acceptance'
+      cluster_operator_install_type: 'bundle'
+      strimzi_rbac_scope: namespace
+      timeout: 240
+
+

--- a/.azure/namespace-rbac-scope-acceptance-pipeline.yaml
+++ b/.azure/namespace-rbac-scope-acceptance-pipeline.yaml
@@ -14,6 +14,7 @@ jobs:
       display_name: 'namespace-rbac-scope-acceptance'
       test_case: '.*ST'
       groups: 'acceptance'
+      excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       strimzi_rbac_scope: NAMESPACE
       timeout: 240

--- a/.azure/namespace-rbac-scope-acceptance-pipeline.yaml
+++ b/.azure/namespace-rbac-scope-acceptance-pipeline.yaml
@@ -15,7 +15,7 @@ jobs:
       test_case: '.*ST'
       groups: 'acceptance'
       cluster_operator_install_type: 'bundle'
-      strimzi_rbac_scope: namespace
+      strimzi_rbac_scope: NAMESPACE
       timeout: 240
 
 

--- a/.azure/namespace-rbac-scope-regression-pipeline.yaml
+++ b/.azure/namespace-rbac-scope-regression-pipeline.yaml
@@ -11,71 +11,78 @@ pr:
 jobs:
   - template: 'templates/system_test_general.yaml'
     parameters:
-      name: 'regression_kafka'
-      display_name: 'regression-bundle I. - kafka'
+      name: 'namespace_rbac_scope_regression_kafka'
+      display_name: 'namespace-rbac-scope-regression-bundle I. - kafka'
       test_case: 'kafka/**/*ST,!kafka/dynamicconfiguration/**/*ST'
       groups: 'regression'
+      excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
 
   - template: 'templates/system_test_general.yaml'
     parameters:
-      name: 'regression_security'
-      display_name: 'regression-bundle II. - security'
+      name: 'namespace_rbac_scope_regression_security'
+      display_name: 'namespace-rbac-scope-regression-bundle II. - security'
       test_case: 'security/**/*ST'
       groups: 'regression'
+      excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
 
   - template: 'templates/system_test_general.yaml'
     parameters:
-      name: 'regression_connect_tracing_watcher'
-      display_name: 'regression-bundle III. - connect + tracing + watcher'
+      name: 'namespace_rbac_scope_regression_connect_tracing_watcher'
+      display_name: 'namespace-rbac-scope-regression-bundle III. - connect + tracing + watcher'
       test_case: 'connect/**/*ST,tracing/**/*ST,watcher/**/*ST'
       groups: 'regression'
+      excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
 
   - template: 'templates/system_test_general.yaml'
     parameters:
-      name: 'regression_operators'
-      display_name: 'regression-bundle IV. - operators'
+      name: 'rnamespace_rbac_scope_egression_operators'
+      display_name: 'namespace-rbac-scope-regression-bundle IV. - operators'
       test_case: 'operators/**/*ST'
       groups: 'regression'
+      excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
 
   - template: 'templates/system_test_general.yaml'
     parameters:
-      name: 'regression_rollingupdate_watcher'
-      display_name: 'regression-bundle V. - rollingupdate'
+      name: 'namespace_rbac_scope_regression_rollingupdate_watcher'
+      display_name: 'namespace-rbac-scope-regression-bundle V. - rollingupdate'
       test_case: 'rollingupdate/**/*ST'
       groups: 'regression'
+      excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
 
   - template: 'templates/system_test_general.yaml'
     parameters:
-      name: 'regression_mirrormaker'
-      display_name: 'regression-bundle VI. - mirrormaker + dynamicconfiguration'
+      name: 'namespace_rbac_scope_regression_mirrormaker'
+      display_name: 'namespace-rbac-scope-regression-bundle VI. - mirrormaker + dynamicconfiguration'
       test_case: 'mirrormaker/**/*ST,kafka/dynamicconfiguration/**/*ST'
       groups: 'regression'
+      excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
 
   - template: 'templates/system_test_general.yaml'
     parameters:
-      name: 'regression_all_remaining'
-      display_name: 'regression-bundle VII. - remaining system tests'
+      name: 'namespace_rbac_scope_regression_all_remaining'
+      display_name: 'namespace-rbac-scope-regression-bundle VII. - remaining system tests'
       # !LoggingChangeST is skipped because it can be flaky on Azure
       test_case: '!kafka/**/*ST,!mirrormaker/**/*ST,!connect/**/*ST,!security/**/*ST,!LoggingChangeST,!operators/**/*ST,!rollingupdate/**/*ST,!watcher/**/*ST,!tracing/**/*ST'
       groups: 'regression'
+      excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE

--- a/.azure/namespace-rbac-scope-regression-pipeline.yaml
+++ b/.azure/namespace-rbac-scope-regression-pipeline.yaml
@@ -17,7 +17,7 @@ jobs:
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
-      strimzi_rbac_scope: namespace
+      strimzi_rbac_scope: NAMESPACE
 
   - template: 'templates/system_test_general.yaml'
     parameters:
@@ -27,7 +27,7 @@ jobs:
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
-      strimzi_rbac_scope: namespace
+      strimzi_rbac_scope: NAMESPACE
 
   - template: 'templates/system_test_general.yaml'
     parameters:
@@ -37,7 +37,7 @@ jobs:
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
-      strimzi_rbac_scope: namespace
+      strimzi_rbac_scope: NAMESPACE
 
   - template: 'templates/system_test_general.yaml'
     parameters:
@@ -47,7 +47,7 @@ jobs:
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
-      strimzi_rbac_scope: namespace
+      strimzi_rbac_scope: NAMESPACE
 
   - template: 'templates/system_test_general.yaml'
     parameters:
@@ -57,7 +57,7 @@ jobs:
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
-      strimzi_rbac_scope: namespace
+      strimzi_rbac_scope: NAMESPACE
 
   - template: 'templates/system_test_general.yaml'
     parameters:
@@ -67,7 +67,7 @@ jobs:
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
-      strimzi_rbac_scope: namespace
+      strimzi_rbac_scope: NAMESPACE
 
   - template: 'templates/system_test_general.yaml'
     parameters:
@@ -78,4 +78,4 @@ jobs:
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360
-      strimzi_rbac_scope: namespace
+      strimzi_rbac_scope: NAMESPACE

--- a/.azure/namespace-rbac-scope-regression-pipeline.yaml
+++ b/.azure/namespace-rbac-scope-regression-pipeline.yaml
@@ -1,0 +1,81 @@
+# Triggers
+# This pipeline will be triggered manually for a release or by github comment
+trigger: none
+pr:
+  autoCancel: false
+  branches:
+    include:
+      - '*'
+      -
+# Regression tests are split into 6 jobs because of timeout set to 360 minutes for each job
+jobs:
+  - template: 'templates/system_test_general.yaml'
+    parameters:
+      name: 'regression_kafka'
+      display_name: 'regression-bundle I. - kafka'
+      test_case: 'kafka/**/*ST,!kafka/dynamicconfiguration/**/*ST'
+      groups: 'regression'
+      cluster_operator_install_type: 'bundle'
+      timeout: 360
+      strimzi_rbac_scope: namespace
+
+  - template: 'templates/system_test_general.yaml'
+    parameters:
+      name: 'regression_security'
+      display_name: 'regression-bundle II. - security'
+      test_case: 'security/**/*ST'
+      groups: 'regression'
+      cluster_operator_install_type: 'bundle'
+      timeout: 360
+      strimzi_rbac_scope: namespace
+
+  - template: 'templates/system_test_general.yaml'
+    parameters:
+      name: 'regression_connect_tracing_watcher'
+      display_name: 'regression-bundle III. - connect + tracing + watcher'
+      test_case: 'connect/**/*ST,tracing/**/*ST,watcher/**/*ST'
+      groups: 'regression'
+      cluster_operator_install_type: 'bundle'
+      timeout: 360
+      strimzi_rbac_scope: namespace
+
+  - template: 'templates/system_test_general.yaml'
+    parameters:
+      name: 'regression_operators'
+      display_name: 'regression-bundle IV. - operators'
+      test_case: 'operators/**/*ST'
+      groups: 'regression'
+      cluster_operator_install_type: 'bundle'
+      timeout: 360
+      strimzi_rbac_scope: namespace
+
+  - template: 'templates/system_test_general.yaml'
+    parameters:
+      name: 'regression_rollingupdate_watcher'
+      display_name: 'regression-bundle V. - rollingupdate'
+      test_case: 'rollingupdate/**/*ST'
+      groups: 'regression'
+      cluster_operator_install_type: 'bundle'
+      timeout: 360
+      strimzi_rbac_scope: namespace
+
+  - template: 'templates/system_test_general.yaml'
+    parameters:
+      name: 'regression_mirrormaker'
+      display_name: 'regression-bundle VI. - mirrormaker + dynamicconfiguration'
+      test_case: 'mirrormaker/**/*ST,kafka/dynamicconfiguration/**/*ST'
+      groups: 'regression'
+      cluster_operator_install_type: 'bundle'
+      timeout: 360
+      strimzi_rbac_scope: namespace
+
+  - template: 'templates/system_test_general.yaml'
+    parameters:
+      name: 'regression_all_remaining'
+      display_name: 'regression-bundle VII. - remaining system tests'
+      # !LoggingChangeST is skipped because it can be flaky on Azure
+      test_case: '!kafka/**/*ST,!mirrormaker/**/*ST,!connect/**/*ST,!security/**/*ST,!LoggingChangeST,!operators/**/*ST,!rollingupdate/**/*ST,!watcher/**/*ST,!tracing/**/*ST'
+      groups: 'regression'
+      cluster_operator_install_type: 'bundle'
+      timeout: 360
+      strimzi_rbac_scope: namespace

--- a/.azure/templates/system_test_general.yaml
+++ b/.azure/templates/system_test_general.yaml
@@ -4,8 +4,10 @@ parameters:
   display_name: ''
   test_case: ''
   groups: ''
+  excludedGroups: ''
   cluster_operator_install_type: ''
   timeout: ''
+  strimzi_rbac_scope: 'CLUSTER'
 
 jobs:
 - job: '${{ parameters.name }}_system_tests'
@@ -54,10 +56,11 @@ jobs:
         publishJUnitResults: true
         testResultsFiles: '**/failsafe-reports/TEST-*.xml'
         goals: 'verify'
-        options: '-Dgroups=${{ parameters.groups }} -Dit.test="${{ parameters.test_case }}" -DexcludedGroups=flaky,loadbalancer,networkpolicies,${{ parameters.excludeGroups }} -Dmaven.javadoc.skip=true -B -V -Dfailsafe.rerunFailingTestsCount=2'
+        options: '-Dgroups=${{ parameters.groups }} -Dit.test="${{ parameters.test_case }}" -DexcludedGroups=flaky,loadbalancer,networkpolicies,${{ parameters.excludedGroups }} -Dmaven.javadoc.skip=true -B -V -Dfailsafe.rerunFailingTestsCount=2'
       env:
         DOCKER_TAG: $(docker_tag)
         BRIDGE_IMAGE: "latest-released"
+        STRIMZI_RBAC_SCOPE: '${{ parameters.strimzi_rbac_scope }}'
       displayName: 'Run systemtests'
 
     - task: PublishTestResults@2

--- a/.azure/templates/system_test_general.yaml
+++ b/.azure/templates/system_test_general.yaml
@@ -56,7 +56,7 @@ jobs:
         publishJUnitResults: true
         testResultsFiles: '**/failsafe-reports/TEST-*.xml'
         goals: 'verify'
-        options: '-Dgroups=${{ parameters.groups }} -Dit.test="${{ parameters.test_case }}" -DexcludedGroups=flaky,loadbalancer,networkpolicies,${{ parameters.excludedGroups }} -Dmaven.javadoc.skip=true -B -V -Dfailsafe.rerunFailingTestsCount=2'
+        options: '-Dgroups=${{ parameters.groups }} -Dit.test="${{ parameters.test_case }}" -DexcludedGroups=flaky,loadbalancer,networkpolicies,${{ parameters.excludedGroups }} -Dmaven.javadoc.skip=true -B -V -Dfailsafe.rerunFailingTestsCount=0'
       env:
         DOCKER_TAG: $(docker_tag)
         BRIDGE_IMAGE: "latest-released"
@@ -81,4 +81,4 @@ jobs:
         pathtoPublish: 'systemtest/target/logs/'
         artifactName: systemtest-logs
       displayName: 'Publish logs from failed tests'
-      condition: failed()
+      condition: always()

--- a/.azure/templates/system_test_general.yaml
+++ b/.azure/templates/system_test_general.yaml
@@ -56,7 +56,7 @@ jobs:
         publishJUnitResults: true
         testResultsFiles: '**/failsafe-reports/TEST-*.xml'
         goals: 'verify'
-        options: '-Dgroups=${{ parameters.groups }} -Dit.test="${{ parameters.test_case }}" -DexcludedGroups=flaky,loadbalancer,networkpolicies,${{ parameters.excludedGroups }} -Dmaven.javadoc.skip=true -B -V -Dfailsafe.rerunFailingTestsCount=0'
+        options: '-Dgroups=${{ parameters.groups }} -Dit.test="${{ parameters.test_case }}" -DexcludedGroups=flaky,loadbalancer,networkpolicies,${{ parameters.excludedGroups }} -Dmaven.javadoc.skip=true -B -V -Dfailsafe.rerunFailingTestsCount=2'
       env:
         DOCKER_TAG: $(docker_tag)
         BRIDGE_IMAGE: "latest-released"

--- a/.azure/templates/system_test_general.yaml
+++ b/.azure/templates/system_test_general.yaml
@@ -54,7 +54,7 @@ jobs:
         publishJUnitResults: true
         testResultsFiles: '**/failsafe-reports/TEST-*.xml'
         goals: 'verify'
-        options: '-Dgroups=${{ parameters.groups }} -Dit.test="${{ parameters.test_case }}" -DexcludedGroups=flaky,loadbalancer,networkpolicies -Dmaven.javadoc.skip=true -B -V -Dfailsafe.rerunFailingTestsCount=2'
+        options: '-Dgroups=${{ parameters.groups }} -Dit.test="${{ parameters.test_case }}" -DexcludedGroups=flaky,loadbalancer,networkpolicies,${{ parameters.excludeGroups }} -Dmaven.javadoc.skip=true -B -V -Dfailsafe.rerunFailingTestsCount=2'
       env:
         DOCKER_TAG: $(docker_tag)
         BRIDGE_IMAGE: "latest-released"

--- a/.azure/templates/system_test_general.yaml
+++ b/.azure/templates/system_test_general.yaml
@@ -74,7 +74,7 @@ jobs:
     - bash: |
         rm -rf systemtest/target/logs/timeMeasuring
       displayName: 'Remove timeMeasuring dir from logs'
-      condition: failed()
+      condition: always()
 
     - task: PublishBuildArtifacts@1
       inputs:

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -231,8 +231,8 @@ public class ClusterOperatorConfig {
         CLUSTER(),
         NAMESPACE();
 
-        public boolean canUseRoles() {
-            return this.equals(RbacScope.NAMESPACE);
+        public boolean canUseClusterRoles() {
+            return this.equals(RbacScope.CLUSTER);
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -37,11 +37,16 @@ public class ClusterOperatorConfig {
     public static final String STRIMZI_NAMESPACE = "STRIMZI_NAMESPACE";
     public static final String STRIMZI_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
     public static final String STRIMZI_OPERATION_TIMEOUT_MS = "STRIMZI_OPERATION_TIMEOUT_MS";
-    public static final String STRIMZI_CREATE_CLUSTER_ROLES = "STRIMZI_CREATE_CLUSTER_ROLES";
     public static final String STRIMZI_IMAGE_PULL_POLICY = "STRIMZI_IMAGE_PULL_POLICY";
     public static final String STRIMZI_IMAGE_PULL_SECRETS = "STRIMZI_IMAGE_PULL_SECRETS";
     public static final String STRIMZI_OPERATOR_NAMESPACE = "STRIMZI_OPERATOR_NAMESPACE";
     public static final String STRIMZI_OPERATOR_NAMESPACE_LABELS = "STRIMZI_OPERATOR_NAMESPACE_LABELS";
+
+    // Feature Flags
+    public static final String STRIMZI_RBAC_SCOPE = "STRIMZI_RBAC_SCOPE";
+    public static final RbacScope DEFAULT_STRIMZI_RBAC_SCOPE = RbacScope.CLUSTER;
+    public static final String STRIMZI_CREATE_CLUSTER_ROLES = "STRIMZI_CREATE_CLUSTER_ROLES";
+    public static final boolean DEFAULT_CREATE_CLUSTER_ROLES = false;
 
     // Env vars for configuring images
     public static final String STRIMZI_KAFKA_IMAGES = "STRIMZI_KAFKA_IMAGES";
@@ -61,7 +66,6 @@ public class ClusterOperatorConfig {
 
     public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_MS = 120_000;
     public static final long DEFAULT_OPERATION_TIMEOUT_MS = 300_000;
-    public static final boolean DEFAULT_CREATE_CLUSTER_ROLES = false;
 
     private final Set<String> namespaces;
     private final long reconciliationIntervalMs;
@@ -72,6 +76,7 @@ public class ClusterOperatorConfig {
     private final List<LocalObjectReference> imagePullSecrets;
     private final String operatorNamespace;
     private final Labels operatorNamespaceLabels;
+    private final RbacScope rbacScope;
 
     /**
      * Constructor
@@ -79,17 +84,26 @@ public class ClusterOperatorConfig {
      * @param namespaces namespace in which the operator will run and create resources
      * @param reconciliationIntervalMs    specify every how many milliseconds the reconciliation runs
      * @param operationTimeoutMs    timeout for internal operations specified in milliseconds
-     * @param createClusterRoles true to create the cluster roles
+     * @param createClusterRoles true to create the ClusterRoles
      * @param versions The configured Kafka versions
      * @param imagePullPolicy Image pull policy configured by the user
      * @param imagePullSecrets Set of secrets for pulling container images from secured repositories
      * @param operatorNamespace Name of the namespace in which the operator is running
      * @param operatorNamespaceLabels Labels of the namespace in which the operator is running (used for network policies)
+     * @param rbacScope true to use Roles where possible instead of ClusterRoles
      */
-    public ClusterOperatorConfig(Set<String> namespaces, long reconciliationIntervalMs, long operationTimeoutMs,
-                                 boolean createClusterRoles, KafkaVersion.Lookup versions, ImagePullPolicy imagePullPolicy,
-                                 List<LocalObjectReference> imagePullSecrets, String operatorNamespace,
-                                 Labels operatorNamespaceLabels) {
+    public ClusterOperatorConfig(
+            Set<String> namespaces,
+            long reconciliationIntervalMs,
+            long operationTimeoutMs,
+            boolean createClusterRoles,
+            KafkaVersion.Lookup versions,
+            ImagePullPolicy imagePullPolicy,
+            List<LocalObjectReference> imagePullSecrets,
+            String operatorNamespace,
+            Labels operatorNamespaceLabels,
+            RbacScope rbacScope
+    ) {
         this.namespaces = unmodifiableSet(new HashSet<>(namespaces));
         this.reconciliationIntervalMs = reconciliationIntervalMs;
         this.operationTimeoutMs = operationTimeoutMs;
@@ -99,6 +113,7 @@ public class ClusterOperatorConfig {
         this.imagePullSecrets = imagePullSecrets;
         this.operatorNamespace = operatorNamespace;
         this.operatorNamespaceLabels = operatorNamespaceLabels;
+        this.rbacScope = rbacScope;
     }
 
     /**
@@ -134,17 +149,27 @@ public class ClusterOperatorConfig {
      * @return  Cluster Operator configuration instance
      */
     public static ClusterOperatorConfig fromMap(Map<String, String> map, KafkaVersion.Lookup lookup) {
-        Set<String> namespaces = parseNamespaceList(map.get(ClusterOperatorConfig.STRIMZI_NAMESPACE));
-        long reconciliationInterval = parseReconciliationInerval(map.get(ClusterOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS));
-        long operationTimeout = parseOperationTimeout(map.get(ClusterOperatorConfig.STRIMZI_OPERATION_TIMEOUT_MS));
-        boolean createClusterRoles = parseCreateClusterRoles(map.get(ClusterOperatorConfig.STRIMZI_CREATE_CLUSTER_ROLES));
-        ImagePullPolicy imagePullPolicy = parseImagePullPolicy(map.get(ClusterOperatorConfig.STRIMZI_IMAGE_PULL_POLICY));
-        List<LocalObjectReference> imagePullSecrets = parseImagePullSecrets(map.get(ClusterOperatorConfig.STRIMZI_IMAGE_PULL_SECRETS));
-        String operatorNamespace = map.get(ClusterOperatorConfig.STRIMZI_OPERATOR_NAMESPACE);
-        Labels operatorNamespaceLabels = parseOperatorNamespaceLabels(map.get(ClusterOperatorConfig.STRIMZI_OPERATOR_NAMESPACE_LABELS));
+        Set<String> namespaces = parseNamespaceList(map.get(STRIMZI_NAMESPACE));
+        long reconciliationInterval = parseReconciliationInterval(map.get(STRIMZI_FULL_RECONCILIATION_INTERVAL_MS));
+        long operationTimeout = parseOperationTimeout(map.get(STRIMZI_OPERATION_TIMEOUT_MS));
+        boolean createClusterRoles = parseCreateClusterRoles(map.get(STRIMZI_CREATE_CLUSTER_ROLES));
+        ImagePullPolicy imagePullPolicy = parseImagePullPolicy(map.get(STRIMZI_IMAGE_PULL_POLICY));
+        List<LocalObjectReference> imagePullSecrets = parseImagePullSecrets(map.get(STRIMZI_IMAGE_PULL_SECRETS));
+        String operatorNamespace = map.get(STRIMZI_OPERATOR_NAMESPACE);
+        Labels operatorNamespaceLabels = parseOperatorNamespaceLabels(map.get(STRIMZI_OPERATOR_NAMESPACE_LABELS));
+        RbacScope rbacScope = parseRbacScope(map.get(STRIMZI_RBAC_SCOPE));
 
-        return new ClusterOperatorConfig(namespaces, reconciliationInterval, operationTimeout, createClusterRoles,
-                lookup, imagePullPolicy, imagePullSecrets, operatorNamespace, operatorNamespaceLabels);
+        return new ClusterOperatorConfig(
+                namespaces,
+                reconciliationInterval,
+                operationTimeout,
+                createClusterRoles,
+                lookup,
+                imagePullPolicy,
+                imagePullSecrets,
+                operatorNamespace,
+                operatorNamespaceLabels,
+                rbacScope);
     }
 
     private static Set<String> parseNamespaceList(String namespacesList)   {
@@ -157,7 +182,7 @@ public class ClusterOperatorConfig {
             } else if (namespacesList.matches("(\\s*[a-z0-9.-]+\\s*,)*\\s*[a-z0-9.-]+\\s*")) {
                 namespaces = new HashSet<>(asList(namespacesList.trim().split("\\s*,+\\s*")));
             } else {
-                throw new InvalidConfigurationException(ClusterOperatorConfig.STRIMZI_NAMESPACE
+                throw new InvalidConfigurationException(STRIMZI_NAMESPACE
                         + " is not a valid list of namespaces nor the 'any namespace' wildcard "
                         + AbstractWatchableResourceOperator.ANY_NAMESPACE);
             }
@@ -166,7 +191,7 @@ public class ClusterOperatorConfig {
         return namespaces;
     }
 
-    private static long parseReconciliationInerval(String reconciliationIntervalEnvVar) {
+    private static long parseReconciliationInterval(String reconciliationIntervalEnvVar) {
         long reconciliationInterval = DEFAULT_FULL_RECONCILIATION_INTERVAL_MS;
 
         if (reconciliationIntervalEnvVar != null) {
@@ -196,6 +221,47 @@ public class ClusterOperatorConfig {
         return createClusterRoles;
     }
 
+    /**
+     * enum to represent the various permission modes the cluster operator can be set to
+     *
+     * CLUSTER is the default and uses ClusterRoles to set permissions
+     * NAMESPACE allows for the use of Roles where possible instead of ClusterRoles
+     */
+    public enum RbacScope {
+        CLUSTER("cluster"),
+        NAMESPACE("namespace");
+
+        private String mode;
+
+        RbacScope(String mode) {
+            this.mode = mode;
+        }
+
+        public boolean canUseClusterRoles() {
+            return this.equals(RbacScope.CLUSTER);
+        }
+
+        public boolean canUseRoles() {
+            return this.equals(RbacScope.NAMESPACE);
+        }
+    }
+
+    private static RbacScope parseRbacScope(String rbacScopeEnvVar) {
+        RbacScope rbacScope = DEFAULT_STRIMZI_RBAC_SCOPE;
+
+        if (rbacScopeEnvVar != null) {
+            try {
+                rbacScope = RbacScope.valueOf(rbacScopeEnvVar);
+            } catch (IllegalArgumentException e) {
+                throw new InvalidConfigurationException(rbacScopeEnvVar
+                        + " is not a valid " + STRIMZI_RBAC_SCOPE + " value. " +
+                        STRIMZI_RBAC_SCOPE + " can have one of the following values: cluster, namespace.");
+            }
+        }
+
+        return rbacScope;
+    }
+
     private static ImagePullPolicy parseImagePullPolicy(String imagePullPolicyEnvVar) {
         ImagePullPolicy imagePullPolicy = null;
 
@@ -212,8 +278,8 @@ public class ClusterOperatorConfig {
                     break;
                 default:
                     throw new InvalidConfigurationException(imagePullPolicyEnvVar
-                            + " is not a valid " + ClusterOperatorConfig.STRIMZI_IMAGE_PULL_POLICY + " value. " +
-                            ClusterOperatorConfig.STRIMZI_IMAGE_PULL_POLICY + " can have one of the following values: Always, IfNotPresent, Never.");
+                            + " is not a valid " + STRIMZI_IMAGE_PULL_POLICY + " value. " +
+                            STRIMZI_IMAGE_PULL_POLICY + " can have one of the following values: Always, IfNotPresent, Never.");
             }
         }
 
@@ -264,7 +330,7 @@ public class ClusterOperatorConfig {
             if (imagePullSecretList.matches("(\\s*[a-z0-9.-]+\\s*,)*\\s*[a-z0-9.-]+\\s*")) {
                 imagePullSecrets = Arrays.stream(imagePullSecretList.trim().split("\\s*,+\\s*")).map(secret -> new LocalObjectReferenceBuilder().withName(secret).build()).collect(Collectors.toList());
             } else {
-                throw new InvalidConfigurationException(ClusterOperatorConfig.STRIMZI_IMAGE_PULL_SECRETS
+                throw new InvalidConfigurationException(STRIMZI_IMAGE_PULL_SECRETS
                         + " is not a valid list of secret names");
             }
         }
@@ -326,7 +392,7 @@ public class ClusterOperatorConfig {
     }
 
     /**
-     * @return Returns list of configured ImagePullSecrets. Null if no secrets were configured.
+     * @return The list of configured ImagePullSecrets. Null if no secrets were configured.
      */
     public List<LocalObjectReference> getImagePullSecrets() {
         return imagePullSecrets;
@@ -346,6 +412,13 @@ public class ClusterOperatorConfig {
         return operatorNamespaceLabels;
     }
 
+    /**
+     * @return permissions mode for the operator, whether to use Roles instead of ClusterRoles wherever possible.
+     */
+    public RbacScope getRbacScope() {
+        return rbacScope;
+    }
+
     @Override
     public String toString() {
         return "ClusterOperatorConfig(" +
@@ -358,6 +431,7 @@ public class ClusterOperatorConfig {
                 ",imagePullSecrets=" + imagePullSecrets +
                 ",operatorNamespace=" + operatorNamespace +
                 ",operatorNamespaceLabels=" + operatorNamespaceLabels +
+                ",rbacScope=" + rbacScope +
                 ")";
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -228,18 +228,8 @@ public class ClusterOperatorConfig {
      * NAMESPACE allows for the use of Roles where possible instead of ClusterRoles
      */
     public enum RbacScope {
-        CLUSTER("cluster"),
-        NAMESPACE("namespace");
-
-        private String mode;
-
-        RbacScope(String mode) {
-            this.mode = mode;
-        }
-
-        public boolean canUseClusterRoles() {
-            return this.equals(RbacScope.CLUSTER);
-        }
+        CLUSTER(),
+        NAMESPACE();
 
         public boolean canUseRoles() {
             return this.equals(RbacScope.NAMESPACE);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -728,7 +728,7 @@ public abstract class AbstractModel {
      * @return the name of the role used by the service account for the deployed cluster for Kubernetes API operations.
      */
     protected String getRoleName() {
-        return null;
+        throw new RuntimeException("Unsupported method: this method should be overridden");
     }
 
     /**
@@ -1375,6 +1375,12 @@ public abstract class AbstractModel {
             .build();
     }
 
+    /**
+     * @param namespace The namespace the role will be deployed into
+     * @param rules the list of rules associated with this role
+     *
+     * @return The role for the component.
+     */
     public Role generateRole(String namespace, List<PolicyRule> rules) {
         return new RoleBuilder()
                 .withNewMetadata()
@@ -1387,6 +1393,14 @@ public abstract class AbstractModel {
                 .build();
     }
 
+    /**
+     * @param name The name of the rolebinding
+     * @param namespace The namespace the rolebinding will be deployed into
+     * @param roleRef a reference to a Role to bind to
+     * @param subjects a list of subject ServiceAccounts to bind the role to
+     *
+     * @return The RoleBinding for the component with thee given name and namespace.
+     */
     public RoleBinding generateRoleBinding(String name, String namespace, RoleRef roleRef, List<Subject> subjects) {
         return new RoleBindingBuilder()
                 .withNewMetadata()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -54,6 +54,8 @@ import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingBuilder;
 import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
 import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder;
 import io.fabric8.kubernetes.api.model.rbac.RoleBuilder;
 import io.fabric8.kubernetes.api.model.rbac.RoleRef;
 import io.fabric8.kubernetes.api.model.rbac.Subject;
@@ -1382,6 +1384,19 @@ public abstract class AbstractModel {
                     .addToLabels(labels.toMap())
                 .endMetadata()
                 .withRules(rules)
+                .build();
+    }
+
+    public RoleBinding generateRoleBinding(String name, String namespace, RoleRef roleRef, List<Subject> subjects) {
+        return new RoleBindingBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withNamespace(namespace)
+                    .withOwnerReferences(createOwnerReference())
+                    .withLabels(labels.toMap())
+                .endMetadata()
+                .withRoleRef(roleRef)
+                .withSubjects(subjects)
                 .build();
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1375,7 +1375,7 @@ public abstract class AbstractModel {
             .build();
     }
 
-    public Role generateRole(List<PolicyRule> rules) {
+    public Role generateRole(String namespace, List<PolicyRule> rules) {
         return new RoleBuilder()
                 .withNewMetadata()
                     .withName(getRoleName())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
@@ -19,6 +21,10 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentStrategy;
 import io.fabric8.kubernetes.api.model.apps.DeploymentStrategyBuilder;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
+import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBuilder;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.JvmOptions;
@@ -29,11 +35,17 @@ import io.strimzi.api.kafka.model.SystemProperty;
 import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.template.EntityOperatorTemplate;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.cluster.Main;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Represents the Entity Operator deployment
@@ -346,6 +358,61 @@ public class EntityOperator extends AbstractModel {
             return null;
         }
         return super.generateServiceAccount();
+    }
+
+    /**
+     * Get the name of the Entity Operator Role given the name of the {@code cluster}.
+     * @param cluster The cluster name
+     * @return The name of the EO role.
+     */
+    public static String entityOperatorRoleName(String cluster) {
+        return entityOperatorName(cluster);
+    }
+
+    @Override
+    protected String getRoleName() {
+        return getRoleName(cluster);
+    }
+
+    protected static String getRoleName(String cluster) {
+        return entityOperatorRoleName(cluster);
+    }
+
+    private Role convert(ClusterRole cr) {
+        return new RoleBuilder()
+                .withNewMetadata()
+                    .withName(cr.getMetadata().getName())
+                .endMetadata()
+                .withRules(cr.getRules())
+                .build();
+    }
+
+    /**
+     * Read the entity operator ClusterRole, and use the rules to create a new Role.
+     * This is done to avoid duplication of the rules set defined in source code.
+     *
+     * @return role for the entity operator
+     */
+    public Role generateRole() {
+
+        List<PolicyRule> rules;
+
+        try (BufferedReader br = new BufferedReader(
+                new InputStreamReader(
+                    Main.class.getResourceAsStream("/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml"),
+                    StandardCharsets.UTF_8)
+            )
+        ) {
+            String yaml = br.lines().collect(Collectors.joining(System.lineSeparator()));
+            ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
+            ClusterRole cr = yamlReader.readValue(yaml, ClusterRole.class);
+            rules = cr.getRules();
+        } catch (IOException e) {
+            log.error("Failed to read entity-operator ClusterRole.", e);
+            throw new RuntimeException(e);
+        }
+
+        return super.generateRole(rules);
     }
 
     protected static void javaOptions(List<EnvVar> envVars, JvmOptions jvmOptions, List<SystemProperty> javaSystemProperties) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -61,7 +61,6 @@ public class EntityOperator extends AbstractModel {
 
     // Entity Operator configuration keys
     public static final String ENV_VAR_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
-    public static final String EO_CLUSTER_ROLE_NAME = "strimzi-entity-operator";
 
     private String zookeeperConnect;
     private EntityTopicOperator topicOperator;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -358,22 +358,18 @@ public class EntityOperator extends AbstractModel {
         return super.generateServiceAccount();
     }
 
-    /**
-     * Get the name of the Entity Operator Role given the name of the {@code cluster}.
-     * @param cluster The cluster name
-     * @return The name of the EO role.
-     */
-    public static String entityOperatorRoleName(String cluster) {
-        return entityOperatorName(cluster);
-    }
-
     @Override
     protected String getRoleName() {
         return getRoleName(cluster);
     }
 
-    protected static String getRoleName(String cluster) {
-        return entityOperatorRoleName(cluster);
+    /**
+     * Get the name of the Entity Operator Role given the name of the {@code cluster}.
+     * @param cluster The cluster name
+     * @return The name of the EO role.
+     */
+    public static String getRoleName(String cluster) {
+        return entityOperatorName(cluster);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -382,7 +382,7 @@ public class EntityOperator extends AbstractModel {
      *
      * @return role for the entity operator
      */
-    public Role generateRole() {
+    public Role generateRole(String namespace) {
         List<PolicyRule> rules;
 
         try (BufferedReader br = new BufferedReader(
@@ -400,7 +400,7 @@ public class EntityOperator extends AbstractModel {
             throw new RuntimeException(e);
         }
 
-        return super.generateRole(rules);
+        return super.generateRole(namespace, rules);
     }
 
     protected static void javaOptions(List<EnvVar> envVars, JvmOptions jvmOptions, List<SystemProperty> javaSystemProperties) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -384,7 +384,6 @@ public class EntityOperator extends AbstractModel {
      * @return role for the entity operator
      */
     public Role generateRole() {
-
         List<PolicyRule> rules;
 
         try (BufferedReader br = new BufferedReader(

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentStrategyBuilder;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
 import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
 import io.fabric8.kubernetes.api.model.rbac.Role;
-import io.fabric8.kubernetes.api.model.rbac.RoleBuilder;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.JvmOptions;
@@ -376,15 +375,6 @@ public class EntityOperator extends AbstractModel {
 
     protected static String getRoleName(String cluster) {
         return entityOperatorRoleName(cluster);
-    }
-
-    private Role convert(ClusterRole cr) {
-        return new RoleBuilder()
-                .withNewMetadata()
-                    .withName(cr.getMetadata().getName())
-                .endMetadata()
-                .withRules(cr.getRules())
-                .build();
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -380,6 +380,8 @@ public class EntityOperator extends AbstractModel {
      * Read the entity operator ClusterRole, and use the rules to create a new Role.
      * This is done to avoid duplication of the rules set defined in source code.
      *
+     * @param namespace the namespace this role will be located
+     *
      * @return role for the entity operator
      */
     public Role generateRole(String namespace) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -170,16 +170,6 @@ public class EntityTopicOperator extends AbstractModel {
 
     /**
      * Get the name of the TO role binding given the name of the {@code cluster}.
-     * This binding binds to a ClusterRole, retains old naming convention for backwards compatibility.
-     * @param cluster The cluster name.
-     * @return The name of the role binding.
-     */
-    public static String roleBindingForClusterRoleName(String cluster) {
-        return "strimzi-" + cluster + "-entity-topic-operator";
-    }
-
-    /**
-     * Get the name of the TO role binding given the name of the {@code cluster}.
      * @param cluster The cluster name.
      * @return The name of the role binding.
      */
@@ -290,35 +280,6 @@ public class EntityTopicOperator extends AbstractModel {
         return asList(VolumeUtils.createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath),
             VolumeUtils.createVolumeMount(EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT),
             VolumeUtils.createVolumeMount(EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT));
-    }
-
-    public RoleBinding generateRoleBindingForClusterRole(String namespace, String watchedNamespace) {
-        Subject ks = new SubjectBuilder()
-                .withKind("ServiceAccount")
-                .withName(EntityOperator.entityOperatorServiceAccountName(cluster))
-                .withNamespace(namespace)
-                .build();
-
-        RoleRef roleRef = new RoleRefBuilder()
-                .withName(EntityOperator.EO_CLUSTER_ROLE_NAME)
-                .withApiGroup("rbac.authorization.k8s.io")
-                .withKind("ClusterRole")
-                .build();
-
-        RoleBinding rb = generateRoleBinding(
-                roleBindingForClusterRoleName(cluster),
-                watchedNamespace,
-                roleRef,
-                singletonList(ks)
-        );
-
-        // We set OwnerReference only within the same namespace since it does not work cross-namespace
-        if (!namespace.equals(watchedNamespace)) {
-            rb.getMetadata().setOwnerReferences(Collections.emptyList());
-        }
-
-        return rb;
-
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -339,12 +339,19 @@ public class EntityTopicOperator extends AbstractModel {
                 .withKind("Role")
                 .build();
 
-        return generateRoleBinding(
+        RoleBinding rb = generateRoleBinding(
                 roleBindingForRoleName(cluster),
                 watchedNamespace,
                 roleRef,
                 singletonList(ks)
         );
+
+        // We set OwnerReference only within the same namespace since it does not work cross-namespace
+        if (!namespace.equals(watchedNamespace)) {
+            rb.getMetadata().setOwnerReferences(Collections.emptyList());
+        }
+
+        return rb;
     }
 
     public void setContainerEnvVars(List<ContainerEnvVar> envVars) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -27,6 +27,7 @@ import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.common.model.OrderedProperties;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -336,12 +337,20 @@ public class EntityUserOperator extends AbstractModel {
                 .withKind("ClusterRole")
                 .build();
 
-        return generateRoleBinding(
+        RoleBinding rb = generateRoleBinding(
                 roleBindingForClusterRoleName(cluster),
                 watchedNamespace,
                 roleRef,
                 singletonList(ks)
         );
+
+        // We set OwnerReference only within the same namespace since it does not work cross-namespace
+        if (!namespace.equals(watchedNamespace)) {
+            rb.getMetadata().setOwnerReferences(Collections.emptyList());
+        }
+
+        return rb;
+
     }
 
     @Override
@@ -370,8 +379,8 @@ public class EntityUserOperator extends AbstractModel {
         );
 
         // We set OwnerReference only within the same namespace since it does not work cross-namespace
-        if (namespace.equals(watchedNamespace)) {
-            rb.getMetadata().setOwnerReferences(singletonList(createOwnerReference()));
+        if (!namespace.equals(watchedNamespace)) {
+            rb.getMetadata().setOwnerReferences(Collections.emptyList());
         }
 
         return rb;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -186,16 +186,6 @@ public class EntityUserOperator extends AbstractModel {
 
     /**
      * Get the name of the UO role binding given the name of the {@code cluster}.
-     * This binding binds to a ClusterRole, retains old naming convention for backwards compatibility.
-     * @param cluster The cluster name.
-     * @return The name of the role binding.
-     */
-    public static String roleBindingForClusterRoleName(String cluster) {
-        return "strimzi-" + cluster + "-entity-user-operator";
-    }
-
-    /**
-     * Get the name of the UO role binding given the name of the {@code cluster}.
      * @param cluster The cluster name.
      * @return The name of the role binding.
      */
@@ -322,35 +312,6 @@ public class EntityUserOperator extends AbstractModel {
         return asList(VolumeUtils.createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath),
                 VolumeUtils.createVolumeMount(EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT),
                 VolumeUtils.createVolumeMount(EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT));
-    }
-
-    public RoleBinding generateRoleBindingForClusterRole(String namespace, String watchedNamespace) {
-        Subject ks = new SubjectBuilder()
-                .withKind("ServiceAccount")
-                .withName(EntityOperator.entityOperatorServiceAccountName(cluster))
-                .withNamespace(namespace)
-                .build();
-
-        RoleRef roleRef = new RoleRefBuilder()
-                .withName(EntityOperator.EO_CLUSTER_ROLE_NAME)
-                .withApiGroup("rbac.authorization.k8s.io")
-                .withKind("ClusterRole")
-                .build();
-
-        RoleBinding rb = generateRoleBinding(
-                roleBindingForClusterRoleName(cluster),
-                watchedNamespace,
-                roleRef,
-                singletonList(ks)
-        );
-
-        // We set OwnerReference only within the same namespace since it does not work cross-namespace
-        if (!namespace.equals(watchedNamespace)) {
-            rb.getMetadata().setOwnerReferences(Collections.emptyList());
-        }
-
-        return rb;
-
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -12,7 +12,6 @@ import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
-import io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder;
 import io.fabric8.kubernetes.api.model.rbac.RoleRef;
 import io.fabric8.kubernetes.api.model.rbac.RoleRefBuilder;
 import io.fabric8.kubernetes.api.model.rbac.Subject;
@@ -337,18 +336,12 @@ public class EntityUserOperator extends AbstractModel {
                 .withKind("ClusterRole")
                 .build();
 
-        RoleBinding rb = new RoleBindingBuilder()
-                .withNewMetadata()
-                    .withName(roleBindingForClusterRoleName(cluster))
-                    .withNamespace(watchedNamespace)
-                    .withOwnerReferences(createOwnerReference())
-                    .withLabels(labels.toMap())
-                .endMetadata()
-                .withRoleRef(roleRef)
-                .withSubjects(singletonList(ks))
-                .build();
-
-        return rb;
+        return generateRoleBinding(
+                roleBindingForClusterRoleName(cluster),
+                watchedNamespace,
+                roleRef,
+                singletonList(ks)
+        );
     }
 
     @Override
@@ -369,18 +362,14 @@ public class EntityUserOperator extends AbstractModel {
                 .withKind("Role")
                 .build();
 
+        RoleBinding rb = generateRoleBinding(
+                roleBindingForRoleName(cluster),
+                watchedNamespace,
+                roleRef,
+                singletonList(ks)
+        );
 
-        RoleBinding rb = new RoleBindingBuilder()
-                .withNewMetadata()
-                    .withName(roleBindingForRoleName(cluster))
-                    .withNamespace(watchedNamespace)
-                    .withLabels(labels.toMap())
-                .endMetadata()
-                .withRoleRef(roleRef)
-                .withSubjects(singletonList(ks))
-                .build();
-
-        // We set OwnerReference only within the same namespace since it does nto work cross-namespace
+        // We set OwnerReference only within the same namespace since it does not work cross-namespace
         if (namespace.equals(watchedNamespace)) {
             rb.getMetadata().setOwnerReferences(singletonList(createOwnerReference()));
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -3171,7 +3171,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     && entityOperator.getUserOperator() != null
                     && entityOperator.getUserOperator().getWatchedNamespace() != null
                     && !entityOperator.getUserOperator().getWatchedNamespace().isEmpty()) {
-                userWatchedNamespace = entityOperator.getTopicOperator().getWatchedNamespace();
+                userWatchedNamespace = entityOperator.getUserOperator().getWatchedNamespace();
             } else {
                 userWatchedNamespace = namespace;
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1823,7 +1823,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         Future<ReconciliationState> kafkaInitClusterRoleBinding() {
             if (!rbacScope.canUseClusterRoles()) {
                 log.debug("Using STRIMZI_RBAC_SCOPE set to namespace requires user to apply ClusterRole and ClusterRoleBinding manually");
-                return Future.succeededFuture();
+                return withVoid(Future.succeededFuture());
             }
 
             ClusterRoleBinding desired = kafkaCluster.generateClusterRoleBinding(namespace);
@@ -3159,6 +3159,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 role = null;
             }
 
+            // Currently only deploys role into target namespace
+            // Role must be applied manually if using 'watchedNamespace' feature
             return withVoid(roleOperations.reconcile(
                     namespace,
                     EntityOperator.entityOperatorRoleName(name),
@@ -3184,7 +3186,10 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             if (!isEntityOperatorDeployed()
                     || entityOperator.getTopicOperator() == null) {
                 log.debug("entityOperatorTopicOpRoleBindingForRole not required");
-                return withVoid(roleBindingOperations.reconcile(namespace, EntityTopicOperator.roleBindingForRoleName(name), null));
+                return withVoid(roleBindingOperations.reconcile(
+                        namespace,
+                        EntityTopicOperator.roleBindingForRoleName(name),
+                        null));
             }
 
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1823,6 +1823,11 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> kafkaInitClusterRoleBinding() {
+            if (!rbacScope.canUseClusterRoles()) {
+                log.debug("Using STRIMZI_RBAC_SCOPE set to namespace requires user to apply ClusterRole and ClusterRoleBinding manually");
+                return Future.succeededFuture();
+            }
+
             ClusterRoleBinding desired = kafkaCluster.generateClusterRoleBinding(namespace);
 
             return withVoid(withIgnoreRbacError(
@@ -3150,7 +3155,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         // Deploy entity operator Role if STRIMZI_RBAC_SCOPE is set to use roles and entity operator is deployed
         Future<ReconciliationState> entityOperatorRole() {
             final Role role;
-            if (canUseRoles(namespace) && isEntityOperatorDeployed()) {
+            if (!shouldUseClusterRoles(namespace) && isEntityOperatorDeployed()) {
                 role = entityOperator.generateRole();
             } else {
                 role = null;
@@ -3177,8 +3182,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         // Check for if roles can be used for the topic and user operator
         // If watched namespace is set to the current namespace Roles can be used
         // Note watchedNamespace can't be unset as it defaults to the deployed namespace
-        public boolean canUseRoles(String watchedNamespace) {
-            return rbacScope.canUseRoles() && this.namespace.equals(watchedNamespace);
+        public boolean shouldUseClusterRoles(String watchedNamespace) {
+            return rbacScope.canUseClusterRoles() || !this.namespace.equals(watchedNamespace);
         }
 
         Future<ReconciliationState> entityOperatorTopicOpRoleBindingForRole() {
@@ -3187,7 +3192,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             // or if the topic operator needs to watch a different namespace
             if (!isEntityOperatorDeployed()
                     || entityOperator.getTopicOperator() == null
-                    || !canUseRoles(entityOperator.getTopicOperator().getWatchedNamespace())) {
+                    || shouldUseClusterRoles(entityOperator.getTopicOperator().getWatchedNamespace())) {
                 log.debug("entityOperatorTopicOpRoleBindingForRole not required");
                 return withVoid(roleBindingOperations.reconcile(namespace, EntityTopicOperator.roleBindingForRoleName(name), null));
             }
@@ -3204,7 +3209,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             // or if the topic operator doesn't need to watch a different namespace
             if (!isEntityOperatorDeployed()
                     || entityOperator.getTopicOperator() == null
-                    || canUseRoles(entityOperator.getTopicOperator().getWatchedNamespace())) {
+                    || !shouldUseClusterRoles(entityOperator.getTopicOperator().getWatchedNamespace())) {
                 log.debug("entityOperatorTopicOpRoleBindingForClusterRole not required");
                 return withVoid(roleBindingOperations.reconcile(
                         namespace,
@@ -3247,7 +3252,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             // or if the user operator needs to watch a different namespace
             if (!isEntityOperatorDeployed()
                     || entityOperator.getUserOperator() == null
-                    || !canUseRoles(entityOperator.getUserOperator().getWatchedNamespace())) {
+                    || shouldUseClusterRoles(entityOperator.getUserOperator().getWatchedNamespace())) {
                 log.debug("entityOperatorUserOpRoleBindingForRole not required");
                 return withVoid(roleBindingOperations.reconcile(
                         namespace,
@@ -3255,7 +3260,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         null));
             }
 
-            // TODO Comment true?
             // Create role binding for the the UI runs in (it needs to access the CA etc.)
             return withVoid(roleBindingOperations.reconcile(
                     namespace,
@@ -3269,7 +3273,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             // or if the user operator doesn't need to watch a different namespace
             if (!isEntityOperatorDeployed()
                     || entityOperator.getUserOperator() == null
-                    || canUseRoles(entityOperator.getUserOperator().getWatchedNamespace())) {
+                    || !shouldUseClusterRoles(entityOperator.getUserOperator().getWatchedNamespace())) {
                 log.debug("entityOperatorUserOpRoleBindingForClusterRole not required");
                 return withVoid(roleBindingOperations.reconcile(namespace, EntityUserOperator.roleBindingForClusterRoleName(name), null));
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1821,11 +1821,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> kafkaInitClusterRoleBinding() {
-            if (!rbacScope.canUseClusterRoles()) {
-                log.debug("Using STRIMZI_RBAC_SCOPE set to namespace requires user to apply ClusterRole and ClusterRoleBinding manually");
-                return withVoid(Future.succeededFuture());
-            }
-
             ClusterRoleBinding desired = kafkaCluster.generateClusterRoleBinding(namespace);
 
             return withVoid(withIgnoreRbacError(
@@ -3163,7 +3158,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             // Role must be applied manually if using 'watchedNamespace' feature
             final Future<ReconcileResult<Role>> ownNamespaceFuture = roleOperations.reconcile(
                     namespace,
-                    EntityOperator.entityOperatorRoleName(name),
+                    EntityOperator.getRoleName(name),
                     role);
 
             final String userWatchedNamespace;
@@ -3180,7 +3175,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             if (!namespace.equals(userWatchedNamespace)) {
                 userWatchedNamespaceFuture = roleOperations.reconcile(
                         userWatchedNamespace,
-                        EntityOperator.entityOperatorRoleName(name),
+                        EntityOperator.getRoleName(name),
                         entityOperator.generateRole(userWatchedNamespace));
             } else {
                 userWatchedNamespaceFuture = Future.succeededFuture();
@@ -3200,7 +3195,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             if (!namespace.equals(topicWatchedNamespace)) {
                 topicWatchedNamespaceFuture = roleOperations.reconcile(
                         topicWatchedNamespace,
-                        EntityOperator.entityOperatorRoleName(name),
+                        EntityOperator.getRoleName(name),
                         entityOperator.generateRole(topicWatchedNamespace));
             } else {
                 topicWatchedNamespaceFuture = Future.succeededFuture();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -190,7 +190,12 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
     Future<ReconcileResult<ClusterRoleBinding>> connectInitClusterRoleBinding(String namespace, String name, KafkaConnectCluster connectCluster) {
         ClusterRoleBinding desired = connectCluster.generateClusterRoleBinding();
 
-        return withIgnoreRbacError(clusterRoleBindingOperations.reconcile(KafkaConnectResources.initContainerClusterRoleBindingName(name, namespace), desired), desired);
+        return withIgnoreRbacError(
+                clusterRoleBindingOperations.reconcile(
+                        KafkaConnectResources.initContainerClusterRoleBindingName(name, namespace),
+                        desired),
+                desired
+        );
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -190,11 +190,6 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
      * @return                  Future for tracking the asynchronous result of the ClusterRoleBinding reconciliation
      */
     Future<ReconcileResult<ClusterRoleBinding>> connectInitClusterRoleBinding(String namespace, String name, KafkaConnectCluster connectCluster) {
-        if (!rbacScope.canUseClusterRoles()) {
-            log.debug("Using STRIMZI_RBAC_SCOPE set to namespace requires user to apply ClusterRole and ClusterRoleBinding manually");
-            return Future.succeededFuture();
-        }
-        
         ClusterRoleBinding desired = connectCluster.generateClusterRoleBinding();
 
         return withIgnoreRbacError(

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -50,6 +50,7 @@ import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
 import io.strimzi.operator.common.operator.resource.RoleBindingOperator;
+import io.strimzi.operator.common.operator.resource.RoleOperator;
 import io.strimzi.operator.common.operator.resource.RouteOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
@@ -71,6 +72,7 @@ public class ResourceOperatorSupplier {
     public final DeploymentOperator deploymentOperations;
     public final ServiceAccountOperator serviceAccountOperations;
     public final RoleBindingOperator roleBindingOperations;
+    public final RoleOperator roleOperations;
     public final ClusterRoleBindingOperator clusterRoleBindingOperator;
     public final CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> kafkaOperator;
     public final CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList, DoneableKafkaConnect> connectOperator;
@@ -117,6 +119,7 @@ public class ResourceOperatorSupplier {
                 new DeploymentOperator(vertx, client),
                 new ServiceAccountOperator(vertx, client),
                 new RoleBindingOperator(vertx, client),
+                new RoleOperator(vertx, client),
                 new ClusterRoleBindingOperator(vertx, client),
                 new NetworkPolicyOperator(vertx, client),
                 new PodDisruptionBudgetOperator(vertx, client),
@@ -150,6 +153,7 @@ public class ResourceOperatorSupplier {
                                     DeploymentOperator deploymentOperations,
                                     ServiceAccountOperator serviceAccountOperations,
                                     RoleBindingOperator roleBindingOperations,
+                                    RoleOperator roleOperations,
                                     ClusterRoleBindingOperator clusterRoleBindingOperator,
                                     NetworkPolicyOperator networkPolicyOperator,
                                     PodDisruptionBudgetOperator podDisruptionBudgetOperator,
@@ -181,6 +185,7 @@ public class ResourceOperatorSupplier {
         this.deploymentOperations = deploymentOperations;
         this.serviceAccountOperations = serviceAccountOperations;
         this.roleBindingOperations = roleBindingOperations;
+        this.roleOperations = roleOperations;
         this.clusterRoleBindingOperator = clusterRoleBindingOperator;
         this.networkPolicyOperator = networkPolicyOperator;
         this.podDisruptionBudgetOperator = podDisruptionBudgetOperator;

--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -8,15 +8,24 @@ rules:
   - apiGroups:
       - "rbac.authorization.k8s.io"
     resources:
-      # The cluster operator needs to access and manage roles to grant the entity operator permissions
-      # This is only needed if the STRIMZI_RBAC_SCOPE is set to 'namespace', otherwise ClusterRoles are used
-      - roles
       # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
       - rolebindings
     verbs:
       - get
       - list
       - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      # The cluster operator needs to access and manage roles to grant the entity operator permissions
+      # This is only needed if the STRIMZI_RBAC_SCOPE is set to 'namespace', otherwise ClusterRoles are used
+      - roles
+    verbs:
+      - get
       - create
       - delete
       - patch

--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -25,6 +25,8 @@ rules:
       - roles
     verbs:
       - get
+      - list
+      - watch
       - create
       - delete
       - patch

--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -8,6 +8,9 @@ rules:
   - apiGroups:
       - "rbac.authorization.k8s.io"
     resources:
+      # The cluster operator needs to access and manage roles to grant the entity operator permissions
+      # This is only needed if the STRIMZI_RBAC_SCOPE is set to 'namespace', otherwise ClusterRoles are used
+      - roles
       # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
       - rolebindings
     verbs:

--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -22,7 +22,6 @@ rules:
       - "rbac.authorization.k8s.io"
     resources:
       # The cluster operator needs to access and manage roles to grant the entity operator permissions
-      # This is only needed if the STRIMZI_RBAC_SCOPE is set to 'namespace', otherwise ClusterRoles are used
       - roles
     verbs:
       - get

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -297,4 +297,10 @@ public class ClusterOperatorConfigTest {
             ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup());
         });
     }
+
+    @Test
+    public void testRbacScopeValueOf() {
+        assertThat(ClusterOperatorConfig.RbacScope.valueOf("NAMESPACE"), is(ClusterOperatorConfig.RbacScope.NAMESPACE));
+        assertThat(ClusterOperatorConfig.RbacScope.valueOf("CLUSTER"), is(ClusterOperatorConfig.RbacScope.CLUSTER));
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -61,7 +61,17 @@ public class ClusterOperatorConfigTest {
 
     @Test
     public void testReconciliationInterval() {
-        ClusterOperatorConfig config = new ClusterOperatorConfig(singleton("namespace"), 60_000, 30_000, false, new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap()), null, null, null, null);
+        ClusterOperatorConfig config = new ClusterOperatorConfig(
+                singleton("namespace"),
+                60_000,
+                30_000,
+                false,
+                new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap()),
+                null,
+                null,
+                null,
+                null,
+                ClusterOperatorConfig.RbacScope.CLUSTER);
 
         assertThat(config.getNamespaces(), is(singleton("namespace")));
         assertThat(config.getReconciliationIntervalMs(), is(60_000L));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -85,6 +85,7 @@ import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
 import io.strimzi.operator.common.operator.resource.RoleBindingOperator;
+import io.strimzi.operator.common.operator.resource.RoleOperator;
 import io.strimzi.operator.common.operator.resource.RouteOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
@@ -732,17 +733,41 @@ public class ResourceUtils {
         RouteOperator routeOps = openShift ? mock(RouteOperator.class) : null;
 
         ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(
-                mock(ServiceOperator.class), routeOps, mock(ZookeeperSetOperator.class),
-                mock(KafkaSetOperator.class), mock(ConfigMapOperator.class), mock(SecretOperator.class),
-                mock(PvcOperator.class), mock(DeploymentOperator.class),
-                mock(ServiceAccountOperator.class), mock(RoleBindingOperator.class), mock(ClusterRoleBindingOperator.class),
-                mock(NetworkPolicyOperator.class), mock(PodDisruptionBudgetOperator.class), mock(PodOperator.class),
-                mock(IngressOperator.class), mock(ImageStreamOperator.class), mock(BuildConfigOperator.class),
-                mock(DeploymentConfigOperator.class), mock(CrdOperator.class), mock(CrdOperator.class), mock(CrdOperator.class),
-                mock(CrdOperator.class), mock(CrdOperator.class), mock(CrdOperator.class), mock(CrdOperator.class), mock(CrdOperator.class),
-                mock(StorageClassOperator.class), mock(NodeOperator.class), zookeeperScalerProvider(), metricsProvider(), adminClientProvider());
+                mock(ServiceOperator.class),
+                routeOps,
+                mock(ZookeeperSetOperator.class),
+                mock(KafkaSetOperator.class),
+                mock(ConfigMapOperator.class),
+                mock(SecretOperator.class),
+                mock(PvcOperator.class),
+                mock(DeploymentOperator.class),
+                mock(ServiceAccountOperator.class),
+                mock(RoleBindingOperator.class),
+                mock(RoleOperator.class),
+                mock(ClusterRoleBindingOperator.class),
+                mock(NetworkPolicyOperator.class),
+                mock(PodDisruptionBudgetOperator.class),
+                mock(PodOperator.class),
+                mock(IngressOperator.class),
+                mock(ImageStreamOperator.class),
+                mock(BuildConfigOperator.class),
+                mock(DeploymentConfigOperator.class),
+                mock(CrdOperator.class),
+                mock(CrdOperator.class),
+                mock(CrdOperator.class),
+                mock(CrdOperator.class),
+                mock(CrdOperator.class),
+                mock(CrdOperator.class),
+                mock(CrdOperator.class),
+                mock(CrdOperator.class),
+                mock(StorageClassOperator.class),
+                mock(NodeOperator.class),
+                zookeeperScalerProvider(),
+                metricsProvider(),
+                adminClientProvider());
         when(supplier.serviceAccountOperations.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.roleBindingOperations.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+        when(supplier.roleOperations.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.clusterRoleBindingOperator.reconcile(anyString(), any())).thenReturn(Future.succeededFuture());
 
         if (openShift) {
@@ -786,7 +811,22 @@ public class ResourceUtils {
                 null,
                 null,
                 null,
-                null);
+                null,
+                ClusterOperatorConfig.RbacScope.CLUSTER);
+    }
+
+    public static ClusterOperatorConfig dummyClusterOperatorConfigRolesOnly(KafkaVersion.Lookup versions, long operationTimeoutMs) {
+        return new ClusterOperatorConfig(
+                singleton("dummy"),
+                60_000,
+                operationTimeoutMs,
+                false,
+                versions,
+                null,
+                null,
+                null,
+                null,
+                ClusterOperatorConfig.RbacScope.NAMESPACE);
     }
 
     public static ClusterOperatorConfig dummyClusterOperatorConfig(KafkaVersion.Lookup versions) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -14,6 +14,10 @@ import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.TolerationBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
+import io.fabric8.kubernetes.api.model.rbac.PolicyRuleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.EntityOperatorSpecBuilder;
@@ -866,5 +870,39 @@ public class EntityOperatorTest {
                         hasProperty("name", equalTo(EntityOperator.TLS_SIDECAR_NAME)),
                         hasProperty("securityContext", equalTo(securityContext))
                 )));
+    }
+
+    @Test
+    public void testRole() {
+
+        Kafka resource = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout))
+                .editSpec()
+                    .editOrNewEntityOperator()
+                    .endEntityOperator()
+                .endSpec()
+                .build();
+
+        EntityOperator eo =  EntityOperator.fromCrd(resource, VERSIONS);
+        Role role = eo.generateRole();
+
+        assertThat(role.getMetadata().getName(), is("foo-entity-operator"));
+
+        List<PolicyRule> rules = new ArrayList<>();
+        rules.add(new PolicyRuleBuilder()
+                .addToResources("kafkatopics", "kafkatopics/status", "kafkausers", "kafkausers/status")
+                .addToVerbs("get", "list", "watch", "create", "patch", "update", "delete")
+                .addToApiGroups(Constants.RESOURCE_GROUP_NAME)
+                .build());
+        rules.add(new PolicyRuleBuilder()
+                .addToResources("events")
+                .addToVerbs("create")
+                .addToApiGroups("")
+                .build());
+        rules.add(new PolicyRuleBuilder()
+                .addToResources("secrets")
+                .addToVerbs("get", "list", "watch", "create", "delete", "patch", "update")
+                .addToApiGroups("")
+                .build());
+        assertThat(role.getRules(), is(rules));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -883,7 +883,7 @@ public class EntityOperatorTest {
                 .build();
 
         EntityOperator eo =  EntityOperator.fromCrd(resource, VERSIONS);
-        Role role = eo.generateRole();
+        Role role = eo.generateRole(namespace);
 
         assertThat(role.getMetadata().getName(), is("foo-entity-operator"));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -886,6 +886,7 @@ public class EntityOperatorTest {
         Role role = eo.generateRole(namespace);
 
         assertThat(role.getMetadata().getName(), is("foo-entity-operator"));
+        assertThat(role.getMetadata().getNamespace(), is(namespace));
 
         List<PolicyRule> rules = new ArrayList<>();
         rules.add(new PolicyRuleBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -224,39 +224,23 @@ public class EntityTopicOperatorTest {
 
     @Test
     public void testRoleBindingInOtherNamespace()   {
-        RoleBinding binding = entityTopicOperator.generateRoleBindingForClusterRole(namespace, toWatchedNamespace);
-
-        assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
-        assertThat(binding.getMetadata().getNamespace(), is(toWatchedNamespace));
-        assertThat(binding.getMetadata().getOwnerReferences().size(), is(0));
-    }
-
-    @Test
-    public void testRoleBindingInTheSameNamespace()   {
-        RoleBinding binding = entityTopicOperator.generateRoleBindingForClusterRole(namespace, namespace);
-
-        assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
-        assertThat(binding.getMetadata().getNamespace(), is(namespace));
-        assertThat(binding.getMetadata().getOwnerReferences().size(), is(1));
-    }
-
-    @Test
-    public void testRoleBindingForClusterRole() {
-        RoleBinding binding = entityTopicOperator.generateRoleBindingForClusterRole(namespace, toWatchedNamespace);
-
-        assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
-        assertThat(binding.getMetadata().getNamespace(), is(toWatchedNamespace));
-
-        assertThat(binding.getRoleRef().getKind(), is("ClusterRole"));
-        assertThat(binding.getRoleRef().getName(), is("strimzi-entity-operator"));
-    }
-
-    @Test
-    public void testRoleBindingForRole() {
         RoleBinding binding = entityTopicOperator.generateRoleBindingForRole(namespace, toWatchedNamespace);
 
         assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getNamespace(), is(toWatchedNamespace));
+        assertThat(binding.getMetadata().getOwnerReferences().size(), is(0));
+
+        assertThat(binding.getRoleRef().getKind(), is("Role"));
+        assertThat(binding.getRoleRef().getName(), is("foo-entity-operator"));
+    }
+
+    @Test
+    public void testRoleBindingInTheSameNamespace()   {
+        RoleBinding binding = entityTopicOperator.generateRoleBindingForRole(namespace, namespace);
+
+        assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
+        assertThat(binding.getMetadata().getNamespace(), is(namespace));
+        assertThat(binding.getMetadata().getOwnerReferences().size(), is(1));
 
         assertThat(binding.getRoleRef().getKind(), is("Role"));
         assertThat(binding.getRoleRef().getName(), is("foo-entity-operator"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -224,7 +224,7 @@ public class EntityTopicOperatorTest {
 
     @Test
     public void testRoleBindingInOtherNamespace()   {
-        RoleBinding binding = entityTopicOperator.generateRoleBinding(namespace, toWatchedNamespace);
+        RoleBinding binding = entityTopicOperator.generateRoleBindingForClusterRole(namespace, toWatchedNamespace);
 
         assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getNamespace(), is(toWatchedNamespace));
@@ -233,10 +233,32 @@ public class EntityTopicOperatorTest {
 
     @Test
     public void testRoleBindingInTheSameNamespace()   {
-        RoleBinding binding = entityTopicOperator.generateRoleBinding(namespace, namespace);
+        RoleBinding binding = entityTopicOperator.generateRoleBindingForClusterRole(namespace, namespace);
 
         assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getOwnerReferences().size(), is(1));
+    }
+
+    @Test
+    public void testRoleBindingForClusterRole() {
+        RoleBinding binding = entityTopicOperator.generateRoleBindingForClusterRole(namespace, toWatchedNamespace);
+
+        assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
+        assertThat(binding.getMetadata().getNamespace(), is(toWatchedNamespace));
+
+        assertThat(binding.getRoleRef().getKind(), is("ClusterRole"));
+        assertThat(binding.getRoleRef().getName(), is("strimzi-entity-operator"));
+    }
+
+    @Test
+    public void testRoleBindingForRole() {
+        RoleBinding binding = entityTopicOperator.generateRoleBindingForRole(namespace, toWatchedNamespace);
+
+        assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
+        assertThat(binding.getMetadata().getNamespace(), is(toWatchedNamespace));
+
+        assertThat(binding.getRoleRef().getKind(), is("Role"));
+        assertThat(binding.getRoleRef().getName(), is("foo-entity-operator"));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -299,7 +299,7 @@ public class EntityUserOperatorTest {
 
     @Test
     public void testRoleBindingInOtherNamespace()   {
-        RoleBinding binding = entityUserOperator.generateRoleBinding(namespace, uoWatchedNamespace);
+        RoleBinding binding = entityUserOperator.generateRoleBindingForClusterRole(namespace, uoWatchedNamespace);
 
         assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getNamespace(), is(uoWatchedNamespace));
@@ -307,11 +307,32 @@ public class EntityUserOperatorTest {
     }
 
     @Test
-    public void testRoleBindingInTheSameNamespace()   {
-        RoleBinding binding = entityUserOperator.generateRoleBinding(namespace, namespace);
+    public void testRoleBindingInTheSameNamespace() {
+        RoleBinding binding = entityUserOperator.generateRoleBindingForClusterRole(namespace, namespace);
 
         assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getOwnerReferences().size(), is(1));
+    }
+
+    public void testRoleBindingForClusterRole()   {
+        RoleBinding binding = entityUserOperator.generateRoleBindingForClusterRole(namespace, uoWatchedNamespace);
+
+        assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
+        assertThat(binding.getMetadata().getNamespace(), is(uoWatchedNamespace));
+
+        assertThat(binding.getRoleRef().getKind(), is("ClusterRole"));
+        assertThat(binding.getRoleRef().getName(), is("strimzi-entity-operator"));
+    }
+
+    @Test
+    public void testRoleBindingForRole()   {
+        RoleBinding binding = entityUserOperator.generateRoleBindingForRole(namespace, uoWatchedNamespace);
+
+        assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
+        assertThat(binding.getMetadata().getNamespace(), is(uoWatchedNamespace));
+
+        assertThat(binding.getRoleRef().getKind(), is("Role"));
+        assertThat(binding.getRoleRef().getName(), is("foo-entity-operator"));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -304,6 +304,9 @@ public class EntityUserOperatorTest {
         assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getNamespace(), is(uoWatchedNamespace));
         assertThat(binding.getMetadata().getOwnerReferences().size(), is(0));
+
+        assertThat(binding.getRoleRef().getKind(), is("Role"));
+        assertThat(binding.getRoleRef().getName(), is("foo-entity-operator"));
     }
 
     @Test
@@ -313,27 +316,9 @@ public class EntityUserOperatorTest {
         assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getOwnerReferences().size(), is(1));
-    }
-
-    @Test
-    public void testRoleBindingForClusterRole()   {
-        RoleBinding binding = entityUserOperator.generateRoleBindingForClusterRole(namespace, uoWatchedNamespace);
-
-        assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
-        assertThat(binding.getMetadata().getNamespace(), is(uoWatchedNamespace));
-
-        assertThat(binding.getRoleRef().getKind(), is("ClusterRole"));
-        assertThat(binding.getRoleRef().getName(), is("strimzi-entity-operator"));
-    }
-
-    @Test
-    public void testRoleBindingForRole()   {
-        RoleBinding binding = entityUserOperator.generateRoleBindingForRole(namespace, uoWatchedNamespace);
-
-        assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
-        assertThat(binding.getMetadata().getNamespace(), is(uoWatchedNamespace));
 
         assertThat(binding.getRoleRef().getKind(), is("Role"));
         assertThat(binding.getRoleRef().getName(), is("foo-entity-operator"));
     }
+
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -299,7 +299,7 @@ public class EntityUserOperatorTest {
 
     @Test
     public void testRoleBindingInOtherNamespace()   {
-        RoleBinding binding = entityUserOperator.generateRoleBindingForClusterRole(namespace, uoWatchedNamespace);
+        RoleBinding binding = entityUserOperator.generateRoleBindingForRole(namespace, uoWatchedNamespace);
 
         assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getNamespace(), is(uoWatchedNamespace));
@@ -308,13 +308,14 @@ public class EntityUserOperatorTest {
 
     @Test
     public void testRoleBindingInTheSameNamespace() {
-        RoleBinding binding = entityUserOperator.generateRoleBindingForClusterRole(namespace, namespace);
+        RoleBinding binding = entityUserOperator.generateRoleBindingForRole(namespace, namespace);
 
         assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getOwnerReferences().size(), is(1));
     }
 
+    @Test
     public void testRoleBindingForClusterRole()   {
         RoleBinding binding = entityUserOperator.generateRoleBindingForClusterRole(namespace, uoWatchedNamespace);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorRbacScopeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorRbacScopeTest.java
@@ -50,6 +50,8 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
@@ -185,6 +187,8 @@ public class KafkaAssemblyOperatorRbacScopeTest {
 
                     assertThat(roleBindingNames.get(3), is("strimzi-test-instance-entity-user-operator"));
                     assertThat(roleBindings.get(3), is(nullValue()));
+
+                    verify(supplier.clusterRoleBindingOperator, never()).reconcile(anyString(), any());
 
                     async.flag();
                 })));
@@ -474,12 +478,10 @@ public class KafkaAssemblyOperatorRbacScopeTest {
                     List<String> clusterRoleBindingNames = clusterRoleBindingNameCaptor.getAllValues();
                     List<ClusterRoleBinding> clusterRoleBindings = clusterRoleBindingCaptor.getAllValues();
 
-                    assertThat(clusterRoleBindingNames, hasSize(1));
-                    assertThat(clusterRoleBindings, hasSize(1));
+                    assertThat(clusterRoleBindingNames, hasSize(0));
+                    assertThat(clusterRoleBindings, hasSize(0));
 
-                    // Check all ClusterRoleBindings, easier to index by order applied
-                    assertThat(clusterRoleBindingNames.get(0), is("strimzi-test-ns-test-instance-kafka-init"));
-                    assertThat(clusterRoleBindings.get(0), is(nullValue()));
+                    verify(supplier.clusterRoleBindingOperator, never()).reconcile(anyString(), any());
 
                     async.flag();
                 })));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorRbacScopeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorRbacScopeTest.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.RoleRef;
+import io.fabric8.kubernetes.api.model.rbac.RoleRefBuilder;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.certs.CertManager;
+import io.strimzi.operator.KubernetesVersion;
+import io.strimzi.operator.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.EntityOperator;
+import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.PasswordGenerator;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.operator.common.operator.resource.CrdOperator;
+import io.strimzi.operator.common.operator.resource.RoleBindingOperator;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+public class KafkaAssemblyOperatorRbacScopeTest {
+    private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_11;
+    private final MockCertManager certManager = new MockCertManager();
+    private final PasswordGenerator passwordGenerator = new PasswordGenerator(10, "a", "a");
+    private final ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);
+    private final ClusterOperatorConfig configRolesOnly = ResourceUtils.dummyClusterOperatorConfigRolesOnly(VERSIONS, ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS);
+    private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
+    private final String namespace = "test-ns";
+    private final String clusterName = "test-instance";
+    protected static Vertx vertx;
+
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
+    }
+
+    /**
+     * Override KafkaAssemblyOperator to only run reconciliation steps that concern the STRIMZI_RBAC_SCOPE feature
+     */
+    class KafkaAssemblyOperatorRolesSubset extends KafkaAssemblyOperator {
+        public KafkaAssemblyOperatorRolesSubset(Vertx vertx, PlatformFeaturesAvailability pfa, CertManager certManager, PasswordGenerator passwordGenerator, ResourceOperatorSupplier supplier, ClusterOperatorConfig config) {
+            super(vertx, pfa, certManager, passwordGenerator, supplier, config);
+        }
+
+        @Override
+        Future<Void> reconcile(ReconciliationState reconcileState)  {
+            return reconcileState.getEntityOperatorDescription()
+                    .compose(state -> state.entityOperatorRole())
+                    .compose(state -> state.entityOperatorServiceAccount())
+                    .compose(state -> state.entityOperatorTopicOpRoleBindingForRole())
+                    .compose(state -> state.entityOperatorTopicOpRoleBindingForClusterRole())
+                    .compose(state -> state.entityOperatorUserOpRoleBindingForRole())
+                    .compose(state -> state.entityOperatorUserOpRoleBindingForClusterRole())
+                    .map((Void) null);
+        }
+
+    }
+
+    /**
+     * This test checks that when STRIMZI_RBAC_SCOPE feature is set to 'namespace', the cluster operator only
+     * deploys and binds to Roles
+     */
+    @Test
+    public void testRolesDeployedWhenNamespaceRbacScope(VertxTestContext context) {
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                    .withName(clusterName)
+                    .withNamespace(namespace)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewKafka()
+                        .withReplicas(3)
+                    .endKafka()
+                    .withNewZookeeper()
+                        .withReplicas(3)
+                    .endZookeeper()
+                    .withNewEntityOperator()
+                        .withNewUserOperator()
+                        .endUserOperator()
+                        .withNewTopicOperator()
+                        .endTopicOperator()
+                    .endEntityOperator()
+                .endSpec()
+                .build();
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the CRD Operator for Kafka resources
+        CrdOperator mockKafkaOps = supplier.kafkaOperator;
+        when(mockKafkaOps.getAsync(eq(namespace), eq(clusterName))).thenReturn(Future.succeededFuture(kafka));
+        when(mockKafkaOps.get(eq(namespace), eq(clusterName))).thenReturn(kafka);
+        when(mockKafkaOps.updateStatusAsync(any(Kafka.class))).thenReturn(Future.succeededFuture());
+
+        // Mock the operations for RoleBindings
+        RoleBindingOperator mockRoleBindingOps = supplier.roleBindingOperations;
+        // Capture the names of reconciled rolebindings and their patched state
+        ArgumentCaptor<String> roleBindingNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<RoleBinding> roleBindingCaptor = ArgumentCaptor.forClass(RoleBinding.class);
+        when(mockRoleBindingOps.reconcile(eq(namespace), roleBindingNameCaptor.capture(), roleBindingCaptor.capture()))
+                .thenReturn(Future.succeededFuture());
+
+        KafkaAssemblyOperatorRolesSubset kao = new KafkaAssemblyOperatorRolesSubset(
+                vertx,
+                new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                passwordGenerator,
+                supplier,
+                configRolesOnly);
+
+        Checkpoint async = context.checkpoint();
+        kao.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    List<String> roleBindingNames = roleBindingNameCaptor.getAllValues();
+                    List<RoleBinding> roleBindings = roleBindingCaptor.getAllValues();
+
+                    assertThat(roleBindingNames, hasSize(4));
+                    assertThat(roleBindings, hasSize(4));
+
+                    // Check all RoleBindings, easier to index by order applied
+                    assertThat(roleBindingNames.get(0), is("test-instance-entity-topic-operator-role"));
+                    assertThat(roleBindings.get(0), hasRoleRef(new RoleRefBuilder()
+                            .withApiGroup("rbac.authorization.k8s.io")
+                            .withKind("Role")
+                            .withName("test-instance-entity-operator")
+                            .build()));
+
+                    assertThat(roleBindingNames.get(1), is("strimzi-test-instance-entity-topic-operator"));
+                    assertThat(roleBindings.get(1), is(nullValue()));
+
+                    assertThat(roleBindingNames.get(2), is("test-instance-entity-user-operator-role"));
+                    assertThat(roleBindings.get(2), hasRoleRef(new RoleRefBuilder()
+                            .withApiGroup("rbac.authorization.k8s.io")
+                            .withKind("Role")
+                            .withName("test-instance-entity-operator")
+                            .build()));
+
+                    assertThat(roleBindingNames.get(3), is("strimzi-test-instance-entity-user-operator"));
+                    assertThat(roleBindings.get(3), is(nullValue()));
+
+                    async.flag();
+                })));
+    }
+
+    /**
+     * This test checks that when STRIMZI_RBAC_SCOPE feature is set to 'cluster', the cluster operator
+     * binds to ClusterRoles
+     */
+    @Test
+    public void testRoleBindingForClusterRoleDeployedWhenClusterRbacScope(VertxTestContext context) {
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                    .withName(clusterName)
+                    .withNamespace(namespace)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewKafka()
+                        .withReplicas(3)
+                    .endKafka()
+                    .withNewZookeeper()
+                        .withReplicas(3)
+                    .endZookeeper()
+                    .withNewEntityOperator()
+                        .withNewUserOperator()
+                        .endUserOperator()
+                        .withNewTopicOperator()
+                        .endTopicOperator()
+                    .endEntityOperator()
+                .endSpec()
+                .build();
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the CRD Operator for Kafka resources
+        CrdOperator mockKafkaOps = supplier.kafkaOperator;
+        when(mockKafkaOps.getAsync(eq(namespace), eq(clusterName))).thenReturn(Future.succeededFuture(kafka));
+        when(mockKafkaOps.get(eq(namespace), eq(clusterName))).thenReturn(kafka);
+        when(mockKafkaOps.updateStatusAsync(any(Kafka.class))).thenReturn(Future.succeededFuture());
+
+        // Mock the operations for RoleBindings
+        RoleBindingOperator mockRoleBindingOps = supplier.roleBindingOperations;
+        // Capture the names of reconciled rolebindings and their patched state
+        ArgumentCaptor<String> roleBindingNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<RoleBinding> roleBindingCaptor = ArgumentCaptor.forClass(RoleBinding.class);
+        when(mockRoleBindingOps.reconcile(eq(namespace), roleBindingNameCaptor.capture(), roleBindingCaptor.capture()))
+                .thenReturn(Future.succeededFuture());
+
+        KafkaAssemblyOperatorRolesSubset kao = new KafkaAssemblyOperatorRolesSubset(
+                vertx,
+                new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                passwordGenerator,
+                supplier,
+                config);
+
+        Checkpoint async = context.checkpoint();
+        kao.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    List<String> roleBindingNames = roleBindingNameCaptor.getAllValues();
+                    List<RoleBinding> roleBindings = roleBindingCaptor.getAllValues();
+
+                    assertThat(roleBindingNames, hasSize(4));
+                    assertThat(roleBindings, hasSize(4));
+
+                    // Check all RoleBindings, easier to index by order applied
+                    assertThat(roleBindingNames.get(0), is("test-instance-entity-topic-operator-role"));
+                    assertThat(roleBindings.get(0), is(nullValue()));
+
+                    assertThat(roleBindingNames.get(1), is("strimzi-test-instance-entity-topic-operator"));
+                    assertThat(roleBindings.get(1), hasRoleRef(new RoleRefBuilder()
+                            .withApiGroup("rbac.authorization.k8s.io")
+                            .withKind("ClusterRole")
+                            .withName(EntityOperator.EO_CLUSTER_ROLE_NAME)
+                            .build()));
+
+                    assertThat(roleBindingNames.get(2), is("test-instance-entity-user-operator-role"));
+                    assertThat(roleBindings.get(2), is(nullValue()));
+
+                    assertThat(roleBindingNames.get(3), is("strimzi-test-instance-entity-user-operator"));
+                    assertThat(roleBindings.get(3), hasRoleRef(new RoleRefBuilder()
+                            .withApiGroup("rbac.authorization.k8s.io")
+                            .withKind("ClusterRole")
+                            .withName(EntityOperator.EO_CLUSTER_ROLE_NAME)
+                            .build()));
+
+                    async.flag();
+                })));
+    }
+
+    /**
+     * This test checks that when STRIMZI_RBAC_SCOPE feature is set to 'namespace', the cluster operator
+     * binds to ClusterRoles when it can't use Roles due to cross namespace permissions
+     */
+    @Test
+    public void testRoleBindingForClusterRoleDeployedWhenNamespaceRbacScopeAndMultiWatchNamespace(VertxTestContext context) {
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                    .withName(clusterName)
+                    .withNamespace(namespace)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewKafka()
+                        .withReplicas(3)
+                    .endKafka()
+                    .withNewZookeeper()
+                        .withReplicas(3)
+                    .endZookeeper()
+                    .withNewEntityOperator()
+                        .withNewUserOperator()
+                            .withWatchedNamespace("other-ns")
+                        .endUserOperator()
+                        .withNewTopicOperator()
+                            .withWatchedNamespace("other-ns")
+                        .endTopicOperator()
+                    .endEntityOperator()
+                .endSpec()
+                .build();
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the CRD Operator for Kafka resources
+        CrdOperator mockKafkaOps = supplier.kafkaOperator;
+        when(mockKafkaOps.getAsync(eq(namespace), eq(clusterName))).thenReturn(Future.succeededFuture(kafka));
+        when(mockKafkaOps.get(eq(namespace), eq(clusterName))).thenReturn(kafka);
+        when(mockKafkaOps.updateStatusAsync(any(Kafka.class))).thenReturn(Future.succeededFuture());
+
+        // Mock the operations for RoleBindings
+        RoleBindingOperator mockRoleBindingOps = supplier.roleBindingOperations;
+        // Capture the names of reconciled rolebindings and their patched state
+        ArgumentCaptor<String> roleBindingNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<RoleBinding> roleBindingCaptor = ArgumentCaptor.forClass(RoleBinding.class);
+        when(mockRoleBindingOps.reconcile(anyString(), roleBindingNameCaptor.capture(), roleBindingCaptor.capture()))
+                .thenReturn(Future.succeededFuture());
+
+        KafkaAssemblyOperatorRolesSubset kao = new KafkaAssemblyOperatorRolesSubset(
+                vertx,
+                new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                passwordGenerator,
+                supplier,
+                configRolesOnly);
+
+        Checkpoint async = context.checkpoint();
+        kao.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    List<String> roleBindingNames = roleBindingNameCaptor.getAllValues();
+                    List<RoleBinding> roleBindings = roleBindingCaptor.getAllValues();
+
+                    assertThat(roleBindingNames, hasSize(6));
+                    assertThat(roleBindings, hasSize(6));
+
+
+                    // Check all RoleBindings, easier to index by order applied
+                    assertThat(roleBindingNames.get(0), is("test-instance-entity-topic-operator-role"));
+                    assertThat(roleBindings.get(0), is(nullValue()));
+
+                    assertThat(roleBindingNames.get(1), is("strimzi-test-instance-entity-topic-operator"));
+                    assertThat(roleBindings.get(1), hasRoleRef(new RoleRefBuilder()
+                            .withApiGroup("rbac.authorization.k8s.io")
+                            .withKind("ClusterRole")
+                            .withName(EntityOperator.EO_CLUSTER_ROLE_NAME)
+                            .build()));
+                    assertThat(roleBindings.get(1).getMetadata().getNamespace(), is("other-ns"));
+
+                    assertThat(roleBindingNames.get(2), is("strimzi-test-instance-entity-topic-operator"));
+                    assertThat(roleBindings.get(2), hasRoleRef(new RoleRefBuilder()
+                            .withApiGroup("rbac.authorization.k8s.io")
+                            .withKind("ClusterRole")
+                            .withName(EntityOperator.EO_CLUSTER_ROLE_NAME)
+                            .build()));
+                    assertThat(roleBindings.get(2).getMetadata().getNamespace(), is("test-ns"));
+
+                    assertThat(roleBindingNames.get(3), is("test-instance-entity-user-operator-role"));
+                    assertThat(roleBindings.get(3), is(nullValue()));
+
+                    assertThat(roleBindingNames.get(4), is("strimzi-test-instance-entity-user-operator"));
+                    assertThat(roleBindings.get(4), hasRoleRef(new RoleRefBuilder()
+                            .withApiGroup("rbac.authorization.k8s.io")
+                            .withKind("ClusterRole")
+                            .withName(EntityOperator.EO_CLUSTER_ROLE_NAME)
+                            .build()));
+                    assertThat(roleBindings.get(4).getMetadata().getNamespace(), is("other-ns"));
+
+                    assertThat(roleBindingNames.get(5), is("strimzi-test-instance-entity-user-operator"));
+                    assertThat(roleBindings.get(5), hasRoleRef(new RoleRefBuilder()
+                            .withApiGroup("rbac.authorization.k8s.io")
+                            .withKind("ClusterRole")
+                            .withName(EntityOperator.EO_CLUSTER_ROLE_NAME)
+                            .build()));
+                    assertThat(roleBindings.get(5).getMetadata().getNamespace(), is("test-ns"));
+
+                    async.flag();
+                })));
+    }
+
+    public static Matcher<RoleBinding> hasRoleRef(RoleRef roleRef) {
+        return new TypeSafeDiagnosingMatcher<RoleBinding>() {
+
+            @Override
+            public void describeTo(final Description description) {
+                description.appendText("Expected Role Reference ").appendValue(roleRef);
+            }
+
+            @Override
+            protected boolean matchesSafely(RoleBinding actual, Description mismatchDescription) {
+                boolean matches = roleRef.equals(actual.getRoleRef());
+                if (!matches) {
+                    mismatchDescription.appendText(" was ").appendValue(actual.getRoleRef())
+                    .appendText(" in ").appendValue(actual);
+                }
+
+                return matches;
+            }
+        };
+    }
+
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorRbacScopeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorRbacScopeTest.java
@@ -94,6 +94,8 @@ public class KafkaAssemblyOperatorRbacScopeTest {
         Future<Void> reconcile(ReconciliationState reconcileState)  {
             return reconcileState.getEntityOperatorDescription()
                     .compose(state -> state.entityOperatorRole())
+                    .compose(state -> state.entityUserOperatorRole())
+                    .compose(state -> state.entityTopicOperatorRole())
                     .compose(state -> state.entityOperatorServiceAccount())
                     .compose(state -> state.entityOperatorTopicOpRoleBindingForRole())
                     .compose(state -> state.entityOperatorUserOpRoleBindingForRole())

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -167,7 +167,7 @@ public class KafkaConnectorIT {
                 new ResourceOperatorSupplier(
                         null, null, null, null, null, null, null, null, null, null, null,
                         null, null, null, null, null, null, null, null, null, null, null,
-                        null, connectCrdOperator, null, null, null, null, null, metrics, null),
+                        null, null, connectCrdOperator, null, null, null, null, null, metrics, null),
                 ClusterOperatorConfig.fromMap(Collections.emptyMap(), KafkaVersionTestUtils.getKafkaVersionLookup()),
             connect -> new KafkaConnectApiImpl(vertx),
             connectCluster.getPort() + 2

--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -214,6 +214,7 @@ All environment variables are defined in [Environment](systemtest/src/main/java/
 | OPERATOR_IMAGE_PULL_POLICY             | Image Pull Policy for Operator image                                                     | Always                                           |
 | COMPONENTS_IMAGE_PULL_POLICY           | Image Pull Policy for Kafka, Bridge, etc.                                                | IfNotPresent                                     |
 | STRIMZI_TEST_LOG_LEVEL                 | Log level for system tests                                                               | INFO                                             |
+| STRIMZI_RBAC_SCOPE               | Set to 'cluster' or 'namespace' to deploy the operator with ClusterRole or Roles respectively | cluster                                     |
 | OLM_OPERATOR_NAME                      | Operator name in manifests CSV                                                           | strimzi                                          |
 | OLM_SOURCE_NAME                        | CatalogSource name which contains desired operator                                       | strimzi-source                                   |
 | OLM_APP_BUNDLE_PREFIX                  | CSV bundle name                                                                          | strimzi                                          |

--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -214,7 +214,7 @@ All environment variables are defined in [Environment](systemtest/src/main/java/
 | OPERATOR_IMAGE_PULL_POLICY             | Image Pull Policy for Operator image                                                     | Always                                           |
 | COMPONENTS_IMAGE_PULL_POLICY           | Image Pull Policy for Kafka, Bridge, etc.                                                | IfNotPresent                                     |
 | STRIMZI_TEST_LOG_LEVEL                 | Log level for system tests                                                               | INFO                                             |
-| STRIMZI_RBAC_SCOPE               | Set to 'cluster' or 'namespace' to deploy the operator with ClusterRole or Roles respectively | cluster                                     |
+| STRIMZI_RBAC_SCOPE                     | Set to 'CLUSTER' or 'NAMESPACE' to deploy the operator with ClusterRole or Roles respectively | cluster                                     |
 | OLM_OPERATOR_NAME                      | Operator name in manifests CSV                                                           | strimzi                                          |
 | OLM_SOURCE_NAME                        | CatalogSource name which contains desired operator                                       | strimzi-source                                   |
 | OLM_APP_BUNDLE_PREFIX                  | CSV bundle name                                                                          | strimzi                                          |

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -24,6 +24,20 @@ rules:
   - patch
   - update
 - apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  # The cluster operator needs to access and manage roles to grant the entity operator permissions
+  # This is only needed if the STRIMZI_RBAC_SCOPE is set to 'namespace', otherwise ClusterRoles are used
+  - roles
+  # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
+  - rolebindings
+  verbs:
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
   - ""
   resources:
     # The cluster operator needs to access and delete pods, this is to allow it to monitor pod health and coordinate rolling updates

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -27,7 +27,6 @@ rules:
   - "rbac.authorization.k8s.io"
   resources:
   # The cluster operator needs to access and manage roles to grant the entity operator permissions
-  # This is only needed if the STRIMZI_RBAC_SCOPE is set to 'namespace', otherwise ClusterRoles are used
   - roles
   verbs:
   - get

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -30,6 +30,8 @@ rules:
   - roles
   verbs:
   - get
+  - list
+  - watch
   - create
   - delete
   - patch

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -29,8 +29,6 @@ rules:
   # The cluster operator needs to access and manage roles to grant the entity operator permissions
   # This is only needed if the STRIMZI_RBAC_SCOPE is set to 'namespace', otherwise ClusterRoles are used
   - roles
-  # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
-  - rolebindings
   verbs:
   - get
   - create

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -29,8 +29,6 @@ rules:
     # The cluster operator needs to access and manage roles to grant the entity operator permissions
     # This is only needed if the STRIMZI_RBAC_SCOPE is set to 'namespace', otherwise ClusterRoles are used
   - roles
-    # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
-  - rolebindings
   verbs:
   - get
   - create

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -30,6 +30,8 @@ rules:
   - roles
   verbs:
   - get
+  - list
+  - watch
   - create
   - delete
   - patch

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -32,11 +32,11 @@ rules:
     # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
   - rolebindings
   verbs:
-    - get
-    - create
-    - delete
-    - patch
-    - update
+  - get
+  - create
+  - delete
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -27,7 +27,6 @@ rules:
   - "rbac.authorization.k8s.io"
   resources:
     # The cluster operator needs to access and manage roles to grant the entity operator permissions
-    # This is only needed if the STRIMZI_RBAC_SCOPE is set to 'namespace', otherwise ClusterRoles are used
   - roles
   verbs:
   - get

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -24,6 +24,20 @@ rules:
   - patch
   - update
 - apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+    # The cluster operator needs to access and manage roles to grant the entity operator permissions
+    # This is only needed if the STRIMZI_RBAC_SCOPE is set to 'namespace', otherwise ClusterRoles are used
+  - roles
+    # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
+  - rolebindings
+  verbs:
+    - get
+    - create
+    - delete
+    - patch
+    - update
+- apiGroups:
   - ""
   resources:
     # The cluster operator needs to access and delete pods, this is to allow it to monitor pod health and coordinate rolling updates

--- a/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -8,15 +8,24 @@ rules:
   - apiGroups:
       - "rbac.authorization.k8s.io"
     resources:
-      # The cluster operator needs to access and manage roles to grant the entity operator permissions
-      # This is only needed if the STRIMZI_RBAC_SCOPE is set to 'namespace', otherwise ClusterRoles are used
-      - roles
       # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
       - rolebindings
     verbs:
       - get
       - list
       - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      # The cluster operator needs to access and manage roles to grant the entity operator permissions
+      # This is only needed if the STRIMZI_RBAC_SCOPE is set to 'namespace', otherwise ClusterRoles are used
+      - roles
+    verbs:
+      - get
       - create
       - delete
       - patch

--- a/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -25,6 +25,8 @@ rules:
       - roles
     verbs:
       - get
+      - list
+      - watch
       - create
       - delete
       - patch

--- a/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -8,6 +8,9 @@ rules:
   - apiGroups:
       - "rbac.authorization.k8s.io"
     resources:
+      # The cluster operator needs to access and manage roles to grant the entity operator permissions
+      # This is only needed if the STRIMZI_RBAC_SCOPE is set to 'namespace', otherwise ClusterRoles are used
+      - roles
       # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
       - rolebindings
     verbs:

--- a/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -22,7 +22,6 @@ rules:
       - "rbac.authorization.k8s.io"
     resources:
       # The cluster operator needs to access and manage roles to grant the entity operator permissions
-      # This is only needed if the STRIMZI_RBAC_SCOPE is set to 'namespace', otherwise ClusterRoles are used
       - roles
     verbs:
       - get

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
@@ -50,9 +50,12 @@ import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudgetList;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingList;
 import io.fabric8.kubernetes.api.model.rbac.DoneableClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.DoneableRole;
 import io.fabric8.kubernetes.api.model.rbac.DoneableRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.RoleBindingList;
+import io.fabric8.kubernetes.api.model.rbac.RoleList;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
@@ -117,6 +120,8 @@ public class MockKube {
     private final Map<String, PodDisruptionBudget> pdbDb = db(emptySet(), PodDisruptionBudget.class, DoneablePodDisruptionBudget.class);
     private final Map<String, RoleBinding> pdbRb = db(emptySet(), RoleBinding.class,
             DoneableRoleBinding.class);
+    private final Map<String, Role> roleDb = db(emptySet(), Role.class,
+            DoneableRole.class);
     private final Map<String, ClusterRoleBinding> pdbCrb = db(emptySet(), ClusterRoleBinding.class,
             DoneableClusterRoleBinding.class);
     private final Map<String, Ingress> ingressDb = db(emptySet(), Ingress.class,
@@ -130,6 +135,7 @@ public class MockKube {
     private MockBuilder<ServiceAccount, ServiceAccountList, DoneableServiceAccount, Resource<ServiceAccount, DoneableServiceAccount>> serviceAccountMockBuilder;
     private MockBuilder<Route, RouteList, DoneableRoute, Resource<Route, DoneableRoute>> routeMockBuilder;
     private MockBuilder<PodDisruptionBudget, PodDisruptionBudgetList, DoneablePodDisruptionBudget, Resource<PodDisruptionBudget, DoneablePodDisruptionBudget>> podDisruptionBudgedMockBuilder;
+    private MockBuilder<Role, RoleList, DoneableRole, Resource<Role, DoneableRole>> roleMockBuilder;
     private MockBuilder<RoleBinding, RoleBindingList, DoneableRoleBinding, Resource<RoleBinding, DoneableRoleBinding>> roleBindingMockBuilder;
     private MockBuilder<ClusterRoleBinding, ClusterRoleBindingList, DoneableClusterRoleBinding, Resource<ClusterRoleBinding, DoneableClusterRoleBinding>> clusterRoleBindingMockBuilder;
     private MockBuilder<NetworkPolicy, NetworkPolicyList, DoneableNetworkPolicy, Resource<NetworkPolicy, DoneableNetworkPolicy>> networkPolicyMockBuilder;
@@ -274,6 +280,7 @@ public class MockKube {
         routeMockBuilder = addMockBuilder("routes", new MockBuilder<>(Route.class, RouteList.class, DoneableRoute.class, MockBuilder.castClass(Resource.class), routeDb));
         podDisruptionBudgedMockBuilder = addMockBuilder("poddisruptionbudgets", new MockBuilder<>(PodDisruptionBudget.class, PodDisruptionBudgetList.class, DoneablePodDisruptionBudget.class, MockBuilder.castClass(Resource.class), pdbDb));
         roleBindingMockBuilder = addMockBuilder("rolebindings", new MockBuilder<>(RoleBinding.class, RoleBindingList.class, DoneableRoleBinding.class, MockBuilder.castClass(Resource.class), pdbRb));
+        roleMockBuilder = addMockBuilder("roles", new MockBuilder<>(Role.class, RoleList.class, DoneableRole.class, MockBuilder.castClass(Resource.class), roleDb));
         clusterRoleBindingMockBuilder = addMockBuilder("clusterrolebindings", new MockBuilder<>(ClusterRoleBinding.class, ClusterRoleBindingList.class, DoneableClusterRoleBinding.class, MockBuilder.castClass(Resource.class), pdbCrb));
         networkPolicyMockBuilder = addMockBuilder("networkpolicies", new MockBuilder<>(NetworkPolicy.class, NetworkPolicyList.class, DoneableNetworkPolicy.class, MockBuilder.castClass(Resource.class), policyDb));
         ingressMockBuilder = addMockBuilder("ingresses",  new MockBuilder<>(Ingress.class, IngressList.class, DoneableIngress.class, MockBuilder.castClass(Resource.class), ingressDb));
@@ -347,6 +354,7 @@ public class MockKube {
         RbacAPIGroupDSL rbac = mock(RbacAPIGroupDSL.class);
         when(mockClient.rbac()).thenReturn(rbac);
         roleBindingMockBuilder.build2(mockClient.rbac()::roleBindings);
+        roleMockBuilder.build2(mockClient.rbac()::roles);
         clusterRoleBindingMockBuilder.build2(mockClient.rbac()::clusterRoleBindings);
 
         // Openshift group

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -528,16 +528,16 @@ public abstract class AbstractOperator<
      */
     public Future<ReconcileResult<ClusterRoleBinding>> withIgnoreRbacError(Future<ReconcileResult<ClusterRoleBinding>> reconcileFuture, ClusterRoleBinding desired) {
         return reconcileFuture.compose(
-                rr -> Future.succeededFuture(),
-                e -> {
-                    if (desired == null
-                            && e.getMessage() != null
-                            && e.getMessage().contains("Message: Forbidden!")) {
-                        log.debug("Ignoring forbidden access to ClusterRoleBindings resource which does not seem to be required.");
-                        return Future.succeededFuture();
-                    }
-                    return Future.failedFuture(e.getMessage());
+            rr -> Future.succeededFuture(),
+            e -> {
+                if (desired == null
+                        && e.getMessage() != null
+                        && e.getMessage().contains("Message: Forbidden!")) {
+                    log.debug("Ignoring forbidden access to ClusterRoleBindings resource which does not seem to be required.");
+                    return Future.succeededFuture();
                 }
+                return Future.failedFuture(e.getMessage());
+            }
         );
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RoleBindingOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RoleBindingOperator.java
@@ -13,10 +13,12 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.vertx.core.Vertx;
 
 
-public class RoleBindingOperator extends AbstractResourceOperator<KubernetesClient, RoleBinding,
-        RoleBindingList, DoneableRoleBinding, Resource<RoleBinding,
-        DoneableRoleBinding>> {
-
+public class RoleBindingOperator extends AbstractResourceOperator<
+        KubernetesClient,
+        RoleBinding,
+        RoleBindingList,
+        DoneableRoleBinding,
+        Resource<RoleBinding, DoneableRoleBinding>> {
     /**
      * Constructor
      * @param vertx The Vertx instance

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RoleOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RoleOperator.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource;
+
+import io.fabric8.kubernetes.api.model.rbac.DoneableRole;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Vertx;
+
+public class RoleOperator extends AbstractResourceOperator<
+        KubernetesClient,
+        Role,
+        RoleList,
+        DoneableRole,
+        Resource<Role, DoneableRole>> {
+
+    /**
+     * Constructor
+     * @param vertx The Vertx instance
+     * @param client The Kubernetes client
+     */
+    public RoleOperator(Vertx vertx, KubernetesClient client) {
+        super(vertx, client, "Role");
+    }
+
+    @Override
+    protected MixedOperation<Role, RoleList, DoneableRole, Resource<Role, DoneableRole>> operation() {
+        return client.rbac().roles();
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleOperatorIT.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource;
+
+import io.fabric8.kubernetes.api.model.rbac.DoneableRole;
+import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
+import io.fabric8.kubernetes.api.model.rbac.PolicyRuleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.RoleList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(VertxExtension.class)
+public class RoleOperatorIT extends AbstractResourceOperatorIT<
+        KubernetesClient,
+        Role,
+        RoleList,
+        DoneableRole,
+        Resource<Role, DoneableRole>> {
+
+    @Override
+    protected AbstractResourceOperator<
+            KubernetesClient,
+            Role,
+            RoleList,
+            DoneableRole,
+            Resource<Role, DoneableRole>> operator() {
+        return new RoleOperator(vertx, client);
+    }
+
+    @Override
+    protected Role getOriginal()  {
+        PolicyRule rule = new PolicyRuleBuilder()
+                .withApiGroups("")
+                .withResources("pods")
+                .withVerbs("get")
+                .build();
+
+        return new RoleBuilder()
+                .withNewMetadata()
+                    .withName(resourceName)
+                    .withNamespace(namespace)
+                    .withLabels(singletonMap("state", "new"))
+                .endMetadata()
+                .withRules(rule)
+                .build();
+    }
+
+    @Override
+    protected Role getModified()  {
+        PolicyRule rule = new PolicyRuleBuilder()
+                .withApiGroups("")
+                .withResources("pods")
+                .withVerbs("get", "list")
+                .build();
+
+        return new RoleBuilder()
+                .withNewMetadata()
+                    .withName(resourceName)
+                    .withNamespace(namespace)
+                    .withLabels(singletonMap("state", "modified"))
+                .endMetadata()
+                .withRules(rule)
+                .build();
+    }
+
+    @Override
+    protected void assertResources(VertxTestContext context, Role expected, Role actual)   {
+        context.verify(() -> assertThat(actual.getMetadata().getName(), is(expected.getMetadata().getName())));
+        context.verify(() -> assertThat(actual.getMetadata().getNamespace(), is(expected.getMetadata().getNamespace())));
+        context.verify(() -> assertThat(actual.getMetadata().getLabels(), is(expected.getMetadata().getLabels())));
+        context.verify(() -> assertThat(actual.getRules().size(), is(expected.getRules().size())));
+        context.verify(() -> assertThat(actual.getRules().get(0).getApiGroups(), is(expected.getRules().get(0).getApiGroups())));
+        context.verify(() -> assertThat(actual.getRules().get(0).getResources(), is(expected.getRules().get(0).getResources())));
+        context.verify(() -> assertThat(actual.getRules().get(0).getVerbs(), is(expected.getRules().get(0).getVerbs())));
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleOperatorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource;
+
+import io.fabric8.kubernetes.api.model.rbac.DoneableRole;
+import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
+import io.fabric8.kubernetes.api.model.rbac.PolicyRuleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.RoleList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.RbacAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Vertx;
+
+import static java.util.Collections.singletonMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RoleOperatorTest extends AbstractResourceOperatorTest<
+        KubernetesClient,
+        Role,
+        RoleList,
+        DoneableRole,
+        Resource<Role, DoneableRole>> {
+
+    @Override
+    protected Class<KubernetesClient> clientType() {
+        return KubernetesClient.class;
+    }
+
+    @Override
+    protected Class<? extends Resource> resourceType() {
+        return Resource.class;
+    }
+
+    @Override
+    protected Role resource() {
+        PolicyRule rule = new PolicyRuleBuilder()
+                .withApiGroups("somegroup")
+                .addNewVerb("someverb")
+                .build();
+
+        return new RoleBuilder()
+                .withNewMetadata()
+                    .withName(RESOURCE_NAME)
+                    .withNamespace(NAMESPACE)
+                    .withLabels(singletonMap("foo", "bar"))
+                .endMetadata()
+                .withRules(rule)
+                .build();
+    }
+
+    @Override
+    protected void mocker(KubernetesClient mockClient, MixedOperation op) {
+        RbacAPIGroupDSL mockRbac = mock(RbacAPIGroupDSL.class);
+        when(mockClient.rbac()).thenReturn(mockRbac);
+        when(mockClient.rbac().roles()).thenReturn(op);
+    }
+
+    @Override
+    protected AbstractResourceOperator<KubernetesClient, Role, RoleList, DoneableRole,
+            Resource<Role, DoneableRole>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
+        return new RoleOperator(vertx, mockClient);
+    }
+}

--- a/systemtest/scripts/run_tests.sh
+++ b/systemtest/scripts/run_tests.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -x
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 TESTCASE=${1:-.*ST}
@@ -9,12 +10,23 @@ function run_test() {
     PROFILE=${2:-systemtests}
 
     if [[ -n "${TESTCASE}" ]]; then
-        EXTRA_TEST_ARGS="-Dit.test=${TESTCASE}"
+        # Concatenate user specified EXTRA_TEST_ARGS if supplied
+        EXTRA_TEST_ARGS="-Dit.test=${TESTCASE} ${EXTRA_TEST_ARGS}"
     fi
 
     echo "Extra args for tests: ${EXTRA_TEST_ARGS}"
 
-    pushd "${SCRIPT_DIR}"/../.. && mvn -B verify -pl systemtest -am -P"${PROFILE}" -Djava.net.preferIPv4Stack=true -DfailIfNoTests=false -Djansi.force=true -Dstyle.color=always -DtrimStackTrace=false "${EXTRA_TEST_ARGS}"
+    pushd "${SCRIPT_DIR}"/../.. && \
+    mvn -B verify \
+      -pl systemtest \
+      -am \
+      -P"${PROFILE}" \
+      -Djava.net.preferIPv4Stack=true \
+      -DfailIfNoTests=false \
+      -Djansi.force=true \
+      -Dstyle.color=always \
+      -DtrimStackTrace=false \
+      ${EXTRA_TEST_ARGS}
     popd || exit
 }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -86,6 +86,11 @@ public class Environment {
      */
     private static final String STRIMZI_FULL_RECONCILIATION_INTERVAL_MS_ENV = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
     /**
+     * CO Roles only mode.
+     */
+    private static final String STRIMZI_RBAC_SCOPE_ENV = "STRIMZI_RBAC_SCOPE";
+    private static final String STRIMZI_RBAC_SCOPE_DEFAULT = "cluster";
+    /**
      * OLM env variables
      */
     private static final String OLM_OPERATOR_NAME_ENV = "OLM_OPERATOR_NAME";
@@ -135,6 +140,7 @@ public class Environment {
     public static final String STRIMZI_LOG_LEVEL = getOrDefault(STRIMZI_LOG_LEVEL_ENV, STRIMZI_LOG_LEVEL_DEFAULT);
     public static final String KUBERNETES_DOMAIN = getOrDefault(KUBERNETES_DOMAIN_ENV, KUBERNETES_DOMAIN_DEFAULT);
     public static final boolean SKIP_TEARDOWN = getOrDefault(SKIP_TEARDOWN_ENV, Boolean::parseBoolean, false);
+    public static final String STRIMZI_RBAC_SCOPE = getOrDefault(STRIMZI_RBAC_SCOPE_ENV, STRIMZI_RBAC_SCOPE_DEFAULT);
     // variables for test-client image
     private static final String TEST_CLIENT_IMAGE_DEFAULT = STRIMZI_REGISTRY + "/" + STRIMZI_ORG + "/test-client:" + STRIMZI_TAG + "-kafka-" + ST_KAFKA_VERSION;
     public static final String TEST_CLIENT_IMAGE = getOrDefault(TEST_CLIENT_IMAGE_ENV, TEST_CLIENT_IMAGE_DEFAULT);
@@ -171,6 +177,10 @@ public class Environment {
 
     public static boolean isHelmInstall() {
         return CLUSTER_OPERATOR_INSTALL_TYPE.equals(ClusterOperatorInstallType.HELM);
+    }
+
+    public static boolean isNamespaceRbacScope() {
+        return "namespace".equals(STRIMZI_RBAC_SCOPE);
     }
 
     public static boolean useLatestReleasedBridge() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -89,7 +89,7 @@ public class Environment {
      * CO Roles only mode.
      */
     private static final String STRIMZI_RBAC_SCOPE_ENV = "STRIMZI_RBAC_SCOPE";
-    private static final String STRIMZI_RBAC_SCOPE_DEFAULT = "cluster";
+    private static final String STRIMZI_RBAC_SCOPE_DEFAULT = "CLUSTER";
     /**
      * OLM env variables
      */
@@ -180,7 +180,7 @@ public class Environment {
     }
 
     public static boolean isNamespaceRbacScope() {
-        return "namespace".equals(STRIMZI_RBAC_SCOPE);
+        return "NAMESPACE".equals(STRIMZI_RBAC_SCOPE);
     }
 
     public static boolean useLatestReleasedBridge() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -89,7 +89,10 @@ public class Environment {
      * CO Roles only mode.
      */
     private static final String STRIMZI_RBAC_SCOPE_ENV = "STRIMZI_RBAC_SCOPE";
-    private static final String STRIMZI_RBAC_SCOPE_DEFAULT = "CLUSTER";
+    private static final String STRIMZI_RBAC_SCOPE_CLUSTER = "CLUSTER";
+    private static final String STRIMZI_RBAC_SCOPE_NAMESPACE = "NAMESPACE";
+    private static final String STRIMZI_RBAC_SCOPE_DEFAULT = STRIMZI_RBAC_SCOPE_CLUSTER;
+
     /**
      * OLM env variables
      */
@@ -180,7 +183,7 @@ public class Environment {
     }
 
     public static boolean isNamespaceRbacScope() {
-        return "NAMESPACE".equals(STRIMZI_RBAC_SCOPE);
+        return STRIMZI_RBAC_SCOPE_NAMESPACE.equals(STRIMZI_RBAC_SCOPE);
     }
 
     public static boolean useLatestReleasedBridge() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
@@ -88,6 +88,10 @@ public class KubernetesResource {
     public static DoneableRoleBinding roleBinding(String yamlPath, String namespace, String clientNamespace) {
         LOGGER.info("Creating RoleBinding from {} in namespace {}", yamlPath, namespace);
         RoleBinding roleBinding = getRoleBindingFromYaml(yamlPath);
+        if (Environment.isNamespaceRbacScope()) {
+            LOGGER.info("Replacing ClusterRole RoleRef for Role RoleRef");
+            roleBinding.getRoleRef().setKind("Role");
+        }
         return roleBinding(
                 new RoleBindingBuilder(roleBinding)
                     .editFirstSubject()

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
@@ -88,10 +88,13 @@ public class KubernetesResource {
     public static DoneableRoleBinding roleBinding(String yamlPath, String namespace, String clientNamespace) {
         LOGGER.info("Creating RoleBinding from {} in namespace {}", yamlPath, namespace);
         RoleBinding roleBinding = getRoleBindingFromYaml(yamlPath);
-        return roleBinding(new RoleBindingBuilder(roleBinding)
-            .editFirstSubject()
-                .withNamespace(namespace)
-            .endSubject().build(), clientNamespace);
+        return roleBinding(
+                new RoleBindingBuilder(roleBinding)
+                    .editFirstSubject()
+                        .withNamespace(namespace)
+                    .endSubject()
+                    .build(),
+                clientNamespace);
     }
 
     private static DoneableRoleBinding roleBinding(RoleBinding roleBinding, String clientNamespace) {
@@ -100,16 +103,18 @@ public class KubernetesResource {
         return new DoneableRoleBinding(roleBinding);
     }
 
-    public static DoneableClusterRoleBinding clusterRoleBinding(String yamlPath, String namespace, String clientNamespace) {
+    public static DoneableClusterRoleBinding clusterRoleBinding(String yamlPath, String namespace) {
         LOGGER.info("Creating ClusterRoleBinding from {} in namespace {}", yamlPath, namespace);
         ClusterRoleBinding clusterRoleBinding = getClusterRoleBindingFromYaml(yamlPath);
-        return clusterRoleBinding(new ClusterRoleBindingBuilder(clusterRoleBinding)
-            .editFirstSubject()
-                .withNamespace(namespace)
-            .endSubject().build(), clientNamespace);
+        return clusterRoleBinding(
+                new ClusterRoleBindingBuilder(clusterRoleBinding)
+                    .editFirstSubject()
+                        .withNamespace(namespace)
+                    .endSubject()
+                    .build());
     }
 
-    public static DoneableClusterRoleBinding clusterRoleBinding(ClusterRoleBinding clusterRoleBinding, String clientNamespace) {
+    public static DoneableClusterRoleBinding clusterRoleBinding(ClusterRoleBinding clusterRoleBinding) {
         ResourceManager.kubeClient().createOrReplaceClusterRoleBinding(clusterRoleBinding);
         deleteLater(clusterRoleBinding);
         return new DoneableClusterRoleBinding(clusterRoleBinding);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
@@ -74,6 +74,7 @@ public class BundleResource {
 
         envVars.add(new EnvVar("STRIMZI_IMAGE_PULL_POLICY", Environment.COMPONENTS_IMAGE_PULL_POLICY, null));
         envVars.add(new EnvVar("STRIMZI_LOG_LEVEL", Environment.STRIMZI_LOG_LEVEL, null));
+        envVars.add(new EnvVar("STRIMZI_RBAC_SCOPE", Environment.STRIMZI_RBAC_SCOPE, null));
         // Apply updated env variables
         clusterOperator.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(envVars);
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/OlmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/OlmResource.java
@@ -240,7 +240,9 @@ public class OlmResource {
                     .replace("${OLM_OPERATOR_VERSION}", version)
                     .replace("${OLM_INSTALL_PLAN_APPROVAL}", installationStrategy.toString())
                     .replace("${STRIMZI_FULL_RECONCILIATION_INTERVAL_MS}", Long.toString(reconciliationInterval))
-                    .replace("${STRIMZI_OPERATION_TIMEOUT_MS}", Long.toString(operationTimeout)));
+                    .replace("${STRIMZI_OPERATION_TIMEOUT_MS}", Long.toString(operationTimeout))
+                    .replace("${STRIMZI_RBAC_SCOPE}", Environment.STRIMZI_RBAC_SCOPE));
+
 
             ResourceManager.cmdKubeClient().apply(subscriptionFile);
         }  catch (IOException e) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/TracingUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/TracingUtils.java
@@ -37,7 +37,7 @@ public class TracingUtils {
     }
 
     private static void verifyThatServiceIsPresent(String jaegerServiceName, String clientPodName) {
-        TestUtils.waitFor("Service" + jaegerServiceName + " is present", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT, () -> {
+        TestUtils.waitFor("Service " + jaegerServiceName + " is present", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT, () -> {
             JsonObject jaegerServices = new JsonObject(cmdKubeClient().execInPod(clientPodName, "/bin/bash", "-c", "curl " + JAEGER_QUERY_SERVICE + ":" + JAEGER_QUERY_PORT + JAEGER_QUERY_SERVICE_ENDPOINT).out());
 
             if (jaegerServices.getJsonArray("data").contains(jaegerServiceName)) {

--- a/systemtest/src/main/resources/olm/subscription.yaml
+++ b/systemtest/src/main/resources/olm/subscription.yaml
@@ -20,4 +20,5 @@ spec:
         value: "${STRIMZI_FULL_RECONCILIATION_INTERVAL_MS}"
       - name: STRIMZI_OPERATION_TIMEOUT_MS
         value: "${STRIMZI_OPERATION_TIMEOUT_MS}"
-
+      - name: STRIMZI_RBAC_SCOPE
+        value: "${STRIMZI_RBAC_SCOPE}"

--- a/systemtest/src/main/resources/olm/subscription.yaml
+++ b/systemtest/src/main/resources/olm/subscription.yaml
@@ -20,5 +20,3 @@ spec:
         value: "${STRIMZI_FULL_RECONCILIATION_INTERVAL_MS}"
       - name: STRIMZI_OPERATION_TIMEOUT_MS
         value: "${STRIMZI_OPERATION_TIMEOUT_MS}"
-      - name: STRIMZI_RBAC_SCOPE
-        value: "${STRIMZI_RBAC_SCOPE}"

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -174,6 +174,7 @@ public abstract class AbstractST implements TestSeparator {
         for (Map.Entry<File, String> entry : operatorFiles.entrySet()) {
             LOGGER.info("Applying configuration file: {}", entry.getKey());
             if (Environment.isNamespaceRbacScope()) {
+                LOGGER.info("as Role");
                 switchClusterRolesToRoles(entry.getValue());
             }
             clusterOperatorConfigs.push(entry.getKey().getPath());

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -43,14 +43,17 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Stack;
 import java.util.stream.Collectors;
 
 import static io.strimzi.systemtest.matchers.Matchers.logHasNoUnexpectedErrors;
@@ -93,6 +96,9 @@ public abstract class AbstractST implements TestSeparator {
     protected String testClass;
     protected String testName;
 
+    private Stack<String> clusterOperatorConfigs = new Stack<>();
+    public static final String CO_INSTALL_DIR = TestUtils.USER_PATH + "/../install/cluster-operator";
+
     public static Random rng = new Random();
 
     public static final int MESSAGE_COUNT = 100;
@@ -129,7 +135,12 @@ public abstract class AbstractST implements TestSeparator {
         } else {
             LOGGER.info("Going to install ClusterOperator via Yaml bundle");
             prepareEnvForOperator(namespace, bindingsNamespaces);
-            applyRoleBindings(namespace, bindingsNamespaces);
+            if (Environment.isNamespaceRbacScope()) {
+                // if roles only, only deploy the rolebindings
+                applyRoleBindings(namespace, namespace);
+            } else {
+                applyBindings(namespace, bindingsNamespaces);
+            }
             // 060-Deployment
             BundleResource.clusterOperator(namespace, operationTimeout, reconciliationInterval).done();
         }
@@ -148,6 +159,48 @@ public abstract class AbstractST implements TestSeparator {
     }
 
     /**
+     * Perform application of ServiceAccount, Roles and CRDs needed for proper cluster operator deployment.
+     * Configuration files are loaded from install/cluster-operator directory.
+     */
+    public void applyClusterOperatorInstallFiles(String namespace) {
+        clusterOperatorConfigs.clear();
+        Map<File, String> operatorFiles = Arrays.stream(new File(CO_INSTALL_DIR).listFiles()).sorted()
+                .filter(file ->
+                        !file.getName().matches(".*(Binding|Deployment)-.*"))
+                .collect(Collectors.toMap(
+                    file -> file,
+                    f -> TestUtils.getContent(f, TestUtils::toYamlString),
+                    (x, y) -> x, LinkedHashMap::new));
+        for (Map.Entry<File, String> entry : operatorFiles.entrySet()) {
+            LOGGER.info("Applying configuration file: {}", entry.getKey());
+            if (Environment.isNamespaceRbacScope()) {
+                switchClusterRolesToRoles(entry.getValue());
+            }
+            clusterOperatorConfigs.push(entry.getKey().getPath());
+            cmdKubeClient().clientWithAdmin().namespace(namespace).apply(entry.getKey().getPath());
+        }
+    }
+
+    /**
+     * Replace all references to ClusterRole to Role.
+     * This includes ClusterRoles themselves as well as RoleBindings that reference them.
+     */
+    private void switchClusterRolesToRoles(String fileContents) {
+        fileContents.replace("ClusterRole", "Role");
+    }
+
+    /**
+     * Delete ServiceAccount, Roles and CRDs from kubernetes cluster.
+     */
+    public void deleteClusterOperatorInstallFiles() {
+        while (!clusterOperatorConfigs.empty()) {
+            String clusterOperatorConfig = clusterOperatorConfigs.pop();
+            LOGGER.info("Deleting configuration file: {}", clusterOperatorConfig);
+            cmdKubeClient().clientWithAdmin().delete(clusterOperatorConfig);
+        }
+    }
+
+    /**
      * Prepare environment for cluster operator which includes creation of namespaces, custom resources and operator
      * specific config files such as ServiceAccount, Roles and CRDs.
      * @param clientNamespace namespace which will be created and used as default by kube client
@@ -158,7 +211,7 @@ public abstract class AbstractST implements TestSeparator {
         assumeTrue(!Environment.isHelmInstall() && !Environment.isOlmInstall());
         cluster.createNamespaces(clientNamespace, namespaces);
         cluster.createCustomResources(resources);
-        cluster.applyClusterOperatorInstallFiles();
+        applyClusterOperatorInstallFiles(clientNamespace);
         KubernetesResource.applyDefaultNetworkPolicySettings(namespaces);
 
         if (cluster.cluster() instanceof Minishift || cluster.cluster() instanceof OpenShift) {
@@ -193,30 +246,20 @@ public abstract class AbstractST implements TestSeparator {
      * Clear cluster from all created namespaces and configurations files for cluster operator.
      */
     protected void teardownEnvForOperator() {
-        cluster.deleteClusterOperatorInstallFiles();
+        deleteClusterOperatorInstallFiles();
         cluster.deleteCustomResources();
         cluster.deleteNamespaces();
     }
 
     /**
-     * Method for apply Strimzi cluster operator specific Role and ClusterRole bindings for specific namespaces.
+     * Method to apply Strimzi cluster operator specific RoleBindings and ClusterRoleBindings for specific namespaces.
      * @param namespace namespace where CO will be deployed to
      * @param bindingsNamespaces list of namespaces where Bindings should be deployed to
      */
-    public static void applyRoleBindings(String namespace, List<String> bindingsNamespaces) {
+    public static void applyBindings(String namespace, List<String> bindingsNamespaces) {
         for (String bindingsNamespace : bindingsNamespaces) {
-            // 020-RoleBinding
-            KubernetesResource.roleBinding(TestUtils.USER_PATH + "/../install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml", namespace, bindingsNamespace);
-            // 021-ClusterRoleBinding
-            KubernetesResource.clusterRoleBinding(TestUtils.USER_PATH + "/../install/cluster-operator/021-ClusterRoleBinding-strimzi-cluster-operator.yaml", namespace, bindingsNamespace);
-            // 030-ClusterRoleBinding
-            KubernetesResource.clusterRoleBinding(TestUtils.USER_PATH + "/../install/cluster-operator/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml", namespace, bindingsNamespace);
-            // 031-RoleBinding
-            KubernetesResource.roleBinding(TestUtils.USER_PATH + "/../install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml", namespace, bindingsNamespace);
-            // 032-RoleBinding
-            KubernetesResource.roleBinding(TestUtils.USER_PATH + "/../install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml", namespace, bindingsNamespace);
-            // 033-ClusterRoleBinding
-            KubernetesResource.clusterRoleBinding(TestUtils.USER_PATH + "/../install/cluster-operator/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-client-delegation.yaml", namespace, bindingsNamespace);
+            applyClusterRoleBindings(namespace);
+            applyRoleBindings(namespace, bindingsNamespace);
         }
     }
 
@@ -224,8 +267,8 @@ public abstract class AbstractST implements TestSeparator {
      * Method for apply Strimzi cluster operator specific Role and ClusterRole bindings for specific namespaces.
      * @param namespace namespace where CO will be deployed to
      */
-    public static void applyRoleBindings(String namespace) {
-        applyRoleBindings(namespace, Collections.singletonList(namespace));
+    public static void applyBindings(String namespace) {
+        applyBindings(namespace, Collections.singletonList(namespace));
     }
 
     /**
@@ -233,8 +276,26 @@ public abstract class AbstractST implements TestSeparator {
      * @param namespace namespace where CO will be deployed to
      * @param bindingsNamespaces array of namespaces where Bindings should be deployed to
      */
-    public static void applyRoleBindings(String namespace, String... bindingsNamespaces) {
-        applyRoleBindings(namespace, Arrays.asList(bindingsNamespaces));
+    public static void applyBindings(String namespace, String... bindingsNamespaces) {
+        applyBindings(namespace, Arrays.asList(bindingsNamespaces));
+    }
+
+    private static void applyClusterRoleBindings(String namespace) {
+        // 021-ClusterRoleBinding
+        KubernetesResource.clusterRoleBinding(TestUtils.USER_PATH + "/../install/cluster-operator/021-ClusterRoleBinding-strimzi-cluster-operator.yaml", namespace);
+        // 030-ClusterRoleBinding
+        KubernetesResource.clusterRoleBinding(TestUtils.USER_PATH + "/../install/cluster-operator/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml", namespace);
+        // 033-ClusterRoleBinding
+        KubernetesResource.clusterRoleBinding(TestUtils.USER_PATH + "/../install/cluster-operator/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-client-delegation.yaml", namespace);
+    }
+
+    private static void applyRoleBindings(String namespace, String bindingsNamespace) {
+        // 020-RoleBinding
+        KubernetesResource.roleBinding(TestUtils.USER_PATH + "/../install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml", namespace, bindingsNamespace);
+        // 031-RoleBinding
+        KubernetesResource.roleBinding(TestUtils.USER_PATH + "/../install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml", namespace, bindingsNamespace);
+        // 032-RoleBinding
+        KubernetesResource.roleBinding(TestUtils.USER_PATH + "/../install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml", namespace, bindingsNamespace);
     }
 
     protected void assertResources(String namespace, String podName, String containerName, String memoryLimit, String cpuLimit, String memoryRequest, String cpuRequest) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -716,11 +716,11 @@ class ConnectST extends AbstractST {
 
         KafkaConnectorResource.kafkaConnector(CLUSTER_NAME)
                 .editSpec()
-                .withClassName("org.apache.kafka.connect.file.FileStreamSinkConnector")
-                .addToConfig("topics", TOPIC_NAME)
-                .addToConfig("file", Constants.DEFAULT_SINK_FILE_PATH)
-                .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
-                .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
+                    .withClassName("org.apache.kafka.connect.file.FileStreamSinkConnector")
+                    .addToConfig("topics", TOPIC_NAME)
+                    .addToConfig("file", Constants.DEFAULT_SINK_FILE_PATH)
+                    .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
+                    .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
                 .endSpec().done();
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -39,6 +39,7 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
@@ -98,6 +99,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @Tag(REGRESSION)
 @SuppressWarnings("checkstyle:ClassFanOutComplexity")
@@ -719,6 +721,9 @@ class KafkaST extends AbstractST {
 
     @Test
     void testRemoveUserAndTopicOperatorsFromEntityOperator() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
+
         LOGGER.info("Deploying Kafka cluster {}", CLUSTER_NAME);
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_DEPLOYMENT));
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -721,7 +721,7 @@ class KafkaST extends AbstractST {
 
     @Test
     void testRemoveUserAndTopicOperatorsFromEntityOperator() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         LOGGER.info("Deploying Kafka cluster {}", CLUSTER_NAME);

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
@@ -10,7 +10,6 @@ import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBui
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
 import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
@@ -74,10 +73,8 @@ public class MultipleListenersST extends AbstractST {
         List<GenericKafkaListener> internalListeners = testCases.get(KafkaListenerType.INTERNAL);
         multipleDifferentListeners.addAll(internalListeners);
 
-        if (!Environment.isNamespaceRbacScope()) {
-            List<GenericKafkaListener> nodeportListeners = testCases.get(KafkaListenerType.NODEPORT);
-            multipleDifferentListeners.addAll(nodeportListeners);
-        }
+        List<GenericKafkaListener> nodeportListeners = testCases.get(KafkaListenerType.NODEPORT);
+        multipleDifferentListeners.addAll(nodeportListeners);
 
         // run INTERNAL + NODEPORT listeners
         runListenersTest(multipleDifferentListeners);

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBui
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
 import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
@@ -71,10 +72,12 @@ public class MultipleListenersST extends AbstractST {
         List<GenericKafkaListener> multipleDifferentListeners = new ArrayList<>();
 
         List<GenericKafkaListener> internalListeners = testCases.get(KafkaListenerType.INTERNAL);
-        List<GenericKafkaListener> nodeportListeners = testCases.get(KafkaListenerType.NODEPORT);
-
         multipleDifferentListeners.addAll(internalListeners);
-        multipleDifferentListeners.addAll(nodeportListeners);
+
+        if (!Environment.isNamespaceRbacScope()) {
+            List<GenericKafkaListener> nodeportListeners = testCases.get(KafkaListenerType.NODEPORT);
+            multipleDifferentListeners.addAll(nodeportListeners);
+        }
 
         // run INTERNAL + NODEPORT listeners
         runListenersTest(multipleDifferentListeners);

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/ClusterOperatorRbacST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/ClusterOperatorRbacST.java
@@ -6,6 +6,7 @@ package io.strimzi.systemtest.operators;
 
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
@@ -28,6 +29,7 @@ import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @Tag(REGRESSION)
 public class ClusterOperatorRbacST extends AbstractST {
@@ -37,6 +39,7 @@ public class ClusterOperatorRbacST extends AbstractST {
     @Test
     @Tag(CONNECT)
     void testCRBDeletionErrorIsIgnoredWhenRackAwarenessIsNotEnabled() {
+        assumeFalse(Environment.isNamespaceRbacScope());
         applyRoleBindingsWithoutCRBs();
         // 060-Deployment
         BundleResource.clusterOperator(NAMESPACE).done();
@@ -60,6 +63,7 @@ public class ClusterOperatorRbacST extends AbstractST {
     @Test
     @Tag(CONNECT)
     void testCRBDeletionErrorsWhenRackAwarenessIsEnabled() {
+        assumeFalse(Environment.isNamespaceRbacScope());
         applyRoleBindingsWithoutCRBs();
         // 060-Deployment
         BundleResource.clusterOperator(NAMESPACE).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
@@ -177,7 +177,7 @@ class NamespaceDeletionRecoveryST extends AbstractST {
     private void prepareEnvironmentForRecovery(String topicName, int messageCount) {
         // Setup Test environment with Kafka and store some messages
         prepareEnvForOperator(NAMESPACE);
-        applyRoleBindings(NAMESPACE);
+        applyBindings(NAMESPACE);
         // 060-Deployment
         BundleResource.clusterOperator(NAMESPACE).done();
         KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3)
@@ -230,8 +230,8 @@ class NamespaceDeletionRecoveryST extends AbstractST {
 
     private void recreateClusterOperator() {
         // Recreate CO
-        cluster.applyClusterOperatorInstallFiles();
-        applyRoleBindings(NAMESPACE);
+        applyClusterOperatorInstallFiles(NAMESPACE);
+        applyBindings(NAMESPACE);
         // 060-Deployment
         BundleResource.clusterOperator(NAMESPACE).done();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceRbacScopeOperatorST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceRbacScopeOperatorST.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.operators;
+
+import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
+import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.operator.BundleResource;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@Tag(REGRESSION)
+class NamespaceRbacScopeOperatorST extends AbstractST {
+
+    static final String NAMESPACE = "roles-only-cluster-test";
+    static final String CLUSTER_NAME = "roles-only-cluster";
+
+    private static final Logger LOGGER = LogManager.getLogger(NamespaceRbacScopeOperatorST.class);
+
+    @Test
+    void testNamespacedRbacScopeDeploysRoles() {
+        assumeTrue(Environment.isNamespaceRbacScope());
+        prepareEnvironment();
+
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 3)
+                .editMetadata()
+                    .addToLabels("app", "strimzi")
+                .endMetadata()
+                .done();
+
+        // Wait for Kafka to be Ready to ensure all potentially erroneous ClusterRole applications have happened
+        KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
+
+        // Assert that no ClusterRoles are present on the server that have app strimzi
+        // Naturally returns false positives if another Strimzi operator has been installed
+        List<ClusterRole> strimziClusterRoles = kubeClient().listClusterRoles().stream()
+                .filter(cr -> {
+                    Map<String, String> labels = cr.getMetadata().getLabels();
+                    return "strimzi".equals(labels.get("app"));
+                })
+                .collect(Collectors.toList());
+        assertThat(strimziClusterRoles, is(Collections.emptyList()));
+    }
+
+    private void prepareEnvironment() {
+        prepareEnvForOperator(NAMESPACE);
+        applyBindings(NAMESPACE);
+        // 060-Deployment
+        BundleResource.clusterOperator(NAMESPACE).done();
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceRbacScopeOperatorST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceRbacScopeOperatorST.java
@@ -52,7 +52,7 @@ class NamespaceRbacScopeOperatorST extends AbstractST {
         // Naturally returns false positives if another Strimzi operator has been installed
         List<ClusterRole> strimziClusterRoles = kubeClient().listClusterRoles().stream()
                 .filter(cr -> {
-                    Map<String, String> labels = cr.getMetadata().getLabels();
+                    Map<String, String> labels = cr.getMetadata().getLabels() != null ? cr.getMetadata().getLabels() : Collections.emptyMap();
                     return "strimzi".equals(labels.get("app"));
                 })
                 .collect(Collectors.toList());

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
@@ -262,13 +262,13 @@ public class NetworkPoliciesST extends AbstractST {
 
         prepareEnvForOperator(NAMESPACE, Arrays.asList(NAMESPACE, secondNamespace));
 
-        // Apply role bindings in CO namespace
-        applyRoleBindings(NAMESPACE);
+        // Apply rolebindings in CO namespace
+        applyBindings(NAMESPACE);
 
         // Create ClusterRoleBindings that grant cluster-wide access to all OpenShift projects
         List<ClusterRoleBinding> clusterRoleBindingList = KubernetesResource.clusterRoleBindingsForAllNamespaces(NAMESPACE);
         clusterRoleBindingList.forEach(clusterRoleBinding ->
-            KubernetesResource.clusterRoleBinding(clusterRoleBinding, NAMESPACE));
+            KubernetesResource.clusterRoleBinding(clusterRoleBinding));
         // 060-Deployment
         BundleResource.clusterOperator("*", Constants.CO_OPERATION_TIMEOUT_DEFAULT)
             .editOrNewSpec()

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
@@ -44,6 +44,7 @@ import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.HTTP_BRIDGE_DEFAULT_PORT;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
+import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.OAUTH;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -112,6 +113,7 @@ public class OauthPlainST extends OauthAbstractST {
     @Description("As an oauth mirror maker, I should be able to replicate topic data between kafka clusters")
     @Test
     @Tag(MIRROR_MAKER)
+    @Tag(NODEPORT_SUPPORTED)
     void testProducerConsumerMirrorMaker() {
         oauthInternalClientJob.producerStrimziOauthPlain().done();
         ClientUtils.waitForClientSuccess(OAUTH_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
@@ -222,6 +224,7 @@ public class OauthPlainST extends OauthAbstractST {
     @Test
     @Tag(MIRROR_MAKER2)
     @Tag(CONNECT_COMPONENTS)
+    @Tag(NODEPORT_SUPPORTED)
     void testProducerConsumerMirrorMaker2() {
         oauthInternalClientJob.producerStrimziOauthPlain().done();
         ClientUtils.waitForClientSuccess(OAUTH_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsST.java
@@ -45,6 +45,7 @@ import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.HTTP_BRIDGE_DEFAULT_PORT;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
+import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.OAUTH;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -182,6 +183,7 @@ public class OauthTlsST extends OauthAbstractST {
     @Description("As a oauth mirror maker, I am able to replicate topic data using using encrypted communication")
     @Test
     @Tag(MIRROR_MAKER)
+    @Tag(NODEPORT_SUPPORTED)
     void testMirrorMaker() {
         oauthInternalClientJob.producerStrimziOauthTls(CLUSTER_NAME).done();
         ClientUtils.waitForClientSuccess(OAUTH_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -20,6 +20,7 @@ import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
@@ -66,6 +67,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @Tag(SPECIFIC)
 public class SpecificST extends AbstractST {
@@ -77,6 +79,7 @@ public class SpecificST extends AbstractST {
     @Tag(REGRESSION)
     @Tag(INTERNAL_CLIENTS_USED)
     void testRackAware() {
+        assumeFalse(Environment.isNamespaceRbacScope());
         String producerName = "hello-world-producer";
         String consumerName = "hello-world-consumer";
         String rackKey = "rack-key";
@@ -130,6 +133,7 @@ public class SpecificST extends AbstractST {
     @Tag(REGRESSION)
     @Tag(INTERNAL_CLIENTS_USED)
     void testRackAwareConnectWrongDeployment() {
+        assumeFalse(Environment.isNamespaceRbacScope());
         // We need to update CO configuration to set OPERATION_TIMEOUT to shorter value, because we expect timeout in that test
         Map<String, String> coSnapshot = DeploymentUtils.depSnapshot(ResourceManager.getCoDeploymentName());
         // We have to install CO in class stack, otherwise it will be deleted at the end of test case and all following tests will fail
@@ -203,6 +207,7 @@ public class SpecificST extends AbstractST {
     @Tag(REGRESSION)
     @Tag(INTERNAL_CLIENTS_USED)
     public void testRackAwareConnectCorrectDeployment() {
+        assumeFalse(Environment.isNamespaceRbacScope());
         // We need to update CO configuration to set OPERATION_TIMEOUT to shorter value, because we expect timeout in that test
         Map<String, String> coSnapshot = DeploymentUtils.depSnapshot(ResourceManager.getCoDeploymentName());
         // We have to install CO in class stack, otherwise it will be deleted at the end of test case and all following tests will fail

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -410,7 +410,7 @@ public class SpecificST extends AbstractST {
         ResourceManager.setClassResources();
         prepareEnvForOperator(NAMESPACE);
 
-        applyRoleBindings(NAMESPACE);
+        applyBindings(NAMESPACE);
         // 060-Deployment
         BundleResource.clusterOperator(NAMESPACE).done();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -113,7 +113,7 @@ public class TracingST extends AbstractST {
 
     @Test
     void testProducerService() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         Map<String, Object> configOfSourceKafka = new HashMap<>();
@@ -158,7 +158,7 @@ public class TracingST extends AbstractST {
     @Tag(CONNECT)
     @Tag(CONNECT_COMPONENTS)
     void testConnectService() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
@@ -248,7 +248,7 @@ public class TracingST extends AbstractST {
 
     @Test
     void testProducerWithStreamsService() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         Map<String, Object> configOfSourceKafka = new HashMap<>();
@@ -307,7 +307,7 @@ public class TracingST extends AbstractST {
 
     @Test
     void testProducerConsumerService() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         Map<String, Object> configOfSourceKafka = new HashMap<>();
@@ -356,7 +356,7 @@ public class TracingST extends AbstractST {
     @Test
     @Tag(ACCEPTANCE)
     void testProducerConsumerStreamsService() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         Map<String, Object> configOfSourceKafka = new HashMap<>();
@@ -421,7 +421,7 @@ public class TracingST extends AbstractST {
     @Test
     @Tag(MIRROR_MAKER2)
     void testProducerConsumerMirrorMaker2Service() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         final String kafkaClusterSourceName = CLUSTER_NAME + "-source";
@@ -532,7 +532,7 @@ public class TracingST extends AbstractST {
     @Test
     @Tag(MIRROR_MAKER)
     void testProducerConsumerMirrorMakerService() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         final String kafkaClusterSourceName = CLUSTER_NAME + "-source";
@@ -647,7 +647,7 @@ public class TracingST extends AbstractST {
     @Tag(CONNECT_COMPONENTS)
     @SuppressWarnings({"checkstyle:MethodLength"})
     void testProducerConsumerMirrorMakerConnectStreamsService() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         final String kafkaClusterSourceName = CLUSTER_NAME + "-source";
@@ -810,7 +810,7 @@ public class TracingST extends AbstractST {
     @Tag(CONNECT_S2I)
     @Tag(CONNECT_COMPONENTS)
     void testConnectS2IService() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -72,6 +72,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @Tag(REGRESSION)
 @Tag(TRACING)
@@ -112,6 +113,9 @@ public class TracingST extends AbstractST {
 
     @Test
     void testProducerService() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
+
         Map<String, Object> configOfSourceKafka = new HashMap<>();
         configOfSourceKafka.put("offsets.topic.replication.factor", "1");
         configOfSourceKafka.put("transaction.state.log.replication.factor", "1");
@@ -154,6 +158,9 @@ public class TracingST extends AbstractST {
     @Tag(CONNECT)
     @Tag(CONNECT_COMPONENTS)
     void testConnectService() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
+
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
                 .editSpec()
                     .editKafka()
@@ -241,6 +248,9 @@ public class TracingST extends AbstractST {
 
     @Test
     void testProducerWithStreamsService() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
+
         Map<String, Object> configOfSourceKafka = new HashMap<>();
         configOfSourceKafka.put("offsets.topic.replication.factor", "1");
         configOfSourceKafka.put("transaction.state.log.replication.factor", "1");
@@ -297,6 +307,9 @@ public class TracingST extends AbstractST {
 
     @Test
     void testProducerConsumerService() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
+
         Map<String, Object> configOfSourceKafka = new HashMap<>();
         configOfSourceKafka.put("offsets.topic.replication.factor", "1");
         configOfSourceKafka.put("transaction.state.log.replication.factor", "1");
@@ -343,6 +356,9 @@ public class TracingST extends AbstractST {
     @Test
     @Tag(ACCEPTANCE)
     void testProducerConsumerStreamsService() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
+
         Map<String, Object> configOfSourceKafka = new HashMap<>();
         configOfSourceKafka.put("offsets.topic.replication.factor", "1");
         configOfSourceKafka.put("transaction.state.log.replication.factor", "1");
@@ -405,6 +421,9 @@ public class TracingST extends AbstractST {
     @Test
     @Tag(MIRROR_MAKER2)
     void testProducerConsumerMirrorMaker2Service() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
+
         final String kafkaClusterSourceName = CLUSTER_NAME + "-source";
         final String kafkaClusterTargetName = CLUSTER_NAME + "-target";
 
@@ -513,6 +532,9 @@ public class TracingST extends AbstractST {
     @Test
     @Tag(MIRROR_MAKER)
     void testProducerConsumerMirrorMakerService() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
+
         final String kafkaClusterSourceName = CLUSTER_NAME + "-source";
         final String kafkaClusterTargetName = CLUSTER_NAME + "-target";
 
@@ -625,6 +647,9 @@ public class TracingST extends AbstractST {
     @Tag(CONNECT_COMPONENTS)
     @SuppressWarnings({"checkstyle:MethodLength"})
     void testProducerConsumerMirrorMakerConnectStreamsService() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
+
         final String kafkaClusterSourceName = CLUSTER_NAME + "-source";
         final String kafkaClusterTargetName = CLUSTER_NAME + "-target";
 
@@ -785,6 +810,8 @@ public class TracingST extends AbstractST {
     @Tag(CONNECT_S2I)
     @Tag(CONNECT_COMPONENTS)
     void testConnectS2IService() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
 
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -1014,7 +1014,7 @@ public class TracingST extends AbstractST {
     }
 
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
@@ -274,7 +274,7 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
         ResourceManager.setClassResources();
         prepareEnvForOperator(NAMESPACE);
 
-        applyRoleBindings(NAMESPACE);
+        applyBindings(NAMESPACE);
         // 060-Deployment
         BundleResource.clusterOperator(NAMESPACE).done();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -193,8 +193,8 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         Map<String, String> eoSnapshot = DeploymentUtils.depSnapshot(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME));
 
         // Update CRDs, CRB, etc.
-        cluster.applyClusterOperatorInstallFiles();
-        applyRoleBindings(NAMESPACE);
+        applyClusterOperatorInstallFiles(NAMESPACE);
+        applyBindings(NAMESPACE);
 
         kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName(ResourceManager.getCoDeploymentName()).delete();
         kubeClient().getClient().apps().deployments().inNamespace(NAMESPACE).withName(ResourceManager.getCoDeploymentName()).create(BundleResource.defaultClusterOperator(NAMESPACE).build());

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
@@ -199,12 +199,12 @@ class AllNamespaceST extends AbstractNamespaceST {
         prepareEnvForOperator(CO_NAMESPACE, Arrays.asList(CO_NAMESPACE, SECOND_NAMESPACE, THIRD_NAMESPACE));
 
         // Apply role bindings in CO namespace
-        applyRoleBindings(CO_NAMESPACE);
+        applyBindings(CO_NAMESPACE);
 
         // Create ClusterRoleBindings that grant cluster-wide access to all OpenShift projects
         List<ClusterRoleBinding> clusterRoleBindingList = KubernetesResource.clusterRoleBindingsForAllNamespaces(CO_NAMESPACE);
         clusterRoleBindingList.forEach(clusterRoleBinding ->
-                KubernetesResource.clusterRoleBinding(clusterRoleBinding, CO_NAMESPACE));
+                KubernetesResource.clusterRoleBinding(clusterRoleBinding));
         // 060-Deployment
         BundleResource.clusterOperator("*").done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
@@ -63,6 +63,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     void testTopicOperatorWatchingOtherNamespace() {
         // TODO temporary fix
         assumeFalse(Environment.isNamespaceRbacScope());
+
         LOGGER.info("Deploying TO to watch a different namespace that it is deployed in");
         String previousNamespace = cluster.setNamespace(THIRD_NAMESPACE);
         List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(CLUSTER_NAME, 0);
@@ -81,6 +82,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     void testKafkaInDifferentNsThanClusterOperator() {
         // TODO temporary fix
         assumeFalse(Environment.isNamespaceRbacScope());
+
         LOGGER.info("Deploying Kafka cluster in different namespace than CO when CO watches all namespaces");
         checkKafkaInDiffNamespaceThanCO(SECOND_CLUSTER_NAME, SECOND_NAMESPACE);
     }
@@ -93,6 +95,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     void testDeployMirrorMakerAcrossMultipleNamespace() {
         // TODO temporary fix
         assumeFalse(Environment.isNamespaceRbacScope());
+
         LOGGER.info("Deploying KafkaMirrorMaker in different namespace than CO when CO watches all namespaces");
         checkMirrorMakerForKafkaInDifNamespaceThanCO(SECOND_CLUSTER_NAME);
     }
@@ -104,6 +107,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     void testDeployKafkaConnectAndKafkaConnectorInOtherNamespaceThanCO() {
         // TODO temporary fix
         assumeFalse(Environment.isNamespaceRbacScope());
+
         String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
         KafkaClientsResource.deployKafkaClients(false, SECOND_CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).done();
         // Deploy Kafka Connect in other namespace than CO
@@ -125,6 +129,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     void testDeployKafkaConnectS2IAndKafkaConnectorInOtherNamespaceThanCO() {
         // TODO temporary fix
         assumeFalse(Environment.isNamespaceRbacScope());
+
         String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
         KafkaClientsResource.deployKafkaClients(false, SECOND_CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).done();
         // Deploy Kafka Connect in other namespace than CO
@@ -142,6 +147,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     void testUOWatchingOtherNamespace() {
         // TODO temporary fix
         assumeFalse(Environment.isNamespaceRbacScope());
+
         String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
         LOGGER.info("Creating user in other namespace than CO and Kafka cluster with UO");
         KafkaUserResource.tlsUser(CLUSTER_NAME, USER_NAME).done();
@@ -153,6 +159,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     void testUserInDifferentNamespace() {
         // TODO temporary fix
         assumeFalse(Environment.isNamespaceRbacScope());
+
         String startingNamespace = cluster.setNamespace(SECOND_NAMESPACE);
         KafkaUser user = KafkaUserResource.tlsUser(CLUSTER_NAME, USER_NAME).done();
 
@@ -248,6 +255,9 @@ class AllNamespaceST extends AbstractNamespaceST {
 
     @BeforeAll
     void setupEnvironment() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
+
         deployTestSpecificResources();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
@@ -61,7 +61,7 @@ class AllNamespaceST extends AbstractNamespaceST {
      */
     @Test
     void testTopicOperatorWatchingOtherNamespace() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         LOGGER.info("Deploying TO to watch a different namespace that it is deployed in");
@@ -80,7 +80,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     @Test
     @Tag(ACCEPTANCE)
     void testKafkaInDifferentNsThanClusterOperator() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         LOGGER.info("Deploying Kafka cluster in different namespace than CO when CO watches all namespaces");
@@ -93,7 +93,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     @Test
     @Tag(MIRROR_MAKER)
     void testDeployMirrorMakerAcrossMultipleNamespace() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         LOGGER.info("Deploying KafkaMirrorMaker in different namespace than CO when CO watches all namespaces");
@@ -105,7 +105,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     @Tag(CONNECTOR_OPERATOR)
     @Tag(CONNECT_COMPONENTS)
     void testDeployKafkaConnectAndKafkaConnectorInOtherNamespaceThanCO() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
@@ -127,7 +127,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     @Tag(CONNECTOR_OPERATOR)
     @Tag(CONNECT_COMPONENTS)
     void testDeployKafkaConnectS2IAndKafkaConnectorInOtherNamespaceThanCO() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
@@ -145,7 +145,7 @@ class AllNamespaceST extends AbstractNamespaceST {
 
     @Test
     void testUOWatchingOtherNamespace() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
@@ -157,7 +157,7 @@ class AllNamespaceST extends AbstractNamespaceST {
 
     @Test
     void testUserInDifferentNamespace() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         String startingNamespace = cluster.setNamespace(SECOND_NAMESPACE);
@@ -255,7 +255,7 @@ class AllNamespaceST extends AbstractNamespaceST {
 
     @BeforeAll
     void setupEnvironment() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         deployTestSpecificResources();

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
@@ -46,6 +47,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @Tag(REGRESSION)
 class AllNamespaceST extends AbstractNamespaceST {
@@ -59,6 +61,8 @@ class AllNamespaceST extends AbstractNamespaceST {
      */
     @Test
     void testTopicOperatorWatchingOtherNamespace() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
         LOGGER.info("Deploying TO to watch a different namespace that it is deployed in");
         String previousNamespace = cluster.setNamespace(THIRD_NAMESPACE);
         List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(CLUSTER_NAME, 0);
@@ -75,6 +79,8 @@ class AllNamespaceST extends AbstractNamespaceST {
     @Test
     @Tag(ACCEPTANCE)
     void testKafkaInDifferentNsThanClusterOperator() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
         LOGGER.info("Deploying Kafka cluster in different namespace than CO when CO watches all namespaces");
         checkKafkaInDiffNamespaceThanCO(SECOND_CLUSTER_NAME, SECOND_NAMESPACE);
     }
@@ -85,6 +91,8 @@ class AllNamespaceST extends AbstractNamespaceST {
     @Test
     @Tag(MIRROR_MAKER)
     void testDeployMirrorMakerAcrossMultipleNamespace() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
         LOGGER.info("Deploying KafkaMirrorMaker in different namespace than CO when CO watches all namespaces");
         checkMirrorMakerForKafkaInDifNamespaceThanCO(SECOND_CLUSTER_NAME);
     }
@@ -94,6 +102,8 @@ class AllNamespaceST extends AbstractNamespaceST {
     @Tag(CONNECTOR_OPERATOR)
     @Tag(CONNECT_COMPONENTS)
     void testDeployKafkaConnectAndKafkaConnectorInOtherNamespaceThanCO() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
         String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
         KafkaClientsResource.deployKafkaClients(false, SECOND_CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).done();
         // Deploy Kafka Connect in other namespace than CO
@@ -113,6 +123,8 @@ class AllNamespaceST extends AbstractNamespaceST {
     @Tag(CONNECTOR_OPERATOR)
     @Tag(CONNECT_COMPONENTS)
     void testDeployKafkaConnectS2IAndKafkaConnectorInOtherNamespaceThanCO() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
         String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
         KafkaClientsResource.deployKafkaClients(false, SECOND_CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).done();
         // Deploy Kafka Connect in other namespace than CO
@@ -128,6 +140,8 @@ class AllNamespaceST extends AbstractNamespaceST {
 
     @Test
     void testUOWatchingOtherNamespace() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
         String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
         LOGGER.info("Creating user in other namespace than CO and Kafka cluster with UO");
         KafkaUserResource.tlsUser(CLUSTER_NAME, USER_NAME).done();
@@ -137,6 +151,8 @@ class AllNamespaceST extends AbstractNamespaceST {
 
     @Test
     void testUserInDifferentNamespace() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
         String startingNamespace = cluster.setNamespace(SECOND_NAMESPACE);
         KafkaUser user = KafkaUserResource.tlsUser(CLUSTER_NAME, USER_NAME).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
@@ -35,7 +35,7 @@ class MultipleNamespaceST extends AbstractNamespaceST {
      */
     @Test
     void testTopicOperatorWatchingOtherNamespace() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         LOGGER.info("Deploying TO to watch a different namespace that it is deployed in");
@@ -53,7 +53,7 @@ class MultipleNamespaceST extends AbstractNamespaceST {
      */
     @Test
     void testKafkaInDifferentNsThanClusterOperator() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         LOGGER.info("Deploying Kafka in different namespace than CO when CO watches multiple namespaces");
@@ -66,7 +66,7 @@ class MultipleNamespaceST extends AbstractNamespaceST {
     @Test
     @Tag(MIRROR_MAKER)
     void testDeployMirrorMakerAcrossMultipleNamespace() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         LOGGER.info("Deploying KafkaMirrorMaker in different namespace than CO when CO watches multiple namespaces");
@@ -75,7 +75,7 @@ class MultipleNamespaceST extends AbstractNamespaceST {
 
     @BeforeAll
     void setupEnvironment() {
-        // TODO temporary fix
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
         deployTestSpecificResources();

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
@@ -71,8 +71,8 @@ class MultipleNamespaceST extends AbstractNamespaceST {
         ResourceManager.setClassResources();
         prepareEnvForOperator(CO_NAMESPACE, Arrays.asList(CO_NAMESPACE, SECOND_NAMESPACE));
 
-        applyRoleBindings(CO_NAMESPACE);
-        applyRoleBindings(CO_NAMESPACE, SECOND_NAMESPACE);
+        applyBindings(CO_NAMESPACE);
+        applyBindings(CO_NAMESPACE, SECOND_NAMESPACE);
         // 060-Deployment
         BundleResource.clusterOperator(String.join(",", CO_NAMESPACE, SECOND_NAMESPACE)).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
@@ -37,6 +37,7 @@ class MultipleNamespaceST extends AbstractNamespaceST {
     void testTopicOperatorWatchingOtherNamespace() {
         // TODO temporary fix
         assumeFalse(Environment.isNamespaceRbacScope());
+
         LOGGER.info("Deploying TO to watch a different namespace that it is deployed in");
         cluster.setNamespace(SECOND_NAMESPACE);
         List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(CLUSTER_NAME, 0);
@@ -54,6 +55,7 @@ class MultipleNamespaceST extends AbstractNamespaceST {
     void testKafkaInDifferentNsThanClusterOperator() {
         // TODO temporary fix
         assumeFalse(Environment.isNamespaceRbacScope());
+
         LOGGER.info("Deploying Kafka in different namespace than CO when CO watches multiple namespaces");
         checkKafkaInDiffNamespaceThanCO(CLUSTER_NAME, SECOND_NAMESPACE);
     }
@@ -66,12 +68,16 @@ class MultipleNamespaceST extends AbstractNamespaceST {
     void testDeployMirrorMakerAcrossMultipleNamespace() {
         // TODO temporary fix
         assumeFalse(Environment.isNamespaceRbacScope());
+
         LOGGER.info("Deploying KafkaMirrorMaker in different namespace than CO when CO watches multiple namespaces");
         checkMirrorMakerForKafkaInDifNamespaceThanCO(CLUSTER_NAME);
     }
 
     @BeforeAll
     void setupEnvironment() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
+
         deployTestSpecificResources();
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.watcher;
 
+import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.resources.operator.BundleResource;
 import org.apache.logging.log4j.LogManager;
@@ -22,6 +23,7 @@ import static io.strimzi.systemtest.Constants.REGRESSION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @Tag(REGRESSION)
 class MultipleNamespaceST extends AbstractNamespaceST {
@@ -33,6 +35,8 @@ class MultipleNamespaceST extends AbstractNamespaceST {
      */
     @Test
     void testTopicOperatorWatchingOtherNamespace() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
         LOGGER.info("Deploying TO to watch a different namespace that it is deployed in");
         cluster.setNamespace(SECOND_NAMESPACE);
         List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(CLUSTER_NAME, 0);
@@ -48,6 +52,8 @@ class MultipleNamespaceST extends AbstractNamespaceST {
      */
     @Test
     void testKafkaInDifferentNsThanClusterOperator() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
         LOGGER.info("Deploying Kafka in different namespace than CO when CO watches multiple namespaces");
         checkKafkaInDiffNamespaceThanCO(CLUSTER_NAME, SECOND_NAMESPACE);
     }
@@ -58,6 +64,8 @@ class MultipleNamespaceST extends AbstractNamespaceST {
     @Test
     @Tag(MIRROR_MAKER)
     void testDeployMirrorMakerAcrossMultipleNamespace() {
+        // TODO temporary fix
+        assumeFalse(Environment.isNamespaceRbacScope());
         LOGGER.info("Deploying KafkaMirrorMaker in different namespace than CO when CO watches multiple namespaces");
         checkMirrorMakerForKafkaInDifNamespaceThanCO(CLUSTER_NAME);
     }

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -27,7 +27,9 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.batch.Job;
 import io.fabric8.kubernetes.api.model.batch.JobList;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -573,6 +575,18 @@ public class KubeClient {
         return listEvents().stream()
                 .filter(event -> event.getInvolvedObject().getUid().equals(resourceUid))
                 .collect(Collectors.toList());
+    }
+
+    // ===========================
+    // ---------> ROLES <---------
+    // ===========================
+
+    public List<Role> listRoles() {
+        return client.rbac().roles().list().getItems();
+    }
+
+    public List<ClusterRole> listClusterRoles() {
+        return client.rbac().clusterRoles().list().getItems();
     }
 
     // ==================================


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Add role permissions to the cluster operator
this allows it to manage the role resources
Introduce a new envar STRIMZI_RBAC_SCOPE to use roles wherever possible
instead of ClusterRoles

Addresses #3826

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

