### PR TITLE
[DOC] Improve the chapter about topic naming

### DIFF
--- a/documentation/modules/ref-operator-topic.adoc
+++ b/documentation/modules/ref-operator-topic.adoc
@@ -107,7 +107,7 @@ spec:
 [NOTE]
 ====
 Some Kafka client applications, such as Kafka Streams, can create topics in Kafka programmatically.
-If those topics have names that are invalid Kubernetes resource names, the Topic Operator gives them valid names based on the Kafka names.
+If those topics have names that are invalid Kubernetes resource names, the Topic Operator gives them a valid `metadata.name` based on the Kafka name.
 Invalid characters are replaced and a hash is appended to the name.
 For example:
 

--- a/documentation/modules/ref-operator-topic.adoc
+++ b/documentation/modules/ref-operator-topic.adoc
@@ -79,7 +79,7 @@ The `spec.topicName` property inherits Kafka naming validation rules:
 
 For example:
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: {KafkaApiVersion}
 kind: KafkaTopic
@@ -93,7 +93,7 @@ spec:
 
 cannot be changed to:
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: {KafkaApiVersion}
 kind: KafkaTopic
@@ -104,4 +104,21 @@ spec:
   # ...
 ----
 
-NOTE: Some Kafka client applications, such as Kafka Streams, can create topics in Kafka programmatically. If those topics have names that are invalid Kubernetes resource names, the Topic Operator gives them valid names based on the Kafka names. Invalid characters are replaced and a hash is appended to the name.
+[NOTE]
+====
+Some Kafka client applications, such as Kafka Streams, can create topics in Kafka programmatically.
+If those topics have names that are invalid Kubernetes resource names, the Topic Operator gives them valid names based on the Kafka names.
+Invalid characters are replaced and a hash is appended to the name.
+For example:
+
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaApiVersion}
+kind: KafkaTopic
+metadata:
+  name: mytopic---c55e57fe2546a33f9e603caf57165db4072e827e
+spec:
+  topicName: myTopic
+  # ...
+----
+====


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This PR fixes the examples in the chapter about topic naming where the `{KafkaApiVersion}` did not render properly. It also adds another example which shows how the auto-generated topics look like so that we can easily point users to it.