### PR TITLE
[DOC] Improve the docs section about upgrading resources from v1alpha1 to v1beta1

### DIFF
--- a/documentation/assemblies/upgrading/assembly-upgrade-resources.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-resources.adoc
@@ -14,7 +14,7 @@ The `{KafkaApiVersionPrev}` API version is deprecated for the following Strimzi 
 * `KafkaTopic`
 * `KafkaUser`
 
-These resources that use the API version `{KafkaApiVersionPrev}` must be updated to use `{KafkaApiVersion}`.
+Update these resources to use the `{KafkaApiVersion}` API version.
 
 This section describes the upgrade steps for the resources.
 
@@ -35,7 +35,7 @@ metadata:
     upgrade: "Upgraded to {KafkaApiVersion}"
 ----
 
-The following sections contain a resource specific conversion guides:
+The following procedures describe the steps to update specific resources to use the `{KafkaApiVersion}` API version:
 
 * xref:proc-upgrade-kafka-resources-{context}[]
 * xref:proc-upgrade-kafka-connect-resources-{context}[]

--- a/documentation/assemblies/upgrading/assembly-upgrade-resources.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-resources.adoc
@@ -5,8 +5,16 @@
 [id='assembly-upgrade-resources-{context}']
 = Strimzi resource upgrades
 
-The `{KafkaApiVersionPrev}` API version is deprecated.
-Resources that use the API version `{KafkaApiVersionPrev}` must be updated to use `{KafkaApiVersion}`.
+The `{KafkaApiVersionPrev}` API version is deprecated for the following Strimzi resources:
+
+* `Kafka`
+* `KafkaConnect`
+* `KafkaConnectS2I`
+* `KafkaMirrorMaker`
+* `KafkaTopic`
+* `KafkaUser`
+
+These resources that use the API version `{KafkaApiVersionPrev}` must be updated to use `{KafkaApiVersion}`.
 
 This section describes the upgrade steps for the resources.
 
@@ -26,6 +34,15 @@ metadata:
   annotations:
     upgrade: "Upgraded to {KafkaApiVersion}"
 ----
+
+The following sections contain a resource specific conversion guides:
+
+* xref:proc-upgrade-kafka-resources-{context}[]
+* xref:proc-upgrade-kafka-connect-resources-{context}[]
+* xref:proc-upgrade-kafka-connect-s2i-resources-{context}[]
+* xref:proc-upgrade-kafka-mirror-maker-resources-{context}[]
+* xref:proc-upgrade-kafka-topic-resources-{context}[]
+* xref:proc-upgrade-kafka-user-resources-{context}[]
 
 include::modules/proc-upgrade-kafka-resources.adoc[leveloffset=+1]
 include::modules/proc-upgrade-kafka-connect-resources.adoc[leveloffset=+1]

--- a/documentation/modules/upgrading/proc-upgrade-kafka-connect-resources.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-kafka-connect-resources.adoc
@@ -30,7 +30,7 @@ with:
 +
 [source,shell,subs="attributes"]
 ----
-apiVersion:{KafkaConnectApiVersion}
+apiVersion: {KafkaConnectApiVersion}
 ----
 
 . If present, move:

--- a/documentation/modules/upgrading/proc-upgrade-kafka-connect-s2i-resources.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-kafka-connect-s2i-resources.adoc
@@ -30,7 +30,7 @@ with:
 +
 [source,shell,subs="attributes"]
 ----
-apiVersion:{KafkaConnectS2IApiVersion}
+apiVersion: {KafkaConnectS2IApiVersion}
 ----
 
 . If present, move:

--- a/documentation/modules/upgrading/proc-upgrade-kafka-mirror-maker-resources.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-kafka-mirror-maker-resources.adoc
@@ -30,7 +30,7 @@ with:
 +
 [source,shell,subs="attributes"]
 ----
-apiVersion:{KafkaMirrorMakerApiVersion}
+apiVersion: {KafkaMirrorMakerApiVersion}
 ----
 
 . If present, move:

--- a/documentation/modules/upgrading/proc-upgrade-kafka-resources.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-kafka-resources.adoc
@@ -30,7 +30,7 @@ with:
 +
 [source,shell,subs="attributes"]
 ----
-apiVersion:{KafkaApiVersion}
+apiVersion: {KafkaApiVersion}
 ----
 
 . If the `Kafka` resource has:

--- a/documentation/modules/upgrading/proc-upgrade-kafka-topic-resources.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-kafka-topic-resources.adoc
@@ -30,7 +30,7 @@ with:
 +
 [source,shell,subs="attributes"]
 ----
-apiVersion:{KafkaTopicApiVersion}
+apiVersion: {KafkaTopicApiVersion}
 ----
 
 . Save the file, exit the editor and wait for the updated resource to be reconciled.

--- a/documentation/modules/upgrading/proc-upgrade-kafka-user-resources.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-kafka-user-resources.adoc
@@ -30,7 +30,7 @@ with:
 +
 [source,shell,subs="attributes"]
 ----
-apiVersion:{KafkaUserApiVersion}
+apiVersion: {KafkaUserApiVersion}
 ----
 
 . Save the file, exit the editor and wait for the updated resource to be reconciled.


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The docs section about resource upgrades (https://strimzi.io/docs/operators/0.20.0/deploying.html#assembly-upgrade-resources-str) is a bit confusing. We have now many other resources which are only on v1alpha1. So this section should not concern them. But since it doesn't really list the affected resources, this is not clear and users think they need to update all resources. Also, it is not obvious that there are more detailed guides for each resource.

This PR tries to fix it and make it more _consumable_:
* It lists all the affected resources
* Adds a small ToC for the detailed chapters

This should resolve #3901