### PR TITLE
Silent error from missing CRB RBAC in Kafka Connect when not needed

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -192,7 +192,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
         Future<ReconcileResult<ClusterRoleBinding>> fut = clusterRoleBindingOperations.reconcile(
                 KafkaConnectResources.initContainerClusterRoleBindingName(name, namespace), desired);
 
-        Promise replacementPromise = Promise.promise();
+        Promise<ReconcileResult<ClusterRoleBinding>> replacementPromise = Promise.promise();
 
         fut.onComplete(res -> {
             if (res.failed()) {
@@ -204,7 +204,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                     replacementPromise.fail(res.cause());
                 }
             } else {
-                replacementPromise.complete();
+                replacementPromise.complete(res.result());
             }
         });
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -188,7 +188,26 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
      * @return                  Future for tracking the asynchronous result of the ClusterRoleBinding reconciliation
      */
     Future<ReconcileResult<ClusterRoleBinding>> connectInitClusterRoleBinding(String namespace, String name, KafkaConnectCluster connectCluster) {
-        return clusterRoleBindingOperations.reconcile(KafkaConnectResources.initContainerClusterRoleBindingName(name, namespace),
-                connectCluster.generateClusterRoleBinding());
+        ClusterRoleBinding desired = connectCluster.generateClusterRoleBinding();
+        Future<ReconcileResult<ClusterRoleBinding>> fut = clusterRoleBindingOperations.reconcile(
+                KafkaConnectResources.initContainerClusterRoleBindingName(name, namespace), desired);
+
+        Promise replacementPromise = Promise.promise();
+
+        fut.onComplete(res -> {
+            if (res.failed()) {
+                if (desired == null && res.cause() != null && res.cause().getMessage() != null &&
+                        res.cause().getMessage().contains("Message: Forbidden!")) {
+                    log.debug("Ignoring forbidden access to ClusterRoleBindings which seems not needed while Kafka Connect rack awareness is disabled.");
+                    replacementPromise.complete();
+                } else {
+                    replacementPromise.fail(res.cause());
+                }
+            } else {
+                replacementPromise.complete();
+            }
+        });
+
+        return replacementPromise.future();
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In KafkaAssemblyOperator, when the rights to create ClusterRoleBindings are missing, we skip over the the error when they are not actually needed (i.e. when node port listeners or rack-awareness is not used). That allows users to install Strimzi without having the rights to create and ClusterRoleBindings.

However, in 0.20 we added the _client_ rack awareness to Kafka Connect. And there we didn't handled the error in the same way so users which install Strimzi in the same way will not be able to run Kafka Connect. This PR fixes that and adds the same handling to Kafka Connect as well.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally