### PR TITLE
[DOC] Add Cruise Control spec to TLS sidecar config

### DIFF
--- a/documentation/modules/ref-tls-sidecar.adoc
+++ b/documentation/modules/ref-tls-sidecar.adoc
@@ -10,6 +10,7 @@ The TLS sidecar can be configured using the `tlsSidecar` property in:
 * `Kafka.spec.kafka`
 * `Kafka.spec.zookeeper`
 * `Kafka.spec.entityOperator`
+* `Kafka.spec.cruiseControl`
 
 The TLS sidecar supports the following additional options:
 


### PR DESCRIPTION
Signed-off-by: Kyle Liberti <kliberti@redhat.com>

### Type of change

_Select the type of your PR_

- Documentation

### Description

Adds `Kafka.spec.cruiseControl` to `TLS sidecar configuration` [1] section of the documentation.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

[1] https://strimzi.io/docs/operators/latest/full/using.html#ref-tls-sidecar-deployment-configuration-kafka
