### PR TITLE
FIX(Tests) testRackAware (no external clients) & new testRackAwareConnect

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -110,6 +110,13 @@ public class KafkaConnectResource {
         return kafkaConnect;
     }
 
+
+    public static void allowNetworkPolicyForKafkaConnect(KafkaConnect kafkaConnect) {
+        if (Environment.DEFAULT_TO_DENY_NETWORK_POLICIES.equals(Boolean.TRUE.toString())) {
+            KubernetesResource.allowNetworkPolicySettingsForResource(kafkaConnect, KafkaConnectResources.deploymentName(kafkaConnect.getMetadata().getName()));
+        }
+    }
+
     public static void deleteKafkaConnectWithoutWait(String resourceName) {
         kafkaConnectClient().inNamespace(ResourceManager.kubeClient().getNamespace()).withName(resourceName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -212,6 +212,8 @@ public abstract class AbstractST implements TestSeparator {
             KubernetesResource.roleBinding(TestUtils.USER_PATH + "/../install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml", namespace, bindingsNamespace);
             // 032-RoleBinding
             KubernetesResource.roleBinding(TestUtils.USER_PATH + "/../install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml", namespace, bindingsNamespace);
+            // 033-ClusterRoleBinding
+            KubernetesResource.clusterRoleBinding(TestUtils.USER_PATH + "/../install/cluster-operator/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-client-delegation.yaml", namespace, bindingsNamespace);
         }
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -100,6 +100,15 @@ public class SpecificST extends AbstractST {
         List<Event> events = kubeClient().listEvents(uid);
         assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
 
+        LOGGER.info("Waiting for reconciliation to happen. " +
+                "Giving some time to DNS/load balancer to propagate kafka address." +
+                "Sleeping for {}ms", Constants.RECONCILIATION_INTERVAL);
+        try {
+            Thread.sleep(Constants.RECONCILIATION_INTERVAL);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(TOPIC_NAME)
             .withNamespaceName(NAMESPACE)

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -6,21 +6,32 @@ package io.strimzi.systemtest.specific;
 
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.api.model.NodeAffinity;
 import io.fabric8.kubernetes.api.model.NodeSelectorRequirement;
+import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodAffinityTerm;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.Rack;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBrokerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
+import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.resources.operator.BundleResource;
 import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.systemtest.utils.specific.BridgeUtils;
 import io.strimzi.test.executor.Exec;
 import org.apache.logging.log4j.LogManager;
@@ -35,7 +46,10 @@ import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static io.strimzi.systemtest.Constants.CONNECT;
+import static io.strimzi.systemtest.Constants.CO_OPERATION_TIMEOUT_SHORT;
 import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.LOADBALANCER_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.Constants.SPECIFIC;
@@ -58,6 +72,8 @@ public class SpecificST extends AbstractST {
     public static final String NAMESPACE = "specific-cluster-test";
 
     @Test
+    @Tag(REGRESSION)
+    @Tag(INTERNAL_CLIENTS_USED)
     void testRackAware() {
         String rackKey = "rack-key";
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 1, 1)
@@ -92,9 +108,9 @@ public class SpecificST extends AbstractST {
         List<Event> events = kubeClient().listEvents(uid);
         assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
 
-        KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.deployKafkaClients(true, KAFKA_CLIENTS_NAME).done();
         final String defaultKafkaClientsPodName =
-                ResourceManager.kubeClient().listPodsByPrefixInName(CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
+                ResourceManager.kubeClient().listPodsByPrefixInName(KAFKA_CLIENTS_NAME).get(0).getMetadata().getName();
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
                 .withUsingPodName(defaultKafkaClientsPodName)
                 .withTopicName(TOPIC_NAME)
@@ -110,6 +126,118 @@ public class SpecificST extends AbstractST {
         );
     }
 
+    @Test
+    @Tag(CONNECT)
+    @Tag(REGRESSION)
+    @Tag(INTERNAL_CLIENTS_USED)
+    void testRackAwareConnectWrongDeployment() throws Exception {
+        installClusterOperator(NAMESPACE, CO_OPERATION_TIMEOUT_SHORT);
+
+        String wrongRackKey = "wrong-key";
+        String rackKey = "rack-key";
+
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3)
+                .editSpec()
+                    .editKafka()
+                        .withNewRack()
+                            .withTopologyKey(rackKey)
+                        .endRack()
+                        .addToConfig("replica.selector.class", "org.apache.kafka.common.replica.RackAwareReplicaSelector")
+                    .endKafka()
+                .endSpec().done();
+
+        KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).done();
+        String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(KAFKA_CLIENTS_NAME).get(0).getMetadata().getName();
+
+        LOGGER.info("Deploy KafkaConnect with wrong rack-aware topology key: {}", wrongRackKey);
+        KafkaConnect kc = KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.defaultKafkaConnect(CLUSTER_NAME, CLUSTER_NAME, 1)
+                .editSpec()
+                    .withNewRack()
+                        .withTopologyKey(wrongRackKey)
+                    .endRack()
+                    .addToConfig("key.converter.schemas.enable", false)
+                    .addToConfig("value.converter.schemas.enable", false)
+                    .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
+                    .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
+                .endSpec().build());
+        KafkaConnectResource.allowNetworkPolicyForKafkaConnect(kc);
+
+        PodUtils.waitForPendingPod(CLUSTER_NAME + "-connect");
+        List<String> connectWrongPods = kubeClient().listPodNames(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND);
+        String connectWrongPodName = connectWrongPods.get(0);
+        LOGGER.info("Waiting for ClusterOperator to get timeout operation of incorrectly set up KafkaConnect");
+        KafkaConnectUtils.waitForPodCondition("TimeoutException", "NotReady", NAMESPACE, CLUSTER_NAME);
+
+        kc = KafkaConnectResource.kafkaConnectClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get();
+        PodStatus kcWrongStatus = kubeClient().getPod(connectWrongPodName).getStatus();
+        assertThat("Unschedulable", is(kcWrongStatus.getConditions().get(0).getReason()));
+        assertThat("PodScheduled", is(kcWrongStatus.getConditions().get(0).getType()));
+
+        KafkaConnectResource.replaceKafkaConnectResource(CLUSTER_NAME, kafkaConnect -> {
+            kafkaConnect.getSpec().setRack(new Rack(rackKey));
+        });
+        KafkaConnectUtils.waitForConnectReady(CLUSTER_NAME);
+        LOGGER.info("KafkaConnect is ready with changed rack key: '{}'.", rackKey);
+        LOGGER.info("Verify KafkaConnect rack key update");
+        kc = KafkaConnectResource.kafkaConnectClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get();
+        assertThat(kc.getSpec().getRack().getTopologyKey(), is(rackKey));
+
+        List<String> kcPods = kubeClient().listPodNames(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND);
+        KafkaConnectUtils.sendReceiveMessagesThroughConnect(kcPods.get(0), TOPIC_NAME, kafkaClientsPodName, NAMESPACE, CLUSTER_NAME);
+    }
+
+    @Test
+    @Tag(CONNECT)
+    @Tag(REGRESSION)
+    @Tag(INTERNAL_CLIENTS_USED)
+    public void testRackAwareConnectCorrectDeployment() throws Exception {
+        installClusterOperator(NAMESPACE, CO_OPERATION_TIMEOUT_SHORT);
+
+        String rackKey = "rack-key";
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3)
+                .editSpec()
+                    .editKafka()
+                        .withNewRack()
+                            .withTopologyKey(rackKey)
+                        .endRack()
+                        .addToConfig("replica.selector.class", "org.apache.kafka.common.replica.RackAwareReplicaSelector")
+                    .endKafka()
+                .endSpec().done();
+
+        KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).done();
+        String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(KAFKA_CLIENTS_NAME).get(0).getMetadata().getName();
+
+        LOGGER.info("Deploy KafkaConnect with correct rack-aware topology key: {}", rackKey);
+        KafkaConnect kc = KafkaConnectResource.kafkaConnect(CLUSTER_NAME, 1)
+                .editSpec()
+                    .withNewRack()
+                        .withTopologyKey(rackKey)
+                    .endRack()
+                    .addToConfig("key.converter.schemas.enable", false)
+                    .addToConfig("value.converter.schemas.enable", false)
+                    .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
+                    .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
+                .endSpec().done();
+        KafkaConnectResource.allowNetworkPolicyForKafkaConnect(kc);
+
+        String topicName = "topic-test-rack-aware";
+        KafkaTopicResource.topic(CLUSTER_NAME, topicName).done();
+
+        List<String> connectPods = kubeClient().listPodNames(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND);
+        for (String connectPodName : connectPods) {
+            Affinity connectPodSpecAffinity = kubeClient().getDeployment(KafkaConnectResources.deploymentName(CLUSTER_NAME)).getSpec().getTemplate().getSpec().getAffinity();
+            NodeSelectorRequirement connectPodNodeSelectorRequirement = connectPodSpecAffinity.getNodeAffinity()
+                    .getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().get(0).getMatchExpressions().get(0);
+            Pod connectPod = kubeClient().getPod(connectPodName);
+            NodeAffinity nodeAffinity = connectPod.getSpec().getAffinity().getNodeAffinity();
+
+            LOGGER.info("PodName: {}\nNodeAffinity: {}", connectPodName, nodeAffinity);
+            assertThat(connectPodNodeSelectorRequirement.getKey(), is(rackKey));
+            assertThat(connectPodNodeSelectorRequirement.getOperator(), is("Exists"));
+
+            KafkaConnectUtils.sendReceiveMessagesThroughConnect(connectPodName, topicName, kafkaClientsPodName, NAMESPACE, CLUSTER_NAME);
+        }
+    }
 
     @Test
     @Tag(LOADBALANCER_SUPPORTED)


### PR DESCRIPTION
…oad balancer

Signed-off-by: Michal Tóth <mtoth@redhat.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

Create new tests for rack awareness of kafka clients. 

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

