### PR TITLE
Fix issue preventing the jmxtrans container from becoming ready

### DIFF
--- a/docker-images/jmxtrans/jmxtrans_readiness_check.sh
+++ b/docker-images/jmxtrans/jmxtrans_readiness_check.sh
@@ -14,7 +14,8 @@ else
     export KAFKA_METRICS_PORT="$2"
 fi
 
-if nc -z "$KAFKA_HEADLESS_SERVICE" "$KAFKA_METRICS_PORT"; then
+nc -z "$KAFKA_HEADLESS_SERVICE" "$KAFKA_METRICS_PORT"
+if [ "$?" -ne 0 ]; then
     echo "Couldn't connect to $KAFKA_HEADLESS_SERVICE:$KAFKA_METRICS_PORT"
     exit 1
 fi

--- a/docker-images/jmxtrans/jmxtrans_readiness_check.sh
+++ b/docker-images/jmxtrans/jmxtrans_readiness_check.sh
@@ -14,8 +14,7 @@ else
     export KAFKA_METRICS_PORT="$2"
 fi
 
-nc -z "$KAFKA_HEADLESS_SERVICE" "$KAFKA_METRICS_PORT"
-if [ "$?" -ne 0 ]; then
+if ! nc -z "$KAFKA_HEADLESS_SERVICE" "$KAFKA_METRICS_PORT"; then
     echo "Couldn't connect to $KAFKA_HEADLESS_SERVICE:$KAFKA_METRICS_PORT"
     exit 1
 fi


### PR DESCRIPTION
Signed-off-by: John Beaven <beavenj@uk.ibm.com>

### Type of change

- Bugfix

### Description

Fix the readiness check. The 'nc -z' does not return a value
in either success or fail cases so you have to examine the
response code in $?. As it stands, the test assumes that not
having a value on the response indicates a connection failure.
This fix switches back to testing the value in $? as it was
in the previous version and that allowed the container to
start when we tested it.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

