### PR TITLE
[systemtest] Small fixes for failing tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
@@ -12,7 +12,6 @@ import io.strimzi.api.kafka.model.KafkaBridgeResources;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
-import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
@@ -387,7 +386,7 @@ class CustomResourceStatusST extends AbstractST {
         KafkaMirrorMaker2Utils.waitForKafkaMirrorMaker2NotReady(CLUSTER_NAME);
 
         KafkaMirrorMaker2Resource.deleteKafkaMirrorMaker2WithoutWait(CLUSTER_NAME);
-        DeploymentUtils.waitForDeploymentDeletion(KafkaMirrorMakerResources.deploymentName(CLUSTER_NAME));
+        DeploymentUtils.waitForDeploymentDeletion(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME));
     }
 
     @Test
@@ -432,7 +431,7 @@ class CustomResourceStatusST extends AbstractST {
     }
 
     void deployTestSpecificResources() throws Exception {
-        installClusterOperator(NAMESPACE);
+        installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_MEDIUM);
 
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
             .editSpec()

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
@@ -431,9 +431,9 @@ class CustomResourceStatusST extends AbstractST {
     }
 
     void deployTestSpecificResources() throws Exception {
-        installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_MEDIUM);
+        installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT);
 
-        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 3)
             .editSpec()
                 .editKafka()
                     .withNewListeners()

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -769,6 +769,6 @@ class RollingUpdateST extends AbstractST {
     @BeforeAll
     void setup() throws Exception {
         ResourceManager.setClassResources();
-        installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT);
+        installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
     }
 }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Test fixes

### Description

 - `CustomResourceStatusST` -  problem here was that when the timeout for operation was set to 5 minutes, the connection to Kafka/MM2 wasn't established and the time for MM2 to become ready ran out
- `RollingUpdateST` - here was similar problem, on ocp4.x when we wanted to change bootstrap for listener, the operation timeout was too short, so the pod didn't roll in time

### Checklist

- [x] Make sure all tests pass

