### PR TITLE
Fix the client rack-awareness in Kafka Connect

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
@@ -89,4 +89,16 @@ public class KafkaConnectResources {
     public static String url(String clusterName, String namespace, int port) {
         return "http://" + qualifiedServiceName(clusterName, namespace) + ":" + port;
     }
+
+    /**
+     * Get the name of the resource init container role binding given the name of the {@code namespace} and {@code cluster}.
+     *
+     * @param clusterName   The cluster name.
+     * @param namespace     The namespace.
+     *
+     * @return The name of the init container's cluster role binding.
+     */
+    public static String initContainerClusterRoleBindingName(String clusterName, String namespace) {
+        return "strimzi-" + namespace + "-" + deploymentName(clusterName) + "-init";
+    }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
@@ -203,4 +203,15 @@ public class KafkaResources {
     public static String zookeeperHeadlessServiceName(String clusterName) {
         return clusterName + "-zookeeper-nodes";
     }
+
+    /**
+     * Get the name of the resource init container role binding given the name of the {@code namespace} and {@code cluster}.
+     *
+     * @param cluster   The cluster name.
+     * @param namespace The namespace.
+     * @return The name of the init container's cluster role binding.
+     */
+    public static String initContainerClusterRoleBindingName(String cluster, String namespace) {
+        return "strimzi-" + namespace + "-" + cluster + "-kafka-init";
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -174,6 +174,7 @@ public class Main {
                     put("strimzi-kafka-broker", "030-ClusterRole-strimzi-kafka-broker.yaml");
                     put("strimzi-entity-operator", "031-ClusterRole-strimzi-entity-operator.yaml");
                     put("strimzi-topic-operator", "032-ClusterRole-strimzi-topic-operator.yaml");
+                    put("strimzi-kafka-client", "033-ClusterRole-strimzi-kafka-client.yaml");
                 }
             };
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1336,28 +1336,16 @@ public abstract class AbstractModel {
         }
     }
 
-    protected ClusterRoleBinding getClusterRoleBinding(Subject subject, RoleRef roleRef) {
-
+    protected ClusterRoleBinding getClusterRoleBinding(String name, Subject subject, RoleRef roleRef) {
         return new ClusterRoleBindingBuilder()
                 .withNewMetadata()
-                .withName(initContainerClusterRoleBindingName(namespace, cluster))
+                .withName(name)
                 .withOwnerReferences(createOwnerReference())
                 .withLabels(labels.toMap())
                 .endMetadata()
                 .withSubjects(subject)
                 .withRoleRef(roleRef)
                 .build();
-    }
-
-    /**
-     * Get the name of the resource init container role binding given the name of the {@code namespace} and {@code cluster}.
-     *
-     * @param namespace The namespace.
-     * @param cluster   The cluster name.
-     * @return The name of the init container's cluster role binding.
-     */
-    public static String initContainerClusterRoleBindingName(String namespace, String cluster) {
-        return "strimzi-" + namespace + "-" + cluster + "-kafka-init";
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1564,7 +1564,7 @@ public class KafkaCluster extends AbstractModel {
                     .withKind("ClusterRole")
                     .build();
 
-            return getClusterRoleBinding(ks, roleRef);
+            return getClusterRoleBinding(KafkaResources.initContainerClusterRoleBindingName(cluster, namespace), ks, roleRef);
         } else {
             return null;
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -814,7 +814,7 @@ public class KafkaConnectCluster extends AbstractModel {
                 .withKind("ClusterRole")
                 .build();
 
-        return getClusterRoleBinding(subject, roleRef);
+        return getClusterRoleBinding(KafkaConnectResources.initContainerClusterRoleBindingName(cluster, namespace), subject, roleRef);
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -798,7 +798,6 @@ public class KafkaConnectCluster extends AbstractModel {
      * @return The cluster role binding.
      */
     public ClusterRoleBinding generateClusterRoleBinding() {
-
         if (rack == null) {
             return null;
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1695,7 +1695,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         Future<ReconciliationState> kafkaInitClusterRoleBinding() {
             ClusterRoleBinding desired = kafkaCluster.generateClusterRoleBinding(namespace);
             Future<ReconcileResult<ClusterRoleBinding>> fut = clusterRoleBindingOperations.reconcile(
-                    KafkaCluster.initContainerClusterRoleBindingName(namespace, name), desired);
+                    KafkaResources.initContainerClusterRoleBindingName(name, namespace), desired);
 
             Promise replacementPromise = Promise.promise();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -188,7 +188,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
      * @return                  Future for tracking the asynchronous result of the ClusterRoleBinding reconciliation
      */
     Future<ReconcileResult<ClusterRoleBinding>> connectInitClusterRoleBinding(String namespace, String name, KafkaConnectCluster connectCluster) {
-        return clusterRoleBindingOperations.reconcile(KafkaConnectCluster.initContainerClusterRoleBindingName(namespace, name),
+        return clusterRoleBindingOperations.reconcile(KafkaConnectResources.initContainerClusterRoleBindingName(name, namespace),
                 connectCluster.generateClusterRoleBinding());
     }
 }

--- a/cluster-operator/src/main/resources/cluster-roles/033-ClusterRole-strimzi-kafka-client.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/033-ClusterRole-strimzi-kafka-client.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-kafka-client
+  labels:
+    app: strimzi
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      # The Kafka clients (Connect, Mirror Maker, etc.) require "get" permissions to view the node they are on
+      # This information is used to generate a Rack ID (client.rack option) that is used for consuming from the closest
+      # replicas when enabled
+      - nodes
+    verbs:
+      - get

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -43,6 +43,7 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaAuthorizationKeycloakBuilder;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.KafkaJmxOptionsBuilder;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.Rack;
 import io.strimzi.api.kafka.model.RackBuilder;
 import io.strimzi.api.kafka.model.SystemProperty;
@@ -2848,7 +2849,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
         ClusterRoleBinding crb = kc.generateClusterRoleBinding(testNamespace);
 
-        assertThat(crb.getMetadata().getName(), is(KafkaCluster.initContainerClusterRoleBindingName(testNamespace, cluster)));
+        assertThat(crb.getMetadata().getName(), is(KafkaResources.initContainerClusterRoleBindingName(cluster, testNamespace)));
         assertThat(crb.getMetadata().getNamespace(), is(nullValue()));
         assertThat(crb.getSubjects().get(0).getNamespace(), is(testNamespace));
         assertThat(crb.getSubjects().get(0).getName(), is(kc.getServiceAccountName()));
@@ -2870,7 +2871,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
         ClusterRoleBinding crb = kc.generateClusterRoleBinding(testNamespace);
 
-        assertThat(crb.getMetadata().getName(), is(KafkaCluster.initContainerClusterRoleBindingName(testNamespace, cluster)));
+        assertThat(crb.getMetadata().getName(), is(KafkaResources.initContainerClusterRoleBindingName(cluster, testNamespace)));
         assertThat(crb.getMetadata().getNamespace(), is(nullValue()));
         assertThat(crb.getSubjects().get(0).getNamespace(), is(testNamespace));
         assertThat(crb.getSubjects().get(0).getName(), is(kc.getServiceAccountName()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -1432,7 +1432,7 @@ public class KafkaConnectClusterTest {
         KafkaConnectCluster kafkaConnectCluster = KafkaConnectCluster.fromCrd(kafkaConnect, VERSIONS);
         ClusterRoleBinding crb = kafkaConnectCluster.generateClusterRoleBinding();
 
-        assertThat(crb.getMetadata().getName(), is(KafkaConnectCluster.initContainerClusterRoleBindingName(testNamespace, cluster)));
+        assertThat(crb.getMetadata().getName(), is(KafkaConnectResources.initContainerClusterRoleBindingName(cluster, testNamespace)));
         assertThat(crb.getMetadata().getNamespace(), is(nullValue()));
         assertThat(crb.getSubjects().get(0).getNamespace(), is(testNamespace));
         assertThat(crb.getSubjects().get(0).getName(), is(kafkaConnectCluster.getServiceAccountName()));

--- a/documentation/modules/ref-operator-cluster.adoc
+++ b/documentation/modules/ref-operator-cluster.adoc
@@ -274,7 +274,7 @@ and
 [source,yaml,options="nowrap"]
 .Example `ClusterRoleBinding` for the Cluster Operator for the Kafka client rack-awarness
 ----
-include::install/cluster-operator/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-clients-delegation[]
+include::install/cluster-operator/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-client-delegation.yaml[]
 ----
 
 `ClusterRoles` containing only namespaced resources are bound using `RoleBindings` only.

--- a/documentation/modules/ref-operator-cluster.adoc
+++ b/documentation/modules/ref-operator-cluster.adoc
@@ -241,6 +241,15 @@ The `strimzi-topic-operator` `ClusterRole` represents the access needed by the T
 include::install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml[]
 ----
 
+The `strimzi-kafka-client` `ClusterRole` represents the access needed by the components based on Kafka clients which use the client rack-awareness.
+As described in the xref:delegated-privileges-str[Delegated privileges] section, this role is also needed by the Cluster Operator in order to be able to delegate this access.
+
+[source,yaml,options="nowrap"]
+.`ClusterRole` for the Cluster Operator allowing it to delegate access to events to the Topic Operator
+----
+include::install/cluster-operator/033-ClusterRole-strimzi-kafka-client.yaml[]
+----
+
 == `ClusterRoleBindings`
 
 The operator needs `ClusterRoleBindings` and `RoleBindings` which associates its `ClusterRole` with its `ServiceAccount`:
@@ -255,9 +264,17 @@ include::install/cluster-operator/021-ClusterRoleBinding-strimzi-cluster-operato
 `ClusterRoleBindings` are also needed for the `ClusterRoles` needed for delegation:
 
 [source,yaml,options="nowrap"]
-.Examples `RoleBinding` for the Cluster Operator
+.Example `ClusterRoleBinding` for the Cluster Operator for the Kafka broker rack-awarness
 ----
 include::install/cluster-operator/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml[]
+----
+
+and
+
+[source,yaml,options="nowrap"]
+.Example `ClusterRoleBinding` for the Cluster Operator for the Kafka client rack-awarness
+----
+include::install/cluster-operator/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-clients-delegation[]
 ----
 
 `ClusterRoles` containing only namespaced resources are bound using `RoleBindings` only.

--- a/documentation/modules/ref-operator-cluster.adoc
+++ b/documentation/modules/ref-operator-cluster.adoc
@@ -245,7 +245,7 @@ The `strimzi-kafka-client` `ClusterRole` represents the access needed by the com
 As described in the xref:delegated-privileges-str[Delegated privileges] section, this role is also needed by the Cluster Operator in order to be able to delegate this access.
 
 [source,yaml,options="nowrap"]
-.`ClusterRole` for the Cluster Operator allowing it to delegate access to events to the Topic Operator
+.`ClusterRole` for the Cluster Operator allowing it to delegate access to Kubernetes nodes to the Kafka client based pods
 ----
 include::install/cluster-operator/033-ClusterRole-strimzi-kafka-client.yaml[]
 ----

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/033-ClusterRole-strimzi-kafka-client.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/033-ClusterRole-strimzi-kafka-client.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.createGlobalResources -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-kafka-client
+  labels:
+    app: {{ template "strimzi.name" . }}
+    chart: {{ template "strimzi.chart" . }}
+    component: client-role
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+    # The Kafka clients (Connect, Mirror Maker, etc.) require "get" permissions to view the node they are on
+    # This information is used to generate a Rack ID (client.rack option) that is used for consuming from the closest
+    # replicas when enabled
+  - nodes
+  verbs:
+  - get
+{{- end -}}

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-client-delegation.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-client-delegation.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.createGlobalResources -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: strimzi-cluster-operator-kafka-client-delegation
+  labels:
+    app: {{ template "strimzi.name" . }}
+    chart: {{ template "strimzi.chart" . }}
+    component: client-role-binding
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+# The Kafka clients cluster role must be bound to the cluster operator service account so that it can delegate the
+# cluster role to the Kafka clients using it for consuming from closest replica.
+# This must be done to avoid escalating privileges which would be blocked by Kubernetes.
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: strimzi-kafka-client
+  apiGroup: rbac.authorization.k8s.io
+
+{{- end -}}

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/033-ClusterRole-strimzi-kafka-client.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/033-ClusterRole-strimzi-kafka-client.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.createGlobalResources -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-kafka-client
+  labels:
+    app: {{ template "strimzi.name" . }}
+    chart: {{ template "strimzi.chart" . }}
+    component: client-role
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+    # The Kafka clients (Connect, Mirror Maker, etc.) require "get" permissions to view the node they are on
+    # This information is used to generate a Rack ID (client.rack option) that is used for consuming from the closest
+    # replicas when enabled
+  - nodes
+  verbs:
+  - get
+{{- end -}}

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-client-delegation.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-client-delegation.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.createGlobalResources -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: strimzi-cluster-operator-kafka-client-delegation
+  labels:
+    app: {{ template "strimzi.name" . }}
+    chart: {{ template "strimzi.chart" . }}
+    component: client-role-binding
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+# The Kafka clients cluster role must be bound to the cluster operator service account so that it can delegate the
+# cluster role to the Kafka clients using it for consuming from closest replica.
+# This must be done to avoid escalating privileges which would be blocked by Kubernetes.
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: strimzi-kafka-client
+  apiGroup: rbac.authorization.k8s.io
+
+{{- end -}}

--- a/install/cluster-operator/033-ClusterRole-strimzi-kafka-client.yaml
+++ b/install/cluster-operator/033-ClusterRole-strimzi-kafka-client.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-kafka-client
+  labels:
+    app: strimzi
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      # The Kafka clients (Connect, Mirror Maker, etc.) require "get" permissions to view the node they are on
+      # This information is used to generate a Rack ID (client.rack option) that is used for consuming from the closest
+      # replicas when enabled
+      - nodes
+    verbs:
+      - get

--- a/install/cluster-operator/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-client-delegation.yaml
+++ b/install/cluster-operator/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-client-delegation.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: strimzi-cluster-operator-kafka-client-delegation
+  labels:
+    app: strimzi
+# The Kafka clients cluster role must be bound to the cluster operator service account so that it can delegate the
+# cluster role to the Kafka clients using it for consuming from closest replica.
+# This must be done to avoid escalating privileges which would be blocked by Kubernetes.
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: myproject
+roleRef:
+  kind: ClusterRole
+  name: strimzi-kafka-client
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The client rack-awareness in Kafka Connect does not work because it references a non-existing cluster role. This PR adds a new cluster role `strimzi-kafka-client` with the required rights. I also had to do some changes to how the ClusterRoleBindings are named to make sure a `KafkaConnect` and `Kafka` with the same name can run together.

I considered re-using the `strimzi-kafka-broker` role which has currently the same rights. But I decided using separate role is cleaner in case the broker role needs to change in the future.

This should resolve #3902.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging