### PR TITLE
Topic Operator metrics

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -216,8 +216,8 @@ public class Session extends AbstractVerticle {
                         if (!stopped) {
                             timerId = null;
                             boolean isInitialReconcile = oldTimerId == null;
+                            topicOperator.getPeriodicReconciliationsCounter().increment();
                             topicOperator.reconcileAllTopics(isInitialReconcile ? "initial " : "periodic ").onComplete(result -> {
-                                topicOperator.getPeriodicReconciliationsCounter().increment();
                                 if (isInitialReconcile) {
                                     initReconcilePromise.complete();
                                 }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -1252,7 +1252,6 @@ class TopicOperator {
             if (reconcileState.ktList.size() == 0) {
                 reconciliationsCounter.increment();
                 successfulReconciliationsCounter.increment();
-                return Future.succeededFuture();
             }
             for (KafkaTopic kt : reconcileState.ktList) {
                 LogContext logContext = LogContext.periodic(reconciliationType + "kube " + kt.getMetadata().getName()).withKubeTopic(kt);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -1067,8 +1067,8 @@ public class TopicOperatorTest {
             context.verify(() -> {
                 MeterRegistry registry = metrics.meterRegistry();
 
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(0.0));
+                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(2.0));
+                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(1.0));
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(1.0));
 
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -597,7 +597,7 @@ public class TopicOperatorTest {
     }
 
     TopicOperator.Reconciliation reconciliation() {
-        return topicOperator.new Reconciliation("test") {
+        return topicOperator.new Reconciliation("test", true) {
             @Override
             public Future<Void> execute() {
                 return Future.succeededFuture();
@@ -1067,8 +1067,8 @@ public class TopicOperatorTest {
             context.verify(() -> {
                 MeterRegistry registry = metrics.meterRegistry();
 
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(2.0));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(1.0));
+                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(1.0));
+                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(0.0));
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(1.0));
 
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
@@ -1131,8 +1131,8 @@ public class TopicOperatorTest {
         reconcileFuture.onComplete(context.succeeding(e -> {
             MeterRegistry registry = metrics.meterRegistry();
 
-            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(1.0));
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(0.0));
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(0.0));
             assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(0.0));
 
             assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(0L));


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
We were wrongly watching reconciliations TO->Kafka. We should watch k8s->TO, what is done in this PR.

![Snímek z 2020-10-27 14-34-07](https://user-images.githubusercontent.com/19408098/97321867-95e23b00-186f-11eb-8370-7ed0bb4d516d.png)

Please anybody from QE check the modified test.

Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/3659

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards

