### PR TITLE
Check connector status when deleting them

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -12,6 +12,7 @@ import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.json.JsonObject;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A Java client for the Kafka Connect REST API.
@@ -38,7 +39,7 @@ public interface KafkaConnectApi {
      */
     Future<Map<String, String>> getConnectorConfig(String host, int port, String connectorName);
 
-    public Future<Map<String, String>> getConnectorConfig(BackOff backOff, String host, int port, String connectorName);
+    Future<Map<String, String>> getConnectorConfig(BackOff backOff, String host, int port, String connectorName);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}}.
@@ -68,6 +69,17 @@ public interface KafkaConnectApi {
      * this returns the connector's status.
      */
     Future<Map<String, Object>> status(String host, int port, String connectorName);
+
+    /**
+     * Make a {@code GET} request to {@code /connectors/${connectorName}/status}.
+     * @param host The host to make the request to.
+     * @param port The port to make the request to.
+     * @param connectorName The name of the connector to get the status of.
+     * @param okStatusCodes List of HTTP codes considered as success
+     * @return A Future which completes with the result of the request. If the request was successful,
+     * this returns the connector's status.
+     */
+    Future<Map<String, Object>> status(String host, int port, String connectorName, Set<Integer> okStatusCodes);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}/status}, retrying according to {@code backoff}.


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

As described in #3894, the connector deletion is asynchronous. The the `DELETE` call succeeds, the connector might still take some time to delete. This PR adds additional check for the connector status to disappear from the Connect REST API after the successful delete call. This should help to keep the reconciliation and make sure new connector with the same name is not created before the old one is deleted.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging