### PR TITLE
Improve Strimzi network policies for Cluster Operator access

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -10,7 +10,6 @@ import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
-import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LifecycleBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -577,20 +576,7 @@ public class CruiseControl extends AbstractModel {
                         .addToMatchLabels(Labels.STRIMZI_KIND_LABEL, "cluster-operator")
                     .endPodSelector()
                     .build();
-
-            if (!namespace.equals(operatorNamespace)) {
-                // If CO and CC do not run in the same namespace, we need to handle cross namespace access
-
-                if (operatorNamespaceLabels != null)    {
-                    // If user specified the namespace labels, we can use them to make the selector as tight as possible
-                    LabelSelector nsLabelSelector = new LabelSelector();
-                    nsLabelSelector.setMatchLabels(operatorNamespaceLabels.toMap());
-                    clusterOperatorPeer.setNamespaceSelector(nsLabelSelector);
-                } else {
-                    // If no namespace labels were specified, we open the network policy to COs in all namespaces
-                    clusterOperatorPeer.setNamespaceSelector(new LabelSelector());
-                }
-            }
+            ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(clusterOperatorPeer, namespace, operatorNamespace, operatorNamespaceLabels);
 
             restApiRule.setFrom(Collections.singletonList(clusterOperatorPeer));
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -13,7 +13,6 @@ import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
-import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -1617,20 +1616,7 @@ public class KafkaCluster extends AbstractModel {
                         .addToMatchLabels(Labels.STRIMZI_KIND_LABEL, "cluster-operator")
                     .endPodSelector()
                     .build();
-
-            if (!namespace.equals(operatorNamespace)) {
-                // If CO and Kafka do not run in the same namespace, we need to handle cross namespace access
-
-                if (operatorNamespaceLabels != null)    {
-                    // If user specified the namespace labels, we can use them to make the selector as tight as possible
-                    LabelSelector nsLabelSelector = new LabelSelector();
-                    nsLabelSelector.setMatchLabels(operatorNamespaceLabels.toMap());
-                    clusterOperatorPeer.setNamespaceSelector(nsLabelSelector);
-                } else {
-                    // If no namespace labels were specified, we open the network policy to COs in all namespaces
-                    clusterOperatorPeer.setNamespaceSelector(new LabelSelector());
-                }
-            }
+            ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(clusterOperatorPeer, namespace, operatorNamespace, operatorNamespaceLabels);
 
             NetworkPolicyPeer kafkaClusterPeer = new NetworkPolicyPeerBuilder()
                     .withNewPodSelector() // kafka cluster

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -16,7 +16,6 @@ import io.fabric8.kubernetes.api.model.EnvVarSource;
 import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
-import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -730,20 +729,7 @@ public class KafkaConnectCluster extends AbstractModel {
                         .addToMatchLabels(Labels.STRIMZI_KIND_LABEL, "cluster-operator")
                         .endPodSelector()
                         .build();
-
-                if (!namespace.equals(operatorNamespace)) {
-                    // If CO and Connect do not run in the same namespace, we need to handle cross namespace access
-
-                    if (operatorNamespaceLabels != null)    {
-                        // If user specified the namespace labels, we can use them to make the selector as tight as possible
-                        LabelSelector nsLabelSelector = new LabelSelector();
-                        nsLabelSelector.setMatchLabels(operatorNamespaceLabels.toMap());
-                        clusterOperatorPeer.setNamespaceSelector(nsLabelSelector);
-                    } else {
-                        // If no namespace labels were specified, we open the network policy to COs in all namespaces
-                        clusterOperatorPeer.setNamespaceSelector(new LabelSelector());
-                    }
-                }
+                ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(clusterOperatorPeer, namespace, operatorNamespace, operatorNamespaceLabels);
 
                 peers.add(clusterOperatorPeer);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -485,7 +485,7 @@ public class ModelUtils {
     /**
      * Decides whether the Cluster Operator needs namespaceSelector to be configured in the network policies in order
      * to talk with the operands. This follows the following rules:
-     *     - If it runs in the same namespace s the operand, do not set namespace selector
+     *     - If it runs in the same namespace as the operand, do not set namespace selector
      *     - If it runs in a different namespace, but user provided selector labels, use the labels
      *     - If it runs in a different namespace, and user didn't provided selector labels, open it to COs in all namespaces
      *

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.AffinityBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.NodeSelectorRequirement;
 import io.fabric8.kubernetes.api.model.NodeSelectorRequirementBuilder;
 import io.fabric8.kubernetes.api.model.NodeSelectorTerm;
@@ -19,6 +20,7 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
 import io.strimzi.api.kafka.model.CertificateAuthority;
 import io.strimzi.api.kafka.model.SystemProperty;
 import io.strimzi.api.kafka.model.storage.JbodStorage;
@@ -478,5 +480,34 @@ public class ModelUtils {
                     .endNodeAffinity();
         }
         return builder;
+    }
+
+    /**
+     * Decides whether the Cluster Operator needs namespaceSelector to be configured in the network policies in order
+     * to talk with the operands. This follows the following rules:
+     *     - If it runs in the same namespace s the operand, do not set namespace selector
+     *     - If it runs in a different namespace, but user provided selector labels, use the labels
+     *     - If it runs in a different namespace, and user didn't provided selector labels, open it to COs in all namespaces
+     *
+     * @param peer                      Network policy peer where the namespace selector should be set
+     * @param operandNamespace          Namespace of the operand
+     * @param operatorNamespace         Namespace of the Strimzi CO
+     * @param operatorNamespaceLabels   Namespace labels provided by the user
+     */
+    public static void setClusterOperatorNetworkPolicyNamespaceSelector(NetworkPolicyPeer peer, String operandNamespace, String operatorNamespace, Labels operatorNamespaceLabels)   {
+        if (!operandNamespace.equals(operatorNamespace)) {
+            // If CO and the operand do not run in the same namespace, we need to handle cross namespace access
+
+            if (operatorNamespaceLabels != null && !operatorNamespaceLabels.toMap().isEmpty())    {
+                // If user specified the namespace labels, we can use them to make the network policy as tight as possible
+                LabelSelector nsLabelSelector = new LabelSelector();
+                nsLabelSelector.setMatchLabels(operatorNamespaceLabels.toMap());
+                peer.setNamespaceSelector(nsLabelSelector);
+            } else {
+                // If no namespace labels were specified, we open the network policy to COs in all namespaces
+                peer.setNamespaceSelector(new LabelSelector());
+            }
+        }
+
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -421,20 +421,7 @@ public class ZookeeperCluster extends AbstractModel {
             expressions4.put(Labels.STRIMZI_KIND_LABEL, "cluster-operator");
             labelSelector4.setMatchLabels(expressions4);
             clusterOperatorPeer.setPodSelector(labelSelector4);
-
-            if (!namespace.equals(operatorNamespace)) {
-                // If CO and Zoo do not run in the same namespace, we need to handle cross namespace access
-
-                if (operatorNamespaceLabels != null)    {
-                    // If user specified the namespace labels, we can use them to make the selector as tight as possible
-                    LabelSelector nsLabelSelector = new LabelSelector();
-                    nsLabelSelector.setMatchLabels(operatorNamespaceLabels.toMap());
-                    clusterOperatorPeer.setNamespaceSelector(nsLabelSelector);
-                } else {
-                    // If no namespace labels were specified, we open the network policy to COs in all namespaces
-                    clusterOperatorPeer.setNamespaceSelector(new LabelSelector());
-                }
-            }
+            ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(clusterOperatorPeer, namespace, operatorNamespace, operatorNamespaceLabels);
 
             NetworkPolicyPeer cruiseControlPeer = new NetworkPolicyPeer();
             LabelSelector labelSelector5 = new LabelSelector();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -104,6 +104,8 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
     protected final PodDisruptionBudgetOperator podDisruptionBudgetOperator;
     protected final List<LocalObjectReference> imagePullSecrets;
     protected final long operationTimeoutMs;
+    protected final String operatorNamespace;
+    protected final Labels operatorNamespaceLabels;
     protected final PlatformFeaturesAvailability pfa;
     protected final ServiceAccountOperator serviceAccountOperations;
     private final int port;
@@ -130,6 +132,8 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         this.imagePullPolicy = config.getImagePullPolicy();
         this.imagePullSecrets = config.getImagePullSecrets();
         this.operationTimeoutMs = config.getOperationTimeoutMs();
+        this.operatorNamespace = config.getOperatorNamespace();
+        this.operatorNamespaceLabels = config.getOperatorNamespaceLabels();
         this.pfa = pfa;
         this.port = port;
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -159,6 +159,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
     private static final Logger log = LogManager.getLogger(KafkaAssemblyOperator.class.getName());
 
     private final long operationTimeoutMs;
+    private final String operatorNamespace;
+    private final Labels operatorNamespaceLabels;
 
     private final ZookeeperSetOperator zkSetOperations;
     private final KafkaSetOperator kafkaSetOperations;
@@ -189,6 +191,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         super(vertx, pfa, Kafka.RESOURCE_KIND, certManager, passwordGenerator,
                 supplier.kafkaOperator, supplier, config);
         this.operationTimeoutMs = config.getOperationTimeoutMs();
+        this.operatorNamespace = config.getOperatorNamespace();
+        this.operatorNamespaceLabels = config.getOperatorNamespaceLabels();
         this.routeOperations = supplier.routeOperations;
         this.zkSetOperations = supplier.zkSetOperations;
         this.kafkaSetOperations = supplier.kafkaSetOperations;
@@ -1449,7 +1453,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> zkNetPolicy() {
-            return withVoid(networkPolicyOperator.reconcile(namespace, ZookeeperCluster.policyName(name), zkCluster.generateNetworkPolicy(pfa.isNamespaceAndPodSelectorNetworkPolicySupported())));
+            return withVoid(networkPolicyOperator.reconcile(namespace, ZookeeperCluster.policyName(name), zkCluster.generateNetworkPolicy(pfa.isNamespaceAndPodSelectorNetworkPolicySupported(), operatorNamespace, operatorNamespaceLabels)));
         }
 
         Future<ReconciliationState> zkPodDisruptionBudget() {
@@ -2452,7 +2456,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> kafkaNetPolicy() {
-            return withVoid(networkPolicyOperator.reconcile(namespace, KafkaCluster.policyName(name), kafkaCluster.generateNetworkPolicy(pfa.isNamespaceAndPodSelectorNetworkPolicySupported())));
+            return withVoid(networkPolicyOperator.reconcile(namespace, KafkaCluster.policyName(name), kafkaCluster.generateNetworkPolicy(pfa.isNamespaceAndPodSelectorNetworkPolicySupported(), operatorNamespace, operatorNamespaceLabels)));
         }
 
         Future<ReconciliationState> kafkaPodDisruptionBudget() {
@@ -3228,7 +3232,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
         Future<ReconciliationState> cruiseControlNetPolicy() {
             return withVoid(networkPolicyOperator.reconcile(namespace, CruiseControl.policyName(name),
-                    cruiseControl != null ? cruiseControl.generateNetworkPolicy(pfa.isNamespaceAndPodSelectorNetworkPolicySupported()) : null));
+                    cruiseControl != null ? cruiseControl.generateNetworkPolicy(pfa.isNamespaceAndPodSelectorNetworkPolicySupported(), operatorNamespace, operatorNamespaceLabels) : null));
         }
 
         private boolean isPodCaCertUpToDate(Pod pod, Ca ca) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -136,7 +136,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                 })
                 .compose(i -> connectServiceAccount(namespace, connect))
                 .compose(i -> connectInitClusterRoleBinding(namespace, kafkaConnect.getMetadata().getName(), connect))
-                .compose(i -> networkPolicyOperator.reconcile(namespace, connect.getName(), connect.generateNetworkPolicy(pfa.isNamespaceAndPodSelectorNetworkPolicySupported(), isUseResources(kafkaConnect))))
+                .compose(i -> networkPolicyOperator.reconcile(namespace, connect.getName(), connect.generateNetworkPolicy(pfa.isNamespaceAndPodSelectorNetworkPolicySupported(), isUseResources(kafkaConnect), operatorNamespace, operatorNamespaceLabels)))
                 .compose(i -> deploymentOperations.scaleDown(namespace, connect.getName(), connect.getReplicas()))
                 .compose(scale -> serviceOperations.reconcile(namespace, connect.getServiceName(), connect.generateService()))
                 .compose(i -> configMapOperations.reconcile(namespace, connect.getAncillaryConfigMapName(), logAndMetricsConfigMap))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -145,7 +145,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<Ope
                     }
                 })
                 .compose(i -> connectServiceAccount(namespace, connect))
-                .compose(i -> networkPolicyOperator.reconcile(namespace, connect.getName(), connect.generateNetworkPolicy(pfa.isNamespaceAndPodSelectorNetworkPolicySupported(), isUseResources(kafkaConnectS2I))))
+                .compose(i -> networkPolicyOperator.reconcile(namespace, connect.getName(), connect.generateNetworkPolicy(pfa.isNamespaceAndPodSelectorNetworkPolicySupported(), isUseResources(kafkaConnectS2I), operatorNamespace, operatorNamespaceLabels)))
                 .compose(i -> deploymentConfigOperations.scaleDown(namespace, connect.getName(), connect.getReplicas()))
                 .compose(scale -> serviceOperations.reconcile(namespace, connect.getServiceName(), connect.generateService()))
                 .compose(i -> configMapOperations.reconcile(namespace, connect.getAncillaryConfigMapName(), logAndMetricsConfigMap))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -146,7 +146,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
 
         log.debug("{}: Updating Kafka MirrorMaker 2.0 cluster", reconciliation);
         mirrorMaker2ServiceAccount(namespace, mirrorMaker2Cluster)
-                .compose(i -> networkPolicyOperator.reconcile(namespace, mirrorMaker2Cluster.getName(), mirrorMaker2Cluster.generateNetworkPolicy(pfa.isNamespaceAndPodSelectorNetworkPolicySupported(), true)))
+                .compose(i -> networkPolicyOperator.reconcile(namespace, mirrorMaker2Cluster.getName(), mirrorMaker2Cluster.generateNetworkPolicy(pfa.isNamespaceAndPodSelectorNetworkPolicySupported(), true, operatorNamespace, operatorNamespaceLabels)))
                 .compose(i -> deploymentOperations.scaleDown(namespace, mirrorMaker2Cluster.getName(), mirrorMaker2Cluster.getReplicas()))
                 .compose(scale -> serviceOperations.reconcile(namespace, mirrorMaker2Cluster.getServiceName(), mirrorMaker2Cluster.generateService()))
                 .compose(i -> configMapOperations.reconcile(namespace, mirrorMaker2Cluster.getAncillaryConfigMapName(), logAndMetricsConfigMap))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
 import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.common.InvalidConfigurationException;
+import io.strimzi.operator.common.model.Labels;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -40,11 +41,11 @@ public class ClusterOperatorConfigTest {
         envVars.put(ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_S2I_IMAGES, KafkaVersionTestUtils.getKafkaConnectS2iImagesEnvVarString());
         envVars.put(ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMakerImagesEnvVarString());
         envVars.put(ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMaker2ImagesEnvVarString());
+        envVars.put(ClusterOperatorConfig.STRIMZI_OPERATOR_NAMESPACE, "operator-namespace");
     }
 
     @Test
     public void testDefaultConfig() {
-
         Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
         envVars.remove(ClusterOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS);
         envVars.remove(ClusterOperatorConfig.STRIMZI_OPERATION_TIMEOUT_MS);
@@ -54,12 +55,13 @@ public class ClusterOperatorConfigTest {
         assertThat(config.getNamespaces(), is(singleton("namespace")));
         assertThat(config.getReconciliationIntervalMs(), is(ClusterOperatorConfig.DEFAULT_FULL_RECONCILIATION_INTERVAL_MS));
         assertThat(config.getOperationTimeoutMs(), is(ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS));
+        assertThat(config.getOperatorNamespace(), is("operator-namespace"));
+        assertThat(config.getOperatorNamespaceLabels(), is(nullValue()));
     }
 
     @Test
     public void testReconciliationInterval() {
-
-        ClusterOperatorConfig config = new ClusterOperatorConfig(singleton("namespace"), 60_000, 30_000, false, new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap()), null, null);
+        ClusterOperatorConfig config = new ClusterOperatorConfig(singleton("namespace"), 60_000, 30_000, false, new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap()), null, null, null, null);
 
         assertThat(config.getNamespaces(), is(singleton("namespace")));
         assertThat(config.getReconciliationIntervalMs(), is(60_000L));
@@ -68,17 +70,16 @@ public class ClusterOperatorConfigTest {
 
     @Test
     public void testEnvVars() {
-
         ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup());
 
         assertThat(config.getNamespaces(), is(singleton("namespace")));
         assertThat(config.getReconciliationIntervalMs(), is(30_000L));
         assertThat(config.getOperationTimeoutMs(), is(30_000L));
+        assertThat(config.getOperatorNamespace(), is("operator-namespace"));
     }
 
     @Test
     public void testEnvVarsDefault() {
-
         Map<String, String> envVars = envWithImages();
         envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "namespace");
 
@@ -87,6 +88,8 @@ public class ClusterOperatorConfigTest {
         assertThat(config.getNamespaces(), is(singleton("namespace")));
         assertThat(config.getReconciliationIntervalMs(), is(ClusterOperatorConfig.DEFAULT_FULL_RECONCILIATION_INTERVAL_MS));
         assertThat(config.getOperationTimeoutMs(), is(ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS));
+        assertThat(config.getOperatorNamespace(), is(nullValue()));
+        assertThat(config.getOperatorNamespaceLabels(), is(nullValue()));
     }
 
     private Map<String, String> envWithImages() {
@@ -261,5 +264,27 @@ public class ClusterOperatorConfigTest {
             InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> ClusterOperatorConfig.fromMap(editedEnvVars));
             assertThat(e.getMessage(), containsString(envVar.getKey()));
         }
+    }
+
+    @Test
+    public void testOperatorNamespaceLabels() {
+        Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
+        envVars.put(ClusterOperatorConfig.STRIMZI_OPERATOR_NAMESPACE_LABELS, "nsLabelKey1=nsLabelValue1,nsLabelKey2=nsLabelValue2");
+
+        Map<String, String> expectedLabels = new HashMap<>(2);
+        expectedLabels.put("nsLabelKey1", "nsLabelValue1");
+        expectedLabels.put("nsLabelKey2", "nsLabelValue2");
+
+        assertThat(ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup()).getOperatorNamespaceLabels(), is(Labels.fromMap(expectedLabels)));
+    }
+
+    @Test
+    public void testInvalidOperatorNamespaceLabels() {
+        Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
+        envVars.put(ClusterOperatorConfig.STRIMZI_OPERATOR_NAMESPACE_LABELS, "nsLabelKey1,nsLabelKey2");
+
+        assertThrows(InvalidConfigurationException.class, () -> {
+            ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup());
+        });
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -771,6 +771,8 @@ public class ResourceUtils {
                 false,
                 versions,
                 null,
+                null,
+                null,
                 null);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -1111,8 +1111,8 @@ public class KafkaAssemblyOperatorTest {
         );
 
         // Mock NetworkPolicy get
-        when(mockPolicyOps.get(clusterNamespace, KafkaCluster.policyName(clusterName))).thenReturn(originalKafkaCluster.generateNetworkPolicy(true));
-        when(mockPolicyOps.get(clusterNamespace, ZookeeperCluster.policyName(clusterName))).thenReturn(originalZookeeperCluster.generateNetworkPolicy(true));
+        when(mockPolicyOps.get(clusterNamespace, KafkaCluster.policyName(clusterName))).thenReturn(originalKafkaCluster.generateNetworkPolicy(true, null, null));
+        when(mockPolicyOps.get(clusterNamespace, ZookeeperCluster.policyName(clusterName))).thenReturn(originalZookeeperCluster.generateNetworkPolicy(true, null, null));
 
         // Mock PodDisruptionBudget get
         when(mockPdbOps.get(clusterNamespace, KafkaCluster.kafkaClusterName(clusterName))).thenReturn(originalKafkaCluster.generatePodDisruptionBudget());

--- a/documentation/modules/ref-operator-cluster.adoc
+++ b/documentation/modules/ref-operator-cluster.adoc
@@ -27,6 +27,23 @@ env:
 The timeout for internal operations, in milliseconds. This value should be
 increased when using Strimzi on clusters where regular Kubernetes operations take longer than usual (because of slow downloading of Docker images, for example).
 
+`STRIMZI_OPERATOR_NAMESPACE`:: The name of the namespace where the Strimzi Cluster Operator is running.
+This variable should not be configured manually but should use the Kubernetes Downward API.
++
+[source,yaml,options="nowrap"]
+----
+env:
+  - name: STRIMZI_OPERATOR_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+----
+
+`STRIMZI_OPERATOR_NAMESPACE_LABELS`:: Optional.
+The labels of the namespace where the Strimzi Cluster Operator is running.
+These labels will be used to configure the namespace selector in network policies to allow Strimzi Cluster Operator to access the operands only from namespace with these labels.
+When not set, the namespace selector in network policies will be configured to allow access from Strimzi Cluster Operator from any namespace in the Kubernetes cluster.
+
 `STRIMZI_KAFKA_IMAGES`:: Required.
 This provides a mapping from Kafka version to the corresponding Docker image containing a Kafka broker of that version.
 The required syntax is whitespace or comma separated `_<version>_=_<image>_` pairs.

--- a/documentation/modules/ref-operator-cluster.adoc
+++ b/documentation/modules/ref-operator-cluster.adoc
@@ -28,7 +28,7 @@ The timeout for internal operations, in milliseconds. This value should be
 increased when using Strimzi on clusters where regular Kubernetes operations take longer than usual (because of slow downloading of Docker images, for example).
 
 `STRIMZI_OPERATOR_NAMESPACE`:: The name of the namespace where the Strimzi Cluster Operator is running.
-This variable should not be configured manually but should use the Kubernetes Downward API.
+Do not configure this variable manually. Use the Kubernetes Downward API.
 +
 [source,yaml,options="nowrap"]
 ----
@@ -41,8 +41,8 @@ env:
 
 `STRIMZI_OPERATOR_NAMESPACE_LABELS`:: Optional.
 The labels of the namespace where the Strimzi Cluster Operator is running.
-These labels will be used to configure the namespace selector in network policies to allow Strimzi Cluster Operator to access the operands only from namespace with these labels.
-When not set, the namespace selector in network policies will be configured to allow access from Strimzi Cluster Operator from any namespace in the Kubernetes cluster.
+Namespace labels are used to configure the namespace selector in network policies to allow the Strimzi Cluster Operator to only have access to the operands from the namespace with these labels.
+When not set, the namespace selector in network policies is configured to allow access to the Strimzi Cluster Operator from any namespace in the Kubernetes cluster.
 
 `STRIMZI_KAFKA_IMAGES`:: Required.
 This provides a mapping from Kafka version to the corresponding Docker image containing a Kafka broker of that version.

--- a/helm-charts/helm2/strimzi-kafka-operator/README.md
+++ b/helm-charts/helm2/strimzi-kafka-operator/README.md
@@ -92,6 +92,7 @@ the documentation for more details.
 | `image.imagePullSecrets`             | Docker registry pull secret               | `nil`                                                |
 | `fullReconciliationIntervalMs`       | Full reconciliation interval in milliseconds | 120000                                            |
 | `operationTimeoutMs`                 | Operation timeout in milliseconds         | 300000                                               |
+| `operatorNamespaceLabels`            | Labels of the namespace where the operator runs | `nil`                                          |
 | `zookeeper.image.registry  `         | ZooKeeper image registry                  | `quay.io`                                            |
 | `zookeeper.image.repository`         | ZooKeeper image repository                | `strimzi`                                            |
 | `zookeeper.image.name`               | ZooKeeper image name                      | `kafka`                                              |

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -73,6 +73,10 @@ spec:
               value: {{ default .Values.kafkaBridge.image.registry .Values.imageRegistryOverride }}/{{ default .Values.kafkaBridge.image.repository .Values.imageRepositoryOverride }}/{{ .Values.kafkaBridge.image.name }}:{{ default .Values.kafkaBridge.image.tag .Values.imageTagOverride }}
             - name: STRIMZI_DEFAULT_JMXTRANS_IMAGE
               value: {{ default .Values.jmxTrans.image.registry .Values.imageRegistryOverride }}/{{ default .Values.jmxTrans.image.repository .Values.imageRepositoryOverride }}/{{ .Values.jmxTrans.image.name }}:{{ default .Values.jmxTrans.image.tag .Values.imageTagOverride }}
+            - name: STRIMZI_OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             {{- if .Values.image.imagePullSecrets }}
             - name: STRIMZI_IMAGE_PULL_SECRETS
               value: {{ .Values.image.imagePullSecrets }}
@@ -80,6 +84,10 @@ spec:
             {{- if .Values.image.imagePullPolicy }}
             - name: STRIMZI_IMAGE_PULL_POLICY
               value: {{ .Values.image.imagePullPolicy }}
+            {{- end }}
+            {{- if .Values.image.operatorNamespaceLabels }}
+            - name: STRIMZI_OPERATOR_NAMESPACE_LABELS
+              value: {{ .Values.image.operatorNamespaceLabels }}
             {{- end }}
             {{ if ne .Values.kubernetesServiceDnsDomain "cluster.local" }}- name: KUBERNETES_SERVICE_DNS_DOMAIN
               value: {{ .Values.kubernetesServiceDnsDomain | quote }}{{ end }}

--- a/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -89,6 +89,7 @@ the documentation for more details.
 | `image.imagePullSecrets`             | Docker registry pull secret               | `nil`                                                |
 | `fullReconciliationIntervalMs`       | Full reconciliation interval in milliseconds | 120000                                            |
 | `operationTimeoutMs`                 | Operation timeout in milliseconds         | 300000                                               |
+| `operatorNamespaceLabels`            | Labels of the namespace where the operator runs | `nil`                                          |
 | `zookeeper.image.registry  `         | ZooKeeper image registry                  | `quay.io`                                            |
 | `zookeeper.image.repository`         | ZooKeeper image repository                | `strimzi`                                            |
 | `zookeeper.image.name`               | ZooKeeper image name                      | `kafka`                                              |

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -73,9 +73,17 @@ spec:
               value: {{ default .Values.kafkaBridge.image.registry .Values.imageRegistryOverride }}/{{ default .Values.kafkaBridge.image.repository .Values.imageRepositoryOverride }}/{{ .Values.kafkaBridge.image.name }}:{{ default .Values.kafkaBridge.image.tag .Values.imageTagOverride }}
             - name: STRIMZI_DEFAULT_JMXTRANS_IMAGE
               value: {{ default .Values.jmxTrans.image.registry .Values.imageRegistryOverride }}/{{ default .Values.jmxTrans.image.repository .Values.imageRepositoryOverride }}/{{ .Values.jmxTrans.image.name }}:{{ default .Values.jmxTrans.image.tag .Values.imageTagOverride }}
+            - name: STRIMZI_OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             {{- if .Values.image.imagePullSecrets }}
             - name: STRIMZI_IMAGE_PULL_SECRETS
               value: {{ .Values.image.imagePullSecrets }}
+            {{- end }}
+            {{- if .Values.image.operatorNamespaceLabels }}
+            - name: STRIMZI_OPERATOR_NAMESPACE_LABELS
+              value: {{ .Values.image.operatorNamespaceLabels }}
             {{- end }}
             {{- if .Values.image.imagePullPolicy }}
             - name: STRIMZI_IMAGE_PULL_POLICY

--- a/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -84,6 +84,10 @@ spec:
               value: quay.io/strimzi/kafka-bridge:0.19.0
             - name: STRIMZI_DEFAULT_JMXTRANS_IMAGE
               value: quay.io/strimzi/jmxtrans:latest
+            - name: STRIMZI_OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           livenessProbe:
             httpGet:
               path: /healthy


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Cluster Operator (CO) needs access to different operands to operate them and network policies are used to protect the access. However, since the CO might be running in different namespace then the operands, network policies need to allow cross-namespace access. So far we handled it by allowing the access to all CO pods running in any namespace (`namespaceSelector: {}`). This in general is not an issue since it still limits the access to CO pods and it is not the only security (TLS client authentication is used as well). However, this is more opened then it has to be and we should look at how it can be improved.

Since we do not control the namespaces, we cannot easily set the `namespaceSelector` to some specific labels. We cannot just label the namespace, since that would need additional labels to be set by the operator, but they can be also deleted by any user tooling. However, there are still things we can improve:
* When CO runs in the same namespace as the operand, we can detect it and allow only local access
* When user provides us the namespace labels, we can use them

Both of these are implemented in this PR. 

For the first, this PR adds new environment variable `STRIMZI_OPERATOR_NAMESPACE` (not to confuse with `STRIMZI_NAMESPACE`) which uses the Kubernetes Downward API to find out in which namespace is the operator running. If it is the same as the operand, the `namespaceSelector` is left out from the network policies. This environment variable is automatically added to our deployments (both YMALs and Helm Charts).

For the second, this PR adds new environment variable `STRIMZI_OPERATOR_NAMESPACE_LABELS`. This env var is optional and not set by default. But it can be configured by the user and if set, the labels passed through it will be used for the network policies. For example `STRIMZI_OPERATOR_NAMESPACE_LABELS` set to `co=yes` will result in network policies with 

```yaml
- namespaceSelector:
    matchLabels:
      co: "yes"
```

This PR also adds very basic docs (adds both env vars to the CO configuration reference) and unit tests.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally