### PR TITLE
[systemtest] Test for owner reference of CA secrets

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -368,7 +368,7 @@ public class KafkaUtils {
                     kubeClient().getDeployment(KafkaResources.entityOperatorDeploymentName(kafkaClusterName)) == null) {
                     return true;
                 } else {
-                    KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(kafkaClusterName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+                    cmdKubeClient().deleteByName(Kafka.RESOURCE_KIND, kafkaClusterName);
                     return false;
                 }
             },

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -5,7 +5,6 @@
 package io.strimzi.systemtest.utils.kafkaUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.utils.kafkaUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
@@ -15,6 +16,7 @@ import io.strimzi.kafka.config.model.ConfigModels;
 import io.strimzi.kafka.config.model.Scope;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
@@ -50,6 +52,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 public class KafkaUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(KafkaUtils.class);
+    private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion();
 
     private KafkaUtils() {}
 
@@ -353,5 +356,22 @@ public class KafkaUtils {
             "-c",
             command
         ).out().trim();
+    }
+
+    public static void waitForKafkaDeletion(String kafkaClusterName) {
+        LOGGER.info("Waiting for deletion of Kafka:{}", kafkaClusterName);
+        TestUtils.waitFor("Kafka deletion " + kafkaClusterName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, DELETION_TIMEOUT,
+            () -> {
+                if (KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(kafkaClusterName).get() == null &&
+                    kubeClient().getStatefulSet(KafkaResources.kafkaStatefulSetName(kafkaClusterName)) == null &&
+                    kubeClient().getStatefulSet(KafkaResources.zookeeperStatefulSetName(kafkaClusterName)) == null &&
+                    kubeClient().getDeployment(KafkaResources.entityOperatorDeploymentName(kafkaClusterName)) == null) {
+                    return true;
+                } else {
+                    KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(kafkaClusterName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+                    return false;
+                }
+            },
+            () -> LOGGER.info(KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(kafkaClusterName).get()));
     }
 }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test

### Description

After #3453 we are able to not delete secrets of Kafka cluster after deletion of whole Kafka cluster. Originally when we deployed Kafka, some `cluster-ca` and `clients-ca` secrets are created as well, deleted always on Kafka deletion (also secrets which are bound to Kafka cluster, not just the automatically created ones) . This feature allow us to keep the secrets even if the Kafka cluster is deleted, which can come handy in some cases.

This PR adds test for this feature. 

### Checklist

- [x] Write tests
- [ ] Make sure all tests pass

