### PR TITLE
[systemtest] Better way how to get Kafka version for upgrade tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -343,4 +343,15 @@ public class KafkaUtils {
     public static String generateRandomNameOfKafka(String clusterName) {
         return clusterName + "-" + new Random().nextInt(Integer.MAX_VALUE);
     }
+
+    public static String getVersionFromKafkaPodLibs(String kafkaPodName) {
+        String command = "ls libs | grep -Po 'kafka_\\d+.\\d+-\\K(\\d+.\\d+.\\d+)(?=.*jar)' | head -1 | cut -d \"-\" -f2";
+        return cmdKubeClient().execInPodContainer(
+            kafkaPodName,
+            "kafka",
+            "/bin/bash",
+            "-c",
+            command
+        ).out().trim();
+    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -27,6 +27,7 @@ import io.strimzi.systemtest.resources.operator.BundleResource;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.FileUtils;
 import io.strimzi.systemtest.utils.StUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
@@ -221,8 +222,7 @@ public class StrimziUpgradeST extends AbstractST {
         StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaSnapshot);
         DeploymentUtils.waitTillDepHasRolled(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), 1, eoSnapshot);
 
-        assertThat(kubeClient().getStatefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).getSpec().getTemplate().getSpec().getContainers()
-                .stream().filter(c -> c.getName().equals("kafka")).findFirst().get().getImage(), containsString(latestKafkaVersion));
+        assertThat(KafkaUtils.getVersionFromKafkaPodLibs(KafkaResources.kafkaPodName(CLUSTER_NAME, 0)), containsString(latestKafkaVersion));
     }
 
     String getValueForLastKafkaVersionInFile(File kafkaVersions, String field) throws IOException {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement / new feature

### Description

Until now in `testKafkaWithoutVersion` we had (after my PR) check, that image contains Kafka version. Problem here is that when the image name doesn't contain the Kafka version (like `2.6.0`) or it have different version pattern (like `26` instead of `2.6.0`), the check will fail. So I decided to get Kafka version from Kafka libs inside the pod, so we will sure that we have correct version. I added method for it and changed it in both `ZookeeperUpgradeST` and `StrimziUpgradeST`.

### Checklist

- [ ] Make sure all tests pass


