### PR TITLE
Running ZooKeeper nodes certificate generation asynchronously

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -335,12 +335,17 @@ public class ZookeeperClusterTest {
         assertThat(resource.getMetadata().getOwnerReferences().get(0), is(ownerRef));
     }
 
-    @Test
-    public void testGenerateBrokerSecret() throws CertificateParsingException {
+    private Secret generateNodeSecret() {
         ClusterCa clusterCa = new ClusterCa(new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), cluster, null, null);
         clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, true);
 
-        Secret secret = zc.generateNodesSecret(clusterCa, ka, true);
+        zc.generateCertificates(ka, clusterCa, true);
+        return zc.generateNodesSecret();
+    }
+
+    @Test
+    public void testGenerateBrokerSecret() throws CertificateParsingException {
+        Secret secret = generateNodeSecret();
         assertThat(secret.getData().keySet(), is(set(
                 "foo-zookeeper-0.crt",  "foo-zookeeper-0.key", "foo-zookeeper-0.p12", "foo-zookeeper-0.password",
                 "foo-zookeeper-1.crt", "foo-zookeeper-1.key", "foo-zookeeper-1.p12", "foo-zookeeper-1.password",


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR fixes #3880 in order to run the ZooKeeper nodes certificates generation asynchronously in a different worker thread and not in the main event-loop avoiding to block it when more it takes more than 2 secs.
It does the same as how it already works for Kafka brokers certificates generation.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
