### PR TITLE
Jaas config secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add support for `secretPrefix` property for User Operator to prefix all secret names created from KafkaUser resource.
 * Allow configuring labels and annotations for Cluster CA certificate secrets
+* Add `sasl.jaas.config` to generated secrets for KafkaUser with SCRAM-SHA-512 authentication.
 
 ## 0.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Add support for `secretPrefix` property for User Operator to prefix all secret names created from KafkaUser resource.
 * Allow configuring labels and annotations for Cluster CA certificate secrets
-* Add `sasl.jaas.config` to generated secrets for KafkaUser with SCRAM-SHA-512 authentication.
+* Add the JAAS configuration string in the sasl.jaas.config property to the generated secrets for KafkaUser with SCRAM-SHA-512 authentication.
 
 ## 0.20.0
 

--- a/documentation/modules/con-securing-client-authentication.adoc
+++ b/documentation/modules/con-securing-client-authentication.adoc
@@ -106,7 +106,7 @@ data:
   sasl.jaas.config: b3JnLmFwYWNoZS5rYWZrYS5jb21tb24uc2VjdXJpdHkuc2NyYW0uU2NyYW1Mb2dpbk1vZHVsZSByZXF1aXJlZCB1c2VybmFtZT0ibXktdXNlciIgcGFzc3dvcmQ9ImdlbmVyYXRlZHBhc3N3b3JkIjsK <2>
 ----
 <1> The generated password, base64 encoded.
-<2> The `sasl.jaas.config` string, base64 encoded.
+<2> The JAAS configuration string for SASL SCRAM-SHA-512 authentication, base64 encoded.
 
 Decoding the generated password:
 ----

--- a/documentation/modules/con-securing-client-authentication.adoc
+++ b/documentation/modules/con-securing-client-authentication.adoc
@@ -103,8 +103,10 @@ metadata:
 type: Opaque
 data:
   password: Z2VuZXJhdGVkcGFzc3dvcmQ= <1>
+  sasl.jaas.config: b3JnLmFwYWNoZS5rYWZrYS5jb21tb24uc2VjdXJpdHkuc2NyYW0uU2NyYW1Mb2dpbk1vZHVsZSByZXF1aXJlZCB1c2VybmFtZT0ibXktdXNlciIgcGFzc3dvcmQ9ImdlbmVyYXRlZHBhc3N3b3JkIjsK <2>
 ----
 <1> The generated password, base64 encoded.
+<2> The `sasl.jaas.config` string, base64 encoded.
 
 Decoding the generated password:
 ----

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -158,9 +158,9 @@ public class KafkaUserModel {
             data.put("user.password", userCertAndKey.storePasswordAsBase64String());
             return createSecret(data);
         } else if (authentication instanceof KafkaUserScramSha512ClientAuthentication) {
-            Map<String, String> data = new HashMap<>(1);
+            Map<String, String> data = new HashMap<>(2);
             data.put(KafkaUserModel.KEY_PASSWORD, Base64.getEncoder().encodeToString(this.scramSha512Password.getBytes(StandardCharsets.US_ASCII)));
-            data.put(KEY_SASL_JAAS_CONFIG, Base64.getEncoder().encodeToString(getSaslJsonConfig().getBytes(StandardCharsets.US_ASCII)));
+            data.put(KafkaUserModel.KEY_SASL_JAAS_CONFIG, Base64.getEncoder().encodeToString(getSaslJsonConfig().getBytes(StandardCharsets.US_ASCII)));
             return createSecret(data);
         } else {
             return null;
@@ -397,11 +397,11 @@ public class KafkaUserModel {
     }
 
     /**
-     * Creates the sasl.jaas.config string for SASL/SCRAM authentication.
+     * Creates the JAAS configuration string for SASL SCRAM-SHA-512 authentication.
      *
      * @param username The SCRAM username.
      * @param password The SCRAM password.
-     * @return The sasl.jaas.config string.
+     * @return The JAAS configuration string.
      */
     public static String getSaslJsonConfig(String username, String password) {
         return "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + username + "\" password=\"" + password + "\";";
@@ -497,9 +497,9 @@ public class KafkaUserModel {
     }
 
     /**
-     * Creates the sasl.jaas.config string for SASL/SCRAM authentication.
+     * Creates the JAAS configuration string for SASL SCRAM-SHA-512 authentication.
      *
-     * @return The sasl.jaas.config string.
+     * @return The JAAS configuration string.
      */
     public String getSaslJsonConfig() {
         return getSaslJsonConfig(getScramUserName(name), scramSha512Password);

--- a/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
@@ -33,6 +33,7 @@ public class ResourceUtils {
     public static final String NAME = "user";
     public static final String CA_CERT_NAME = NAME + "-cert";
     public static final String CA_KEY_NAME = NAME + "-key";
+    public static final String PASSWORD = "my-password";
 
     public static KafkaUser createKafkaUser(KafkaUserAuthentication authentication) {
         return new KafkaUserBuilder()
@@ -170,7 +171,8 @@ public class ResourceUtils {
                     .withNamespace(NAMESPACE)
                     .withLabels(Labels.fromMap(LABELS).withStrimziKind(KafkaUser.RESOURCE_KIND).toMap())
                 .endMetadata()
-                .addToData("password", Base64.getEncoder().encodeToString("my-password".getBytes()))
+                .addToData(KafkaUserModel.KEY_PASSWORD, Base64.getEncoder().encodeToString(PASSWORD.getBytes()))
+                .addToData(KafkaUserModel.KEY_SASL_JAAS_CONFIG, Base64.getEncoder().encodeToString(KafkaUserModel.getSaslJsonConfig(NAME, PASSWORD).getBytes()))
                 .build();
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -303,7 +303,7 @@ public class KafkaUserModelTest {
         String password = "aaaaaaaaaa";
         assertThat(new String(Base64.getDecoder().decode(generatedSecret.getData().get(KafkaUserModel.KEY_PASSWORD))), is(password));
         assertThat(new String(Base64.getDecoder().decode(generatedSecret.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG))),
-                is(KafkaUserModel.getSaslJsonConfig(ResourceUtils.NAME, password)));
+                is("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + ResourceUtils.NAME + "\" password=\"" + password + "\";"));
 
         // Check owner reference
         checkOwnerReference(model.createOwnerReference(), generatedSecret);
@@ -355,7 +355,7 @@ public class KafkaUserModelTest {
         String password = "aaaaaaaaaa";
         assertThat(new String(Base64.getDecoder().decode(generated.getData().get(KafkaUserModel.KEY_PASSWORD))), is(password));
         assertThat(new String(Base64.getDecoder().decode(generated.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG))),
-                is(KafkaUserModel.getSaslJsonConfig(ResourceUtils.NAME, password)));
+                is("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + ResourceUtils.NAME + "\" password=\"" + password + "\";"));
 
         // Check owner reference
         checkOwnerReference(model.createOwnerReference(), generated);


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This adds  `sasl.jaas.config` property for SASL/SCRAM authentication to the generated secret.

See #3332 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

