### PR TITLE
Using container CPU usage including kernel time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Allow configuring labels and annotations for Cluster CA certificate secrets
 * Add the JAAS configuration string in the sasl.jaas.config property to the generated secrets for KafkaUser with SCRAM-SHA-512 authentication.
 * Strimzi `test-container` has been renamed to `strimzi-test-container` to make the name more clear
+* Updated the CPU usage metric in the Kafka, ZooKeeper and Cruise Control dashboards to include the CPU kernel time (other than the current user time)
 
 ## 0.20.0
 

--- a/examples/metrics/grafana-dashboards/strimzi-cruise-control.json
+++ b/examples/metrics/grafana-dashboards/strimzi-cruise-control.json
@@ -1921,7 +1921,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_user_seconds_total{namespace=\"$kubernetes_namespace\",pod=~\"$strimzi_cluster_name-cruise-control-.*\",container=\"cruise-control\"}[5m])) by (pod)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$kubernetes_namespace\",pod=~\"$strimzi_cluster_name-cruise-control-.*\",container=\"cruise-control\"}[5m])) by (pod)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,

--- a/examples/metrics/grafana-dashboards/strimzi-kafka.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kafka.json
@@ -852,7 +852,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_user_seconds_total{namespace=\"$kubernetes_namespace\",pod=~\"$strimzi_cluster_name-$kafka_broker\",container=\"kafka\"}[5m])) by (pod)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$kubernetes_namespace\",pod=~\"$strimzi_cluster_name-$kafka_broker\",container=\"kafka\"}[5m])) by (pod)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,

--- a/examples/metrics/grafana-dashboards/strimzi-zookeeper.json
+++ b/examples/metrics/grafana-dashboards/strimzi-zookeeper.json
@@ -602,7 +602,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_user_seconds_total{namespace=\"$kubernetes_namespace\",container=\"zookeeper\",pod=~\"$strimzi_cluster_name-$zk_node\"}[5m])) by (pod)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$kubernetes_namespace\",container=\"zookeeper\",pod=~\"$strimzi_cluster_name-$zk_node\"}[5m])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}}",

--- a/examples/metrics/prometheus-additional-properties/prometheus-additional.yaml
+++ b/examples/metrics/prometheus-additional-properties/prometheus-additional.yaml
@@ -61,7 +61,7 @@
     action: drop
   - source_labels: [__name__]
     separator: ;
-    regex: container_(network_tcp_usage_total|tasks_state|cpu_usage_seconds_total|memory_failures_total|network_udp_usage_total)
+    regex: container_(network_tcp_usage_total|tasks_state|memory_failures_total|network_udp_usage_total)
     replacement: $1
     action: drop
 


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Refactoring

### Description

This PR fixes #3909 using the `container_cpu_usage_seconds_total` metric which includes the kernel CPU time other than the user one.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
