### PR TITLE
ST: Move testTriggerRollingUpdateAfterOverrideBootstrap to AlternativeReconcileTriggersST

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -252,7 +252,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
         assertThat(sentAfter, is(MESSAGE_COUNT));
     }
 
-    // This test is affected by https://issues.redhat.com/browse/ENTMQST-2033 so it needs longer operation timeout set in CO
+    // This test is affected by https://github.com/strimzi/strimzi-kafka-operator/issues/3913 so it needs longer operation timeout set in CO
     @Description("Test for checking that overriding of bootstrap server, triggers the rolling update and verifying that" +
             " new bootstrap DNS is appended inside certificate in subject alternative names property.")
     @Test


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

Test `testTriggerRollingUpdateAfterOverrideBootstrap` currently needs 5 minutes operation timeout set in CO to avoid stop of the RU in the middle. In case the RU is not finished in timeout (set for 30s in `RollingUpdateST`) the CO will not finish RU of pods, which weren't rolled in time.

This PR should be cherry-picked into `release-0.20.x`

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
