### PR TITLE
Some further fixes to TLS Sidecar docs

### DIFF
--- a/documentation/modules/ref-tls-sidecar.adoc
+++ b/documentation/modules/ref-tls-sidecar.adoc
@@ -7,8 +7,6 @@
 
 The TLS sidecar can be configured using the `tlsSidecar` property in:
 
-* `Kafka.spec.kafka`
-* `Kafka.spec.zookeeper`
 * `Kafka.spec.entityOperator`
 * `Kafka.spec.cruiseControl`
 
@@ -49,7 +47,8 @@ kind: Kafka
 metadata:
   name: my-cluster
 spec:
-  kafka:
+  # ...
+  cruiseControl:
     # ...
     tlsSidecar:
       image: my-org/my-image:latest
@@ -67,7 +66,5 @@ spec:
       livenessProbe:
         initialDelaySeconds: 15
         timeoutSeconds: 5
-    # ...
-  zookeeper:
     # ...
 ----


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

#3882 did some fixes to the TLS sidecar docs. But there are still some more needed. This PR removes the reference to the TLS sidecars inside Kafka and Zoo pods which do not exist anymore. I also fixes the example.

