### PR TITLE
[DOC] Correct the Kafka Connect config indentation

### DIFF
--- a/documentation/modules/configuring/proc-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect.adoc
@@ -106,17 +106,17 @@ spec:
     initialDelaySeconds: 15
     timeoutSeconds: 5
   metrics: <12>
-      lowercaseOutputName: true
-      lowercaseOutputLabelNames: true
-      rules:
-        - pattern: kafka.connect<type=connect-worker-metrics><>([a-z-]+)
-          name: kafka_connect_worker_$1
-          help: "Kafka Connect JMX metric worker"
-          type: GAUGE
-        - pattern: kafka.connect<type=connect-worker-rebalance-metrics><>([a-z-]+)
-          name: kafka_connect_worker_rebalance_$1
-          help: "Kafka Connect JMX metric rebalance information"
-          type: GAUGE
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    rules:
+      - pattern: kafka.connect<type=connect-worker-metrics><>([a-z-]+)
+        name: kafka_connect_worker_$1
+        help: "Kafka Connect JMX metric worker"
+        type: GAUGE
+      - pattern: kafka.connect<type=connect-worker-rebalance-metrics><>([a-z-]+)
+        name: kafka_connect_worker_rebalance_$1
+        help: "Kafka Connect JMX metric rebalance information"
+        type: GAUGE
   jvmOptions: <13>
     "-Xmx": "1g"
     "-Xms": "1g"


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Small change to the _Configuring Kafka Connect_ procedure in _Using Guide_ to correct indentation.

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

