### PR TITLE
Try to autodetect Kubernetes Service DNS suffix

### DIFF
--- a/cluster-operator/scripts/cluster_operator_run.sh
+++ b/cluster-operator/scripts/cluster_operator_run.sh
@@ -2,6 +2,18 @@
 export JAVA_CLASSPATH=lib/io.strimzi.@project.build.finalName@.@project.packaging@:@project.dist.classpath@
 export JAVA_MAIN=io.strimzi.operator.cluster.Main
 
+if [ -z "$KUBERNETES_SERVICE_DNS_DOMAIN" ]; then
+  KUBERNETES_SERVICE_DNS_DOMAIN=$(nslookup kubernetes.default | grep "Name:" | sed "s/Name:\skubernetes.default.svc.//")
+  if [ -n "$KUBERNETES_SERVICE_DNS_DOMAIN" ]; then
+    echo "Auto-detected KUBERNETES_SERVICE_DNS_DOMAIN: $KUBERNETES_SERVICE_DNS_DOMAIN"
+    export KUBERNETES_SERVICE_DNS_DOMAIN
+  else
+    echo "Auto-detection of KUBERNETES_SERVICE_DNS_DOMAIN failed. The default value cluster.local will be used."
+  fi
+else
+  echo "KUBERNETES_SERVICE_DNS_DOMAIN is already set. Skipping auto-detection."
+fi
+
 if [ -f /opt/strimzi/custom-config/log4j2.properties ]; then
     # if ConfigMap was not mounted and thus this file was not created, use properties file from the classpath
     export JAVA_OPTS="${JAVA_OPTS} -Dlog4j2.configurationFile=file:/opt/strimzi/custom-config/log4j2.properties"

--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 ARG JAVA_VERSION=11
 
 RUN yum -y update \
-    && yum -y install java-${JAVA_VERSION}-openjdk-headless openssl \
+    && yum -y install java-${JAVA_VERSION}-openjdk-headless openssl bind-utils \
     && yum -y clean all
 
 #####

--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -5,7 +5,7 @@ ARG KAFKA_VERSION
 ARG THIRD_PARTY_LIBS
 ARG strimzi_version
 
-RUN yum -y install gettext nmap-ncat stunnel net-tools bind-utils && yum clean all -y
+RUN yum -y install gettext nmap-ncat stunnel net-tools && yum clean all -y
 
 # Add kafka user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Most users use the default DNS suffix for service hostnames which is `cluster.local`. But some users decide to change it. That often causes issues such as in the #3999 when the users do not set it explicitly using the `KUBERNETES_SERVICE_DNS_DOMAIN` environment variable.

Unfortunately, Kubernetes do not offer any easy and straight forward way how to autodetect the suffix. This PR tries to do it using `nslookup` and the `kubernetes.default` service which should exist in most clusters (that is the Kube API server). When `KUBERNETES_SERVICE_DNS_DOMAIN` is not set, it tries to `nslookup` the `kubernetes.default` service and read the suffix from it. If it fails (the resulting suffix is empty) and leaves it to the CO to use the default.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging