### PR TITLE
fix: update OPA Authorizer version

### DIFF
--- a/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <strimzi-oauth.version>0.6.1</strimzi-oauth.version>
         <cruise-control.version>2.5.11</cruise-control.version>
-        <opa-authorizer.version>0.4.1</opa-authorizer.version>
+        <opa-authorizer.version>0.4.2</opa-authorizer.version>
     </properties>
 
     <repositories>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <strimzi-oauth.version>0.6.1</strimzi-oauth.version>
         <cruise-control.version>2.5.11</cruise-control.version>
-        <opa-authorizer.version>0.4.1</opa-authorizer.version>
+        <opa-authorizer.version>0.4.2</opa-authorizer.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Current version of opa-kafka-plugin uses a vulnerable version of Google Guava.
Updating the version fixes this issue.

Closes: #3852 

Signed-off-by: Will Treston <w.treston@gmail.com>

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards