### PR TITLE
[DOC] Add docs and CHANGELOG record for disabling ownerReference on CA secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add the JAAS configuration string in the sasl.jaas.config property to the generated secrets for KafkaUser with SCRAM-SHA-512 authentication.
 * Strimzi `test-container` has been renamed to `strimzi-test-container` to make the name more clear
 * Updated the CPU usage metric in the Kafka, ZooKeeper and Cruise Control dashboards to include the CPU kernel time (other than the current user time)
+* Allow disabling ownerReference on CA secrets
 
 ## 0.20.0
 

--- a/documentation/modules/security/ref-certificates-and-secrets.adoc
+++ b/documentation/modules/security/ref-certificates-and-secrets.adoc
@@ -164,13 +164,13 @@ You can enforce this using Kubernetes role-based access controls if necessary.
 
 == Disabling `ownerReference` in the CA Secrets
 
-By default, the CA secrets created by Strimzi will have the `ownerReference` field set to the `Kafka` custom resource.
-This means that when the custom resource is deleted, the CA secrets will be garbage collected (deleted) by Kubernetes as well.
+By default, the CA secrets created by Strimzi have an `ownerReference` property set to the `Kafka` custom resource.
+This means that when the `Kafka` custom resource is deleted, the CA secrets are garbage collected (deleted) by Kubernetes as well.
 
-If you want to re-use the CA for a new cluster, you can disable the `ownerReference`.
-When disabled, the CA secrets will not be deleted by Kubernetes together with the corresponding `Kafka` custom resource.
+If you want to reuse the CA for a new cluster, you can disable the `ownerReference` by setting the `generateSecretOwnerReference` property for the cluster and client CAs to `false` in the `Kafka` configuration.
+When disabled, CA secrets are not deleted by Kubernetes when the corresponding `Kafka` custom resource is deleted.
 
-.Example Kafka configuration with disabled `ownerReference` for Cluster and Client CAs
+.Example Kafka configuration with disabled `ownerReference` for cluster and client CAs
 [source,shell,subs="+quotes"]
 ----
 apiVersion: kafka.strimzi.io/v1beta1

--- a/documentation/modules/security/ref-certificates-and-secrets.adoc
+++ b/documentation/modules/security/ref-certificates-and-secrets.adoc
@@ -162,6 +162,29 @@ NOTE: `_<cluster>_-clients-ca` is used to sign certificates of client applicatio
 It needs to be accessible to the Strimzi components and for administrative access if you are intending to issue application certificates without using the User Operator.
 You can enforce this using Kubernetes role-based access controls if necessary.
 
+== Disabling `ownerReference` in the CA Secrets
+
+By default, the CA secrets created by Strimzi will have the `ownerReference` field set to the `Kafka` custom resource.
+This means that when the custom resource is deleted, the CA secrets will be garbage collected (deleted) by Kubernetes as well.
+
+If you want to re-use the CA for a new cluster, you can disable the `ownerReference`.
+When disabled, the CA secrets will not be deleted by Kubernetes together with the corresponding `Kafka` custom resource.
+
+.Example Kafka configuration with disabled `ownerReference` for Cluster and Client CAs
+[source,shell,subs="+quotes"]
+----
+apiVersion: kafka.strimzi.io/v1beta1
+kind: Kafka
+# ...
+spec:
+# ...
+  clusterCa:
+    generateSecretOwnerReference: false
+  clientsCa:
+    generateSecretOwnerReference: false
+# ...
+----
+
 == User Secrets
 
 .`Secrets` managed by the User Operator


### PR DESCRIPTION
### Type of change

- Documentation

### Description

In #3453 we forgot to update the Docs and the CHANGELOG.md file. This PR fixes it.