### PR TITLE
Fix the config-model-generator artifactId

### DIFF
--- a/config-model-generator/pom.xml
+++ b/config-model-generator/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>cluster-operator-generator</artifactId>
+    <artifactId>config-model-generator</artifactId>
 
     <properties>
         <kafka-metadata-version>${kafka.version}</kafka-metadata-version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

For some reason which seems more like a typo then intention, the Java module `config-model-generator` seems to have an artifactId `cluster-operator-generator` which does not match. That makes it to stand out from our other modules. The PR changes the artifactId to `config-model-generator` to make it in sync with the rest. Since this module is not published anywhere, the renaming should have no impact.