### PR TITLE
[systemtest] Test recovery of Kafka cluster when impossible memory request is set

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -277,20 +277,25 @@ public class PodUtils {
      * */
     public static void verifyThatRunningPodsAreStable(String podPrefix) {
         LOGGER.info("Verify that all pods with prefix: {} are stable", podPrefix);
-        verifyThatPodsAreStable(podPrefix);
+        verifyThatPodsAreStable(podPrefix, "Running");
     }
 
-    private static void verifyThatPodsAreStable(String podPrefix) {
+    public static void verifyThatPendingPodsAreStable(String podPrefix) {
+        LOGGER.info("Verify that all pods with prefix: {} are stable in pending phase", podPrefix);
+        verifyThatPodsAreStable(podPrefix, "Pending");
+    }
+
+    private static void verifyThatPodsAreStable(String podPrefix, String phase) {
         int[] stabilityCounter = {0};
         List<Pod> runningPods = kubeClient().listPodsByPrefixInName(podPrefix).stream()
-            .filter(pod -> pod.getStatus().getPhase().equals("Running")).collect(Collectors.toList());
+            .filter(pod -> pod.getStatus().getPhase().equals(phase)).collect(Collectors.toList());
 
-        TestUtils.waitFor("Pods stability", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+        TestUtils.waitFor(String.format("Pods stability in phase %s", phase), Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
             () -> {
                 List<Pod> actualPods = runningPods.stream().map(p -> kubeClient().getPod(p.getMetadata().getName())).collect(Collectors.toList());
 
                 for (Pod pod : actualPods) {
-                    if (pod.getStatus().getPhase().equals("Running")) {
+                    if (pod.getStatus().getPhase().equals(phase)) {
                         LOGGER.info("Pod {} is in the {} state. Remaining seconds pod to be stable {}",
                             pod.getMetadata().getName(), pod.getStatus().getPhase(),
                             Constants.GLOBAL_RECONCILIATION_COUNT - stabilityCounter[0]);

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
+import io.strimzi.systemtest.rollingupdate.KafkaRollerST;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.ConfigMapUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
@@ -238,13 +239,15 @@ class RecoveryST extends AbstractST {
     }
 
     /**
-     * The main difference between this test and {@link io.strimzi.systemtest.rollingupdate.KafkaRollerST#testKafkaPodPending() testKafkaPodPending}
+     * The main difference between this test and KafkaRollerST#testKafkaPodPending()
      * is that in this test, we are deploying Kafka cluster with an impossible memory request,
-     * but in the {@link io.strimzi.systemtest.rollingupdate.KafkaRollerST#testKafkaPodPending() testKafkaPodPending}
+     * but in the KafkaRollerST#testKafkaPodPending()
      * we first deploy Kafka cluster with a correct configuration, then change the configuration to an unschedulable one, waiting
      * for one Kafka pod to be in the `Pending` phase. In this test, all 3 Kafka pods are `Pending`. After we
      * check that Kafka pods are stable in `Pending` phase (for one minute), we change the memory request so that the pods are again schedulable
      * and wait until the Kafka cluster recovers and becomes `Ready`.
+     *
+     * @see KafkaRollerST#testKafkaPodPending()
      */
     @Test
     void testRecoveryFromImpossibleMemoryRequest() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
@@ -254,7 +254,7 @@ class RecoveryST extends AbstractST {
             .endSpec()
             .build());
 
-        PodUtils.waitForPendingPod(clusterName + "-kafka");
+        PodUtils.waitForPendingPod(KafkaResources.kafkaStatefulSetName(clusterName));
 
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_RECOVERY));
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.KafkaBridgeResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.ConfigMapUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
@@ -265,6 +266,7 @@ class RecoveryST extends AbstractST {
         });
 
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(clusterName), 3);
+        KafkaUtils.waitForKafkaReady(clusterName);
 
         timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.strimzi.api.kafka.model.KafkaBridgeResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.ConfigMapUtils;
@@ -40,6 +41,7 @@ class RecoveryST extends AbstractST {
 
     static final String NAMESPACE = "recovery-cluster-test";
     static final String CLUSTER_NAME = "recovery-cluster";
+    static final String KAFKA_CLIENTS_NAME = CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS;
 
     private static final Logger LOGGER = LogManager.getLogger(RecoveryST.class);
 
@@ -235,9 +237,19 @@ class RecoveryST extends AbstractST {
         timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
     }
 
+    /**
+     * The main difference between this test and {@link io.strimzi.systemtest.rollingupdate.KafkaRollerST#testKafkaPodPending() testKafkaPodPending}
+     * is that in this test, we are deploying Kafka cluster with an impossible memory request,
+     * but in the {@link io.strimzi.systemtest.rollingupdate.KafkaRollerST#testKafkaPodPending() testKafkaPodPending}
+     * we first deploy Kafka cluster with a correct configuration, then change the configuration to an unschedulable one, waiting
+     * for one Kafka pod to be in the `Pending` phase. In this test, all 3 Kafka pods are `Pending`. After we
+     * check that Kafka pods are stable in `Pending` phase (for one minute), we change the memory request so that the pods are again schedulable
+     * and wait until the Kafka cluster recovers and becomes `Ready`.
+     */
     @Test
     void testRecoveryFromImpossibleMemoryRequest() {
         String clusterName = "my-cluster";
+        String kafkaSsName = KafkaResources.kafkaStatefulSetName(clusterName);
 
         Map<String, Quantity> requests = new HashMap<>(2);
         requests.put("memory", new Quantity("465458732Gi"));
@@ -254,7 +266,8 @@ class RecoveryST extends AbstractST {
             .endSpec()
             .build());
 
-        PodUtils.waitForPendingPod(KafkaResources.kafkaStatefulSetName(clusterName));
+        PodUtils.waitForPendingPod(kafkaSsName);
+        PodUtils.verifyThatPendingPodsAreStable(kafkaSsName);
 
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_RECOVERY));
 
@@ -265,7 +278,7 @@ class RecoveryST extends AbstractST {
             kafka.getSpec().getKafka().setResources(resourceReq);
         });
 
-        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(clusterName), 3);
+        StatefulSetUtils.waitForAllStatefulSetPodsReady(kafkaSsName, 3);
         KafkaUtils.waitForKafkaReady(clusterName);
 
         timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -158,8 +158,6 @@ class KafkaRollerST extends AbstractST {
 
         KafkaUtils.waitForKafkaNotReady(CLUSTER_NAME);
 
-        assertTrue(checkRunningAndNotRunningKafkaPods(CLUSTER_NAME));
-
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka ->
                 kafka.getSpec().getKafka().getJvmOptions().setXx(Collections.emptyMap()));
 
@@ -180,7 +178,7 @@ class KafkaRollerST extends AbstractST {
 
         KafkaUtils.waitForKafkaNotReady(CLUSTER_NAME);
 
-        assertTrue(checkRunningAndNotRunningKafkaPods(CLUSTER_NAME));
+        assertTrue(checkIfOneKafkaPodIsNotReady(CLUSTER_NAME));
 
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka ->
                 kafka.getSpec().getKafka().setImage("strimzi/kafka:latest-kafka-" + Environment.ST_KAFKA_VERSION));
@@ -212,7 +210,7 @@ class KafkaRollerST extends AbstractST {
 
         KafkaUtils.waitForKafkaNotReady(CLUSTER_NAME);
 
-        assertTrue(checkRunningAndNotRunningKafkaPods(CLUSTER_NAME));
+        assertTrue(checkIfOneKafkaPodIsNotReady(CLUSTER_NAME));
 
         requests.put("cpu", new Quantity("250m"));
 
@@ -269,8 +267,6 @@ class KafkaRollerST extends AbstractST {
         // pods are stable in the Pending state
         PodUtils.waitUntilPodStabilityReplicasCount(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3);
 
-        assertTrue(checkRunningAndNotRunningKafkaPods(CLUSTER_NAME));
-
         LOGGER.info("Removing requirement for the affinity");
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka ->
                 kafka.getSpec().getKafka().getTemplate().getPod().setAffinity(null));
@@ -279,7 +275,7 @@ class KafkaRollerST extends AbstractST {
         KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
     }
 
-    boolean checkRunningAndNotRunningKafkaPods(String clusterName) {
+    boolean checkIfOneKafkaPodIsNotReady(String clusterName) {
         List<Pod> kafkaPods = kubeClient().listPodsByPrefixInName(KafkaResources.kafkaStatefulSetName(clusterName));
         int runningKafkaPods = kafkaPods.stream().filter(pod -> pod.getStatus().getPhase().equals("Running")).collect(Collectors.toList()).size();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -62,7 +62,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Tag(REGRESSION)
 @Tag(INTERNAL_CLIENTS_USED)
 @Tag(ROLLING_UPDATE)
-class KafkaRollerST extends AbstractST {
+public class KafkaRollerST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(RollingUpdateST.class);
     static final String NAMESPACE = "kafka-roller-cluster-test";
 
@@ -178,7 +178,7 @@ class KafkaRollerST extends AbstractST {
 
         KafkaUtils.waitForKafkaNotReady(CLUSTER_NAME);
 
-        assertTrue(checkIfOneKafkaPodIsNotReady(CLUSTER_NAME));
+        assertTrue(checkIfExactlyOneKafkaPodIsNotReady(CLUSTER_NAME));
 
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka ->
                 kafka.getSpec().getKafka().setImage("strimzi/kafka:latest-kafka-" + Environment.ST_KAFKA_VERSION));
@@ -190,7 +190,7 @@ class KafkaRollerST extends AbstractST {
     }
 
     @Test
-    void testKafkaPodPending() {
+    public void testKafkaPodPending() {
         ResourceRequirements rr = new ResourceRequirementsBuilder()
                 .withRequests(Collections.emptyMap())
                 .build();
@@ -210,7 +210,7 @@ class KafkaRollerST extends AbstractST {
 
         KafkaUtils.waitForKafkaNotReady(CLUSTER_NAME);
 
-        assertTrue(checkIfOneKafkaPodIsNotReady(CLUSTER_NAME));
+        assertTrue(checkIfExactlyOneKafkaPodIsNotReady(CLUSTER_NAME));
 
         requests.put("cpu", new Quantity("250m"));
 
@@ -275,7 +275,7 @@ class KafkaRollerST extends AbstractST {
         KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
     }
 
-    boolean checkIfOneKafkaPodIsNotReady(String clusterName) {
+    boolean checkIfExactlyOneKafkaPodIsNotReady(String clusterName) {
         List<Pod> kafkaPods = kubeClient().listPodsByPrefixInName(KafkaResources.kafkaStatefulSetName(clusterName));
         int runningKafkaPods = kafkaPods.stream().filter(pod -> pod.getStatus().getPhase().equals("Running")).collect(Collectors.toList()).size();
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test

### Description

In https://github.com/strimzi/strimzi-kafka-operator/pull/3721 was comment about adding recovery test for KafkaRoller, when we deploy Kafka cluster with some impossible memory request -> the pods are in `Pending` state. After the fix, there should be option to change the CR with correct values, Kafka pods should then "recover" itself and become running and `Ready`. 

This PR adds test for it.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
