### PR TITLE
Fix illegal reflective access exception in ExamplesTest and remove unnecessary checks

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -27,10 +27,6 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model-rbac</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-model-networking</artifactId>
         </dependency>
         <dependency>

--- a/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
@@ -13,8 +13,6 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionSpec;
-import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
-import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.Test;
@@ -23,6 +21,7 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
@@ -50,7 +49,7 @@ public class ExamplesTest {
      * and validating them.
      */
     @Test
-    public void examples() throws Exception {
+    public void examples() {
         validateRecursively(new File(TestUtils.USER_PATH + "/../examples"));
     }
 
@@ -101,12 +100,6 @@ public class ExamplesTest {
     private void recurseForAdditionalProperties(Stack<String> path, Object resource) {
         try {
             Class<?> cls = resource.getClass();
-            if (RoleBinding.class.equals(cls)
-                    || ClusterRoleBinding.class.equals(cls)) {
-                // XXX: hack because fabric8 RoleBinding reflect the openshift role binding API
-                // not the k8s one, and has an unexpected apiGroup property
-                return;
-            }
             for (Method method : cls.getMethods()) {
                 checkForJsonAnyGetter(path, resource, cls, method);
             }
@@ -131,7 +124,8 @@ public class ExamplesTest {
                 Object result = method.invoke(resource);
                 if (result != null
                     && !result.getClass().isPrimitive()
-                    && !result.getClass().isEnum()) {
+                    && !result.getClass().isEnum()
+                    && !result.getClass().equals(Collections.emptyMap().getClass())) {
                     path.push(method.getName());
                     recurseForAdditionalProperties(path, result);
                     path.pop();


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

Fixes: #3595

After some investigation where the problem is, I found that in one check we are getting the `resource.getClass()`, but when the `resource` is `{}` or `Collections.emptyMap`, the illegal reflective access exception appeared.

This PR adding the check if the "method" is not the `Collenctions.emptyMap` and also removing the unnecessary checks of `RoleBinding.class` and `ClusterRoleBinding.class` -> fabric8 is using the k8s ones now.

### Checklist

- [x] Make sure all tests pass

