### PR TITLE
Corrected secret name

### DIFF
--- a/documentation/modules/security/proc-configuring-internal-clients-to-trust-cluster-ca.adoc
+++ b/documentation/modules/security/proc-configuring-internal-clients-to-trust-cluster-ca.adoc
@@ -50,7 +50,7 @@ spec:
   volumes:
   - name: secret-volume
     secret:
-      secretName: my-cluster-cluster-cert
+      secretName: my-cluster-cluster-ca-cert
 ----
 +
 Here we're mounting:
@@ -89,7 +89,7 @@ spec:
   volumes:
   - name: secret-volume
     secret:
-      secretName: my-cluster-cluster-cert
+      secretName: my-cluster-cluster-ca-cert
 ----
 
 . Use the certificate with clients that use certificates in X.509 format.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Fixed secret name in _9.6 Configuring internal clients to trust the cluster CA_ to correct one: it's `my-cluster-cluster-ca-cert` and not `my-cluster-cluster-cert`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

