### PR TITLE
[DOC] Note for route address length

### DIFF
--- a/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
+++ b/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
@@ -71,6 +71,11 @@ For example:
 ----
 apiVersion: {KafkaApiVersion}
 kind: Kafka
+metadata:
+  labels:
+    app: my-cluster
+  name: my-cluster
+  namespace: myproject
 spec:
   kafka:
     # ...
@@ -106,6 +111,10 @@ The override configuration differs according to the listener type.
 For example, you can override hosts for `route`, DNS names or IP addresses for `loadbalancer`, and node ports for `nodeport`.
 <9> Authoization specified as `simple`, which uses the `AclAuthorizer` Kafka plugin.
 <10> (Optional) Super users can access all brokers regardless of any access restrictions defined in ACLs.
++
+WARNING: An OpenShift Route address comprises the name of the Kafka cluster, the name of the listener, and the name of the namespace it is created in.
+For example, `my-cluster-kafka-listener1-bootstrap-myproject` (_CLUSTER-NAME_-kafka-_LISTENER-NAME_-bootstrap-_NAMESPACE_).
+If you are using a `route` listener type, be careful that the whole length of the address does not exceed a maximum limit of 63 characters.
 
 . Create or update the `Kafka` resource.
 +

--- a/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
+++ b/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
@@ -72,8 +72,6 @@ For example:
 apiVersion: {KafkaApiVersion}
 kind: Kafka
 metadata:
-  labels:
-    app: my-cluster
   name: my-cluster
   namespace: myproject
 spec:


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Added a warning note for `route` address length limit to _Deploying Guide_ section _Setting up access for clients outside of Kubernetes_ . Also updated the config to show cluster name and project to make the warning clearer.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

