### PR TITLE
Fix NPE when certificates are missing in secrets

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -322,12 +322,16 @@ public class ModelUtils {
         Map<String, String> currentData = current.getData();
         Map<String, String> desiredData = desired.getData();
 
-        for (Map.Entry<String, String> entry : currentData.entrySet()) {
-            String desiredValue = desiredData.get(entry.getKey());
-            if (entry.getValue() != null
-                    && desiredValue != null
-                    && !entry.getValue().equals(desiredValue)) {
-                return true;
+        if (currentData == null) {
+            return true;
+        } else {
+            for (Map.Entry<String, String> entry : currentData.entrySet()) {
+                String desiredValue = desiredData.get(entry.getKey());
+                if (entry.getValue() != null
+                        && desiredValue != null
+                        && !entry.getValue().equals(desiredValue)) {
+                    return true;
+                }
             }
         }
 

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -345,8 +345,12 @@ public abstract class Ca {
            Secret secret,
            Function<Integer, String> podNameFn,
            boolean isMaintenanceTimeWindowsSatisfied) throws IOException {
-        int replicasInSecret = secret == null || this.certRenewed() ? 0 :
-                (int) secret.getData().keySet().stream().filter(k -> k.contains(".crt")).count();
+        int replicasInSecret;
+        if (secret == null || secret.getData() == null || this.certRenewed())   {
+            replicasInSecret = 0;
+        } else {
+            replicasInSecret = (int) secret.getData().keySet().stream().filter(k -> k.contains(".crt")).count();
+        }
 
         File brokerCsrFile = File.createTempFile("tls", "broker-csr");
         File brokerKeyFile = File.createTempFile("tls", "broker-key");
@@ -595,10 +599,12 @@ public abstract class Ca {
         String reason = null;
         RenewalType renewalType = RenewalType.NOOP;
         if (caKeySecret == null
+                || caKeySecret.getData() == null
                 || caKeySecret.getData().get(CA_KEY) == null) {
             reason = "CA key secret " + caKeySecretName + " is missing or lacking data." + CA_KEY.replace(".", "\\.");
             renewalType = RenewalType.CREATE;
         } else if (this.caCertSecret == null
+                || this.caCertSecret.getData() == null
                 || this.caCertSecret.getData().get(CA_CRT) == null) {
             reason = "CA certificate secret " + caCertSecretName + " is missing or lacking data." + CA_CRT.replace(".", "\\.");
             renewalType = RenewalType.RENEW_CERT;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes some NPEs when happen when certificates are missing from the secrets. In most cases, we just check the secret existence and not he existence of the `data` section. That can cause the NPEs. Additional checks should avoid them and regenerate the certificates as no secrets would do.

This should close #3868.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging