### PR TITLE
Fix useServiceDnsDomain documentation

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration.adoc
@@ -115,7 +115,25 @@ listeners:
 === `useServiceDnsDomain`
 
 The `useServiceDnsDomain` property is only used with `internal` listeners,
-and defines whether the fully-qualified DNS names including the cluster service suffix (usually `.cluster.local`) are assigned.
+and defines whether the fully-qualified DNS names including the cluster service suffix (usually `.cluster.local`) are used.
+With `useServiceDnsDomain` set as `false`, the advertised addresses are generated without the service suffix - for example `my-cluster-kafka-0.my-cluster-kafka-brokers.myproject.svc`.
+With `useServiceDnsDomain` set as `false`, the advertised addresses are generated without the service suffix - for example `my-cluster-kafka-0.my-cluster-kafka-brokers.myproject.svc.cluster.local`.
 Default is `false`.
 
-With `useServiceDnsDomain` set as `false` and advertised addresses defined, the Kubernetes network can join an outside network.
+.Example of an internal listener configured to use the Service DNS domain
+[source,yaml,subs=attributes+]
+----
+listeners:
+  #...
+  - name: plain
+    port: 9092
+    type: internal
+    tls: false
+    configuration:
+      useServiceDnsDomain: true
+      # ...
+# ...
+----
+
+In case your Kubernetes cluster uses different service suffix then `.cluster.local`, you can configure it using the `KUBERNETES_SERVICE_DNS_DOMAIN` environment variable in the Cluster Operator configuration.
+See xref:ref-operator-cluster-str[] for more details.

--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration.adoc
@@ -114,7 +114,7 @@ listeners:
 [id='property-listener-config-dns-{context}']
 === `useServiceDnsDomain`
 
-The `useServiceDnsDomain` property is only used with `internal` listeners,
+The `useServiceDnsDomain` property is only used with `internal` listeners.
 It defines whether the fully-qualified DNS names that include the cluster service suffix (usually `.cluster.local`) are used.
 With `useServiceDnsDomain` set as `false`, the advertised addresses are generated without the service suffix; for example, `my-cluster-kafka-0.my-cluster-kafka-brokers.myproject.svc`.
 With `useServiceDnsDomain` set as `true`, the advertised addresses are generated with the service suffix; for example, `my-cluster-kafka-0.my-cluster-kafka-brokers.myproject.svc.cluster.local`.

--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration.adoc
@@ -115,9 +115,9 @@ listeners:
 === `useServiceDnsDomain`
 
 The `useServiceDnsDomain` property is only used with `internal` listeners,
-and defines whether the fully-qualified DNS names including the cluster service suffix (usually `.cluster.local`) are used.
-With `useServiceDnsDomain` set as `false`, the advertised addresses are generated without the service suffix - for example `my-cluster-kafka-0.my-cluster-kafka-brokers.myproject.svc`.
-With `useServiceDnsDomain` set as `false`, the advertised addresses are generated without the service suffix - for example `my-cluster-kafka-0.my-cluster-kafka-brokers.myproject.svc.cluster.local`.
+It defines whether the fully-qualified DNS names that include the cluster service suffix (usually `.cluster.local`) are used.
+With `useServiceDnsDomain` set as `false`, the advertised addresses are generated without the service suffix; for example, `my-cluster-kafka-0.my-cluster-kafka-brokers.myproject.svc`.
+With `useServiceDnsDomain` set as `true`, the advertised addresses are generated with the service suffix; for example, `my-cluster-kafka-0.my-cluster-kafka-brokers.myproject.svc.cluster.local`.
 Default is `false`.
 
 .Example of an internal listener configured to use the Service DNS domain
@@ -135,5 +135,5 @@ listeners:
 # ...
 ----
 
-In case your Kubernetes cluster uses different service suffix then `.cluster.local`, you can configure it using the `KUBERNETES_SERVICE_DNS_DOMAIN` environment variable in the Cluster Operator configuration.
+If your Kubernetes cluster uses a different service suffix than `.cluster.local`, you can configure the suffix using the `KUBERNETES_SERVICE_DNS_DOMAIN` environment variable in the Cluster Operator configuration.
 See xref:ref-operator-cluster-str[] for more details.

--- a/documentation/modules/proc-securing-kafka.adoc
+++ b/documentation/modules/proc-securing-kafka.adoc
@@ -46,7 +46,6 @@ spec:
         tls: true
         authentication:
           type: tls <3>
-        useServiceDnsDomain: true <4>
     # ...
   zookeeper:
     # ...
@@ -54,7 +53,6 @@ spec:
 <1> Authorization xref:con-securing-kafka-authorization-str[enables `simple` authorization on the Kafka broker using the `AclAuthorizer` Kafka plugin].
 <2> List of user principals with unlimited access to Kafka. _CN_ is the common name from the client certificate when TLS authentication is used.
 <3> Listener authentication mechanisms may be configured for each listener, and xref:assembly-securing-kafka-brokers-{context}[specified as mutual TLS, SCRAM-SHA-512 or token-based OAuth 2.0].
-<4> Defines whether the fully-qualified DNS names including the cluster service suffix (usually `.cluster.local`) are assigned.
 +
 If you are configuring an external listener, the configuration is dependent on the chosen connection mechanism.
 

--- a/documentation/modules/ref-sample-kafka-resource-config.adoc
+++ b/documentation/modules/ref-sample-kafka-resource-config.adoc
@@ -42,7 +42,8 @@ spec:
         port: 9092 <8>
         type: internal <9>
         tls: false <10>
-        useServiceDnsDomain: true <11>
+        configuration:
+          useServiceDnsDomain: true <11>
       - name: tls
         port: 9093
         type: internal


### PR DESCRIPTION
Signed-off-by: Jakub Scholz <www@scholzj.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

This PR fixes / improves the documentation about the `useServiceDnsDomain` option in listener configuration. It fixes bad YAML in some parts of the docs and improves the description in the API reference.

This PR should close #3898.

This should be cherry-picked for 0.20.0 in case we do some patch release.
