### PR TITLE
[systemtest] Test for user's secret prefix

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/AbstractKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/AbstractKafkaClient.java
@@ -32,6 +32,7 @@ public abstract class AbstractKafkaClient<C extends AbstractKafkaClient.Builder<
     protected String listenerName;
     protected ProducerProperties producerProperties;
     protected ConsumerProperties consumerProperties;
+    protected String secretPrefix;
 
     public abstract static class Builder<SELF extends Builder<SELF>> {
 
@@ -47,6 +48,7 @@ public abstract class AbstractKafkaClient<C extends AbstractKafkaClient.Builder<
         protected String listenerName;
         private ProducerProperties producerProperties;
         private ConsumerProperties consumerProperties;
+        private String secretPrefix;
 
         public SELF withTopicName(String topicName) {
             this.topicName = topicName;
@@ -108,6 +110,11 @@ public abstract class AbstractKafkaClient<C extends AbstractKafkaClient.Builder<
             return self();
         }
 
+        public SELF withSecretPrefix(String secretPrefix) {
+            this.secretPrefix = secretPrefix;
+            return self();
+        }
+
         @SuppressWarnings("unchecked")
         protected SELF self() {
             return (SELF) this;
@@ -136,7 +143,8 @@ public abstract class AbstractKafkaClient<C extends AbstractKafkaClient.Builder<
             .withCertificateAuthorityCertificateName(caCertName)
             .withListenerName(listenerName)
             .withProducerProperties(producerProperties)
-            .withConsumerProperties(consumerProperties);
+            .withConsumerProperties(consumerProperties)
+            .withSecretPrefix(secretPrefix);
     }
 
     protected AbstractKafkaClient(Builder<?> builder) {
@@ -154,6 +162,7 @@ public abstract class AbstractKafkaClient<C extends AbstractKafkaClient.Builder<
         listenerName = builder.listenerName;
         producerProperties = builder.producerProperties;
         consumerProperties = builder.consumerProperties;
+        secretPrefix = builder.secretPrefix;
     }
 
     private void verifyEssentialInstanceAttributes() {
@@ -242,6 +251,9 @@ public abstract class AbstractKafkaClient<C extends AbstractKafkaClient.Builder<
     public String getListenerName() {
         return listenerName;
     }
+    public String getSecretPrefix() {
+        return secretPrefix;
+    }
 
     @Override
     public String toString() {
@@ -258,6 +270,7 @@ public abstract class AbstractKafkaClient<C extends AbstractKafkaClient.Builder<
             ", listenerName='" + listenerName + '\'' +
             ", producerProperties=" + producerProperties +
             ", consumerProperties=" + consumerProperties +
+            ", secretPrefix=" + secretPrefix +
             '}';
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/InternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/InternalKafkaClient.java
@@ -27,6 +27,8 @@ public class InternalKafkaClient extends AbstractKafkaClient<InternalKafkaClient
     private static final Logger LOGGER = LogManager.getLogger(InternalKafkaClient.class);
 
     private String podName;
+    // name of KafkaUser with/without prefix for secret
+    private String completeKafkaUsername = secretPrefix == null ? kafkaUsername : secretPrefix + kafkaUsername;
 
     public static class Builder extends AbstractKafkaClient.Builder<Builder> {
 
@@ -75,7 +77,7 @@ public class InternalKafkaClient extends AbstractKafkaClient<InternalKafkaClient
             .withUsingPodName(podName)
             .withPodNamespace(namespaceName)
             .withMaxMessages(messageCount)
-            .withKafkaUsername(kafkaUsername)
+            .withKafkaUsername(completeKafkaUsername)
             .withBootstrapServer(getBootstrapServerFromStatus())
             .withTopicName(topicName)
             .build();
@@ -105,7 +107,7 @@ public class InternalKafkaClient extends AbstractKafkaClient<InternalKafkaClient
             .withUsingPodName(podName)
             .withPodNamespace(namespaceName)
             .withMaxMessages(messageCount)
-            .withKafkaUsername(kafkaUsername)
+            .withKafkaUsername(completeKafkaUsername)
             .withBootstrapServer(getBootstrapServerFromStatus())
             .withTopicName(topicName)
             .build();
@@ -135,7 +137,7 @@ public class InternalKafkaClient extends AbstractKafkaClient<InternalKafkaClient
             .withUsingPodName(podName)
             .withPodNamespace(namespaceName)
             .withMaxMessages(messageCount)
-            .withKafkaUsername(kafkaUsername)
+            .withKafkaUsername(completeKafkaUsername)
             .withBootstrapServer(getBootstrapServerFromStatus())
             .withTopicName(topicName)
             .withConsumerGroupName(consumerGroup)
@@ -171,7 +173,7 @@ public class InternalKafkaClient extends AbstractKafkaClient<InternalKafkaClient
             .withUsingPodName(podName)
             .withPodNamespace(namespaceName)
             .withMaxMessages(messageCount)
-            .withKafkaUsername(kafkaUsername)
+            .withKafkaUsername(completeKafkaUsername)
             .withBootstrapServer(getBootstrapServerFromStatus())
             .withTopicName(topicName)
             .withConsumerGroupName(consumerGroup)

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -706,7 +706,7 @@ public class ListenersST extends AbstractST {
         );
 
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
-        KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, false, customListenerName, aliceUser).done();
+        KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, false, customListenerName, null, aliceUser).done();
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
             .withUsingPodName(kubeClient().listPodsByPrefixInName(CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName())


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test

### Description

From #3849 we are able to specify prefixes for user's secrets. This is useful when we already have secrets with same name (like user name) and we want another -> so we simply add new `secretPrefix` to the User Operator.

This PR test #3333 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

