### PR TITLE
Remove support for Java 8

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -19,10 +19,6 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'java-8':
-          image: 'Ubuntu-18.04'
-          jdk_version: '1.8'
-          jdk_path: '/usr/lib/jvm/java-8-openjdk-amd64'
         'java-11':
           image: 'Ubuntu-18.04'
           jdk_version: '11'

--- a/.azure/templates/setup_java.yaml
+++ b/.azure/templates/setup_java.yaml
@@ -1,10 +1,10 @@
 # Step to setup JAVA on the agent
-# We use openjdk-X, where X is Java version (8 or 11). Images are based on Java 8
+# We use openjdk-X, where X is Java version (currently, only 11 is used). Images are based on Java 11
 parameters:
   - name: JDK_PATH
-    default: '/usr/lib/jvm/java-8-openjdk-amd64'
+    default: '/usr/lib/jvm/java-11-openjdk-amd64'
   - name: JDK_VERSION
-    default: '1.8'
+    default: '11'
 steps:
 
 - bash: |
@@ -12,20 +12,9 @@ steps:
   displayName: 'Update package list'
 
 - bash: |
-    sudo apt-get install openjdk-8-jdk
-  displayName: 'Install openjdk8'
-  condition: eq(variables['JDK_VERSION'], '1.8')
-
-- bash: |
     sudo apt-get install openjdk-11-jdk
   displayName: 'Install openjdk11'
   condition: eq(variables['JDK_VERSION'], '11')
-
-- bash: |
-    echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]1.8"
-    echo "##vso[task.setvariable variable=JAVA_VERSION]1.8.0"
-  displayName: 'Setup JAVA_VERSION=1.8'
-  condition: eq(variables['JDK_VERSION'], '1.8')
 
 - bash: |
     echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]11"

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.version>3.8.1</maven.compiler.version>
         <maven.surefire.version>3.0.0-M5</maven.surefire.version>
         <maven.failsafe.version>3.0.0-M5</maven.failsafe.version>
@@ -409,7 +409,7 @@
             <dependency>
                 <!-- transitive dep; override here to avoid buggy version -->
                 <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jdk8</artifactId>
+                <artifactId>jackson-datatype-jdk11</artifactId>
                 <version>${fasterxml.jackson-core.version}</version>
             </dependency>
             <dependency>
@@ -1151,15 +1151,6 @@
             <properties>
                 <maven.compiler.source>${env.JAVA_VERSION_BUILD}</maven.compiler.source>
                 <maven.compiler.target>${env.JAVA_VERSION_BUILD}</maven.compiler.target>
-            </properties>
-        </profile>
-        <profile>
-            <id>jdk-8-config</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <properties>
-                <javadocExecutable>${java.home}/../bin/javadoc</javadocExecutable>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
### Type of change

- Task

### Description

As per https://github.com/strimzi/proposals/blob/master/001-move-strimzi-kafka-operators-to-java-11.md, this PR removes the support for Java 8. It keeps most of the structures (e.g. matrix builds) to make it easy to add some newer Java version in the future. But for the time being it keeps only Java 11.

This doesn't touch the Travis build which is being removed in #3861 to avoid conflicts. #3861 should be merged as a first.