### PR TITLE
Changed references from SimpleAclAuthorizer to AclAuthorizer

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRule.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRule.java
@@ -15,7 +15,7 @@ import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
 /**
- * Immutable class which represents a single ACL rule for SimpleAclAuthorizer.
+ * Immutable class which represents a single ACL rule for AclAuthorizer.
  * The main reason for not using directly the classes from the api module is that we need immutable objects for use in Sets.
  */
 public class SimpleAclRule {

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
@@ -36,12 +36,7 @@ import java.util.concurrent.ExecutionException;
 
 /**
  * SimlpeAclOperator is responsible for managing the authorization rules in Apache Kafka / Apache Zookeeper.
- * It is using Kafka's SimpleAclAuthorizer class to interact with Zookeeper and manage Acl rules.
- * Since SimpleAclAuthorizer is written in Scala, this operator is using some Scala structures required for passing to / returned from the SimpleAclAuthorizer object.
- * This class expects the SimpleAclAuthorizer instance to be passed from the outside.
- * That is useful for testing and is similar to how the Kubernetes client is passed around.
  */
-@SuppressWarnings("deprecation")
 public class SimpleAclOperator {
     private static final Logger log = LogManager.getLogger(SimpleAclOperator.class.getName());
 
@@ -130,8 +125,7 @@ public class SimpleAclOperator {
 
     /**
      * Update all ACLs for given user.
-     * SimpleAclAuthorizer doesn't support modification of existing rules.
-     * This class is using Sets to decide which rules need to be added and which need to be deleted.
+     * This method is using Sets to decide which rules need to be added and which need to be deleted.
      * It delagates to {@link #internalCreate internalCreate} and {@link #internalDelete internalDelete} methods for the actual addition or deletion.
      */
     protected Future<ReconcileResult<Set<SimpleAclRule>>> internalUpdate(String username, Set<SimpleAclRule> desired, Set<SimpleAclRule> current) {

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorIT.java
@@ -53,7 +53,7 @@ public class SimpleAclOperatorIT {
 
     private static Properties kafkaClusterConfig() {
         Properties config = new Properties();
-        config.setProperty("authorizer.class.name", "kafka.security.auth.SimpleAclAuthorizer");
+        config.setProperty("authorizer.class.name", "kafka.security.authorizer.AclAuthorizer");
         config.setProperty("super.users", "User:ANONYMOUS");
         return config;
     }


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Refactoring

### Description

This trivial PR changes the references from `SimpleAclAuthorizer` to `AclAuthorizer` in the UO and use the last one for the ITs.