### PR TITLE
Make sure CertificateAuthorityBuilder generates valid Kafka CR

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/CertificateAuthority.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CertificateAuthority.java
@@ -40,6 +40,7 @@ public class CertificateAuthority implements UnknownPropertyPreserving, Serializ
 
     @Description("The number of days generated certificates should be valid for. The default is 365.")
     @Minimum(1)
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public int getValidityDays() {
         return validityDays;
     }
@@ -76,6 +77,7 @@ public class CertificateAuthority implements UnknownPropertyPreserving, Serializ
             "When `generateCertificateAuthority` is true, this will cause extra logging at WARN level about the pending certificate expiry. " +
             "Default is 30.")
     @Minimum(1)
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public int getRenewalDays() {
         return renewalDays;
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaTest.java
@@ -78,6 +78,52 @@ public class KafkaTest extends AbstractCrdTest<Kafka> {
     }
 
     @Test
+    public void testCertificationAuthorityBuilderAndInts() throws URISyntaxException {
+        List<GenericKafkaListener> listeners = Collections.singletonList(
+                new GenericKafkaListenerBuilder()
+                        .withName("lst")
+                        .withPort(9092)
+                        .withType(KafkaListenerType.INTERNAL)
+                        .withTls(true)
+                        .build()
+        );
+
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                    .withName("my-cluster")
+                    .withNamespace("my-namespace")
+                .endMetadata()
+                .withNewSpec()
+                    .withNewZookeeper()
+                        .withReplicas(1)
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endZookeeper()
+                    .withNewKafka()
+                        .withReplicas(1)
+                        .withListeners(new ArrayOrObjectKafkaListeners(listeners))
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endKafka()
+                    .withNewEntityOperator()
+                        .withNewTopicOperator()
+                        .endTopicOperator()
+                        .withNewUserOperator()
+                        .endUserOperator()
+                    .endEntityOperator()
+                    .withNewClientsCa()
+                        .withGenerateSecretOwnerReference(false)
+                    .endClientsCa()
+                    .withNewClusterCa()
+                        .withGenerateSecretOwnerReference(false)
+                    .endClusterCa()
+                .endSpec()
+                .build();
+
+        assertThat(TestUtils.toYamlString(kafka), is(TestUtils.getFileAsString(this.getClass().getResource("Kafka-ca-ints.yaml").toURI().getPath())));
+    }
+
+    @Test
     public void testNewListenerSerialization() throws URISyntaxException {
         List<GenericKafkaListener> listeners = Collections.singletonList(
                 new GenericKafkaListenerBuilder()

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-ca-ints.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-ca-ints.yaml
@@ -1,0 +1,33 @@
+---
+kind: "Kafka"
+metadata:
+  name: "my-cluster"
+  namespace: "my-namespace"
+spec:
+  kafka:
+    replicas: 1
+    storage:
+      type: "ephemeral"
+    listeners:
+    - name: "lst"
+      port: 9092
+      type: "internal"
+      tls: true
+  zookeeper:
+    replicas: 1
+    storage:
+      type: "ephemeral"
+  entityOperator:
+    topicOperator:
+      reconciliationIntervalSeconds: 90
+      zookeeperSessionTimeoutSeconds: 20
+      topicMetadataMaxAttempts: 6
+    userOperator:
+      reconciliationIntervalSeconds: 120
+      zookeeperSessionTimeoutSeconds: 6
+  clusterCa:
+    generateCertificateAuthority: true
+    generateSecretOwnerReference: false
+  clientsCa:
+    generateCertificateAuthority: true
+    generateSecretOwnerReference: false


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The CertificateAuthority API class contains the `validityDays` and `renewalDays` fields which are `int` and therefore default to `0`. When one of the generated builder classes is used to generate the `clusterCa` or `clientsCa` parts of the Kafka CR, the generated YAML contains the default values. However, both `validityDays` and `renewalDays` have also configured minimal value of `1`. So the CR containing `0` is invalid.

For example this:

```java
                .editOrNewClientsCa()
                    .withGenerateSecretOwnerReference(false)
                .endClientsCa()
```

Generates following invalid YAML:

```yaml
 clusterCa:
    generateCertificateAuthority: true
    generateSecretOwnerReference: false
    validityDays: 0
    renewalDays: 0
```

and the CR cannot be created.

This PR uses the Jackson `JsonInclude` annotation to not include these two fields when they are set to the default value:

```
@JsonInclude(JsonInclude.Include.NON_DEFAULT)
```

With this annotation, the code above generates only a valid YAM:

```yaml
 clusterCa:
    generateCertificateAuthority: true
    generateSecretOwnerReference: false
```

_Credit for discovery goes to @im-konge_

### Checklist

- [x] Write tests
- [x] Make sure all tests pass