### PR TITLE
Add truststore support for Kafka MSK

### DIFF
--- a/docker-images/kafka/cruise-control-scripts/cruise_control_tls_prepare_certificates.sh
+++ b/docker-images/kafka/cruise-control-scripts/cruise_control_tls_prepare_certificates.sh
@@ -8,37 +8,7 @@ set +x
 # $3: Public key to be imported
 # $4: Alias of the certificate
 function create_truststore {
-  cacerts_path=$(find /usr/lib/jvm -name cacerts)
-  cat $cacerts_path > "$1"
-
-  keytool -keystore "$1" \
-      -alias "$4" \
-      -import \
-      -file "$3" \
-      -keypass changeit \
-      -storepass changeit \
-      -noprompt
-
-  # if CA certificate is chained, only import root cert into trustore
-  FULLCHAIN=$(<$3)
-  ROOT_CERT=$(echo -e "${FULLCHAIN#*-----END CERTIFICATE-----}" | sed '/./,$!d')
-  
-  if [[ ! -z "${ROOT_CERT// }" ]] ; then
-    RND_FILE=$(< /dev/urandom tr -dc _A-Z-a-z | head -c12)
-    echo "$ROOT_CERT" > /tmp/$RND_FILE.crt
-    
-    keytool -keystore "$1" \
-      -alias rootCA \
-      -import \
-      -file /tmp/$RND_FILE.crt \
-      -keypass changeit \
-      -storepass changeit \
-      -noprompt
-  fi
-
-  # change default truststore password
-  keytool -storepasswd -storepass "changeit" -new "$2" -keystore "$1"
-    
+   keytool -keystore "$1" -storepass "$2" -noprompt -alias "$4" -import -file "$3" -storetype PKCS12
 }
 
 # Parameters:

--- a/docker-images/kafka/cruise-control-scripts/cruise_control_tls_prepare_certificates.sh
+++ b/docker-images/kafka/cruise-control-scripts/cruise_control_tls_prepare_certificates.sh
@@ -8,7 +8,37 @@ set +x
 # $3: Public key to be imported
 # $4: Alias of the certificate
 function create_truststore {
-   keytool -keystore "$1" -storepass "$2" -noprompt -alias "$4" -import -file "$3" -storetype PKCS12
+  cacerts_path=$(find /usr/lib/jvm -name cacerts)
+  cat $cacerts_path > "$1"
+
+  keytool -keystore "$1" \
+      -alias "$4" \
+      -import \
+      -file "$3" \
+      -keypass changeit \
+      -storepass changeit \
+      -noprompt
+
+  # if CA certificate is chained, only import root cert into trustore
+  FULLCHAIN=$(<$3)
+  ROOT_CERT=$(echo -e "${FULLCHAIN#*-----END CERTIFICATE-----}" | sed '/./,$!d')
+  
+  if [[ ! -z "${ROOT_CERT// }" ]] ; then
+    RND_FILE=$(< /dev/urandom tr -dc _A-Z-a-z | head -c12)
+    echo "$ROOT_CERT" > /tmp/$RND_FILE.crt
+    
+    keytool -keystore "$1" \
+      -alias rootCA \
+      -import \
+      -file /tmp/$RND_FILE.crt \
+      -keypass changeit \
+      -storepass changeit \
+      -noprompt
+  fi
+
+  # change default truststore password
+  keytool -storepasswd -storepass "changeit" -new "$2" -keystore "$1"
+    
 }
 
 # Parameters:

--- a/docker-images/kafka/scripts/kafka_connect_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_connect_tls_prepare_certificates.sh
@@ -7,7 +7,37 @@ set -e
 # $3: Public key to be imported
 # $4: Alias of the certificate
 function create_truststore {
-   keytool -keystore "$1" -storepass "$2" -noprompt -alias "$4" -import -file "$3" -storetype PKCS12
+  cacerts_path=$(find /usr/lib/jvm -name cacerts)
+  cat $cacerts_path > "$1"
+
+  keytool -keystore "$1" \
+      -alias "$4" \
+      -import \
+      -file "$3" \
+      -keypass changeit \
+      -storepass changeit \
+      -noprompt
+
+  # if CA certificate is chained, only import root cert into trustore
+  FULLCHAIN=$(<$3)
+  ROOT_CERT=$(echo -e "${FULLCHAIN#*-----END CERTIFICATE-----}" | sed '/./,$!d')
+  
+  if [[ ! -z "${ROOT_CERT// }" ]] ; then
+    RND_FILE=$(< /dev/urandom tr -dc _A-Z-a-z | head -c12)
+    echo "$ROOT_CERT" > /tmp/$RND_FILE.crt
+    
+    keytool -keystore "$1" \
+      -alias rootCA \
+      -import \
+      -file /tmp/$RND_FILE.crt \
+      -keypass changeit \
+      -storepass changeit \
+      -noprompt
+  fi
+
+  # change default truststore password
+  keytool -storepasswd -storepass "changeit" -new "$2" -keystore "$1"
+    
 }
 
 # Parameters:

--- a/docker-images/kafka/scripts/kafka_connect_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_connect_tls_prepare_certificates.sh
@@ -8,7 +8,7 @@ set -e
 # $4: Alias of the certificate
 function create_truststore {
   cacerts_path=$(find /usr/lib/jvm -name cacerts)
-  cat $cacerts_path > "$1"
+  cat "$cacerts_path" > "$1"
 
   keytool -keystore "$1" \
       -alias "$4" \
@@ -19,17 +19,17 @@ function create_truststore {
       -noprompt
 
   # if CA certificate is chained, only import root cert into trustore
-  FULLCHAIN=$(<$3)
+  FULLCHAIN=$(<"$3")
   ROOT_CERT=$(echo -e "${FULLCHAIN#*-----END CERTIFICATE-----}" | sed '/./,$!d')
   
-  if [[ ! -z "${ROOT_CERT// }" ]] ; then
+  if [[ -n "${ROOT_CERT// }" ]] ; then
     RND_FILE=$(< /dev/urandom tr -dc _A-Z-a-z | head -c12)
-    echo "$ROOT_CERT" > /tmp/$RND_FILE.crt
+    echo "$ROOT_CERT" > /tmp/"$RND_FILE".crt
     
     keytool -keystore "$1" \
       -alias rootCA \
       -import \
-      -file /tmp/$RND_FILE.crt \
+      -file /tmp/"$RND_FILE".crt \
       -keypass changeit \
       -storepass changeit \
       -noprompt

--- a/docker-images/kafka/scripts/kafka_mirror_maker_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_tls_prepare_certificates.sh
@@ -7,7 +7,37 @@ set -e
 # $3: Public key to be imported
 # $4: Alias of the certificate
 function create_truststore {
-   keytool -keystore "$1" -storepass "$2" -noprompt -alias "$4" -import -file "$3" -storetype PKCS12
+  cacerts_path=$(find /usr/lib/jvm -name cacerts)
+  cat $cacerts_path > "$1"
+
+  keytool -keystore "$1" \
+      -alias "$4" \
+      -import \
+      -file "$3" \
+      -keypass changeit \
+      -storepass changeit \
+      -noprompt
+
+  # if CA certificate is chained, only import root cert into trustore
+  FULLCHAIN=$(<$3)
+  ROOT_CERT=$(echo -e "${FULLCHAIN#*-----END CERTIFICATE-----}" | sed '/./,$!d')
+  
+  if [[ ! -z "${ROOT_CERT// }" ]] ; then
+    RND_FILE=$(< /dev/urandom tr -dc _A-Z-a-z | head -c12)
+    echo "$ROOT_CERT" > /tmp/$RND_FILE.crt
+    
+    keytool -keystore "$1" \
+      -alias rootCA \
+      -import \
+      -file /tmp/$RND_FILE.crt \
+      -keypass changeit \
+      -storepass changeit \
+      -noprompt
+  fi
+
+  # change default truststore password
+  keytool -storepasswd -storepass "changeit" -new "$2" -keystore "$1"
+    
 }
 
 # Parameters:

--- a/docker-images/kafka/scripts/kafka_mirror_maker_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_tls_prepare_certificates.sh
@@ -8,7 +8,7 @@ set -e
 # $4: Alias of the certificate
 function create_truststore {
   cacerts_path=$(find /usr/lib/jvm -name cacerts)
-  cat $cacerts_path > "$1"
+  cat "$cacerts_path" > "$1"
 
   keytool -keystore "$1" \
       -alias "$4" \
@@ -19,17 +19,17 @@ function create_truststore {
       -noprompt
 
   # if CA certificate is chained, only import root cert into trustore
-  FULLCHAIN=$(<$3)
+  FULLCHAIN=$(<"$3")
   ROOT_CERT=$(echo -e "${FULLCHAIN#*-----END CERTIFICATE-----}" | sed '/./,$!d')
   
-  if [[ ! -z "${ROOT_CERT// }" ]] ; then
+  if [[ -n "${ROOT_CERT// }" ]] ; then
     RND_FILE=$(< /dev/urandom tr -dc _A-Z-a-z | head -c12)
-    echo "$ROOT_CERT" > /tmp/$RND_FILE.crt
+    echo "$ROOT_CERT" > /tmp/"$RND_FILE".crt
     
     keytool -keystore "$1" \
       -alias rootCA \
       -import \
-      -file /tmp/$RND_FILE.crt \
+      -file /tmp/"$RND_FILE".crt \
       -keypass changeit \
       -storepass changeit \
       -noprompt

--- a/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -7,37 +7,7 @@ set -e
 # $3: Public key to be imported
 # $4: Alias of the certificate
 function create_truststore {
-  cacerts_path=$(find /usr/lib/jvm -name cacerts)
-  cat $cacerts_path > "$1"
-
-  keytool -keystore "$1" \
-      -alias "$4" \
-      -import \
-      -file "$3" \
-      -keypass changeit \
-      -storepass changeit \
-      -noprompt
-
-  # if CA certificate is chained, only import root cert into trustore
-  FULLCHAIN=$(<$3)
-  ROOT_CERT=$(echo -e "${FULLCHAIN#*-----END CERTIFICATE-----}" | sed '/./,$!d')
-  
-  if [[ ! -z "${ROOT_CERT// }" ]] ; then
-    RND_FILE=$(< /dev/urandom tr -dc _A-Z-a-z | head -c12)
-    echo "$ROOT_CERT" > /tmp/$RND_FILE.crt
-    
-    keytool -keystore "$1" \
-      -alias rootCA \
-      -import \
-      -file /tmp/$RND_FILE.crt \
-      -keypass changeit \
-      -storepass changeit \
-      -noprompt
-  fi
-
-  # change default truststore password
-  keytool -storepasswd -storepass "changeit" -new "$2" -keystore "$1"
-    
+   keytool -keystore "$1" -storepass "$2" -noprompt -alias "$4" -import -file "$3" -storetype PKCS12
 }
 
 # Parameters:

--- a/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -7,7 +7,37 @@ set -e
 # $3: Public key to be imported
 # $4: Alias of the certificate
 function create_truststore {
-   keytool -keystore "$1" -storepass "$2" -noprompt -alias "$4" -import -file "$3" -storetype PKCS12
+  cacerts_path=$(find /usr/lib/jvm -name cacerts)
+  cat $cacerts_path > "$1"
+
+  keytool -keystore "$1" \
+      -alias "$4" \
+      -import \
+      -file "$3" \
+      -keypass changeit \
+      -storepass changeit \
+      -noprompt
+
+  # if CA certificate is chained, only import root cert into trustore
+  FULLCHAIN=$(<$3)
+  ROOT_CERT=$(echo -e "${FULLCHAIN#*-----END CERTIFICATE-----}" | sed '/./,$!d')
+  
+  if [[ ! -z "${ROOT_CERT// }" ]] ; then
+    RND_FILE=$(< /dev/urandom tr -dc _A-Z-a-z | head -c12)
+    echo "$ROOT_CERT" > /tmp/$RND_FILE.crt
+    
+    keytool -keystore "$1" \
+      -alias rootCA \
+      -import \
+      -file /tmp/$RND_FILE.crt \
+      -keypass changeit \
+      -storepass changeit \
+      -noprompt
+  fi
+
+  # change default truststore password
+  keytool -storepasswd -storepass "changeit" -new "$2" -keystore "$1"
+    
 }
 
 # Parameters:

--- a/docker-images/kafka/scripts/zookeeper_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/zookeeper_tls_prepare_certificates.sh
@@ -7,37 +7,7 @@ set -e
 # $3: Public key to be imported
 # $4: Alias of the certificate
 function create_truststore {
-  cacerts_path=$(find /usr/lib/jvm -name cacerts)
-  cat $cacerts_path > "$1"
-
-  keytool -keystore "$1" \
-      -alias "$4" \
-      -import \
-      -file "$3" \
-      -keypass changeit \
-      -storepass changeit \
-      -noprompt
-
-  # if CA certificate is chained, only import root cert into trustore
-  FULLCHAIN=$(<$3)
-  ROOT_CERT=$(echo -e "${FULLCHAIN#*-----END CERTIFICATE-----}" | sed '/./,$!d')
-  
-  if [[ ! -z "${ROOT_CERT// }" ]] ; then
-    RND_FILE=$(< /dev/urandom tr -dc _A-Z-a-z | head -c12)
-    echo "$ROOT_CERT" > /tmp/$RND_FILE.crt
-    
-    keytool -keystore "$1" \
-      -alias rootCA \
-      -import \
-      -file /tmp/$RND_FILE.crt \
-      -keypass changeit \
-      -storepass changeit \
-      -noprompt
-  fi
-
-  # change default truststore password
-  keytool -storepasswd -storepass "changeit" -new "$2" -keystore "$1"
-    
+   keytool -keystore "$1" -storepass "$2" -noprompt -alias "$4" -import -file "$3" -storetype PKCS12
 }
 
 # Parameters:

--- a/docker-images/kafka/scripts/zookeeper_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/zookeeper_tls_prepare_certificates.sh
@@ -7,7 +7,37 @@ set -e
 # $3: Public key to be imported
 # $4: Alias of the certificate
 function create_truststore {
-   keytool -keystore "$1" -storepass "$2" -noprompt -alias "$4" -import -file "$3" -storetype PKCS12
+  cacerts_path=$(find /usr/lib/jvm -name cacerts)
+  cat $cacerts_path > "$1"
+
+  keytool -keystore "$1" \
+      -alias "$4" \
+      -import \
+      -file "$3" \
+      -keypass changeit \
+      -storepass changeit \
+      -noprompt
+
+  # if CA certificate is chained, only import root cert into trustore
+  FULLCHAIN=$(<$3)
+  ROOT_CERT=$(echo -e "${FULLCHAIN#*-----END CERTIFICATE-----}" | sed '/./,$!d')
+  
+  if [[ ! -z "${ROOT_CERT// }" ]] ; then
+    RND_FILE=$(< /dev/urandom tr -dc _A-Z-a-z | head -c12)
+    echo "$ROOT_CERT" > /tmp/$RND_FILE.crt
+    
+    keytool -keystore "$1" \
+      -alias rootCA \
+      -import \
+      -file /tmp/$RND_FILE.crt \
+      -keypass changeit \
+      -storepass changeit \
+      -noprompt
+  fi
+
+  # change default truststore password
+  keytool -storepasswd -storepass "changeit" -new "$2" -keystore "$1"
+    
 }
 
 # Parameters:


### PR DESCRIPTION
### Type of change

_Select the type of your PR_
- Enhancement / new feature


### Description
In order to support the use of Amazon MSK, Strimzi needs to allow importing chained certificates into its truststore (whereby only importing the root certificate is allowed).

in addition, generating a brand new truststore using the keytool utility is not supported for MSK due to the requirement of of some standard Certificate Authorities. these can be found in the default JVM cacerts which is then copied over in the base image.


