### PR TITLE
Topic operator improvements

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Kafka.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Kafka.java
@@ -42,7 +42,7 @@ public interface Kafka {
      * @param topicName The name of the topic to delete.
      * @return A future which is completed once the topic has been deleted.
      */
-    Future<Void> awaitNotExists(TopicName topicName);
+    Future<Boolean> topicExists(TopicName topicName);
 
     /**
      * Asynchronously update the topic config in Kafka,

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Kafka.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Kafka.java
@@ -35,6 +35,16 @@ public interface Kafka {
     Future<Void> deleteTopic(TopicName topicName);
 
     /**
+     * Wait for the given topic to not existing Kafka ,
+     * completing the returned Future when the topic does not exists.
+     * If the operation fails the returned Future will be failed with the
+     * KafkaException (not an ExecutionException).
+     * @param topicName The name of the topic to delete.
+     * @return A future which is completed once the topic has been deleted.
+     */
+    Future<Void> awaitNotExists(TopicName topicName);
+
+    /**
      * Asynchronously update the topic config in Kafka,
      * completing the returned Future when the topic has been updated.
      * If the operation fails the returned Future will be failed with the

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicsWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicsWatcher.java
@@ -113,7 +113,11 @@ class ZkTopicsWatcher {
             Set<String> created;
             synchronized (ZkTopicsWatcher.this) {
                 LOGGER.debug("{}: znode {} now has children {}, previous children {}", watchCount, TOPICS_ZNODE, result, ZkTopicsWatcher.this.children);
-                deleted = new HashSet<>(ZkTopicsWatcher.this.children);
+                List<String> oldChildren = ZkTopicsWatcher.this.children;
+                if (oldChildren == null) {
+                    return;
+                }
+                deleted = new HashSet<>(oldChildren);
                 deleted.removeAll(result);
                 created = new HashSet<>(result);
                 created.removeAll(ZkTopicsWatcher.this.children);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicsWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicsWatcher.java
@@ -5,7 +5,9 @@
 package io.strimzi.operator.topic;
 
 import io.strimzi.operator.topic.zk.Zk;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -56,10 +58,47 @@ class ZkTopicsWatcher {
     }
 
     void start(Zk zk) {
-        children = null;
+        synchronized (this) {
+            children = null;
+        }
         tcw.start(zk);
         tw.start(zk);
-        zk.watchChildren(TOPICS_ZNODE, childResult -> {
+        zk.watchChildren(TOPICS_ZNODE, new ChildrenWatchHandler(zk)).<Void>compose(zk2 -> {
+            zk.children(TOPICS_ZNODE, childResult -> {
+                if (childResult.failed()) {
+                    LOGGER.error("Error on znode {} children", TOPICS_ZNODE, childResult.cause());
+                    return;
+                }
+                List<String> result = childResult.result();
+                LOGGER.debug("Setting initial children {}", result);
+                synchronized (this) {
+                    this.children = result;
+                }
+                // Start watching existing children for config and partition changes
+                for (String child : result) {
+                    tcw.addChild(child);
+                    tw.addChild(child);
+                }
+                this.state = 1;
+            });
+            return Future.succeededFuture();
+        });
+    }
+
+    /**
+     * Handler which runs on ZkClient's single event handling thread.
+     */
+    private class ChildrenWatchHandler implements Handler<AsyncResult<List<String>>> {
+
+        private final Zk zk;
+        private int watchCount = 0;
+
+        public ChildrenWatchHandler(Zk zk) {
+            this.zk = zk;
+        }
+
+        @Override
+        public void handle(AsyncResult<List<String>> childResult) {
             if (state == 2) {
                 zk.unwatchChildren(TOPICS_ZNODE);
                 return;
@@ -68,20 +107,25 @@ class ZkTopicsWatcher {
                 LOGGER.error("Error on znode {} children", TOPICS_ZNODE, childResult.cause());
                 return;
             }
+            ++watchCount;
             List<String> result = childResult.result();
-            LOGGER.debug("znode {} now has children {}, previous children {}", TOPICS_ZNODE, result, this.children);
-            Set<String> deleted = new HashSet<>(this.children);
-            deleted.removeAll(result);
-            Set<String> created = new HashSet<>(result);
-            created.removeAll(this.children);
-            this.children = result;
+            Set<String> deleted;
+            Set<String> created;
+            synchronized (ZkTopicsWatcher.this) {
+                LOGGER.debug("{}: znode {} now has children {}, previous children {}", watchCount, TOPICS_ZNODE, result, ZkTopicsWatcher.this.children);
+                deleted = new HashSet<>(ZkTopicsWatcher.this.children);
+                deleted.removeAll(result);
+                created = new HashSet<>(result);
+                created.removeAll(ZkTopicsWatcher.this.children);
+                ZkTopicsWatcher.this.children = result;
+            }
 
+            LOGGER.info("Topics deleted from ZK for watch {}: {}", watchCount, deleted);
             if (!deleted.isEmpty()) {
-                LOGGER.info("Deleted topics: {}", deleted);
                 for (String topicName : deleted) {
                     tcw.removeChild(topicName);
                     tw.removeChild(topicName);
-                    LogContext logContext = LogContext.zkWatch(TOPICS_ZNODE, "-" + topicName);
+                    LogContext logContext = LogContext.zkWatch(TOPICS_ZNODE, watchCount + ":-" + topicName);
                     topicOperator.onTopicDeleted(logContext, new TopicName(topicName)).onComplete(ar -> {
                         if (ar.succeeded()) {
                             LOGGER.debug("{}: Success responding to deletion of topic {}", logContext, topicName);
@@ -92,12 +136,12 @@ class ZkTopicsWatcher {
                 }
             }
 
+            LOGGER.info("Topics created in ZK for watch {}: {}", watchCount, created);
             if (!created.isEmpty()) {
-                LOGGER.info("Created topics: {}", created);
                 for (String topicName : created) {
                     tcw.addChild(topicName);
                     tw.addChild(topicName);
-                    LogContext logContext = LogContext.zkWatch(TOPICS_ZNODE, "+" + topicName);
+                    LogContext logContext = LogContext.zkWatch(TOPICS_ZNODE, watchCount + ":+" + topicName);
                     topicOperator.onTopicCreated(logContext, new TopicName(topicName)).onComplete(ar -> {
                         if (ar.succeeded()) {
                             LOGGER.debug("{}: Success responding to creation of topic {}", logContext, topicName);
@@ -107,24 +151,6 @@ class ZkTopicsWatcher {
                     });
                 }
             }
-
-        }).<Void>compose(zk2 -> {
-            zk.children(TOPICS_ZNODE, childResult -> {
-                if (childResult.failed()) {
-                    LOGGER.error("Error on znode {} children", TOPICS_ZNODE, childResult.cause());
-                    return;
-                }
-                List<String> result = childResult.result();
-                LOGGER.debug("Setting initial children {}", result);
-                this.children = result;
-                // Start watching existing children for config and partition changes
-                for (String child : result) {
-                    tcw.addChild(child);
-                    tw.addChild(child);
-                }
-                this.state = 1;
-            });
-            return Future.succeededFuture();
-        });
+        }
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/KafkaImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/KafkaImplTest.java
@@ -12,23 +12,31 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.CreateTopicsOptions;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatcher;
 
+import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toMap;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -49,11 +57,11 @@ public class KafkaImplTest {
         }
 
         public static <Left, Right> Either<Left, Right> ofLeft(Left left) {
-            return new Either(true, left, null);
+            return new Either<>(true, left, null);
         }
 
         public static <Left, Right> Either<Left, Right> ofRight(Right right) {
-            return new Either(false, null, right);
+            return new Either<>(false, null, right);
         }
 
         public boolean isLeft() {
@@ -80,7 +88,7 @@ public class KafkaImplTest {
     private void mockDescribeConfigs(Admin admin, Map<ConfigResource, Either<Config, Exception>> result) {
         DescribeConfigsResult describeConfigsResult = mock(DescribeConfigsResult.class);
         when(describeConfigsResult.values()).thenReturn(result.entrySet().stream().collect(toMap(
-            entry -> entry.getKey(),
+            Map.Entry::getKey,
             entry -> {
                 KafkaFutureImpl<Config> kafkaFuture = new KafkaFutureImpl<>();
                 if (entry.getValue().isLeft()) {
@@ -93,10 +101,29 @@ public class KafkaImplTest {
         when(admin.describeConfigs(result.keySet())).thenReturn(describeConfigsResult);
     }
 
+    private void mockCreateTopicsValidateOnly(Admin admin, NewTopic topic, Exception result) {
+        CreateTopicsResult createTopicsResult = mock(CreateTopicsResult.class);
+        when(createTopicsResult.all()).then(invocation -> {
+            KafkaFutureImpl<Void> kafkaFuture1 = new KafkaFutureImpl<>();
+            if (result == null) {
+                kafkaFuture1.complete(null);
+            } else {
+                kafkaFuture1.completeExceptionally(result);
+            }
+            return kafkaFuture1;
+        });
+        when(admin.createTopics(eq(singleton(topic)),
+                argThat(isValidateOnly()))).thenReturn(createTopicsResult);
+    }
+
+    private ArgumentMatcher<CreateTopicsOptions> isValidateOnly() {
+        return CreateTopicsOptions::shouldValidateOnly;
+    }
+
     private void mockDescribeTopics(Admin admin, Map<String, Either<TopicDescription, Exception>> result) {
         DescribeTopicsResult describeTopicsResult = mock(DescribeTopicsResult.class);
         when(describeTopicsResult.values()).thenReturn(result.entrySet().stream().collect(toMap(
-            entry1 -> entry1.getKey(),
+            Map.Entry::getKey,
             entry1 -> {
                 KafkaFutureImpl<TopicDescription> kafkaFuture1 = new KafkaFutureImpl<>();
                 if (entry1.getValue().isLeft()) {
@@ -114,7 +141,7 @@ public class KafkaImplTest {
         } else {
             when(describeTopicsResult.all()).thenReturn(KafkaFuture.completedFuture(
                 result.entrySet().stream().collect(toMap(
-                    entry -> entry.getKey(),
+                    Map.Entry::getKey,
                     entry -> entry.getValue().left()))
             ));
         }
@@ -124,7 +151,7 @@ public class KafkaImplTest {
     private void mockDeleteTopics(Admin admin, Map<String, Either<Void, Exception>> result) {
         DeleteTopicsResult deleteTopicsResult = mock(DeleteTopicsResult.class);
         when(deleteTopicsResult.values()).thenReturn(result.entrySet().stream().collect(toMap(
-            entry -> entry.getKey(),
+            Map.Entry::getKey,
             entry -> {
                 KafkaFutureImpl<Void> kafkaFuture = new KafkaFutureImpl<>();
                 if (entry.getValue().isLeft()) {
@@ -141,6 +168,7 @@ public class KafkaImplTest {
     @Test
     public void testTopicMetadataBothNotFound(VertxTestContext testContext) {
         Admin admin = mock(Admin.class);
+        mockCreateTopicsValidateOnly(admin, new NewTopic("test", 1, (short) 1), null);
         mockDescribeTopics(admin, singletonMap("test", Either.ofRight(new UnknownTopicOrPartitionException())));
         mockDescribeConfigs(admin, singletonMap(
                 new ConfigResource(ConfigResource.Type.TOPIC, "test"),
@@ -156,6 +184,7 @@ public class KafkaImplTest {
     @Test
     public void testTopicMetadataDescribeTopicNotFound(VertxTestContext testContext) {
         Admin admin = mock(Admin.class);
+        mockCreateTopicsValidateOnly(admin, new NewTopic("test", 1, (short) 1), null);
         mockDescribeTopics(admin, singletonMap("test", Either.ofRight(new UnknownTopicOrPartitionException())));
         mockDescribeConfigs(admin, singletonMap(
                 new ConfigResource(ConfigResource.Type.TOPIC, "test"),
@@ -171,6 +200,7 @@ public class KafkaImplTest {
     @Test
     public void testTopicMetadataDescribeConfigsNotFound(VertxTestContext testContext) {
         Admin admin = mock(Admin.class);
+        mockCreateTopicsValidateOnly(admin, new NewTopic("test", 1, (short) 1), null);
         mockDescribeTopics(admin, singletonMap("test", Either.ofLeft(mock(TopicDescription.class))));
         mockDescribeConfigs(admin, singletonMap(
                 new ConfigResource(ConfigResource.Type.TOPIC, "test"),
@@ -186,6 +216,7 @@ public class KafkaImplTest {
     @Test
     public void testTopicMetadataBothFound(VertxTestContext testContext) {
         Admin admin = mock(Admin.class);
+        mockCreateTopicsValidateOnly(admin, new NewTopic("test", 1, (short) 1), new TopicExistsException(""));
         mockDescribeTopics(admin, singletonMap("test", Either.ofLeft(mock(TopicDescription.class))));
         mockDescribeConfigs(admin, singletonMap(new ConfigResource(ConfigResource.Type.TOPIC, "test"),
                 Either.ofLeft(mock(Config.class))));
@@ -202,6 +233,7 @@ public class KafkaImplTest {
     @Test
     public void testTopicMetadataDescribeTimeout(VertxTestContext testContext) {
         Admin admin = mock(Admin.class);
+        mockCreateTopicsValidateOnly(admin, new NewTopic("test", 1, (short) 1), new TopicExistsException(""));
         mockDescribeTopics(admin, singletonMap("test", Either.ofLeft(mock(TopicDescription.class))));
         mockDescribeConfigs(admin, singletonMap(new ConfigResource(ConfigResource.Type.TOPIC, "test"),
                     Either.ofRight(new TimeoutException())));
@@ -220,9 +252,9 @@ public class KafkaImplTest {
         mockDeleteTopics(admin, singletonMap("test", Either.ofLeft(null)));
 
         KafkaImpl impl = new KafkaImpl(admin, vertx);
-        impl.deleteTopic(new TopicName("test")).onComplete(testContext.succeeding(error -> testContext.verify(() -> {
-            testContext.completeNow();
-        })));
+        impl.deleteTopic(new TopicName("test"))
+                .onComplete(testContext.succeeding(error ->
+                        testContext.verify(testContext::completeNow)));
     }
 
     @Test
@@ -230,19 +262,6 @@ public class KafkaImplTest {
         Admin admin = mock(Admin.class);
         mockDescribeTopics(admin, singletonMap("test", Either.ofRight(new UnknownTopicOrPartitionException())));
         mockDeleteTopics(admin, singletonMap("test", Either.ofRight(new TimeoutException())));
-
-        KafkaImpl impl = new KafkaImpl(admin, vertx);
-        impl.deleteTopic(new TopicName("test")).onComplete(testContext.failing(error -> testContext.verify(() -> {
-            assertTrue(error instanceof TimeoutException);
-            testContext.completeNow();
-        })));
-    }
-
-    @Test
-    public void testDeleteDescribeTimeout(VertxTestContext testContext) {
-        Admin admin = mock(Admin.class);
-        mockDeleteTopics(admin, singletonMap("test", Either.ofLeft(null)));
-        mockDescribeTopics(admin, singletonMap("test", Either.ofRight(new TimeoutException())));
 
         KafkaImpl impl = new KafkaImpl(admin, vertx);
         impl.deleteTopic(new TopicName("test")).onComplete(testContext.failing(error -> testContext.verify(() -> {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockKafka.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockKafka.java
@@ -41,6 +41,8 @@ public class MockKafka implements Kafka {
         t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a deleteTopicResponse.");
     private Function<TopicName, Future<Void>> updateTopicResponse =
         t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a updateTopicResponse.");
+    private Function<TopicName, Future<Void>> awaitNotExistsResult =
+        t -> null;
 
     public MockKafka setTopicsListResponse(Future<Set<String>> topicsListResponse) {
         this.topicsListResponse = topicsListResponse;
@@ -121,6 +123,11 @@ public class MockKafka implements Kafka {
         return this;
     }
 
+    public MockKafka setAwaitNotExistsResult(Function<TopicName, Future<Void>> awaitNotExistsResult) {
+        this.awaitNotExistsResult = awaitNotExistsResult;
+        return this;
+    }
+
     @Override
     public Future<Void> createTopic(Topic t) {
         NewTopic newTopic = TopicSerialization.toNewTopic(t, null);
@@ -155,7 +162,12 @@ public class MockKafka implements Kafka {
 
     @Override
     public Future<Void> awaitNotExists(TopicName topicName) {
-        return Future.succeededFuture();
+        Future<Void> event = awaitNotExistsResult.apply(topicName);
+        if (event == null) {
+            return Future.succeededFuture();
+        } else {
+            return event;
+        }
     }
 
     public MockKafka setUpdateTopicResponse(Function<TopicName, Future<Void>> updateTopicResponse) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockKafka.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockKafka.java
@@ -35,14 +35,14 @@ public class MockKafka implements Kafka {
     private int topicMetadataResposeCall = 0;
     private List<Function<TopicName, Future<TopicMetadata>>> topicMetadataRespose = singletonList(
         t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a topicMetadataResponse."));
+    private Function<TopicName, Future<Boolean>> topicExistsResult =
+        t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a topicExistsResult.");
     private Function<String, Future<Void>> createTopicResponse =
         t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a createTopicResponse.");
     private Function<TopicName, Future<Void>> deleteTopicResponse =
         t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a deleteTopicResponse.");
     private Function<TopicName, Future<Void>> updateTopicResponse =
         t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a updateTopicResponse.");
-    private Function<TopicName, Future<Void>> awaitNotExistsResult =
-        t -> null;
 
     public MockKafka setTopicsListResponse(Future<Set<String>> topicsListResponse) {
         this.topicsListResponse = topicsListResponse;
@@ -123,8 +123,8 @@ public class MockKafka implements Kafka {
         return this;
     }
 
-    public MockKafka setAwaitNotExistsResult(Function<TopicName, Future<Void>> awaitNotExistsResult) {
-        this.awaitNotExistsResult = awaitNotExistsResult;
+    public MockKafka setTopicExistsResult(Function<TopicName, Future<Boolean>> topicExistsResult) {
+        this.topicExistsResult = topicExistsResult;
         return this;
     }
 
@@ -161,10 +161,10 @@ public class MockKafka implements Kafka {
     }
 
     @Override
-    public Future<Void> awaitNotExists(TopicName topicName) {
-        Future<Void> event = awaitNotExistsResult.apply(topicName);
+    public Future<Boolean> topicExists(TopicName topicName) {
+        Future<Boolean> event = topicExistsResult.apply(topicName);
         if (event == null) {
-            return Future.succeededFuture();
+            throw new IllegalStateException();
         } else {
             return event;
         }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockKafka.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockKafka.java
@@ -153,6 +153,11 @@ public class MockKafka implements Kafka {
         return event;
     }
 
+    @Override
+    public Future<Void> awaitNotExists(TopicName topicName) {
+        return Future.succeededFuture();
+    }
+
     public MockKafka setUpdateTopicResponse(Function<TopicName, Future<Void>> updateTopicResponse) {
         this.updateTopicResponse = updateTopicResponse;
         return this;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Try to fix #1157 by using both checks suggested in the issue, namely:

1. We should be prepared to wait longer for the the Kafka controller to delete a topic, since deleting a large number of topics is known to basically lock up the controller for a time. So we bump the timeout for that from 2 to 5 minutes.
2. When we observe the deletion of a topic via ZK don't assume the topic deletion has propagated to observations of the topic via the Admin client. Instead wait for the Admin client to confirm that the topic doesn't exist before proceeding with the reconciliation. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

