### PR TITLE
Rename the test container artifact to make it less confusing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add support for `secretPrefix` property for User Operator to prefix all secret names created from KafkaUser resource.
 * Allow configuring labels and annotations for Cluster CA certificate secrets
 * Add the JAAS configuration string in the sasl.jaas.config property to the generated secrets for KafkaUser with SCRAM-SHA-512 authentication.
+* Strimzi `test-container` has been renamed to `strimzi-test-container` to make the name more clear
 
 ## 0.20.0
 

--- a/test-container/pom.xml
+++ b/test-container/pom.xml
@@ -11,7 +11,7 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>test-container</artifactId>
+    <artifactId>strimzi-test-container</artifactId>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The issue #3874 raises a good point that the artifact name `test-container` is too generic and can be confusing. This PR tries to rename it to `strimzi-test-container` to make it a bit more clear.