### PR TITLE
Improve the description of the Rack API

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/Rack.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Rack.java
@@ -39,7 +39,7 @@ public class Rack implements UnknownPropertyPreserving, Serializable {
     }
 
     @Description("A key that matches labels assigned to the Kubernetes cluster nodes. " +
-            "The value of the label is used to set the broker's `broker.rack` config.")
+            "The value of the label is used to set the broker's `broker.rack` config and `client.rack` in Kafka Connect.")
     @Example("topology.kubernetes.io/zone")
     @JsonProperty(required = true)
     public String getTopologyKey() {

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
@@ -743,7 +743,8 @@ spec:
                         example: topology.kubernetes.io/zone
                         description: A key that matches labels assigned to the Kubernetes
                           cluster nodes. The value of the label is used to set the
-                          broker's `broker.rack` config.
+                          broker's `broker.rack` config and `client.rack` in Kafka
+                          Connect.
                     required:
                     - topologyKey
                     description: Configuration of the `broker.rack` broker config.

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
@@ -736,7 +736,8 @@ spec:
                         example: topology.kubernetes.io/zone
                         description: A key that matches labels assigned to the Kubernetes
                           cluster nodes. The value of the label is used to set the
-                          broker's `broker.rack` config.
+                          broker's `broker.rack` config and `client.rack` in Kafka
+                          Connect.
                     required:
                     - topologyKey
                     description: Configuration of the `broker.rack` broker config.
@@ -7092,7 +7093,8 @@ spec:
                         example: topology.kubernetes.io/zone
                         description: A key that matches labels assigned to the Kubernetes
                           cluster nodes. The value of the label is used to set the
-                          broker's `broker.rack` config.
+                          broker's `broker.rack` config and `client.rack` in Kafka
+                          Connect.
                     required:
                     - topologyKey
                     description: Configuration of the `broker.rack` broker config.
@@ -14623,7 +14625,8 @@ spec:
                         example: topology.kubernetes.io/zone
                         description: A key that matches labels assigned to the Kubernetes
                           cluster nodes. The value of the label is used to set the
-                          broker's `broker.rack` config.
+                          broker's `broker.rack` config and `client.rack` in Kafka
+                          Connect.
                     required:
                     - topologyKey
                     description: Configuration of the `broker.rack` broker config.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -936,7 +936,7 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-Kaf
 [options="header"]
 |====
 |Property            |Description
-|topologyKey  1.2+<.<|A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config.
+|topologyKey  1.2+<.<|A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config and `client.rack` in Kafka Connect.
 |string
 |====
 

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -1109,7 +1109,7 @@ spec:
                     topologyKey:
                       type: string
                       example: topology.kubernetes.io/zone
-                      description: A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config.
+                      description: A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config and `client.rack` in Kafka Connect.
                   required:
                     - topologyKey
                   description: Configuration of the `broker.rack` broker config.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -1137,7 +1137,7 @@ spec:
                 topologyKey:
                   type: string
                   example: topology.kubernetes.io/zone
-                  description: A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config.
+                  description: A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config and `client.rack` in Kafka Connect.
               required:
                 - topologyKey
               description: Configuration of the node label which will be used as the client.rack consumer configuration.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -1091,7 +1091,7 @@ spec:
                 topologyKey:
                   type: string
                   example: topology.kubernetes.io/zone
-                  description: A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config.
+                  description: A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config and `client.rack` in Kafka Connect.
               required:
                 - topologyKey
               description: Configuration of the node label which will be used as the client.rack consumer configuration.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1105,7 +1105,7 @@ spec:
                     topologyKey:
                       type: string
                       example: topology.kubernetes.io/zone
-                      description: A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config.
+                      description: A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config and `client.rack` in Kafka Connect.
                   required:
                     - topologyKey
                   description: Configuration of the `broker.rack` broker config.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1133,7 +1133,7 @@ spec:
                 topologyKey:
                   type: string
                   example: topology.kubernetes.io/zone
-                  description: A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config.
+                  description: A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config and `client.rack` in Kafka Connect.
               required:
                 - topologyKey
               description: Configuration of the node label which will be used as the client.rack consumer configuration.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -1087,7 +1087,7 @@ spec:
                 topologyKey:
                   type: string
                   example: topology.kubernetes.io/zone
-                  description: A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config.
+                  description: A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config and `client.rack` in Kafka Connect.
               required:
                 - topologyKey
               description: Configuration of the node label which will be used as the client.rack consumer configuration.

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1581,7 +1581,7 @@ spec:
                       example: topology.kubernetes.io/zone
                       description: A key that matches labels assigned to the Kubernetes
                         cluster nodes. The value of the label is used to set the broker's
-                        `broker.rack` config.
+                        `broker.rack` config and `client.rack` in Kafka Connect.
                   required:
                   - topologyKey
                   description: Configuration of the `broker.rack` broker config.

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1245,7 +1245,7 @@ spec:
                   example: topology.kubernetes.io/zone
                   description: A key that matches labels assigned to the Kubernetes
                     cluster nodes. The value of the label is used to set the broker's
-                    `broker.rack` config.
+                    `broker.rack` config and `client.rack` in Kafka Connect.
               required:
               - topologyKey
               description: Configuration of the node label which will be used as the

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -1197,7 +1197,7 @@ spec:
                   example: topology.kubernetes.io/zone
                   description: A key that matches labels assigned to the Kubernetes
                     cluster nodes. The value of the label is used to set the broker's
-                    `broker.rack` config.
+                    `broker.rack` config and `client.rack` in Kafka Connect.
               required:
               - topologyKey
               description: Configuration of the node label which will be used as the


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The description of the `Rack` API (https://strimzi.io/docs/operators/latest/full/using.html#type-Rack-reference) currently references only the `broker.rack` and not the `client.rack` for which it is now used as well. This PR improves the description to mention also `client.rack`.