### PR TITLE
Add ready status to the crd columns

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -60,6 +60,18 @@ import static java.util.Collections.unmodifiableList;
                                 description = "The desired number of ZooKeeper replicas in the cluster",
                                 jsonPath = ".spec.zookeeper.replicas",
                                 type = "integer"
+                        ),
+                        @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Ready",
+                                description = "The state of the custom resource",
+                                jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",
+                                type = "string"
+                        ),
+                        @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Warnings",
+                                description = "Warnings related to the custom resource",
+                                jsonPath = ".status.conditions[?(@.type==\"Warning\")].status",
+                                type = "string"
                         )
                 }
         )

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
@@ -68,6 +68,12 @@ import static java.util.Collections.unmodifiableList;
                                 jsonPath = ".spec.bootstrapServers",
                                 type = "string",
                                 priority = 1
+                        ),
+                        @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Ready",
+                                description = "The state of the custom resource",
+                                jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",
+                                type = "string"
                         )
                 }
         )

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
@@ -66,6 +66,12 @@ import static java.util.Collections.unmodifiableList;
                                 description = "The desired number of Kafka Connect replicas",
                                 jsonPath = ".spec.replicas",
                                 type = "integer"
+                        ),
+                        @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Ready",
+                                description = "The state of the custom resource",
+                                jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",
+                                type = "string"
                         )
                 }
         )

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
@@ -69,6 +69,12 @@ import static java.util.Collections.unmodifiableList;
                                 description = "The desired number of Kafka Connect replicas",
                                 jsonPath = ".spec.replicas",
                                 type = "integer"
+                        ),
+                        @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Ready",
+                                description = "The state of the custom resource",
+                                jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",
+                                type = "string"
                         )
                 }
         )

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
@@ -68,6 +68,12 @@ import static java.util.Collections.unmodifiableList;
                                 description = "Maximum number of tasks",
                                 jsonPath = ".spec.tasksMax",
                                 type = "integer"
+                        ),
+                        @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Ready",
+                                description = "The state of the custom resource",
+                                jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",
+                                type = "string"
                         )
                 }
         )

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
@@ -81,6 +81,12 @@ import static java.util.Collections.unmodifiableList;
                                 type = "string",
                                 priority = 1
                         ),
+                        @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Ready",
+                                description = "The state of the custom resource",
+                                jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",
+                                type = "string"
+                        )
                 }
         )
 )

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
@@ -60,6 +60,12 @@ import static java.util.Collections.unmodifiableList;
                                 description = "The desired number of Kafka MirrorMaker 2.0 replicas",
                                 jsonPath = ".spec.replicas",
                                 type = "integer"
+                        ),
+                        @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Ready",
+                                description = "The state of the custom resource",
+                                jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",
+                                type = "string"
                         )
                 }
         )

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
@@ -55,6 +55,12 @@ import static java.util.Collections.unmodifiableList;
                                 description = "The name of the Kafka cluster this resource rebalances",
                                 jsonPath = ".metadata.labels.strimzi\\.io/cluster",
                                 type = "string"
+                        ),
+                        @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Ready",
+                                description = "The state of the custom resource",
+                                jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",
+                                type = "string"
                         )
                 }
         )

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
@@ -55,12 +55,6 @@ import static java.util.Collections.unmodifiableList;
                                 description = "The name of the Kafka cluster this resource rebalances",
                                 jsonPath = ".metadata.labels.strimzi\\.io/cluster",
                                 type = "string"
-                        ),
-                        @Crd.Spec.AdditionalPrinterColumn(
-                                name = "Ready",
-                                description = "The state of the custom resource",
-                                jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",
-                                type = "string"
                         )
                 }
         )

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
@@ -74,6 +74,12 @@ import static java.util.Collections.unmodifiableList;
                                 description = "The desired number of replicas of each partition",
                                 jsonPath = ".spec.replicas",
                                 type = "integer"
+                        ),
+                        @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Ready",
+                                description = "The state of the custom resource",
+                                jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",
+                                type = "string"
                         )
                 }
         )

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -72,6 +72,12 @@ import static java.util.Collections.unmodifiableList;
                                 description = "How the user is authorised",
                                 jsonPath = ".spec.authorization.type",
                                 type = "string"
+                        ),
+                        @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Ready",
+                                description = "The state of the custom resource",
+                                jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",
+                                type = "string"
                         )
                 }
         )

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
@@ -34,6 +34,14 @@ spec:
       description: The desired number of ZooKeeper replicas in the cluster
       jsonPath: .spec.zookeeper.replicas
       type: integer
+    - name: Ready
+      description: The state of the custom resource
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
+    - name: Warnings
+      description: Warnings related to the custom resource
+      jsonPath: .status.conditions[?(@.type=="Warning")].status
+      type: string
     schema:
       openAPIV3Schema:
         type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
@@ -26,6 +26,14 @@ spec:
     description: The desired number of ZooKeeper replicas in the cluster
     JSONPath: .spec.zookeeper.replicas
     type: integer
+  - name: Ready
+    description: The state of the custom resource
+    JSONPath: .status.conditions[?(@.type=="Ready")].status
+    type: string
+  - name: Warnings
+    description: Warnings related to the custom resource
+    JSONPath: .status.conditions[?(@.type=="Warning")].status
+    type: string
   subresources:
     status: {}
   conversion:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -31,6 +31,14 @@ spec:
       description: The desired number of ZooKeeper replicas in the cluster
       JSONPath: .spec.zookeeper.replicas
       type: integer
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
+    - name: Warnings
+      description: Warnings related to the custom resource
+      JSONPath: .status.conditions[?(@.type=="Warning")].status
+      type: string
   subresources:
     status: {}
   conversion:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -27,6 +27,10 @@ spec:
       description: The desired number of Kafka Connect replicas
       JSONPath: .spec.replicas
       type: integer
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
     scale:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -27,6 +27,10 @@ spec:
       description: The desired number of Kafka Connect replicas
       JSONPath: .spec.replicas
       type: integer
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
     scale:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
@@ -35,6 +35,10 @@ spec:
       description: The desired number of replicas of each partition
       JSONPath: .spec.replicas
       type: integer
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
   conversion:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
@@ -35,6 +35,10 @@ spec:
       description: How the user is authorised
       JSONPath: .spec.authorization.type
       type: string
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
   conversion:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -37,6 +37,10 @@ spec:
       JSONPath: .spec.producer.bootstrapServers
       type: string
       priority: 1
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
     scale:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -32,6 +32,10 @@ spec:
       JSONPath: .spec.bootstrapServers
       type: string
       priority: 1
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
     scale:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
@@ -35,6 +35,10 @@ spec:
       description: Maximum number of tasks
       JSONPath: .spec.tasksMax
       type: integer
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
     scale:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -27,6 +27,10 @@ spec:
       description: The desired number of Kafka MirrorMaker 2.0 replicas
       JSONPath: .spec.replicas
       type: integer
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
     scale:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/049-Crd-kafkarebalance.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/049-Crd-kafkarebalance.yaml
@@ -27,10 +27,6 @@ spec:
       description: The name of the Kafka cluster this resource rebalances
       JSONPath: .metadata.labels.strimzi\.io/cluster
       type: string
-    - name: Ready
-      description: The state of the custom resource
-      JSONPath: .status.conditions[?(@.type=="Ready")].status
-      type: string
   subresources:
     status: {}
   conversion:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/049-Crd-kafkarebalance.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/049-Crd-kafkarebalance.yaml
@@ -27,6 +27,10 @@ spec:
       description: The name of the Kafka cluster this resource rebalances
       JSONPath: .metadata.labels.strimzi\.io/cluster
       type: string
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
   conversion:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -27,6 +27,14 @@ spec:
       description: The desired number of ZooKeeper replicas in the cluster
       JSONPath: .spec.zookeeper.replicas
       type: integer
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
+    - name: Warnings
+      description: Warnings related to the custom resource
+      JSONPath: .status.conditions[?(@.type=="Warning")].status
+      type: string
   subresources:
     status: {}
   conversion:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -23,6 +23,10 @@ spec:
       description: The desired number of Kafka Connect replicas
       JSONPath: .spec.replicas
       type: integer
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
     scale:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -23,6 +23,10 @@ spec:
       description: The desired number of Kafka Connect replicas
       JSONPath: .spec.replicas
       type: integer
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
     scale:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
@@ -31,6 +31,10 @@ spec:
       description: The desired number of replicas of each partition
       JSONPath: .spec.replicas
       type: integer
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
   conversion:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
@@ -31,6 +31,10 @@ spec:
       description: How the user is authorised
       JSONPath: .spec.authorization.type
       type: string
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
   conversion:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -33,6 +33,10 @@ spec:
       JSONPath: .spec.producer.bootstrapServers
       type: string
       priority: 1
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
     scale:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -28,6 +28,10 @@ spec:
       JSONPath: .spec.bootstrapServers
       type: string
       priority: 1
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
     scale:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
@@ -31,6 +31,10 @@ spec:
       description: Maximum number of tasks
       JSONPath: .spec.tasksMax
       type: integer
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
     scale:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -23,6 +23,10 @@ spec:
       description: The desired number of Kafka MirrorMaker 2.0 replicas
       JSONPath: .spec.replicas
       type: integer
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
     scale:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
@@ -23,6 +23,10 @@ spec:
       description: The name of the Kafka cluster this resource rebalances
       JSONPath: .metadata.labels.strimzi\.io/cluster
       type: string
+    - name: Ready
+      description: The state of the custom resource
+      JSONPath: .status.conditions[?(@.type=="Ready")].status
+      type: string
   subresources:
     status: {}
   conversion:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
@@ -23,10 +23,6 @@ spec:
       description: The name of the Kafka cluster this resource rebalances
       JSONPath: .metadata.labels.strimzi\.io/cluster
       type: string
-    - name: Ready
-      description: The state of the custom resource
-      JSONPath: .status.conditions[?(@.type=="Ready")].status
-      type: string
   subresources:
     status: {}
   conversion:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -26,6 +26,14 @@ spec:
     description: The desired number of ZooKeeper replicas in the cluster
     JSONPath: .spec.zookeeper.replicas
     type: integer
+  - name: Ready
+    description: The state of the custom resource
+    JSONPath: .status.conditions[?(@.type=="Ready")].status
+    type: string
+  - name: Warnings
+    description: Warnings related to the custom resource
+    JSONPath: .status.conditions[?(@.type=="Warning")].status
+    type: string
   subresources:
     status: {}
   conversion:

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -22,6 +22,10 @@ spec:
     description: The desired number of Kafka Connect replicas
     JSONPath: .spec.replicas
     type: integer
+  - name: Ready
+    description: The state of the custom resource
+    JSONPath: .status.conditions[?(@.type=="Ready")].status
+    type: string
   subresources:
     status: {}
     scale:

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -22,6 +22,10 @@ spec:
     description: The desired number of Kafka Connect replicas
     JSONPath: .spec.replicas
     type: integer
+  - name: Ready
+    description: The state of the custom resource
+    JSONPath: .status.conditions[?(@.type=="Ready")].status
+    type: string
   subresources:
     status: {}
     scale:

--- a/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -30,6 +30,10 @@ spec:
     description: The desired number of replicas of each partition
     JSONPath: .spec.replicas
     type: integer
+  - name: Ready
+    description: The state of the custom resource
+    JSONPath: .status.conditions[?(@.type=="Ready")].status
+    type: string
   subresources:
     status: {}
   conversion:

--- a/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -30,6 +30,10 @@ spec:
     description: How the user is authorised
     JSONPath: .spec.authorization.type
     type: string
+  - name: Ready
+    description: The state of the custom resource
+    JSONPath: .status.conditions[?(@.type=="Ready")].status
+    type: string
   subresources:
     status: {}
   conversion:

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -32,6 +32,10 @@ spec:
     JSONPath: .spec.producer.bootstrapServers
     type: string
     priority: 1
+  - name: Ready
+    description: The state of the custom resource
+    JSONPath: .status.conditions[?(@.type=="Ready")].status
+    type: string
   subresources:
     status: {}
     scale:

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -27,6 +27,10 @@ spec:
     JSONPath: .spec.bootstrapServers
     type: string
     priority: 1
+  - name: Ready
+    description: The state of the custom resource
+    JSONPath: .status.conditions[?(@.type=="Ready")].status
+    type: string
   subresources:
     status: {}
     scale:

--- a/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -30,6 +30,10 @@ spec:
     description: Maximum number of tasks
     JSONPath: .spec.tasksMax
     type: integer
+  - name: Ready
+    description: The state of the custom resource
+    JSONPath: .status.conditions[?(@.type=="Ready")].status
+    type: string
   subresources:
     status: {}
     scale:

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -22,6 +22,10 @@ spec:
     description: The desired number of Kafka MirrorMaker 2.0 replicas
     JSONPath: .spec.replicas
     type: integer
+  - name: Ready
+    description: The state of the custom resource
+    JSONPath: .status.conditions[?(@.type=="Ready")].status
+    type: string
   subresources:
     status: {}
     scale:

--- a/install/cluster-operator/049-Crd-kafkarebalance.yaml
+++ b/install/cluster-operator/049-Crd-kafkarebalance.yaml
@@ -22,6 +22,10 @@ spec:
     description: The name of the Kafka cluster this resource rebalances
     JSONPath: .metadata.labels.strimzi\.io/cluster
     type: string
+  - name: Ready
+    description: The state of the custom resource
+    JSONPath: .status.conditions[?(@.type=="Ready")].status
+    type: string
   subresources:
     status: {}
   conversion:

--- a/install/cluster-operator/049-Crd-kafkarebalance.yaml
+++ b/install/cluster-operator/049-Crd-kafkarebalance.yaml
@@ -22,10 +22,6 @@ spec:
     description: The name of the Kafka cluster this resource rebalances
     JSONPath: .metadata.labels.strimzi\.io/cluster
     type: string
-  - name: Ready
-    description: The state of the custom resource
-    JSONPath: .status.conditions[?(@.type=="Ready")].status
-    type: string
   subresources:
     status: {}
   conversion:

--- a/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -30,6 +30,10 @@ spec:
     description: The desired number of replicas of each partition
     JSONPath: .spec.replicas
     type: integer
+  - name: Ready
+    description: The state of the custom resource
+    JSONPath: .status.conditions[?(@.type=="Ready")].status
+    type: string
   subresources:
     status: {}
   conversion:

--- a/install/user-operator/04-Crd-kafkauser.yaml
+++ b/install/user-operator/04-Crd-kafkauser.yaml
@@ -30,6 +30,10 @@ spec:
     description: How the user is authorised
     JSONPath: .spec.authorization.type
     type: string
+  - name: Ready
+    description: The state of the custom resource
+    JSONPath: .status.conditions[?(@.type=="Ready")].status
+    type: string
   subresources:
     status: {}
   conversion:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Sometimes, when users provide in some issues output of some `kubectl` commands, it would be useful if it printed a column with the state of the Ready condition from our CRs. This PR implements it. Once merged, when you do `kubectl get`, you should get a new column called `READY` which prints `True` if the custom resource is ready. Additionally, for the Kafka resource, it also prints if there are any warnings in the Kafka CR status.

It does not include the KafkaRebalance resource where the statuses are more complicated.

```
$> kubectl get strimzi
NAME                                    CLUSTER      AUTHENTICATION   AUTHORIZATION   READY
kafkauser.kafka.strimzi.io/my-connect   my-cluster   tls                              True

NAME                                                                                      CLUSTER      PARTITIONS   REPLICATION FACTOR   READY
kafkatopic.kafka.strimzi.io/connect-cluster-configs                                       my-cluster   1            3                    True
kafkatopic.kafka.strimzi.io/connect-cluster-offsets                                       my-cluster   25           3                    True
kafkatopic.kafka.strimzi.io/connect-cluster-status                                        my-cluster   5            3                    True
kafkatopic.kafka.strimzi.io/consumer-offsets---84e7a678d08f4bd226872e5cdd4eb527fadc1c6a   my-cluster   50           3                    True
kafkatopic.kafka.strimzi.io/strimzi.cruisecontrol.metrics                                 my-cluster   1            1                    True
kafkatopic.kafka.strimzi.io/strimzi.cruisecontrol.modeltrainingsamples                    my-cluster   32           2                    True
kafkatopic.kafka.strimzi.io/strimzi.cruisecontrol.partitionmetricsamples                  my-cluster   32           2                    True

NAME                                DESIRED KAFKA REPLICAS   DESIRED ZK REPLICAS   READY   WARNINGS
kafka.kafka.strimzi.io/my-cluster   3                        3                     True    True

NAME                                       DESIRED REPLICAS   READY
kafkaconnect.kafka.strimzi.io/my-connect   1                  True

NAME                                                  CLUSTER      CONNECTOR CLASS   MAX TASKS   READY
kafkaconnector.kafka.strimzi.io/file-sink-connector   my-connect   FileStreamSink    3           True

NAME                                           CLUSTER
kafkarebalance.kafka.strimzi.io/my-rebalance   my-cluster
```