### PR TITLE
Add inter.broker.protocol.version to all examples and to Upgrade STs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.21.0
 
+* Add `inter.broker.protocol.version` to the default configuration in example YAMLs
 * Add support for `secretPrefix` property for User Operator to prefix all secret names created from KafkaUser resource.
 * Allow configuring labels and annotations for Cluster CA certificate secrets
 * Add the JAAS configuration string in the sasl.jaas.config property to the generated secrets for KafkaUser with SCRAM-SHA-512 authentication.

--- a/examples/cruise-control/kafka-cruise-control.yaml
+++ b/examples/cruise-control/kafka-cruise-control.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: ephemeral
   zookeeper:

--- a/examples/kafka/kafka-ephemeral-single.yaml
+++ b/examples/kafka/kafka-ephemeral-single.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: ephemeral
   zookeeper:

--- a/examples/kafka/kafka-ephemeral.yaml
+++ b/examples/kafka/kafka-ephemeral.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: ephemeral
   zookeeper:

--- a/examples/kafka/kafka-jbod.yaml
+++ b/examples/kafka/kafka-jbod.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: jbod
       volumes:

--- a/examples/kafka/kafka-persistent-single.yaml
+++ b/examples/kafka/kafka-persistent-single.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: jbod
       volumes:

--- a/examples/kafka/kafka-persistent.yaml
+++ b/examples/kafka/kafka-persistent.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: jbod
       volumes:

--- a/examples/metrics/jmxtrans/jmxtrans.yaml
+++ b/examples/metrics/jmxtrans/jmxtrans.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: ephemeral
     jmxOptions:

--- a/examples/metrics/kafka-cruise-control-metrics.yaml
+++ b/examples/metrics/kafka-cruise-control-metrics.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: ephemeral
   zookeeper:

--- a/examples/metrics/kafka-metrics.yaml
+++ b/examples/metrics/kafka-metrics.yaml
@@ -26,6 +26,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: jbod
       volumes:

--- a/examples/mirror-maker/kafka-source.yaml
+++ b/examples/mirror-maker/kafka-source.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: jbod
       volumes:

--- a/examples/mirror-maker/kafka-target.yaml
+++ b/examples/mirror-maker/kafka-target.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: jbod
       volumes:

--- a/examples/security/scram-sha-512-auth/kafka.yaml
+++ b/examples/security/scram-sha-512-auth/kafka.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: jbod
       volumes:

--- a/examples/security/tls-auth/kafka.yaml
+++ b/examples/security/tls-auth/kafka.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: jbod
       volumes:

--- a/operator-common/src/test/resources/example.yaml
+++ b/operator-common/src/test/resources/example.yaml
@@ -15,6 +15,7 @@ spec:
   kafka:
     config:
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
       offsets.topic.replication.factor: 3
       transaction.state.log.min.isr: 2
       transaction.state.log.replication.factor: 3

--- a/operator-common/src/test/resources/example2.yaml
+++ b/operator-common/src/test/resources/example2.yaml
@@ -15,6 +15,7 @@ spec:
   kafka:
     config:
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
       offsets.topic.replication.factor: 3
       transaction.state.log.min.isr: 2
       transaction.state.log.replication.factor: 3

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -190,6 +190,7 @@ public class KafkaResource {
                     .withVersion(Environment.ST_KAFKA_VERSION)
                     .withReplicas(kafkaReplicas)
                     .addToConfig("log.message.format.version", TestKafkaVersion.getKafkaVersionsInMap().get(Environment.ST_KAFKA_VERSION).protocolVersion())
+                    .addToConfig("inter.broker.protocol.version", TestKafkaVersion.getKafkaVersionsInMap().get(Environment.ST_KAFKA_VERSION).protocolVersion())
                     .addToConfig("offsets.topic.replication.factor", Math.min(kafkaReplicas, 3))
                     .addToConfig("transaction.state.log.min.isr", Math.min(kafkaReplicas, 2))
                     .addToConfig("transaction.state.log.replication.factor", Math.min(kafkaReplicas, 3))

--- a/systemtest/src/main/resources/StrimziUpgradeST.json
+++ b/systemtest/src/main/resources/StrimziUpgradeST.json
@@ -21,11 +21,13 @@
     },
     "proceduresBefore": {
       "kafkaVersion": "",
-      "logMessageVersion": ""
+      "logMessageVersion": "",
+      "interBrokerProtocolVersion": ""
     },
     "proceduresAfter": {
       "kafkaVersion": "2.2.1",
-      "logMessageVersion": "2.2"
+      "logMessageVersion": "2.2",
+      "interBrokerProtocolVersion": ""
     },
     "client": {
       "beforeKafkaUpdate": "strimzi/test-client:0.12.1-kafka-2.1.0",
@@ -62,11 +64,13 @@
     },
     "proceduresBefore": {
       "kafkaVersion": "",
-      "logMessageVersion": ""
+      "logMessageVersion": "",
+      "interBrokerProtocolVersion": ""
     },
     "proceduresAfter": {
       "kafkaVersion": "2.3.0",
-      "logMessageVersion": "2.3"
+      "logMessageVersion": "2.3",
+      "interBrokerProtocolVersion": ""
     },
     "client": {
       "beforeKafkaUpdate": "strimzi/test-client:0.12.1-kafka-2.2.1",
@@ -103,11 +107,13 @@
     },
     "proceduresBefore": {
       "kafkaVersion": "",
-      "logMessageVersion": ""
+      "logMessageVersion": "",
+      "interBrokerProtocolVersion": ""
     },
     "proceduresAfter": {
       "kafkaVersion": "",
-      "logMessageVersion": ""
+      "logMessageVersion": "",
+      "interBrokerProtocolVersion": ""
     },
     "client": {
       "beforeKafkaUpdate": "strimzi/test-client:0.13.0-kafka-2.3.0",
@@ -144,11 +150,13 @@
     },
     "proceduresBefore": {
       "kafkaVersion": "",
-      "logMessageVersion": ""
+      "logMessageVersion": "",
+      "interBrokerProtocolVersion": ""
     },
     "proceduresAfter": {
       "kafkaVersion": "2.3.1",
-      "logMessageVersion": ""
+      "logMessageVersion": "",
+      "interBrokerProtocolVersion": ""
     },
     "client": {
       "beforeKafkaUpdate": "strimzi/test-client:0.14.0-kafka-2.3.0",
@@ -185,11 +193,13 @@
     },
     "proceduresBefore": {
       "kafkaVersion": "",
-      "logMessageVersion": ""
+      "logMessageVersion": "",
+      "interBrokerProtocolVersion": ""
     },
     "proceduresAfter": {
       "kafkaVersion": "2.4.0",
-      "logMessageVersion": "2.4"
+      "logMessageVersion": "2.4",
+      "interBrokerProtocolVersion": ""
     },
     "client": {
       "beforeKafkaUpdate": "strimzi/test-client:0.15.0-kafka-2.3.1",
@@ -226,11 +236,13 @@
     },
     "proceduresBefore": {
       "kafkaVersion": "",
-      "logMessageVersion": ""
+      "logMessageVersion": "",
+      "interBrokerProtocolVersion": ""
     },
     "proceduresAfter": {
       "kafkaVersion": "",
-      "logMessageVersion": ""
+      "logMessageVersion": "",
+      "interBrokerProtocolVersion": ""
     },
     "client": {
       "beforeKafkaUpdate": "strimzi/test-client:0.16.2-kafka-2.4.0",
@@ -267,11 +279,13 @@
     },
     "proceduresBefore": {
       "kafkaVersion": "",
-      "logMessageVersion": ""
+      "logMessageVersion": "",
+      "interBrokerProtocolVersion": ""
     },
     "proceduresAfter": {
       "kafkaVersion": "2.5.0",
-      "logMessageVersion": "2.5"
+      "logMessageVersion": "2.5",
+      "interBrokerProtocolVersion": ""
     },
     "client": {
       "beforeKafkaUpdate": "strimzi/test-client:0.17.0-kafka-2.4.0",
@@ -308,11 +322,13 @@
     },
     "proceduresBefore": {
       "kafkaVersion": "",
-      "logMessageVersion": ""
+      "logMessageVersion": "",
+      "interBrokerProtocolVersion": ""
     },
     "proceduresAfter": {
       "kafkaVersion": "",
-      "logMessageVersion": ""
+      "logMessageVersion": "",
+      "interBrokerProtocolVersion": ""
     },
     "client": {
       "beforeKafkaUpdate": "strimzi/test-client:0.18.0-kafka-2.5.0",
@@ -349,11 +365,13 @@
     },
     "proceduresBefore": {
       "kafkaVersion": "",
-      "logMessageVersion": ""
+      "logMessageVersion": "",
+      "interBrokerProtocolVersion": ""
     },
     "proceduresAfter": {
       "kafkaVersion": "2.6.0",
-      "logMessageVersion": "2.6"
+      "logMessageVersion": "2.6",
+      "interBrokerProtocolVersion": ""
     },
     "client": {
       "beforeKafkaUpdate": "strimzi/test-client:0.19.0-kafka-2.5.0",
@@ -390,11 +408,13 @@
     },
     "proceduresBefore": {
       "kafkaVersion": "",
-      "logMessageVersion": ""
+      "logMessageVersion": "",
+      "interBrokerProtocolVersion": ""
     },
     "proceduresAfter": {
       "kafkaVersion": "",
-      "logMessageVersion": ""
+      "logMessageVersion": "",
+      "interBrokerProtocolVersion": ""
     },
     "client": {
       "beforeKafkaUpdate": "strimzi/test-client:0.20.0-kafka-2.6.0",

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -181,6 +181,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
                 .editKafka()
                     .withVersion(null)
                     .addToConfig("log.message.format.version", getValueForLastKafkaVersionInFile(previousKafkaVersionsYaml, "format"))
+                    .addToConfig("inter.broker.protocol.version", getValueForLastKafkaVersionInFile(previousKafkaVersionsYaml, "format"))
                 .endKafka()
             .endSpec()
             .done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -181,7 +181,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
                 .editKafka()
                     .withVersion(null)
                     .addToConfig("log.message.format.version", getValueForLastKafkaVersionInFile(previousKafkaVersionsYaml, "format"))
-                    .addToConfig("inter.broker.protocol.version", getValueForLastKafkaVersionInFile(previousKafkaVersionsYaml, "format"))
+                    .addToConfig("inter.broker.protocol.version", getValueForLastKafkaVersionInFile(previousKafkaVersionsYaml, "protocol"))
                 .endKafka()
             .endSpec()
             .done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
@@ -56,7 +56,8 @@ public class ZookeeperUpgradeST extends AbstractST {
 
             // If it is an upgrade test we keep the message format as the lower version number
             String logMsgFormat = initialVersion.messageVersion();
-            runVersionChange(initialVersion, newVersion, logMsgFormat, 3, 3, testContext);
+            String interBrokerProtocol = initialVersion.protocolVersion();
+            runVersionChange(initialVersion, newVersion, logMsgFormat, interBrokerProtocol, 3, 3, testContext);
         }
 
         // ##############################
@@ -76,7 +77,8 @@ public class ZookeeperUpgradeST extends AbstractST {
 
             // If it is a downgrade then we make sure to use the lower version number for the message format
             String logMsgFormat = newVersion.messageVersion();
-            runVersionChange(initialVersion, newVersion, logMsgFormat, 3, 3, testContext);
+            String interBrokerProtocol = newVersion.protocolVersion();
+            runVersionChange(initialVersion, newVersion, logMsgFormat, interBrokerProtocol, 3, 3, testContext);
         }
 
         // ##############################
@@ -98,11 +100,19 @@ public class ZookeeperUpgradeST extends AbstractST {
             initLogMsgFormat = tmp.toString();
         }
 
+        String interBrokerProtocol = sortedVersions.get(0).messageVersion();
+
+        if (interBrokerProtocol.charAt(2) + 1 >= sortedVersions.get(sortedVersions.size() - 1).messageVersion().charAt(2)) {
+            StringBuilder tmp = new StringBuilder(interBrokerProtocol);
+            tmp.setCharAt(2, (char) (interBrokerProtocol.charAt(2) - 1));
+            interBrokerProtocol = tmp.toString();
+        }
+
         for (int x = sortedVersions.size() - 1; x > 0; x--) {
             TestKafkaVersion initialVersion = sortedVersions.get(x);
             TestKafkaVersion newVersion = sortedVersions.get(x - 1);
 
-            runVersionChange(initialVersion, newVersion, initLogMsgFormat, 3, 3, testContext);
+            runVersionChange(initialVersion, newVersion, initLogMsgFormat, interBrokerProtocol, 3, 3, testContext);
         }
 
         // ##############################
@@ -112,7 +122,7 @@ public class ZookeeperUpgradeST extends AbstractST {
         // ##############################
     }
 
-    void runVersionChange(TestKafkaVersion initialVersion, TestKafkaVersion newVersion, String initLogMsgFormat, int kafkaReplicas, int zkReplicas, ExtensionContext testContext) {
+    void runVersionChange(TestKafkaVersion initialVersion, TestKafkaVersion newVersion, String initLogMsgFormat, String interBrokerProtocol, int kafkaReplicas, int zkReplicas, ExtensionContext testContext) {
         Map<String, String> kafkaPods;
 
         boolean sameMinorVersion = initialVersion.protocolVersion().equals(newVersion.protocolVersion());
@@ -124,6 +134,7 @@ public class ZookeeperUpgradeST extends AbstractST {
                     .editKafka()
                         .withVersion(initialVersion.version())
                         .addToConfig("log.message.format.version", initLogMsgFormat)
+                        .addToConfig("inter.broker.protocol.version", interBrokerProtocol)
                     .endKafka()
                 .endSpec()
                 .done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
@@ -100,7 +100,7 @@ public class ZookeeperUpgradeST extends AbstractST {
             initLogMsgFormat = tmp.toString();
         }
 
-        String interBrokerProtocol = sortedVersions.get(0).messageVersion();
+        String interBrokerProtocol = sortedVersions.get(0).protocolVersion();
 
         if (interBrokerProtocol.charAt(2) + 1 >= sortedVersions.get(sortedVersions.size() - 1).messageVersion().charAt(2)) {
             StringBuilder tmp = new StringBuilder(interBrokerProtocol);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

After the `inter.broker.protocol.version` is changed during the upgrade to the new version, it might happen that downgrade is not possibly anymore. Today, the operator is responsible for updating this version automatically. But that seems to not be the optimal solution. Instead, users should drive this them self => that gives them better options to roll back / downgrade. To drive this, we should set the `inter.broker.protocol.version` in all our examples to make sure it is fixed there and not left to the operator.

This also adds this as an option to the STs in the upgrade tests since they will need to handle this change as well during the upgrade tests.
