### PR TITLE
Fix documentation about EO resources

### DIFF
--- a/documentation/modules/proc-topic-operator-with-resource-requests-limits.adoc
+++ b/documentation/modules/proc-topic-operator-with-resource-requests-limits.adoc
@@ -31,10 +31,10 @@ spec:
   entityOperator:
     topicOperator:
       resources:
-        request:
+        requests:
           cpu: "1"
           memory: 500Mi
-        limit:
+        limits:
           cpu: "1"
           memory: 500Mi
 ----

--- a/documentation/modules/proc-user-operator-with-resource-requests-limits.adoc
+++ b/documentation/modules/proc-user-operator-with-resource-requests-limits.adoc
@@ -31,10 +31,10 @@ spec:
   entityOperator:
     userOperator:
       resources:
-        request:
+        requests:
           cpu: "1"
           memory: 500Mi
-        limit:
+        limits:
           cpu: "1"
           memory: 500Mi
 ----


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Documentation

### Description
We used singular instead of the plural form of `requests` and `limits`.

### Checklist


- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

