### PR TITLE
Only extra strimzi relevant pod labels

### DIFF
--- a/examples/metrics/prometheus-install/strimzi-pod-monitor.yaml
+++ b/examples/metrics/prometheus-install/strimzi-pod-monitor.yaml
@@ -10,7 +10,7 @@ spec:
       strimzi.io/kind: cluster-operator
   namespaceSelector:
     matchNames:
-      - my-project
+      - myproject
   podMetricsEndpoints:
   - path: /metrics
     port: http
@@ -27,7 +27,7 @@ spec:
       app.kubernetes.io/name: entity-operator
   namespaceSelector:
     matchNames:
-      - my-project
+      - myproject
   podMetricsEndpoints:
   - path: /metrics
     port: healthcheck
@@ -44,7 +44,7 @@ spec:
       strimzi.io/kind: KafkaBridge
   namespaceSelector:
     matchNames:
-      - my-project
+      - myproject
   podMetricsEndpoints:
   - path: /metrics
     port: rest-api
@@ -63,14 +63,14 @@ spec:
         values: ["Kafka", "KafkaConnect"]
   namespaceSelector:
     matchNames:
-      - my-project
+      - myproject
   podMetricsEndpoints:
   - path: /metrics
     port: tcp-prometheus
     relabelings:
     - separator: ;
-      regex: __meta_kubernetes_pod_label_strimzi_(.+)
-      replacement: strimzi_$1
+      regex: __meta_kubernetes_pod_label_(strimzi_.+)
+      replacement: $1
       action: labelmap
     - sourceLabels: [__meta_kubernetes_namespace]
       separator: ;

--- a/examples/metrics/prometheus-install/strimzi-pod-monitor.yaml
+++ b/examples/metrics/prometheus-install/strimzi-pod-monitor.yaml
@@ -10,7 +10,7 @@ spec:
       strimzi.io/kind: cluster-operator
   namespaceSelector:
     matchNames:
-      - myproject
+      - kafka
   podMetricsEndpoints:
   - path: /metrics
     port: http
@@ -27,27 +27,27 @@ spec:
       app.kubernetes.io/name: entity-operator
   namespaceSelector:
     matchNames:
-      - myproject
+      - kafka
   podMetricsEndpoints:
   - path: /metrics
     port: healthcheck
----
-apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
-metadata:
-  name: bridge-metrics
-  labels:
-    app: strimzi
-spec:
-  selector:
-    matchLabels:
-      strimzi.io/kind: KafkaBridge
-  namespaceSelector:
-    matchNames:
-      - myproject
-  podMetricsEndpoints:
-  - path: /metrics
-    port: rest-api
+# ---
+# apiVersion: monitoring.coreos.com/v1
+# kind: PodMonitor
+# metadata:
+#   name: bridge-metrics
+#   labels:
+#     app: strimzi
+# spec:
+#   selector:
+#     matchLabels:
+#       strimzi.io/kind: KafkaBridge
+#   namespaceSelector:
+#     matchNames:
+#       - kafka
+#   podMetricsEndpoints:
+#   - path: /metrics
+#     port: rest-api
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -63,14 +63,14 @@ spec:
         values: ["Kafka", "KafkaConnect"]
   namespaceSelector:
     matchNames:
-      - myproject
+      - kafka
   podMetricsEndpoints:
   - path: /metrics
     port: tcp-prometheus
     relabelings:
     - separator: ;
-      regex: __meta_kubernetes_pod_label_(.+)
-      replacement: $1
+      regex: __meta_kubernetes_pod_label_strimzi_(.+)
+      replacement: strimzi_$1
       action: labelmap
     - sourceLabels: [__meta_kubernetes_namespace]
       separator: ;
@@ -96,4 +96,3 @@ spec:
       targetLabel: node_ip
       replacement: $1
       action: replace
-    

--- a/examples/metrics/prometheus-install/strimzi-pod-monitor.yaml
+++ b/examples/metrics/prometheus-install/strimzi-pod-monitor.yaml
@@ -69,7 +69,7 @@ spec:
     port: tcp-prometheus
     relabelings:
     - separator: ;
-      regex: __meta_kubernetes_pod_label_(strimzi_.+)
+      regex: __meta_kubernetes_pod_label_(strimzi_io_.+)
       replacement: $1
       action: labelmap
     - sourceLabels: [__meta_kubernetes_namespace]

--- a/examples/metrics/prometheus-install/strimzi-pod-monitor.yaml
+++ b/examples/metrics/prometheus-install/strimzi-pod-monitor.yaml
@@ -10,7 +10,7 @@ spec:
       strimzi.io/kind: cluster-operator
   namespaceSelector:
     matchNames:
-      - kafka
+      - my-project
   podMetricsEndpoints:
   - path: /metrics
     port: http
@@ -27,27 +27,27 @@ spec:
       app.kubernetes.io/name: entity-operator
   namespaceSelector:
     matchNames:
-      - kafka
+      - my-project
   podMetricsEndpoints:
   - path: /metrics
     port: healthcheck
-# ---
-# apiVersion: monitoring.coreos.com/v1
-# kind: PodMonitor
-# metadata:
-#   name: bridge-metrics
-#   labels:
-#     app: strimzi
-# spec:
-#   selector:
-#     matchLabels:
-#       strimzi.io/kind: KafkaBridge
-#   namespaceSelector:
-#     matchNames:
-#       - kafka
-#   podMetricsEndpoints:
-#   - path: /metrics
-#     port: rest-api
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: bridge-metrics
+  labels:
+    app: strimzi
+spec:
+  selector:
+    matchLabels:
+      strimzi.io/kind: KafkaBridge
+  namespaceSelector:
+    matchNames:
+      - my-project
+  podMetricsEndpoints:
+  - path: /metrics
+    port: rest-api
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -63,7 +63,7 @@ spec:
         values: ["Kafka", "KafkaConnect"]
   namespaceSelector:
     matchNames:
-      - kafka
+      - my-project
   podMetricsEndpoints:
   - path: /metrics
     port: tcp-prometheus


### PR DESCRIPTION
Many environments have labels on pods with potentially high cardinality that you don't want in your prometheus environment. This changes the podmonitor to only include the strimzi.io labels.

### Type of change

- Bugfix

### Description
The existing podmonitor in the repo pulls all the labels from a pod into prometheus. This was a problem in my cluster as I have a lot of pod labels with relatively high cardinality. So I changed the pod monitor to only pull in the strimzi_(.+) labels. This is working in my cluster with the stock dashboards.



