### PR TITLE
Unify logging pattern across operators

### DIFF
--- a/cluster-operator/src/main/resources/entityTopicOperatorDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/entityTopicOperatorDefaultLoggingProperties
@@ -3,7 +3,7 @@ name = TOConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
 rootLogger.level = INFO
 rootLogger.appenderRefs = stdout

--- a/cluster-operator/src/main/resources/entityTopicOperatorDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/entityTopicOperatorDefaultLoggingProperties
@@ -3,7 +3,7 @@ name = TOConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
 rootLogger.level = INFO
 rootLogger.appenderRefs = stdout

--- a/cluster-operator/src/main/resources/entityTopicOperatorDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/entityTopicOperatorDefaultLoggingProperties
@@ -3,7 +3,7 @@ name = TOConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,nnnnn} %-5p [%t] %c{1}:%L - %m%n
 
 rootLogger.level = INFO
 rootLogger.appenderRefs = stdout

--- a/cluster-operator/src/main/resources/entityUserOperatorDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/entityUserOperatorDefaultLoggingProperties
@@ -3,7 +3,7 @@ name = UOConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
 rootLogger.level = INFO
 rootLogger.appenderRefs = stdout

--- a/cluster-operator/src/main/resources/kafkaBridgeDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/kafkaBridgeDefaultLoggingProperties
@@ -3,7 +3,7 @@ name = BridgeConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
 rootLogger.level = INFO
 rootLogger.appenderRefs = console

--- a/cluster-operator/src/main/resources/topicOperatorDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/topicOperatorDefaultLoggingProperties
@@ -3,7 +3,7 @@ name = TOConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
 property.topic-operator.root.logger=${env:STRIMZI_LOG_LEVEL:-INFO}
 

--- a/cluster-operator/src/main/resources/topicOperatorDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/topicOperatorDefaultLoggingProperties
@@ -3,7 +3,7 @@ name = TOConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,nnnnn} %-5p [%t] %c{1}:%L - %m%n
 
 property.topic-operator.root.logger=${env:STRIMZI_LOG_LEVEL:-INFO}
 

--- a/cluster-operator/src/main/resources/topicOperatorDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/topicOperatorDefaultLoggingProperties
@@ -3,7 +3,7 @@ name = TOConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
 property.topic-operator.root.logger=${env:STRIMZI_LOG_LEVEL:-INFO}
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -255,7 +255,7 @@ class LoggingChangeST extends AbstractST {
                         "appender.console.type=Console\n" +
                         "appender.console.name=STDOUT\n" +
                         "appender.console.layout.type=PatternLayout\n" +
-                        "appender.console.layout.pattern=[%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n\n" +
+                        "appender.console.layout.pattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n\n" +
                         "rootLogger.level=OFF\n" +
                         "rootLogger.appenderRefs=stdout\n" +
                         "rootLogger.appenderRef.console.ref=STDOUT\n" +
@@ -271,7 +271,7 @@ class LoggingChangeST extends AbstractST {
                         "appender.console.type=Console\n" +
                         "appender.console.name=STDOUT\n" +
                         "appender.console.layout.type=PatternLayout\n" +
-                        "appender.console.layout.pattern=[%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n\n" +
+                        "appender.console.layout.pattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n\n" +
                         "rootLogger.level=OFF\n" +
                         "rootLogger.appenderRefs=stdout\n" +
                         "rootLogger.appenderRef.console.ref=STDOUT\n" +
@@ -321,7 +321,7 @@ class LoggingChangeST extends AbstractST {
                         "appender.console.type=Console\n" +
                         "appender.console.name=STDOUT\n" +
                         "appender.console.layout.type=PatternLayout\n" +
-                        "appender.console.layout.pattern=[%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n\n" +
+                        "appender.console.layout.pattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n\n" +
                         "rootLogger.level=DEBUG\n" +
                         "rootLogger.appenderRefs=stdout\n" +
                         "rootLogger.appenderRef.console.ref=STDOUT\n" +
@@ -337,7 +337,7 @@ class LoggingChangeST extends AbstractST {
                         "appender.console.type=Console\n" +
                         "appender.console.name=STDOUT\n" +
                         "appender.console.layout.type=PatternLayout\n" +
-                        "appender.console.layout.pattern=[%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n\n" +
+                        "appender.console.layout.pattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n\n" +
                         "rootLogger.level=DEBUG\n" +
                         "rootLogger.appenderRefs=stdout\n" +
                         "rootLogger.appenderRef.console.ref=STDOUT\n" +
@@ -425,7 +425,7 @@ class LoggingChangeST extends AbstractST {
                                 "appender.console.type = Console\n" +
                                 "appender.console.name = STDOUT\n" +
                                 "appender.console.layout.type = PatternLayout\n" +
-                                "appender.console.layout.pattern = [%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n\n" +
+                                "appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n\n" +
                                 "\n" +
                                 "rootLogger.level = OFF\n" +
                                 "rootLogger.appenderRefs = console\n" +


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement

### Description
We use different logging patterns for each operator. It would be good to have them unified.
This PR changes a patter for each operator to `%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

