### PR TITLE
[DOCS] Use the new Zookeeper address valid after sidecar removal

### DIFF
--- a/documentation/assemblies/assembly-zookeeper-connection.adoc
+++ b/documentation/assemblies/assembly-zookeeper-connection.adoc
@@ -8,6 +8,6 @@
 
 ZooKeeper services are secured with encryption and authentication and are not intended to be used by external applications that are not part of Strimzi.
 
-However, if you want to use Kafka CLI tools that require a connection to ZooKeeper, you can use a terminal inside a Zookeeper container and connect to `localhost:12181` as the ZooKeeper address.
+However, if you want to use Kafka CLI tools that require a connection to ZooKeeper, you can use a terminal inside a ZooKeeper container and connect to `localhost:12181` as the ZooKeeper address.
 
 include::../modules/proc-connecting-to-zookeeper.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-zookeeper-connection.adoc
+++ b/documentation/assemblies/assembly-zookeeper-connection.adoc
@@ -8,6 +8,6 @@
 
 ZooKeeper services are secured with encryption and authentication and are not intended to be used by external applications that are not part of Strimzi.
 
-However, if you want to use Kafka CLI tools that require a connection to ZooKeeper, such as the `kafka-topics` tool, you can use a terminal inside a Kafka container and connect to the local end of the TLS tunnel to ZooKeeper by using `localhost:2181` as the ZooKeeper address.
+However, if you want to use Kafka CLI tools that require a connection to ZooKeeper, you can use a terminal inside a Zookeeper container and connect to `localhost:12181` as the ZooKeeper address.
 
 include::../modules/proc-connecting-to-zookeeper.adoc[leveloffset=+1]

--- a/documentation/modules/managing/proc-cluster-recovery-volume.adoc
+++ b/documentation/modules/managing/proc-cluster-recovery-volume.adoc
@@ -199,7 +199,7 @@ For example, where _my-cluster-kafka-0_ is the name of the broker pod:
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-kubectl exec _my-cluster-kafka-0_ bin/zookeeper-shell.sh localhost:2181
+kubectl exec _my-cluster-zookeeper-0_ bin/zookeeper-shell.sh localhost:12181
 ----
 . Delete the whole `/strimzi` path to remove the Topic Operator storage:
 +

--- a/documentation/modules/managing/proc-cluster-recovery-volume.adoc
+++ b/documentation/modules/managing/proc-cluster-recovery-volume.adoc
@@ -199,7 +199,7 @@ For example, where _my-cluster-kafka-0_ is the name of the broker pod:
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-kubectl exec _my-cluster-zookeeper-0_ bin/zookeeper-shell.sh localhost:12181
+kubectl exec -ti _my-cluster-zookeeper-0_ -- bin/zookeeper-shell.sh localhost:12181
 ----
 . Delete the whole `/strimzi` path to remove the Topic Operator storage:
 +


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The way to access ZooKeeper changed after we removed the TLS sidecars from Kafka pods. This PR fixes some of the docs about it.

This should be picked for the 0.20.0 release branch.

### Checklist

- [x] Update documentation