### PR TITLE
Correct connect configuration comparison

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -427,7 +427,8 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                     updateLoggers.put("root", entry.getValue());
                 }
             } else if (entry.getKey().startsWith("log4j.logger.")) {
-                if (!entry.getValue().equals(fetchedLoggers.get(entry.getKey().substring("log4j.logger.".length())))) {
+                Map<String, String> fetchedLogger = fetchedLoggers.get(entry.getKey().substring("log4j.logger.".length()));
+                if (fetchedLogger == null || fetchedLogger.get("level") == null || !entry.getValue().equals(fetchedLogger.get("level"))) {
                     updateLoggers.put(entry.getKey().substring("log4j.logger.".length()), entry.getValue());
                 }
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -423,7 +423,8 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
         ops.asMap().entrySet().forEach(entry -> {
             // set desired loggers to desired levels
             if (entry.getKey().equals("log4j.rootLogger")) {
-                if (!entry.getValue().equals(fetchedLoggers.get("root"))) {
+                if (fetchedLoggers.get("root") == null || fetchedLoggers.get("root").get("level") == null ||
+                        !entry.getValue().equals(fetchedLoggers.get("root").get("level"))) {
                     updateLoggers.put("root", entry.getValue());
                 }
             } else if (entry.getKey().startsWith("log4j.logger.")) {


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
We do compare fetched loggers to the desired one, we update the logging configuration by sending a request to Connect API.
The comparison is currently done wrong as we do compare `String` and `Map` objects. IMHO the bug is nothing else than an optimization issue.

Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/3978

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

