### PR TITLE
[DOC] Guidelines for downgrade

### DIFF
--- a/documentation/assemblies/upgrading/assembly-downgrade-kafka-versions.adoc
+++ b/documentation/assemblies/upgrading/assembly-downgrade-kafka-versions.adoc
@@ -5,7 +5,7 @@
 [id='assembly-downgrade-kafka-versions-{context}']
 = Downgrading Kafka
 
-Kafka version downgrades are performed using the Cluster Operator.
+Kafka version downgrades are performed by the Cluster Operator.
 
 //Version constraints on the downgrade
 include::modules/con-downgrade-target-version.adoc[leveloffset=+1]

--- a/documentation/assemblies/upgrading/assembly-downgrade-kafka-versions.adoc
+++ b/documentation/assemblies/upgrading/assembly-downgrade-kafka-versions.adoc
@@ -1,20 +1,13 @@
 // This assembly is included in the following assemblies:
 //
-// assembly-upgrade.adoc
+// assembly-downgrade.adoc
 
-
-[id='assembly-downgrading-kafka-versions-{context}']
-
+[id='assembly-downgrade-kafka-versions-{context}']
 = Downgrading Kafka
 
 Kafka version downgrades are performed using the Cluster Operator.
 
-Whether and how the Cluster Operator performs a downgrade depends on the differences between versions of:
-
-* Interbroker protocol
-* Log message format
-* ZooKeeper
-
+//Version constraints on the downgrade
 include::modules/con-downgrade-target-version.adoc[leveloffset=+1]
-
+//procedure to downgrade Kafka
 include::modules/proc-downgrade-brokers-older-kafka.adoc[leveloffset=+1]

--- a/documentation/assemblies/upgrading/assembly-downgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-downgrade.adoc
@@ -5,10 +5,10 @@
 [id='assembly-downgrade-{context}']
 = Downgrading Strimzi
 
-If you are encountering issues with the latest version of Strimzi,
+If you are encountering issues with the version of Strimzi you upgraded to,
 you can revert your installation to the previous version.
 
-As with the Strimzi upgrade process, you can perform your downgrade in two stages:
+You can perform a downgrade to:
 
 . Revert your Cluster Operator to the previous Strimzi version.
 ** xref:proc-downgrade-cluster-operator-{context}[]

--- a/documentation/assemblies/upgrading/assembly-downgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-downgrade.adoc
@@ -1,0 +1,26 @@
+// This assembly is included in the following assemblies:
+//
+// deploying/master.adoc
+
+[id='assembly-downgrade-{context}']
+= Downgrading Strimzi
+
+If you are encountering issues with the latest version of Strimzi,
+you can revert your installation to the previous version.
+
+As with the Strimzi upgrade process, you can perform your downgrade in two stages:
+
+. Revert your Cluster Operator to the previous Strimzi version.
+** xref:proc-downgrade-cluster-operator-{context}[]
+
+. Downgrade all Kafka brokers and client applications to the previous Kafka version.
+** xref:assembly-downgrade-kafka-versions-{context}[]
+
+If the previous version of Strimzi does not support the version of Kafka you are using,
+you can also downgrade Kafka as long as the log message format versions appended to messages match.
+
+//steps to downgrade the operators
+include::modules/proc-downgrade-cluster-operator.adoc[leveloffset=+1]
+
+//steps to downgrade Kafka
+include::assembly-downgrade-kafka-versions.adoc[leveloffset=+1]

--- a/documentation/assemblies/upgrading/assembly-upgrade-kafka-versions.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-kafka-versions.adoc
@@ -10,7 +10,7 @@ After you have upgraded your Cluster Operator, you can upgrade your brokers to a
 
 Kafka upgrades are performed using the Cluster Operator. How the Cluster Operator performs an upgrade depends on the differences between versions of:
 
-* Interbroker protocol
+* Inter-broker protocol
 * Log message format
 * ZooKeeper
 

--- a/documentation/assemblies/upgrading/assembly-upgrade-kafka.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-kafka.adoc
@@ -18,5 +18,3 @@ include::modules/ref-upgrade-kafka-versions.adoc[leveloffset=+1]
 include::assembly-upgrade-kafka-cluster-operator.adoc[leveloffset=+1]
 
 include::assembly-upgrade-kafka-versions.adoc[leveloffset=+1]
-
-include::assembly-downgrade-kafka-versions.adoc[leveloffset=+1]

--- a/documentation/deploying/master.adoc
+++ b/documentation/deploying/master.adoc
@@ -21,4 +21,4 @@ include::assemblies/metrics/assembly-metrics.adoc[leveloffset=+1]
 //Upgrading the deployment
 include::assemblies/upgrading/assembly-upgrade.adoc[leveloffset=+1]
 //Downgrading the deployment
-include::assemblies/upgrading/assembly-downgrade.adoc[leveloffset=+1]
+include::modules/upgrading/proc-downgrade-cluster-operator.adoc[leveloffset=+1]

--- a/documentation/deploying/master.adoc
+++ b/documentation/deploying/master.adoc
@@ -20,3 +20,5 @@ include::assemblies/deploying/assembly-deploy-verify.adoc[leveloffset=+1]
 include::assemblies/metrics/assembly-metrics.adoc[leveloffset=+1]
 //Upgrading the deployment
 include::assemblies/upgrading/assembly-upgrade.adoc[leveloffset=+1]
+//Downgrading the deployment
+include::assemblies/upgrading/assembly-downgrade.adoc[leveloffset=+1]

--- a/documentation/deploying/master.adoc
+++ b/documentation/deploying/master.adoc
@@ -21,4 +21,4 @@ include::assemblies/metrics/assembly-metrics.adoc[leveloffset=+1]
 //Upgrading the deployment
 include::assemblies/upgrading/assembly-upgrade.adoc[leveloffset=+1]
 //Downgrading the deployment
-include::modules/upgrading/proc-downgrade-cluster-operator.adoc[leveloffset=+1]
+include::assemblies/upgrading/assembly-downgrade.adoc[leveloffset=+1]

--- a/documentation/modules/oauth/proc-oauth-authentication-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authentication-broker-config.adoc
@@ -135,7 +135,7 @@ Depending on how you apply OAuth 2.0 authentication, and the type of authorizati
 [source,shell,subs="+quotes,attributes"]
 ----
 kubectl logs -f ${POD_NAME} -c ${CONTAINER_NAME}
-kubectl get po -w
+kubectl get pod -w
 ----
 +
 The rolling update configures the brokers to use OAuth 2.0 authentication.

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -86,7 +86,7 @@ Default is `false`.
 [source,shell,subs="+quotes,attributes"]
 ----
 kubectl logs -f ${POD_NAME} -c kafka
-kubectl get po -w
+kubectl get pod -w
 ----
 +
 The rolling update configures the brokers to use OAuth 2.0 authorization.

--- a/documentation/modules/upgrading/con-downgrade-target-version.adoc
+++ b/documentation/modules/upgrading/con-downgrade-target-version.adoc
@@ -29,7 +29,7 @@ Downgrading is _not possible_ if the new version has ever used a `log.message.fo
 
 [source,yaml,subs=attributes+]
 ----
-apiVersion: v1alpha1
+apiVersion: {KafkaApiVersion}
 kind: Kafka
 spec:
   # ...

--- a/documentation/modules/upgrading/con-downgrade-target-version.adoc
+++ b/documentation/modules/upgrading/con-downgrade-target-version.adoc
@@ -13,7 +13,7 @@ You cannot revert to the previous Kafka version if that version does not support
 or messages have been added to message logs that use a newer `log.message.format.version`.
 
 The `inter.broker.protocol.version` determines the schemas used for persistent metadata stored by the broker, such as the schema for messages written to `__consumer_offsets`.
-If you downgrade to a version of Kafka that doesn't understand an `inter.broker.protocol.version` that has (ever) been previously used in the cluster the broker will encounter data they cannot understand.
+If you downgrade to a version of Kafka that does not understand an `inter.broker.protocol.version` that has (ever) been previously used in the cluster the broker will encounter data they cannot understand.
 
 If the target downgrade version of Kafka has:
 

--- a/documentation/modules/upgrading/con-downgrade-target-version.adoc
+++ b/documentation/modules/upgrading/con-downgrade-target-version.adoc
@@ -13,7 +13,7 @@ You cannot revert to the previous Kafka version if the `inter.broker.protocol.ve
 to message logs that use a newer `log.message.format.version`.
 
 The `inter.broker.protocol.version` determines the schemas used for persistent metadata stored by the broker, such as the schema for messages written to `__consumer_offsets`.
-If you downgrade to a version of Kafka that uses an earlier `inter.broker.protocol.version`, the the cluster will not work as it will not understand the messages.
+If you downgrade to a version of Kafka that uses an earlier `inter.broker.protocol.version`, the cluster will not work as it will not understand the messages.
 
 If the target downgrade version of Kafka has:
 

--- a/documentation/modules/upgrading/con-downgrade-target-version.adoc
+++ b/documentation/modules/upgrading/con-downgrade-target-version.adoc
@@ -4,15 +4,40 @@
 
 [id='com-target-downgrade-version-{context}']
 
-= Target downgrade version
+= Kafka version compatibility for downgrades
 
-How the Cluster Operator handles a downgrade operation depends on the `log.message.format.version`.
+Kafka downgrades are dependent on compatible current and target xref:ref-kafka-versions-{context}[Kafka versions],
+and the state at which messages have been logged.
 
-* If the target downgrade version of Kafka has the same `log.message.format.version` as the current version, the Cluster Operator downgrades by performing a single rolling restart of the brokers.
-* If the target downgrade version of Kafka has a different `log.message.format.version`, downgrading is only possible if the running cluster has _always_ had `log.message.format.version` set to the version used by the downgraded version.
-+
+You cannot revert to the previous Kafka version if the `inter.broker.protocol.version` differs, or messages have been added
+to message logs that use a newer `log.message.format.version`.
+
+The `inter.broker.protocol.version` determines the schema used in the messages written to `__consumer_offsets`.
+If you downgrade to a version of Kafka that uses an earlier `inter.broker.protocol.version`, the broker will not understand the messages.
+
+If the target downgrade version of Kafka has:
+
+* The _same_ `log.message.format.version` as the current version, the Cluster Operator downgrades by performing a single rolling restart of the brokers.
+* A _different_ `log.message.format.version`, downgrading is only possible if the running cluster has _always_ had `log.message.format.version` set to the version used by the downgraded version.
 This is typically only the case if the upgrade procedure was aborted before the `log.message.format.version` was changed.
 In this case, the downgrade requires:
-+
+
 ** Two rolling restarts of the brokers if the interbroker protocol of the two versions is different
 ** A single rolling restart if they are the same
+
+Downgrading is _not possible_ if the new version has ever used a `log.message.format.version` that is not supported by the previous version, including when the default value for `log.message.format.version` is used. For example, this resource can be downgraded to Kafka version {KafkaVersionLower} because the `log.message.format.version` has not been changed:
+
+[source,yaml,subs=attributes+]
+----
+apiVersion: v1alpha1
+kind: Kafka
+spec:
+  # ...
+  kafka:
+    version: {KafkaVersionHigher}
+    config:
+      log.message.format.version: "{LogMsgVersLower}"
+      # ...
+----
+
+The downgrade would not be possible if the `log.message.format.version` was set at `"{LogMsgVersHigher}"` or a value was absent (so that the parameter took the default value for a {KafkaVersionHigher} broker of {LogMsgVersHigher}).

--- a/documentation/modules/upgrading/con-downgrade-target-version.adoc
+++ b/documentation/modules/upgrading/con-downgrade-target-version.adoc
@@ -9,11 +9,11 @@
 Kafka downgrades are dependent on compatible current and target xref:ref-kafka-versions-{context}[Kafka versions],
 and the state at which messages have been logged.
 
-You cannot revert to the previous Kafka version if the `inter.broker.protocol.version` differs, or messages have been added
-to message logs that use a newer `log.message.format.version`.
+You cannot revert to the previous Kafka version if that version don't support any of the `inter.broker.protocol.version` settings which have ever been used in that cluster,
+or messages have been added to message logs that use a newer `log.message.format.version`.
 
 The `inter.broker.protocol.version` determines the schemas used for persistent metadata stored by the broker, such as the schema for messages written to `__consumer_offsets`.
-If you downgrade to a version of Kafka that uses an earlier `inter.broker.protocol.version`, the cluster will not work because it will not understand the messages.
+If you downgrade to a version of Kafka that doesn't understand an `inter.broker.protocol.version` that has (ever) been previously used in the cluster the broker will encounter data they cannot understand.
 
 If the target downgrade version of Kafka has:
 

--- a/documentation/modules/upgrading/con-downgrade-target-version.adoc
+++ b/documentation/modules/upgrading/con-downgrade-target-version.adoc
@@ -9,7 +9,7 @@
 Kafka downgrades are dependent on compatible current and target xref:ref-kafka-versions-{context}[Kafka versions],
 and the state at which messages have been logged.
 
-You cannot revert to the previous Kafka version if that version don't support any of the `inter.broker.protocol.version` settings which have ever been used in that cluster,
+You cannot revert to the previous Kafka version if that version does not support any of the `inter.broker.protocol.version` settings which have _ever been used_ in that cluster,
 or messages have been added to message logs that use a newer `log.message.format.version`.
 
 The `inter.broker.protocol.version` determines the schemas used for persistent metadata stored by the broker, such as the schema for messages written to `__consumer_offsets`.

--- a/documentation/modules/upgrading/con-downgrade-target-version.adoc
+++ b/documentation/modules/upgrading/con-downgrade-target-version.adoc
@@ -12,8 +12,8 @@ and the state at which messages have been logged.
 You cannot revert to the previous Kafka version if the `inter.broker.protocol.version` differs, or messages have been added
 to message logs that use a newer `log.message.format.version`.
 
-The `inter.broker.protocol.version` determines the schema used in the messages written to `__consumer_offsets`.
-If you downgrade to a version of Kafka that uses an earlier `inter.broker.protocol.version`, the broker will not understand the messages.
+The `inter.broker.protocol.version` determines the schemas used for persistent metadata stored by the broker, such as the schema for messages written to `__consumer_offsets`.
+If you downgrade to a version of Kafka that uses an earlier `inter.broker.protocol.version`, the the cluster will not work as it will not understand the messages.
 
 If the target downgrade version of Kafka has:
 

--- a/documentation/modules/upgrading/con-downgrade-target-version.adoc
+++ b/documentation/modules/upgrading/con-downgrade-target-version.adoc
@@ -2,7 +2,7 @@
 //
 // assembly-downgrading-kafka-versions.adoc
 
-[id='com-target-downgrade-version-{context}']
+[id='con-target-downgrade-version-{context}']
 
 = Kafka version compatibility for downgrades
 

--- a/documentation/modules/upgrading/con-downgrade-target-version.adoc
+++ b/documentation/modules/upgrading/con-downgrade-target-version.adoc
@@ -13,7 +13,7 @@ You cannot revert to the previous Kafka version if the `inter.broker.protocol.ve
 to message logs that use a newer `log.message.format.version`.
 
 The `inter.broker.protocol.version` determines the schemas used for persistent metadata stored by the broker, such as the schema for messages written to `__consumer_offsets`.
-If you downgrade to a version of Kafka that uses an earlier `inter.broker.protocol.version`, the cluster will not work as it will not understand the messages.
+If you downgrade to a version of Kafka that uses an earlier `inter.broker.protocol.version`, the cluster will not work because it will not understand the messages.
 
 If the target downgrade version of Kafka has:
 

--- a/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
@@ -8,30 +8,11 @@
 
 This procedure describes how you can downgrade a Strimzi Kafka cluster to a lower (previous) version of Kafka, such as downgrading from {KafkaVersionHigher} to {KafkaVersionLower}.
 
-[IMPORTANT]
-====
-Downgrading is _not possible_ if the new version has ever used a `log.message.format.version` that is not supported by the previous version, including when the default value for `log.message.format.version` is used. For example, this resource can be downgraded to Kafka version {KafkaVersionLower} because the `log.message.format.version` has not been changed:
-
-[source,yaml,subs=attributes+]
-----
-apiVersion: v1alpha1
-kind: Kafka
-spec:
-  # ...
-  kafka:
-    version: {KafkaVersionHigher}
-    config:
-      log.message.format.version: "{LogMsgVersLower}"
-      # ...
-----
-
-The downgrade would not be possible if the `log.message.format.version` was set at `"{LogMsgVersHigher}"` or a value was absent (so that the parameter took the default value for a {KafkaVersionHigher} broker of {LogMsgVersHigher}).
-====
-
 .Prerequisites
 
 For the `Kafka` resource to be downgraded, check:
 
+* [IMPORTANT] xref:com-target-downgrade-version-{context}[Compatibility of Kafka versions].
 * The Cluster Operator, which supports both versions of Kafka, is up and running.
 * The `Kafka.spec.kafka.config` does not contain options that are not supported in the version of Kafka you are downgrading to.
 * The `Kafka.spec.kafka.config` has a `log.message.format.version` that is supported by the version being downgraded to.
@@ -69,6 +50,11 @@ NOTE: You must format the value of `log.message.format.version` as a string to p
 .. If the image for the Kafka version is different from the image defined in `STRIMZI_KAFKA_IMAGES` for the Cluster Operator, update `Kafka.spec.kafka.image`.
 +
 See xref:con-versions-and-images-str[]
+
+.. If you changed the Kafka listener configuration to use the array format of the `GenericKafkaListener` schema,
+revert the `Kafka.spec.kafka.listeners` to use the old format.
++
+See xref:con-upgrade-listeners-str[]
 
 . Save and exit the editor, then wait for rolling updates to complete.
 +

--- a/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
@@ -12,10 +12,10 @@ This procedure describes how you can downgrade a Strimzi Kafka cluster to a lowe
 
 For the `Kafka` resource to be downgraded, check:
 
-* [IMPORTANT] xref:com-target-downgrade-version-{context}[Compatibility of Kafka versions].
+* IMPORTANT: xref:com-target-downgrade-version-{context}[Compatibility of Kafka versions].
 * The Cluster Operator, which supports both versions of Kafka, is up and running.
-* The `Kafka.spec.kafka.config` does not contain options that are not supported in the version of Kafka you are downgrading to.
-* The `Kafka.spec.kafka.config` has a `log.message.format.version` that is supported by the version being downgraded to.
+* The `Kafka.spec.kafka.config` does not contain options that are not supported by the Kafka version being downgraded to.
+* The `Kafka.spec.kafka.config` has a `log.message.format.version` that is supported by the Kafka version being downgraded to.
 
 .Procedure
 

--- a/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
@@ -12,21 +12,19 @@ This procedure describes how you can downgrade a Strimzi Kafka cluster to a lowe
 
 For the `Kafka` resource to be downgraded, check:
 
-* IMPORTANT: xref:com-target-downgrade-version-{context}[Compatibility of Kafka versions].
+* IMPORTANT: xref:con-target-downgrade-version-{context}[Compatibility of Kafka versions].
 * The Cluster Operator, which supports both versions of Kafka, is up and running.
 * The `Kafka.spec.kafka.config` does not contain options that are not supported by the Kafka version being downgraded to.
-* The `Kafka.spec.kafka.config` has a `log.message.format.version` that is supported by the Kafka version being downgraded to.
+* The `Kafka.spec.kafka.config` has a `log.message.format.version` and `inter.broker.protocol.version` that is supported by the Kafka version being downgraded to.
 
 .Procedure
 
-. Update the Kafka cluster configuration in an editor, as required:
-+
-Use `kubectl edit`:
+. Update the Kafka cluster configuration in an editor, as required.
 +
 [source,shell,subs=+quotes]
 kubectl edit kafka _my-cluster_
 
-.. Change the `Kafka.spec.kafka.version` to specify the previous version.
+. Change the `Kafka.spec.kafka.version` to specify the previous version.
 +
 For example, if downgrading from Kafka {KafkaVersionHigher} to {KafkaVersionLower}:
 +
@@ -40,14 +38,16 @@ spec:
     version: {KafkaVersionLower} <1>
     config:
       log.message.format.version: "{LogMsgVersLower}" <2>
+      inter.broker.protocol.version: "{LogMsgVersLower}" <3>
       # ...
 ----
-<1> This is changed to the previous version
-<2> This is unchanged
+<1> Kafka version is changed to the previous version.
+<2> Message format version is unchanged.
+<3> Inter-broker protocol version is unchanged.
 +
-NOTE: You must format the value of `log.message.format.version` as a string to prevent it from being interpreted as a floating point number.
+NOTE: You must format the value of `log.message.format.version` and `inter.broker.protocol.version` as a string to prevent it from being interpreted as a floating point number.
 
-.. If the image for the Kafka version is different from the image defined in `STRIMZI_KAFKA_IMAGES` for the Cluster Operator, update `Kafka.spec.kafka.image`.
+. If the image for the Kafka version is different from the image defined in `STRIMZI_KAFKA_IMAGES` for the Cluster Operator, update `Kafka.spec.kafka.image`.
 +
 See xref:con-versions-and-images-str[]
 
@@ -57,7 +57,7 @@ Check the update in the logs or by watching the pod state transitions:
 +
 [source,shell,subs=+quotes]
 ----
-kubectl logs -f _<cluster-operator-pod-name>_ | grep -E "Kafka version downgrade from [0-9.]+ to [0-9.]+, phase ([0-9]+) of \1 completed"
+kubectl logs -f _CLUSTER-OPERATOR-POD-NAME_ | grep -E "Kafka version downgrade from [0-9.]+ to [0-9.]+, phase ([0-9]+) of \1 completed"
 ----
 +
 [source,shell,subs=+quotes]
@@ -65,21 +65,13 @@ kubectl logs -f _<cluster-operator-pod-name>_ | grep -E "Kafka version downgrade
 kubectl get po -w
 ----
 +
-====
-If the previous and current versions of Kafka have different interbroker protocol versions, check the Cluster Operator logs for an `INFO` level message:
-
-[source,shell,subs=+quotes]
-----
-Reconciliation #_<num>_(watch) Kafka(_<namespace>_/_<name>_): Kafka version downgrade from _<from-version>_ to _<to-version>_, phase 2 of 2 completed
-----
-Alternatively, if the previous and current versions of Kafka have the same interbroker protocol version, check for:
-
-[source,shell,subs=+quotes]
-----
-Reconciliation #_<num>_(watch) Kafka(_<namespace>_/_<name>_): Kafka version downgrade from _<from-version>_ to _<to-version>_, phase 1 of 1 completed
-----
-====
+Check the Cluster Operator logs for an `INFO` level message:
 +
+[source,shell,subs=+quotes]
+----
+Reconciliation #_NUM_(watch) Kafka(_NAMESPACE_/_NAME_): Kafka version downgrade from _FROM-VERSION_ to _TO-VERSION_, phase 1 of 1 completed
+----
+
 . Downgrade all client applications (consumers) to use the previous version of the client binaries.
 +
 The Kafka cluster and clients are now using the previous Kafka version.

--- a/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
@@ -51,11 +51,6 @@ NOTE: You must format the value of `log.message.format.version` as a string to p
 +
 See xref:con-versions-and-images-str[]
 
-.. If you changed the Kafka listener configuration to use the array format of the `GenericKafkaListener` schema,
-revert the `Kafka.spec.kafka.listeners` to use the old format.
-+
-See xref:con-upgrade-listeners-str[]
-
 . Save and exit the editor, then wait for rolling updates to complete.
 +
 Check the update in the logs or by watching the pod state transitions:

--- a/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
@@ -62,7 +62,7 @@ kubectl logs -f _CLUSTER-OPERATOR-POD-NAME_ | grep -E "Kafka version downgrade f
 +
 [source,shell,subs=+quotes]
 ----
-kubectl get po -w
+kubectl get pod -w
 ----
 +
 Check the Cluster Operator logs for an `INFO` level message:

--- a/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
@@ -30,7 +30,7 @@ For example, if downgrading from Kafka {KafkaVersionHigher} to {KafkaVersionLowe
 +
 [source,yaml,subs=attributes+]
 ----
-apiVersion: v1alpha1
+apiVersion: {KafkaApiVersion}
 kind: Kafka
 spec:
   # ...

--- a/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
@@ -29,7 +29,7 @@ Any changes will be *overwritten* by the previous version of the Cluster Operato
 include::snip-cluster-operator-namespace-sed.adoc[]
 +
 .. If you modified one or more environment variables in your existing Cluster Operator `Deployment`, edit the
-`install/cluster-operator/060-Deployment-cluster-operator.yaml` file to use those environment variables.
+`install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml` file to use those environment variables.
 
 . When you have an updated configuration, deploy it along with the rest of the installation resources:
 +
@@ -49,4 +49,4 @@ kubectl get po my-cluster-kafka-0 -o jsonpath='{.spec.containers[0].image}'
 +
 The image tag shows the new Strimzi version followed by the Kafka version. For example, `_NEW-STRIMZI-VERSION_-kafka-_CURRENT-KAFKA-VERSION_`.
 
-You now have an updated Cluster Operator.
+Your Cluster Operator was downgraded to the previous version.

--- a/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
@@ -1,25 +1,25 @@
-// This module is included in the following assemblies:
+// Module included in the following assemblies:
 //
-// assembly-upgrade.adoc
+// assembly-downgrade.adoc
 
-[id='proc-upgrading-the-co-{context}']
-= Upgrading the Cluster Operator to a later version
+[id='proc-downgrade-cluster-operator-{context}']
+= Downgrading the Cluster Operator to a previous version
 
-This procedure describes how to upgrade a Cluster Operator deployment to a later version.
+This procedure describes how to downgrade a Cluster Operator deployment to a previous version.
 
 .Prerequisites
 
 * An existing Cluster Operator deployment is available.
-* You have xref:downloads-{context}[downloaded the installation files for the new version].
+* You have xref:downloads-{context}[downloaded the installation files for the previous version].
 
 .Procedure
 
 . Take note of any configuration changes made to the existing Cluster Operator resources (in the `/install/cluster-operator` directory).
-Any changes will be *overwritten* by the new version of the Cluster Operator.
+Any changes will be *overwritten* by the previous version of the Cluster Operator.
 
 . Update the Cluster Operator.
 
-.. Modify the installation files for the new version according to the namespace the Cluster Operator is running in.
+.. Modify the installation files for the previous version according to the namespace the Cluster Operator is running in.
 +
 include::snip-cluster-operator-namespace-sed.adoc[]
 +
@@ -35,7 +35,7 @@ kubectl apply -f install/cluster-operator
 +
 Wait for the rolling updates to complete.
 
-. Get the image for the Kafka pod to ensure the upgrade was successful:
+. Get the image for the Kafka pod to ensure the downgrade was successful:
 +
 [source,shell,subs="+quotes,attributes"]
 ----
@@ -44,12 +44,8 @@ kubectl get po my-cluster-kafka-0 -o jsonpath='{.spec.containers[0].image}'
 +
 The image tag shows the new Strimzi version followed by the Kafka version. For example, `_NEW-STRIMZI-VERSION_-kafka-_CURRENT-KAFKA-VERSION_`.
 
-. Update existing resources to handle deprecated custom resource properties.
-+
-* xref:assembly-upgrade-resources-{context}[Strimzi resource upgrades]
-
 You now have an updated Cluster Operator, but the version of Kafka running in the cluster it manages is unchanged.
 
 .What to do next
 
-Following the Cluster Operator upgrade, you can perform a xref:assembly-upgrading-kafka-versions-str[Kafka downgrade].
+Following the Cluster Operator downgrade, you can perform a xref:assembly-downgrade-kafka-versions-{context}[Kafka downgrade].

--- a/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
@@ -5,7 +5,7 @@
 [id='proc-downgrade-cluster-operator-{context}']
 = Downgrading the Cluster Operator to a previous version
 
-If you are encountering issues with the latest version of Strimzi,
+If you are encountering issues with Strimzi,
 you can revert your installation.
 
 This procedure describes how to downgrade a Cluster Operator deployment to a previous version.
@@ -19,6 +19,8 @@ This procedure describes how to downgrade a Cluster Operator deployment to a pre
 
 . Take note of any configuration changes made to the existing Cluster Operator resources (in the `/install/cluster-operator` directory).
 Any changes will be *overwritten* by the previous version of the Cluster Operator.
++
+. Revert your custom resources to reflect the supported configuration options available for the version of Strimzi you are downgrading to.
 
 . Update the Cluster Operator.
 

--- a/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
@@ -46,6 +46,4 @@ The image tag shows the new Strimzi version followed by the Kafka version. For e
 
 You now have an updated Cluster Operator, but the version of Kafka running in the cluster it manages is unchanged.
 
-.What to do next
-
 Following the Cluster Operator downgrade, you can perform a xref:assembly-downgrade-kafka-versions-{context}[Kafka downgrade].

--- a/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
@@ -44,7 +44,7 @@ Wait for the rolling updates to complete.
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-kubectl get po my-cluster-kafka-0 -o jsonpath='{.spec.containers[0].image}'
+kubectl get pod my-cluster-kafka-0 -o jsonpath='{.spec.containers[0].image}'
 ----
 +
 The image tag shows the new Strimzi version followed by the Kafka version. For example, `_NEW-STRIMZI-VERSION_-kafka-_CURRENT-KAFKA-VERSION_`.

--- a/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
@@ -5,6 +5,9 @@
 [id='proc-downgrade-cluster-operator-{context}']
 = Downgrading the Cluster Operator to a previous version
 
+If you are encountering issues with the latest version of Strimzi,
+you can revert your installation.
+
 This procedure describes how to downgrade a Cluster Operator deployment to a previous version.
 
 .Prerequisites
@@ -44,6 +47,4 @@ kubectl get po my-cluster-kafka-0 -o jsonpath='{.spec.containers[0].image}'
 +
 The image tag shows the new Strimzi version followed by the Kafka version. For example, `_NEW-STRIMZI-VERSION_-kafka-_CURRENT-KAFKA-VERSION_`.
 
-You now have an updated Cluster Operator, but the version of Kafka running in the cluster it manages is unchanged.
-
-Following the Cluster Operator downgrade, you can perform a xref:assembly-downgrade-kafka-versions-{context}[Kafka downgrade].
+You now have an updated Cluster Operator.

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -91,7 +91,7 @@ kubectl logs -f _CLUSTER-OPERATOR-POD-NAME_ | grep -E "Kafka version upgrade fro
 +
 [source,shell,subs=+quotes]
 ----
-kubectl get po my-cluster-kafka-0 -o jsonpath='{.spec.containers[0].image}'
+kubectl get pod my-cluster-kafka-0 -o jsonpath='{.spec.containers[0].image}'
 ----
 +
 If the current and new versions of Kafka have different inter-broker protocol versions, check the Cluster Operator logs for an `INFO` level message:

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -70,8 +70,7 @@ spec:
 <2> This remains at the current version
 --
 +
-WARNING: You cannot downgrade Kafka once `spec.kafka.version` has changed.
-
+WARNING: You cannot downgrade Kafka once `spec.kafka.version` has changed, as the `inter.broker.protocol.version` for the new Kafka version will differ. The protocol version determines the schemas used for persistent metadata stored by the broker, including messages written to `__consumer_offsets`. The cluster will not understand the messages.
 
 .. If the image for the Kafka version is different from the image defined in `STRIMZI_KAFKA_IMAGES` for the Cluster Operator, update `Kafka.spec.kafka.image`.
 +

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -14,8 +14,7 @@ For the `Kafka` resource to be upgraded, check:
 
 * The Cluster Operator, which supports both versions of Kafka, is up and running.
 * The `Kafka.spec.kafka.config` does not contain options that are not supported in the version of Kafka that you are upgrading to.
-* Whether the `log.message.format.version` for the current Kafka version needs to be updated for the new version.
-+
+* Whether the `log.message.format.version` and `inter.broker.protocol.version` for the current Kafka version needs to be updated for the new version.
 xref:ref-kafka-versions-{context}[Consult the Kafka versions table].
 
 .Procedure
@@ -27,9 +26,9 @@ xref:ref-kafka-versions-{context}[Consult the Kafka versions table].
 kubectl edit kafka _my-cluster_
 ----
 
-.. If the `log.message.format.version` of the current Kafka version is the same as that of the new Kafka version, proceed to the next step.
+. If the `log.message.format.version` and `inter.broker.protocol.version` of the current Kafka version is the same as that of the new Kafka version, proceed to the next step.
 +
-Otherwise, ensure that `Kafka.spec.kafka.config` has the `log.message.format.version` configured to the default for the _current_ version.
+Otherwise, ensure that `Kafka.spec.kafka.config` has the `log.message.format.version` and `inter.broker.protocol.version` configured to the default for the _current_ version.
 +
 For example, if upgrading from Kafka {KafkaVersionLower}:
 +
@@ -42,14 +41,15 @@ spec:
     version: {KafkaVersionLower}
     config:
       log.message.format.version: "{LogMsgVersLower}"
+      inter.broker.protocol.version: "{LogMsgVersLower}"
       # ...
 ----
 +
-If the `log.message.format.version` is unset, set it to the current version.
+If the `log.message.format.version` and `inter.broker.protocol.version` are unset, set them to the current version.
 +
-NOTE: The value of `log.message.format.version` must be a string to prevent it from being interpreted as a floating point number.
+NOTE: The value of `log.message.format.version` and `inter.broker.protocol.version` must be a string to prevent it from being interpreted as a floating point number.
 
-.. Change the `Kafka.spec.kafka.version` to specify the new version (leaving the `log.message.format.version` as the current version).
+. Change the `Kafka.spec.kafka.version` to specify the new version (leaving the `log.message.format.version` and and `inter.broker.protocol.version` at the current version).
 +
 For example, if upgrading from Kafka {KafkaVersionLower} to {KafkaVersionHigher}:
 +
@@ -64,22 +64,19 @@ spec:
     version: {KafkaVersionHigher} <1>
     config:
       log.message.format.version: "{LogMsgVersLower}" <2>
+      inter.broker.protocol.version: "{LogMsgVersLower}" <3>
       # ...
 ----
-<1> This is changed to the new version
-<2> This remains at the current version
+<1> Kafka version is changed to the new version.
+<2> Message format version is unchanged.
+<3> Inter-broker protocol version is unchanged.
 --
 +
-WARNING: You cannot downgrade Kafka after the `spec.kafka.version` has changed, because the `inter.broker.protocol.version` for the new Kafka version will differ. The inter-broker protocol version determines the schemas used for persistent metadata stored by the broker, including messages written to `__consumer_offsets`. The downgraded cluster will not understand the messages.
+WARNING: You cannot downgrade Kafka if the `inter.broker.protocol.version` for the new Kafka version changes. The inter-broker protocol version determines the schemas used for persistent metadata stored by the broker, including messages written to `__consumer_offsets`. The downgraded cluster will not understand the messages.
 
-.. If the image for the Kafka version is different from the image defined in `STRIMZI_KAFKA_IMAGES` for the Cluster Operator, update `Kafka.spec.kafka.image`.
+. If the image for the Kafka version is different from the image defined in `STRIMZI_KAFKA_IMAGES` for the Cluster Operator, update `Kafka.spec.kafka.image`.
 +
 See xref:con-versions-and-images-str[Kafka version and image mappings]
-
-.. If the Kafka listener configuration does not use the array format of the `GenericKafkaListener` schema,
-update `Kafka.spec.kafka.listeners`.
-+
-See xref:con-upgrade-listeners-str[Updating listener configuration]
 
 . Save and exit the editor, then wait for rolling updates to complete.
 +
@@ -97,25 +94,23 @@ kubectl logs -f _<cluster-operator-pod-name>_ | grep -E "Kafka version upgrade f
 kubectl get po -w
 ----
 +
-====
-If the current and new versions of Kafka have different interbroker protocol versions, check the Cluster Operator logs for an `INFO` level message:
-
+If the current and new versions of Kafka have different inter-broker protocol versions, check the Cluster Operator logs for an `INFO` level message:
++
 [source,shell,subs=+quotes]
 ----
-Reconciliation #_<num>_(watch) Kafka(_<namespace>_/_<name>_): Kafka version upgrade from _<from-version>_ to _<to-version>_, phase 2 of 2 completed
+Reconciliation #_NUM_(watch) Kafka(_NAMESPACE_/_NAME_): Kafka version upgrade from _FROM-VERSION_ to _TO-VERSION_, phase 2 of 2 completed
 ----
 Alternatively, if the current and new versions of Kafka have the same interbroker protocol version, check for:
-
++
 [source,shell,subs=+quotes]
 ----
-Reconciliation #_<num>_(watch) Kafka(_<namespace>_/_<name>_): Kafka version upgrade from _<from-version>_ to _<to-version>_, phase 1 of 1 completed
+Reconciliation #_NUM_(watch) Kafka(_NAMESPACE_/_NAME_): Kafka version upgrade from _FROM-VERSION_ to _TO-VERSION_, phase 1 of 1 completed
 ----
-====
 +
 The rolling updates:
 +
 * Ensure each pod is using the broker binaries for the new version of Kafka
-* Configure the brokers to send messages using the interbroker protocol of the new version of Kafka
+* Configure the brokers to send messages using the inter-broker protocol of the new version of Kafka
 +
 NOTE: Clients are still using the old version, so brokers will convert messages to the old version before sending them to the clients. To minimize this additional load, update the clients as quickly as possible.
 
@@ -129,9 +124,9 @@ If required, set the version property for Kafka Connect and MirrorMaker as the n
 .. For Kafka Connect, update `KafkaConnect.spec.version`
 .. For MirrorMaker, update `KafkaMirrorMaker.spec.version`
 
-. If the `log.message.format.version` identified in step 1 is the same as the new version proceed to the next step.
+. If the `log.message.format.version` and `inter.broker.protocol.version` identified in step 1 are the same as the new version proceed to the next step.
 +
-Otherwise change the `log.message.format.version` in `Kafka.spec.kafka.config` to the default version for the new version of Kafka now being used.
+Otherwise change the `log.message.format.version` and `inter.broker.protocol.version` in `Kafka.spec.kafka.config` to the default version for the new version of Kafka now being used.
 +
 For example, if upgrading to {KafkaVersionHigher}:
 +

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -86,12 +86,12 @@ Check the update in the logs or by watching the pod state transitions:
 +
 [source,shell,subs=+quotes]
 ----
-kubectl logs -f _<cluster-operator-pod-name>_ | grep -E "Kafka version upgrade from [0-9.]+ to [0-9.]+, phase ([0-9]+) of \1 completed"
+kubectl logs -f _CLUSTER-OPERATOR-POD-NAME_ | grep -E "Kafka version upgrade from KafkaVersion.*[0-9.]+.* to KafkaVersion.*[0-9.]+.*completed"
 ----
 +
 [source,shell,subs=+quotes]
 ----
-kubectl get po -w
+kubectl get po my-cluster-kafka-0 -o jsonpath='{.spec.containers[0].image}'
 ----
 +
 If the current and new versions of Kafka have different inter-broker protocol versions, check the Cluster Operator logs for an `INFO` level message:

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -70,7 +70,7 @@ spec:
 <2> This remains at the current version
 --
 +
-WARNING: You cannot downgrade Kafka once `spec.kafka.version` has changed, as the `inter.broker.protocol.version` for the new Kafka version will differ. The protocol version determines the schemas used for persistent metadata stored by the broker, including messages written to `__consumer_offsets`. The cluster will not understand the messages.
+WARNING: You cannot downgrade Kafka after the `spec.kafka.version` has changed, because the `inter.broker.protocol.version` for the new Kafka version will differ. The inter-broker protocol version determines the schemas used for persistent metadata stored by the broker, including messages written to `__consumer_offsets`. The downgraded cluster will not understand the messages.
 
 .. If the image for the Kafka version is different from the image defined in `STRIMZI_KAFKA_IMAGES` for the Cluster Operator, update `Kafka.spec.kafka.image`.
 +

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -53,6 +53,7 @@ NOTE: The value of `log.message.format.version` must be a string to prevent it f
 +
 For example, if upgrading from Kafka {KafkaVersionLower} to {KafkaVersionHigher}:
 +
+--
 [source,yaml,subs=attributes+]
 ----
 apiVersion: v1alpha1
@@ -67,6 +68,10 @@ spec:
 ----
 <1> This is changed to the new version
 <2> This remains at the current version
+--
++
+WARNING: You cannot downgrade Kafka once `spec.kafka.version` has changed.
+
 
 .. If the image for the Kafka version is different from the image defined in `STRIMZI_KAFKA_IMAGES` for the Cluster Operator, update `Kafka.spec.kafka.image`.
 +
@@ -118,8 +123,6 @@ NOTE: Clients are still using the old version, so brokers will convert messages 
 . Depending on your chosen strategy for upgrading clients, upgrade all client applications to use the new version of the client binaries.
 +
 See xref:con-strategies-for-upgrading-clients-str[Strategies for upgrading clients]
-+
-WARNING: You cannot downgrade after completing this step. If you need to revert the update at this point, follow the procedure xref:proc-downgrading-brokers-older-kafka-{context}[].
 
 +
 If required, set the version property for Kafka Connect and MirrorMaker as the new version of Kafka:

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -56,7 +56,7 @@ For example, if upgrading from Kafka {KafkaVersionLower} to {KafkaVersionHigher}
 --
 [source,yaml,subs=attributes+]
 ----
-apiVersion: v1alpha1
+apiVersion: {KafkaApiVersion}
 kind: Kafka
 spec:
   # ...
@@ -132,7 +132,7 @@ For example, if upgrading to {KafkaVersionHigher}:
 +
 [source,yaml,subs=attributes+]
 ----
-apiVersion: v1alpha1
+apiVersion: {KafkaApiVersion}
 kind: Kafka
 spec:
   # ...

--- a/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
@@ -41,7 +41,7 @@ Wait for the rolling updates to complete.
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-kubectl get po my-cluster-kafka-0 -o jsonpath='{.spec.containers[0].image}'
+kubectl get pod my-cluster-kafka-0 -o jsonpath='{.spec.containers[0].image}'
 ----
 +
 The image tag shows the new Strimzi version followed by the Kafka version. For example, `_NEW-STRIMZI-VERSION_-kafka-_CURRENT-KAFKA-VERSION_`.

--- a/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
@@ -50,6 +50,4 @@ The image tag shows the new Strimzi version followed by the Kafka version. For e
 
 You now have an updated Cluster Operator, but the version of Kafka running in the cluster it manages is unchanged.
 
-.What to do next
-
-Following the Cluster Operator upgrade, you can perform a xref:assembly-upgrading-kafka-versions-str[Kafka downgrade].
+Following the Cluster Operator upgrade, you can perform a xref:assembly-upgrading-kafka-versions-str[Kafka upgrade].

--- a/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
@@ -24,7 +24,7 @@ Any changes will be *overwritten* by the new version of the Cluster Operator.
 include::snip-cluster-operator-namespace-sed.adoc[]
 +
 .. If you modified one or more environment variables in your existing Cluster Operator `Deployment`, edit the
-`install/cluster-operator/060-Deployment-cluster-operator.yaml` file to use those environment variables.
+`install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml` file to use those environment variables.
 
 . When you have an updated configuration, deploy it along with the rest of the installation resources:
 +
@@ -48,6 +48,6 @@ The image tag shows the new Strimzi version followed by the Kafka version. For e
 +
 * xref:assembly-upgrade-resources-{context}[Strimzi resource upgrades]
 
-You now have an updated Cluster Operator, but the version of Kafka running in the cluster it manages is unchanged.
+Your Cluster Operator was upgraded to the later version., but the version of Kafka running in the cluster it manages is unchanged.
 
 Following the Cluster Operator upgrade, you can perform a xref:assembly-upgrading-kafka-versions-str[Kafka upgrade].

--- a/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
@@ -17,6 +17,8 @@ This procedure describes how to upgrade a Cluster Operator deployment to a later
 . Take note of any configuration changes made to the existing Cluster Operator resources (in the `/install/cluster-operator` directory).
 Any changes will be *overwritten* by the new version of the Cluster Operator.
 
+. Update your custom resources to reflect the supported configuration options available for the version of Strimzi you are upgrading to.
+
 . Update the Cluster Operator.
 
 .. Modify the installation files for the new version according to the namespace the Cluster Operator is running in.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

New section in the _Deploying and Upgrading_ guide to provide guidance on how to revert to previous versions of Operators and Kafka. 

Described in two stages like the upgrade: Cluster Operator, then Kafka downgrade (optionally). The CO procedure reverses the upgrade steps. Downgrade of Kafka mentions reverting `genericKafkaListener` as a step (but no mention of API versions).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

