### PR TITLE
[DOC] Fix alternative names example in documentation

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBootstrap.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBootstrap.adoc
@@ -22,7 +22,9 @@ listeners:
       type: tls
     configuration:
       bootstrap:
-        alternativeNames: example.hostname
+        alternativeNames:
+          - example.hostname1
+          - example.hostname2
 # ...
 ----
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The documentation example of the `alternativeNames` in listener configuration is wrong because it should contain a list of names instead of just a single name now. This PR fixes it. 

This should be cherry-picked for 0.20.0.