### PR TITLE
Make it possible to configure DeplomentStrategy for KC, KMM and KB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Updated the CPU usage metric in the Kafka, ZooKeeper and Cruise Control dashboards to include the CPU kernel time (other than the current user time)
 * Allow disabling ownerReference on CA secrets
 * Move from Docker Hub to Quay.io as our container registry
+* Add possibility to configure DeploymentStrategy for Kafka Connect, Kafka Mirror Maker (1 and 2), and Kafka Bridge
 
 ## 0.20.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/DeploymentStrategy.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/DeploymentStrategy.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.template;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Locale;
+
+public enum DeploymentStrategy {
+    ROLLING_UPDATE,
+    RECREATE;
+
+    @JsonCreator
+    public static DeploymentStrategy forValue(String value) {
+        switch (value.toLowerCase(Locale.ENGLISH)) {
+            case "rollingupdate":
+                return ROLLING_UPDATE;
+            case "recreate":
+                return RECREATE;
+            default:
+                return null;
+        }
+    }
+
+    @JsonValue
+    public String toValue() {
+        switch (this) {
+            case RECREATE:
+                return "Recreate";
+            case ROLLING_UPDATE:
+                return "RollingUpdate";
+            default:
+                return null;
+        }
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/DeploymentTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/DeploymentTemplate.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.template;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.Constants;
+import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation of a template for Strimzi resources.
+ */
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"metadata", "deploymentStrategy"})
+@EqualsAndHashCode
+public class DeploymentTemplate implements Serializable, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
+
+    private MetadataTemplate metadata;
+    private DeploymentStrategy deploymentStrategy;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @Description("Metadata applied to the resource.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public MetadataTemplate getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(MetadataTemplate metadata) {
+        this.metadata = metadata;
+    }
+
+    @Description("DeploymentStrategy which will be used for this Deployment. " +
+            "Valid values are `RollingUpdate` and `Recreate`. " +
+            "Defaults to `RollingUpdate`.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public DeploymentStrategy getDeploymentStrategy() {
+        return deploymentStrategy;
+    }
+
+    public void setDeploymentStrategy(DeploymentStrategy deploymentStrategy) {
+        this.deploymentStrategy = deploymentStrategy;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaBridgeTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaBridgeTemplate.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class KafkaBridgeTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
-    private ResourceTemplate deployment;
+    private DeploymentTemplate deployment;
     private PodTemplate pod;
     private ResourceTemplate apiService;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
@@ -39,11 +39,11 @@ public class KafkaBridgeTemplate implements Serializable, UnknownPropertyPreserv
 
     @Description("Template for Kafka Bridge `Deployment`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getDeployment() {
+    public DeploymentTemplate getDeployment() {
         return deployment;
     }
 
-    public void setDeployment(ResourceTemplate deployment) {
+    public void setDeployment(DeploymentTemplate deployment) {
         this.deployment = deployment;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class KafkaConnectTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
-    private ResourceTemplate deployment;
+    private DeploymentTemplate deployment;
     private PodTemplate pod;
     private ResourceTemplate apiService;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
@@ -40,11 +40,11 @@ public class KafkaConnectTemplate implements Serializable, UnknownPropertyPreser
 
     @Description("Template for Kafka Connect `Deployment`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getDeployment() {
+    public DeploymentTemplate getDeployment() {
         return deployment;
     }
 
-    public void setDeployment(ResourceTemplate deployment) {
+    public void setDeployment(DeploymentTemplate deployment) {
         this.deployment = deployment;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaMirrorMaker2Template.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaMirrorMaker2Template.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class KafkaMirrorMaker2Template implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
-    private ResourceTemplate deployment;
+    private DeploymentTemplate deployment;
     private PodTemplate pod;
     private ResourceTemplate apiService;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
@@ -39,11 +39,11 @@ public class KafkaMirrorMaker2Template implements Serializable, UnknownPropertyP
 
     @Description("Template for Kafka MirrorMaker 2.0 `Deployment`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getDeployment() {
+    public DeploymentTemplate getDeployment() {
         return deployment;
     }
 
-    public void setDeployment(ResourceTemplate deployment) {
+    public void setDeployment(DeploymentTemplate deployment) {
         this.deployment = deployment;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaMirrorMakerTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaMirrorMakerTemplate.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class KafkaMirrorMakerTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
-    private ResourceTemplate deployment;
+    private DeploymentTemplate deployment;
     private PodTemplate pod;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
     private ContainerTemplate mirrorMakerContainer;
@@ -38,11 +38,11 @@ public class KafkaMirrorMakerTemplate implements Serializable, UnknownPropertyPr
 
     @Description("Template for Kafka MirrorMaker `Deployment`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getDeployment() {
+    public DeploymentTemplate getDeployment() {
         return deployment;
     }
 
-    public void setDeployment(ResourceTemplate deployment) {
+    public void setDeployment(DeploymentTemplate deployment) {
         this.deployment = deployment;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -16,6 +16,7 @@ import io.fabric8.kubernetes.api.model.EnvVarSource;
 import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.HostAlias;
+import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
@@ -39,6 +40,8 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentStrategy;
+import io.fabric8.kubernetes.api.model.apps.DeploymentStrategyBuilder;
+import io.fabric8.kubernetes.api.model.apps.RollingUpdateDeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetUpdateStrategyBuilder;
@@ -82,7 +85,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 
 /**
  * AbstractModel an abstract base model for all components of the {@code Kafka} custom resource
@@ -234,6 +236,7 @@ public abstract class AbstractModel {
     protected Map<String, String> templateStatefulSetAnnotations;
     protected Map<String, String> templateDeploymentLabels;
     protected Map<String, String> templateDeploymentAnnotations;
+    protected io.strimzi.api.kafka.model.template.DeploymentStrategy templateDeploymentStrategy = io.strimzi.api.kafka.model.template.DeploymentStrategy.ROLLING_UPDATE;
     protected Map<String, String> templatePodLabels;
     protected Map<String, String> templatePodAnnotations;
     protected Map<String, String> templateServiceLabels;
@@ -1364,5 +1367,21 @@ public abstract class AbstractModel {
      */
     public List<Condition> getWarningConditions() {
         return warningConditions;
+    }
+
+    public DeploymentStrategy getDeploymentStrategy()   {
+        if (templateDeploymentStrategy == io.strimzi.api.kafka.model.template.DeploymentStrategy.ROLLING_UPDATE) {
+            return new DeploymentStrategyBuilder()
+                    .withType("RollingUpdate")
+                    .withRollingUpdate(new RollingUpdateDeploymentBuilder()
+                            .withMaxSurge(new IntOrString(1))
+                            .withMaxUnavailable(new IntOrString(0))
+                            .build())
+                    .build();
+        } else {
+            return new DeploymentStrategyBuilder()
+                    .withType("Recreate")
+                    .build();
+        }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -106,13 +106,21 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                 .endImageChangeParams()
                 .build();
 
-        DeploymentStrategy updateStrategy = new DeploymentStrategyBuilder()
-                .withType("Rolling")
-                .withNewRollingParams()
+        DeploymentStrategy updateStrategy;
+
+        if (templateDeploymentStrategy == io.strimzi.api.kafka.model.template.DeploymentStrategy.ROLLING_UPDATE) {
+            updateStrategy = new DeploymentStrategyBuilder()
+                    .withType("Rolling")
+                    .withNewRollingParams()
                     .withMaxSurge(new IntOrString(1))
                     .withMaxUnavailable(new IntOrString(0))
-                .endRollingParams()
-                .build();
+                    .endRollingParams()
+                    .build();
+        } else {
+            updateStrategy = new DeploymentStrategyBuilder()
+                    .withType("Recreate")
+                    .build();
+        }
 
         DeploymentConfig dc = new DeploymentConfigBuilder()
                 .withNewMetadata()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -26,6 +26,7 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TlsSidecarLogLevel;
+import io.strimzi.api.kafka.model.template.DeploymentTemplate;
 import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.template.PodTemplate;
 import io.strimzi.certs.CertAndKey;
@@ -234,7 +235,6 @@ public class ModelUtils {
      * @param model AbstractModel class where the values from the PodTemplate should be set
      * @param pod PodTemplate with the values form the CRD
      */
-
     public static void parsePodTemplate(AbstractModel model, PodTemplate pod)   {
         if (pod != null)  {
             if (pod.getMetadata() != null) {
@@ -256,6 +256,27 @@ public class ModelUtils {
             model.templatePodPriorityClassName = pod.getPriorityClassName();
             model.templatePodSchedulerName = pod.getSchedulerName();
             model.templatePodHostAliases = pod.getHostAliases();
+        }
+    }
+
+    /**
+     * Parses the values from the DeploymentTemplate in CRD model into the component model
+     *
+     * @param model AbstractModel class where the values from the DeploymentTemplate should be set
+     * @param template DeploymentTemplate with the values form the CRD
+     */
+    public static void parseDeploymentTemplate(AbstractModel model, DeploymentTemplate template)   {
+        if (template != null) {
+            if (template.getMetadata() != null) {
+                model.templateDeploymentLabels = template.getMetadata().getLabels();
+                model.templateDeploymentAnnotations = template.getMetadata().getAnnotations();
+            }
+
+            if (template.getDeploymentStrategy() != null)   {
+                model.templateDeploymentStrategy = template.getDeploymentStrategy();
+            } else {
+                model.templateDeploymentStrategy = io.strimzi.api.kafka.model.template.DeploymentStrategy.ROLLING_UPDATE;
+            }
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -32,6 +32,7 @@ import io.strimzi.api.kafka.model.KafkaBridgeResources;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationOAuthBuilder;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationTlsBuilder;
 import io.strimzi.api.kafka.model.template.ContainerTemplate;
+import io.strimzi.api.kafka.model.template.DeploymentStrategy;
 import io.strimzi.api.kafka.model.tracing.JaegerTracing;
 import io.strimzi.kafka.oauth.client.ClientConfig;
 import io.strimzi.kafka.oauth.server.ServerConfig;
@@ -375,6 +376,7 @@ public class KafkaBridgeClusterTest {
                                 .withLabels(depLabels)
                                 .withAnnotations(depAnots)
                             .endMetadata()
+                            .withDeploymentStrategy(DeploymentStrategy.RECREATE)
                         .endDeployment()
                         .withNewPod()
                             .withNewMetadata()
@@ -408,6 +410,8 @@ public class KafkaBridgeClusterTest {
         assertThat(dep.getMetadata().getLabels().entrySet().containsAll(expectedDepLabels.entrySet()), is(true));
         assertThat(dep.getMetadata().getAnnotations().entrySet().containsAll(depAnots.entrySet()), is(true));
         assertThat(dep.getSpec().getTemplate().getSpec().getPriorityClassName(), is("top-priority"));
+        assertThat(dep.getSpec().getStrategy().getType(), is("Recreate"));
+        assertThat(dep.getSpec().getStrategy().getRollingUpdate(), is(nullValue()));
 
         // Check Pods
         assertThat(dep.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()), is(true));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -46,6 +46,7 @@ import io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationVolumeSource;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationVolumeSourceBuilder;
 import io.strimzi.api.kafka.model.template.ContainerTemplate;
+import io.strimzi.api.kafka.model.template.DeploymentStrategy;
 import io.strimzi.kafka.oauth.client.ClientConfig;
 import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
@@ -536,6 +537,7 @@ public class KafkaConnectClusterTest {
                                 .withLabels(depLabels)
                                 .withAnnotations(depAnots)
                             .endMetadata()
+                            .withDeploymentStrategy(DeploymentStrategy.RECREATE)
                         .endDeployment()
                         .withNewPod()
                             .withNewMetadata()
@@ -568,6 +570,8 @@ public class KafkaConnectClusterTest {
         assertThat(dep.getMetadata().getLabels().entrySet().containsAll(expectedDepLabels.entrySet()), is(true));
         assertThat(dep.getMetadata().getAnnotations().entrySet().containsAll(depAnots.entrySet()), is(true));
         assertThat(dep.getSpec().getTemplate().getSpec().getPriorityClassName(), is("top-priority"));
+        assertThat(dep.getSpec().getStrategy().getType(), is("Recreate"));
+        assertThat(dep.getSpec().getStrategy().getRollingUpdate(), is(nullValue()));
 
         // Check Pods
         assertThat(dep.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()), is(true));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -47,6 +47,7 @@ import io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationVolumeSource;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationVolumeSourceBuilder;
 import io.strimzi.api.kafka.model.template.ContainerTemplate;
+import io.strimzi.api.kafka.model.template.DeploymentStrategy;
 import io.strimzi.kafka.oauth.client.ClientConfig;
 import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
@@ -522,6 +523,7 @@ public class KafkaConnectS2IClusterTest {
                                 .withLabels(depLabels)
                                 .withAnnotations(depAnots)
                             .endMetadata()
+                            .withDeploymentStrategy(DeploymentStrategy.RECREATE)
                         .endDeployment()
                         .withNewPod()
                             .withNewMetadata()
@@ -554,6 +556,8 @@ public class KafkaConnectS2IClusterTest {
         assertThat(dep.getMetadata().getLabels().entrySet().containsAll(expectedDepLabels.entrySet()), is(true));
         assertThat(dep.getMetadata().getAnnotations().entrySet().containsAll(depAnots.entrySet()), is(true));
         assertThat(dep.getSpec().getTemplate().getSpec().getPriorityClassName(), is("top-priority"));
+        assertThat(dep.getSpec().getStrategy().getType(), is("Recreate"));
+        assertThat(dep.getSpec().getStrategy().getRollingParams(), is(nullValue()));
 
         // Check Pods
         assertThat(dep.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()), is(true));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -43,6 +43,7 @@ import io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationVolumeSource;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationVolumeSourceBuilder;
 import io.strimzi.api.kafka.model.template.ContainerTemplate;
+import io.strimzi.api.kafka.model.template.DeploymentStrategy;
 import io.strimzi.kafka.oauth.client.ClientConfig;
 import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
@@ -648,6 +649,7 @@ public class KafkaMirrorMaker2ClusterTest {
                                 .withLabels(depLabels)
                                 .withAnnotations(depAnots)
                             .endMetadata()
+                            .withDeploymentStrategy(DeploymentStrategy.RECREATE)
                         .endDeployment()
                         .withNewPod()
                             .withNewMetadata()
@@ -680,6 +682,8 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(dep.getMetadata().getLabels().entrySet().containsAll(expectedDepLabels.entrySet()), is(true));
         assertThat(dep.getMetadata().getAnnotations().entrySet().containsAll(depAnots.entrySet()), is(true));
         assertThat(dep.getSpec().getTemplate().getSpec().getPriorityClassName(), is("top-priority"));
+        assertThat(dep.getSpec().getStrategy().getType(), is("Recreate"));
+        assertThat(dep.getSpec().getStrategy().getRollingUpdate(), is(nullValue()));
 
         // Check Pods
         assertThat(dep.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()), is(true));

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1176,7 +1176,7 @@ Used in: xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`], xref:
 [id='type-MetadataTemplate-{context}']
 ### `MetadataTemplate` schema reference
 
-Used in: xref:type-ExternalServiceTemplate-{context}[`ExternalServiceTemplate`], xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`], xref:type-PodTemplate-{context}[`PodTemplate`], xref:type-ResourceTemplate-{context}[`ResourceTemplate`], xref:type-StatefulSetTemplate-{context}[`StatefulSetTemplate`]
+Used in: xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`], xref:type-ExternalServiceTemplate-{context}[`ExternalServiceTemplate`], xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`], xref:type-PodTemplate-{context}[`PodTemplate`], xref:type-ResourceTemplate-{context}[`ResourceTemplate`], xref:type-StatefulSetTemplate-{context}[`StatefulSetTemplate`]
 
 include::../api/io.strimzi.api.kafka.model.template.MetadataTemplate.adoc[leveloffset=+1]
 
@@ -1240,7 +1240,7 @@ include::../api/io.strimzi.api.kafka.model.template.PodTemplate.adoc[leveloffset
 [id='type-ResourceTemplate-{context}']
 ### `ResourceTemplate` schema reference
 
-Used in: xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`], xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], xref:type-JmxTransTemplate-{context}[`JmxTransTemplate`], xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`], xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`], xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`], xref:type-KafkaExporterTemplate-{context}[`KafkaExporterTemplate`], xref:type-KafkaMirrorMakerTemplate-{context}[`KafkaMirrorMakerTemplate`], xref:type-KafkaUserTemplate-{context}[`KafkaUserTemplate`], xref:type-ZookeeperClusterTemplate-{context}[`ZookeeperClusterTemplate`]
+Used in: xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`], xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], xref:type-JmxTransTemplate-{context}[`JmxTransTemplate`], xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`], xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`], xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`], xref:type-KafkaExporterTemplate-{context}[`KafkaExporterTemplate`], xref:type-KafkaUserTemplate-{context}[`KafkaUserTemplate`], xref:type-ZookeeperClusterTemplate-{context}[`ZookeeperClusterTemplate`]
 
 
 [options="header"]
@@ -2103,7 +2103,7 @@ Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:ty
 |====
 |Property                    |Description
 |deployment           1.2+<.<|Template for Kafka Connect `Deployment`.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`]
 |pod                  1.2+<.<|Template for Kafka Connect `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
 |apiService           1.2+<.<|Template for Kafka Connect API `Service`.
@@ -2114,6 +2114,21 @@ Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:ty
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |podDisruptionBudget  1.2+<.<|Template for Kafka Connect `PodDisruptionBudget`.
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
+|====
+
+[id='type-DeploymentTemplate-{context}']
+### `DeploymentTemplate` schema reference
+
+Used in: xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`], xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`], xref:type-KafkaMirrorMakerTemplate-{context}[`KafkaMirrorMakerTemplate`]
+
+
+[options="header"]
+|====
+|Property                   |Description
+|metadata            1.2+<.<|Metadata applied to the resource.
+|xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
+|deploymentStrategy  1.2+<.<|DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
+|string (one of [RollingUpdate, Recreate])
 |====
 
 [id='type-ExternalConfiguration-{context}']
@@ -2769,7 +2784,7 @@ Used in: xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
 |====
 |Property                     |Description
 |deployment            1.2+<.<|Template for Kafka MirrorMaker `Deployment`.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`]
 |pod                   1.2+<.<|Template for Kafka MirrorMaker `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
 |mirrorMakerContainer  1.2+<.<|Template for Kafka MirrorMaker container.
@@ -2954,7 +2969,7 @@ Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`]
 |====
 |Property                    |Description
 |deployment           1.2+<.<|Template for Kafka Bridge `Deployment`.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`]
 |pod                  1.2+<.<|Template for Kafka Bridge `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
 |apiService           1.2+<.<|Template for Kafka Bridge API `Service`.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -555,6 +555,12 @@ spec:
                           type: object
                           description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
+                    deploymentStrategy:
+                      type: string
+                      enum:
+                        - RollingUpdate
+                        - Recreate
+                      description: DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
                   type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -381,6 +381,12 @@ spec:
                           type: object
                           description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
+                    deploymentStrategy:
+                      type: string
+                      enum:
+                        - RollingUpdate
+                        - Recreate
+                      description: DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
                   type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -694,6 +694,12 @@ spec:
                           type: object
                           description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
+                    deploymentStrategy:
+                      type: string
+                      enum:
+                        - RollingUpdate
+                        - Recreate
+                      description: DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                   description: Template for Kafka MirrorMaker `Deployment`.
                 pod:
                   type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -355,6 +355,12 @@ spec:
                           type: object
                           description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
+                    deploymentStrategy:
+                      type: string
+                      enum:
+                        - RollingUpdate
+                        - Recreate
+                      description: DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                   description: Template for Kafka Bridge `Deployment`.
                 pod:
                   type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -637,6 +637,12 @@ spec:
                           type: object
                           description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
+                    deploymentStrategy:
+                      type: string
+                      enum:
+                        - RollingUpdate
+                        - Recreate
+                      description: DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
                   type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -551,6 +551,12 @@ spec:
                           type: object
                           description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
+                    deploymentStrategy:
+                      type: string
+                      enum:
+                        - RollingUpdate
+                        - Recreate
+                      description: DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
                   type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -377,6 +377,12 @@ spec:
                           type: object
                           description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
+                    deploymentStrategy:
+                      type: string
+                      enum:
+                        - RollingUpdate
+                        - Recreate
+                      description: DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
                   type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -690,6 +690,12 @@ spec:
                           type: object
                           description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
+                    deploymentStrategy:
+                      type: string
+                      enum:
+                        - RollingUpdate
+                        - Recreate
+                      description: DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                   description: Template for Kafka MirrorMaker `Deployment`.
                 pod:
                   type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -351,6 +351,12 @@ spec:
                           type: object
                           description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
+                    deploymentStrategy:
+                      type: string
+                      enum:
+                        - RollingUpdate
+                        - Recreate
+                      description: DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                   description: Template for Kafka Bridge `Deployment`.
                 pod:
                   type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -633,6 +633,12 @@ spec:
                           type: object
                           description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
+                    deploymentStrategy:
+                      type: string
+                      enum:
+                        - RollingUpdate
+                        - Recreate
+                      description: DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
                   type: object

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -608,6 +608,14 @@ spec:
                             Can be applied to different resources such as `StatefulSets`,
                             `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
+                    deploymentStrategy:
+                      type: string
+                      enum:
+                      - RollingUpdate
+                      - Recreate
+                      description: DeploymentStrategy which will be used for this
+                        Deployment. Valid values are `RollingUpdate` and `Recreate`.
+                        Defaults to `RollingUpdate`.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
                   type: object

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -396,6 +396,14 @@ spec:
                             Can be applied to different resources such as `StatefulSets`,
                             `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
+                    deploymentStrategy:
+                      type: string
+                      enum:
+                      - RollingUpdate
+                      - Recreate
+                      description: DeploymentStrategy which will be used for this
+                        Deployment. Valid values are `RollingUpdate` and `Recreate`.
+                        Defaults to `RollingUpdate`.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
                   type: object

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -780,6 +780,14 @@ spec:
                             Can be applied to different resources such as `StatefulSets`,
                             `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
+                    deploymentStrategy:
+                      type: string
+                      enum:
+                      - RollingUpdate
+                      - Recreate
+                      description: DeploymentStrategy which will be used for this
+                        Deployment. Valid values are `RollingUpdate` and `Recreate`.
+                        Defaults to `RollingUpdate`.
                   description: Template for Kafka MirrorMaker `Deployment`.
                 pod:
                   type: object

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -408,6 +408,14 @@ spec:
                             Can be applied to different resources such as `StatefulSets`,
                             `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
+                    deploymentStrategy:
+                      type: string
+                      enum:
+                      - RollingUpdate
+                      - Recreate
+                      description: DeploymentStrategy which will be used for this
+                        Deployment. Valid values are `RollingUpdate` and `Recreate`.
+                        Defaults to `RollingUpdate`.
                   description: Template for Kafka Bridge `Deployment`.
                 pod:
                   type: object

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -714,6 +714,14 @@ spec:
                             Can be applied to different resources such as `StatefulSets`,
                             `Deployments`, `Pods`, and `Services`.
                       description: Metadata applied to the resource.
+                    deploymentStrategy:
+                      type: string
+                      enum:
+                      - RollingUpdate
+                      - Recreate
+                      description: DeploymentStrategy which will be used for this
+                        Deployment. Valid values are `RollingUpdate` and `Recreate`.
+                        Defaults to `RollingUpdate`.
                   description: Template for Kafka Connect `Deployment`.
                 pod:
                   type: object


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In some cases, it makes sense to use the Recreate deployment strategy for things like Connect, Mirror Maker and Bridge. Sometimes, the user might not want to run multiple containers in parallel or as described in #3952 does not want to keep spare resources to run multiple pods during the rolling update.

This Pr allows to configure the deployment strategy in the Deployment template. It can use used with:
* Kafka Connect and S2I
* Kafka Mirror Maker
* Kafka Mirror Maker 2
* Kafka Bridge

Other deployments (e.g. topic and user operators etc.) keep using Recreate as hardcoded options since it is required by their functionality.

This PR should close #3952

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md