### PR TITLE
[DOC] Description of hostAliases property for PodTemplate schema

### DIFF
--- a/.azure/scripts/check_docs.sh
+++ b/.azure/scripts/check_docs.sh
@@ -25,7 +25,7 @@ function grep_check {
 # Check for latin abbrevs
 grep_check '[^[:alpha:]](e\.g\.|eg)[^[:alpha:]]' "Replace 'e.g'. with 'for example, '"
 grep_check '[^[:alpha:]](i\.e\.|ie)[^[:alpha:]]' "Replace 'i.e'. with 'that is, '"
-grep_check '[^[:alpha:]]etc\.?[^[:alpha:]]' "Replace 'etc.'. with ' and so on.'"
+grep_check '[^[:alpha:]]etc\.[^[:alpha:]]?' "Replace 'etc.'. with ' and so on.'"
 
 # And/or
 grep_check '[^[:alpha:]]and/or[^[:alpha:]]' "Use either 'and' or 'or', but not 'and/or'"

--- a/documentation/api/io.strimzi.api.kafka.model.template.PodTemplate.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.template.PodTemplate.adoc
@@ -1,4 +1,4 @@
-.An example showing the `PodTemplate`
+.Example `PodTemplate` configuration
 [source,yaml,subs=attributes+]
 ----
 # ...
@@ -16,4 +16,30 @@ template:
       fsGroup: 0
     terminationGracePeriodSeconds: 120
 # ...
+----
+
+[id='property-hostaliases-config-{context}']
+=== `hostAliases`
+
+Use the `hostAliases` property to a specify a list of hosts and IP addresses,
+which are injected into the `/etc/hosts` file of the pod.
+
+This configuration is especially useful for Kafka Connect or MirrorMaker when a connection outside of the cluster is also requested by users.
+
+.Example `hostAliases` configuration
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: KafkaConnect
+#...
+spec:
+  # ...
+  template:
+    pod:
+      hostAliases:
+      - ip: "192.168.1.86"
+        hostnames:
+        - "my-host-1"
+        - "my-host-2"
+      #...
 ----


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Added a description of the `hostAliases` property in the _PodTemplate schema reference_ of the User Guide, with example.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

