### PR TITLE
ST/IT: Rework kubeCluster init for ST/IT

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
@@ -137,6 +137,6 @@ public abstract class AbstractCrdIT {
 
     @BeforeEach
     public void setupTests() {
-        cluster.before();
+        cluster.cluster();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -71,7 +71,7 @@ public abstract class AbstractST implements TestSeparator {
         Crds.registerCustomKinds();
     }
 
-    protected KubeClusterResource cluster = KubeClusterResource.getInstance();
+    protected KubeClusterResource cluster;
     protected static TimeMeasuringSystem timeMeasuringSystem = TimeMeasuringSystem.getInstance();
     private static final Logger LOGGER = LogManager.getLogger(AbstractST.class);
 
@@ -642,6 +642,7 @@ public abstract class AbstractST implements TestSeparator {
 
     @BeforeAll
     void setTestClassName(ExtensionContext testContext) {
+        cluster = KubeClusterResource.getInstance();
         if (testContext.getTestClass().isPresent()) {
             testClass = testContext.getTestClass().get().getName();
         }

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -11,7 +11,6 @@ import io.strimzi.test.k8s.cluster.OpenShift;
 import io.strimzi.test.k8s.cmdClient.KubeCmdClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Assumptions;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -58,14 +57,10 @@ public class KubeClusterResource {
 
     public static synchronized KubeClusterResource getInstance() {
         if (kubeClusterResource == null) {
-            try {
-                kubeClusterResource = new KubeClusterResource();
-                initNamespaces();
-                LOGGER.info("Cluster default namespace is {}", kubeClusterResource.getNamespace());
-                LOGGER.info("Cluster command line client default namespace is {}", kubeClusterResource.getTestNamespace());
-            } catch (RuntimeException e) {
-                Assumptions.assumeTrue(false, e.getMessage());
-            }
+            kubeClusterResource = new KubeClusterResource();
+            initNamespaces();
+            LOGGER.info("Cluster default namespace is {}", kubeClusterResource.getNamespace());
+            LOGGER.info("Cluster command line client default namespace is {}", kubeClusterResource.getTestNamespace());
         }
         return kubeClusterResource;
     }
@@ -293,12 +288,7 @@ public class KubeClusterResource {
 
     public KubeCluster cluster() {
         if (kubeCluster == null) {
-            try {
-                kubeCluster = KubeCluster.bootstrap();
-            } catch (Exception e) {
-                LOGGER.error("Test setup failed: {}", e.getMessage());
-                throw e;
-            }
+            kubeCluster = KubeCluster.bootstrap();
         }
         return kubeCluster;
     }

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/KubeCluster.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/KubeCluster.java
@@ -77,16 +77,17 @@ public interface KubeCluster {
                     cluster = kc;
                     break;
                 } else {
-                    logger.debug("Cluster {} is not running", kc);
+                    logger.warn("Cluster {} is not running!", kc);
                 }
             } else {
-                logger.debug("Cluster {} is not installed", kc);
+                logger.warn("Cluster {} is not installed!", kc);
             }
         }
         if (cluster == null) {
             throw new NoClusterException(
                     "Unable to find a cluster; tried " + Arrays.toString(clusters));
         }
+        logger.info("Using cluster: {}", cluster);
         return cluster;
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Kubernetes.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Kubernetes.java
@@ -13,6 +13,9 @@ import io.strimzi.test.k8s.exceptions.KubeClusterException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * A {@link KubeCluster} implementation for any {@code Kubernetes} cluster.
  */
@@ -29,10 +32,12 @@ public class Kubernetes implements KubeCluster {
 
     @Override
     public boolean isClusterUp() {
+        List<String> cmd = Arrays.asList(CMD, "cluster-info");
         try {
-            return Exec.exec(CMD, "cluster-info").exitStatus() && !Exec.exec(CMD, "api-resources").out().contains("openshift.io");
+            return Exec.exec(cmd).exitStatus() && !Exec.exec(CMD, "api-resources").out().contains("openshift.io");
         } catch (KubeClusterException e) {
-            LOGGER.debug("Error:", e);
+            LOGGER.debug("'" + String.join(" ", cmd) + "' failed. Please double check connectivity to your cluster!");
+            LOGGER.debug(e);
             return false;
         }
     }

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Minikube.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Minikube.java
@@ -13,6 +13,9 @@ import io.strimzi.test.k8s.cmdClient.Kubectl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * A {@link KubeCluster} implementation for {@code minikube} and {@code minishift}.
  */
@@ -30,10 +33,12 @@ public class Minikube implements KubeCluster {
 
     @Override
     public boolean isClusterUp() {
+        List<String> cmd = Arrays.asList(CMD, "status");
         try {
-            return Exec.exec(CMD, "status").exitStatus();
+            return Exec.exec(cmd).exitStatus();
         } catch (KubeClusterException e) {
-            LOGGER.debug("Error: ", e);
+            LOGGER.debug("'" + String.join(" ", cmd) + "' failed. Please double check connectivity to your cluster!");
+            LOGGER.debug(e);
             return false;
         }
     }

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Minishift.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Minishift.java
@@ -11,6 +11,9 @@ import io.strimzi.test.k8s.cmdClient.Oc;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class Minishift implements KubeCluster {
 
     private static final String CMD = "minishift";
@@ -24,14 +27,17 @@ public class Minishift implements KubeCluster {
 
     @Override
     public boolean isClusterUp() {
+        List<String> cmd = Arrays.asList(CMD, "status");
+        String output = Exec.exec(cmd).out();
         try {
-            String output = Exec.exec(CMD, "status").out();
             return output.contains("Minishift:  Running")
                     && output.contains("OpenShift:  Running");
         } catch (KubeClusterException e) {
-            LOGGER.debug("Error:", e);
+            LOGGER.debug("'" + String.join(" ", cmd) + "' failed. Please double check connectivity to your cluster!");
+            LOGGER.debug(e);
             return false;
         }
+
     }
 
     @Override

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Minishift.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Minishift.java
@@ -28,8 +28,8 @@ public class Minishift implements KubeCluster {
     @Override
     public boolean isClusterUp() {
         List<String> cmd = Arrays.asList(CMD, "status");
-        String output = Exec.exec(cmd).out();
         try {
+            String output = Exec.exec(cmd).out();
             return output.contains("Minishift:  Running")
                     && output.contains("OpenShift:  Running");
         } catch (KubeClusterException e) {

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/OpenShift.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/OpenShift.java
@@ -11,23 +11,28 @@ import io.strimzi.test.k8s.cmdClient.Oc;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class OpenShift implements KubeCluster {
 
-    private static final String OC = "oc";
+    private static final String CMD = "oc";
     private static final String OLM_NAMESPACE = "openshift-operators";
     private static final Logger LOGGER = LogManager.getLogger(OpenShift.class);
 
     @Override
     public boolean isAvailable() {
-        return Exec.isExecutableOnPath(OC);
+        return Exec.isExecutableOnPath(CMD);
     }
 
     @Override
     public boolean isClusterUp() {
+        List<String> cmd = Arrays.asList(CMD, "status");
         try {
-            return Exec.exec(OC, "status").exitStatus() && Exec.exec(OC, "api-resources").out().contains("openshift.io");
+            return Exec.exec(cmd).exitStatus() && Exec.exec(CMD, "api-resources").out().contains("openshift.io");
         } catch (KubeClusterException e) {
-            LOGGER.debug("Error:", e);
+            LOGGER.debug("'" + String.join(" ", cmd) + "' failed. Please double check connectivity to your cluster!");
+            LOGGER.debug(e);
             return false;
         }
     }
@@ -38,7 +43,7 @@ public class OpenShift implements KubeCluster {
     }
 
     public String toString() {
-        return OC;
+        return CMD;
     }
 
     @Override

--- a/test/src/main/java/io/strimzi/test/k8s/exceptions/NoClusterException.java
+++ b/test/src/main/java/io/strimzi/test/k8s/exceptions/NoClusterException.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.test.k8s.exceptions;
 
-public class NoClusterException extends Exception {
+public class NoClusterException extends RuntimeException {
     public NoClusterException(String message) {
         super(message);
     }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -148,7 +148,7 @@ public abstract class TopicOperatorBaseIT {
     @BeforeEach
     public void setup() throws Exception {
         LOGGER.info("Setting up test");
-        cluster.before();
+        cluster.cluster();
         int counts = 3;
         do {
             try {


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Refactoring

### Description

`KubeCluster`and `KubeClusterResource` is a little bit chaotic and in some cases, the user is not able to see in the test log that his cluster is not working properly. This PR refactor the current implementation and add some more logging.

### Checklist

- [x] Make sure all tests pass

