### PR TITLE
Fix invalid references to custom resource paths

### DIFF
--- a/documentation/modules/proc-jmxtrans-deployment.adoc
+++ b/documentation/modules/proc-jmxtrans-deployment.adoc
@@ -27,7 +27,7 @@ Output definitions specify where JMX metrics are pushed to, and in which data fo
 For information about supported data formats, see link:https://github.com/jmxtrans/jmxtrans/wiki/OutputWriters[Data formats^].
 How many seconds JmxTrans agent waits for before pushing new data can be configured through the `flushDelay` property.
 The `host` and `port` properties define the target host address and target port the data is pushed to.
-The `name` property is a required property that is referenced by the `Kafka.spec.kafka.jmxOptions.jmxTrans.queries` property.
+The `name` property is a required property that is referenced by the `Kafka.spec.jmxTrans.kafkaQueries` property.
 
 Here is an example configuration pushing JMX data in the Graphite format every 5 seconds to a Logstash database on \http://myLogstash:9999, and another pushing to `standardOut` (standard output):
 [source,yaml,subs=attributes+]

--- a/documentation/modules/ref-healthchecks.adoc
+++ b/documentation/modules/ref-healthchecks.adoc
@@ -12,7 +12,7 @@ Liveness and readiness probes can be configured using the `livenessProbe` and `r
 * `Kafka.spec.entityOperator.tlsSidecar`
 * `Kafka.spec.entityOperator.topicOperator`
 * `Kafka.spec.entityOperator.userOperator`
-* `Kafka.spec.KafkaExporter`
+* `Kafka.spec.kafkaExporter`
 * `KafkaConnect.spec`
 * `KafkaConnectS2I.spec`
 * `KafkaMirrorMaker.spec`

--- a/documentation/modules/ref-resource-limits-and-requests.adoc
+++ b/documentation/modules/ref-resource-limits-and-requests.adoc
@@ -12,7 +12,7 @@ Resource limits and requests are configured using the `resources` property in th
 * `Kafka.spec.entityOperator.topicOperator`
 * `Kafka.spec.entityOperator.userOperator`
 * `Kafka.spec.entityOperator.tlsSidecar`
-* `Kafka.spec.KafkaExporter`
+* `Kafka.spec.kafkaExporter`
 * `KafkaConnect.spec`
 * `KafkaConnectS2I.spec`
 * `KafkaBridge.spec`


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This PR should fix the invalid references to path in our CRs used in different parts of the documentation. This should fix #3564.