### PR TITLE
Fix never ending rolling update of STS when initialDelay is set to 0

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/Probe.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Probe.java
@@ -54,7 +54,7 @@ public class Probe implements UnknownPropertyPreserving, Serializable {
         this.initialDelaySeconds = initialDelaySeconds;
     }
 
-    @Description("The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.")
+    @Description("The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.")
     @Minimum(1)
     @DefaultValue("5")
     public int getTimeoutSeconds() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/Probe.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Probe.java
@@ -43,7 +43,7 @@ public class Probe implements UnknownPropertyPreserving, Serializable {
         this.timeoutSeconds = timeoutSeconds;
     }
 
-    @Description("The initial delay before first the health is first checked.")
+    @Description("The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.")
     @Minimum(0)
     @DefaultValue("15")
     public int getInitialDelaySeconds() {
@@ -54,8 +54,8 @@ public class Probe implements UnknownPropertyPreserving, Serializable {
         this.initialDelaySeconds = initialDelaySeconds;
     }
 
-    @Description("The timeout for each attempted health check.")
-    @Minimum(0)
+    @Description("The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.")
+    @Minimum(1)
     @DefaultValue("5")
     public int getTimeoutSeconds() {
         return timeoutSeconds;
@@ -66,6 +66,8 @@ public class Probe implements UnknownPropertyPreserving, Serializable {
     }
 
     @Description("How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.")
+    @Minimum(1)
+    @DefaultValue("10")
     public Integer getPeriodSeconds() {
         return periodSeconds;
     }
@@ -75,6 +77,8 @@ public class Probe implements UnknownPropertyPreserving, Serializable {
     }
 
     @Description("Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.")
+    @Minimum(1)
+    @DefaultValue("1")
     public Integer getSuccessThreshold() {
         return successThreshold;
     }
@@ -84,6 +88,8 @@ public class Probe implements UnknownPropertyPreserving, Serializable {
     }
 
     @Description("Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.")
+    @Minimum(1)
+    @DefaultValue("3")
     public Integer getFailureThreshold() {
         return failureThreshold;
     }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
@@ -766,6 +766,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -773,26 +774,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -800,20 +805,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -1837,6 +1845,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -1844,26 +1853,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -1871,20 +1884,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -2560,6 +2576,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -2567,26 +2584,31 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -2594,20 +2616,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -2704,6 +2730,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -2711,26 +2738,31 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -2738,20 +2770,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -3058,6 +3094,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -3065,20 +3102,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -3098,6 +3139,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -3105,20 +3147,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -3827,6 +3873,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -3834,20 +3881,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -3867,6 +3918,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -3874,20 +3926,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -3916,6 +3972,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -3923,26 +3980,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness checking for the Cruise Control container.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -3950,20 +4011,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness checking for the Cruise Control container.
                   jvmOptions:
                     type: object
@@ -5727,6 +5791,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -5734,26 +5799,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness check.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -5761,20 +5830,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness check.
                 description: Configuration of the Kafka Exporter. Kafka Exporter can
                   provide additional metrics, for example lag of consumer group at

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
@@ -790,7 +790,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
@@ -821,7 +821,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -1869,7 +1869,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
@@ -1900,7 +1900,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -2601,7 +2601,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
@@ -2633,7 +2633,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -2755,7 +2755,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
@@ -2787,7 +2787,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -3119,7 +3119,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -3164,7 +3164,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -3898,7 +3898,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -3943,7 +3943,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -3996,7 +3996,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness checking for the Cruise Control container.
                   readinessProbe:
                     type: object
@@ -4027,7 +4027,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness checking for the Cruise Control container.
                   jvmOptions:
                     type: object
@@ -5815,7 +5815,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness check.
                   readinessProbe:
                     type: object
@@ -5846,7 +5846,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness check.
                 description: Configuration of the Kafka Exporter. Kafka Exporter can
                   provide additional metrics, for example lag of consumer group at

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
@@ -759,6 +759,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -766,26 +767,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -793,20 +798,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -1794,6 +1802,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -1801,26 +1810,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -1828,20 +1841,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -2497,6 +2513,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -2504,26 +2521,31 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -2531,20 +2553,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -2637,6 +2663,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -2644,26 +2671,31 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -2671,20 +2703,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -2983,6 +3019,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -2990,20 +3027,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -3023,6 +3064,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -3030,20 +3072,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -3742,6 +3788,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -3749,20 +3796,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -3782,6 +3833,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -3789,20 +3841,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -3827,6 +3883,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -3834,26 +3891,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness checking for the Cruise Control container.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -3861,20 +3922,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness checking for the Cruise Control container.
                   jvmOptions:
                     type: object
@@ -5601,6 +5665,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -5608,26 +5673,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness check.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -5635,20 +5704,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness check.
                 description: Configuration of the Kafka Exporter. Kafka Exporter can
                   provide additional metrics, for example lag of consumer group at
@@ -7543,6 +7615,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -7550,26 +7623,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -7577,20 +7654,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -7714,6 +7794,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -7721,20 +7802,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -7754,6 +7839,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -7761,20 +7847,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -8962,6 +9052,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -8969,26 +9060,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -8996,20 +9091,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -9726,6 +9824,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -9733,20 +9832,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -9766,6 +9869,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -9773,20 +9877,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -10051,6 +10159,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -10058,20 +10167,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -10091,6 +10204,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -10098,20 +10212,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -10178,6 +10296,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -10185,26 +10304,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -10212,20 +10335,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                 description: Configuration of the Topic Operator.
               entityOperator:
@@ -10253,6 +10379,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -10260,26 +10387,31 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -10287,20 +10419,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -10393,6 +10529,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -10400,26 +10537,31 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -10427,20 +10569,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -10739,6 +10885,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -10746,20 +10893,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -10779,6 +10930,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -10786,20 +10938,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -11498,6 +11654,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -11505,20 +11662,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -11538,6 +11699,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -11545,20 +11707,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -11583,6 +11749,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -11590,26 +11757,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness checking for the Cruise Control container.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -11617,20 +11788,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness checking for the Cruise Control container.
                   jvmOptions:
                     type: object
@@ -13361,6 +13535,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -13368,26 +13543,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness check.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -13395,20 +13574,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness check.
                 description: Configuration of the Kafka Exporter. Kafka Exporter can
                   provide additional metrics, for example lag of consumer group at
@@ -15303,6 +15485,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -15310,26 +15493,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -15337,20 +15524,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -15474,6 +15664,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -15481,20 +15672,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -15514,6 +15709,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -15521,20 +15717,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -16722,6 +16922,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -16729,26 +16930,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -16756,20 +16961,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -17486,6 +17694,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -17493,20 +17702,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -17526,6 +17739,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -17533,20 +17747,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -17811,6 +18029,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -17818,20 +18037,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -17851,6 +18074,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -17858,20 +18082,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -17938,6 +18166,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -17945,26 +18174,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -17972,20 +18205,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                 description: Configuration of the Topic Operator.
               entityOperator:
@@ -18013,6 +18249,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -18020,26 +18257,31 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -18047,20 +18289,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -18153,6 +18399,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -18160,26 +18407,31 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -18187,20 +18439,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -18499,6 +18755,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -18506,20 +18763,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -18539,6 +18800,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -18546,20 +18808,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -19258,6 +19524,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -19265,20 +19532,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -19298,6 +19569,7 @@ spec:
                         properties:
                           failureThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive failures for the probe
                               to be considered failed after having succeeded. Defaults
                               to 3. Minimum value is 1.
@@ -19305,20 +19577,24 @@ spec:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health
-                              is first checked.
+                              is first checked. Default to 15 seconds. Minimum value
+                              is 0.
                           periodSeconds:
                             type: integer
+                            minimum: 1
                             description: How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                           successThreshold:
                             type: integer
+                            minimum: 1
                             description: Minimum consecutive successes for the probe
                               to be considered successful after having failed. Defaults
                               to 1. Must be 1 for liveness. Minimum value is 1.
                           timeoutSeconds:
                             type: integer
-                            minimum: 0
+                            minimum: 1
                             description: The timeout for each attempted health check.
+                              Default to 10 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -19343,6 +19619,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -19350,26 +19627,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness checking for the Cruise Control container.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -19377,20 +19658,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness checking for the Cruise Control container.
                   jvmOptions:
                     type: object
@@ -21121,6 +21405,7 @@ spec:
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -21128,26 +21413,30 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod liveness check.
                   readinessProbe:
                     type: object
                     properties:
                       failureThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
                           3. Minimum value is 1.
@@ -21155,20 +21444,23 @@ spec:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is
-                          first checked.
+                          first checked. Default to 15 seconds. Minimum value is 0.
                       periodSeconds:
                         type: integer
+                        minimum: 1
                         description: How often (in seconds) to perform the probe.
                           Default to 10 seconds. Minimum value is 1.
                       successThreshold:
                         type: integer
+                        minimum: 1
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
                           1. Must be 1 for liveness. Minimum value is 1.
                       timeoutSeconds:
                         type: integer
-                        minimum: 0
+                        minimum: 1
                         description: The timeout for each attempted health check.
+                          Default to 10 seconds. Minimum value is 1.
                     description: Pod readiness check.
                 description: Configuration of the Kafka Exporter. Kafka Exporter can
                   provide additional metrics, for example lag of consumer group at

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
@@ -783,7 +783,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
@@ -814,7 +814,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -1826,7 +1826,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
@@ -1857,7 +1857,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -2538,7 +2538,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
@@ -2570,7 +2570,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -2688,7 +2688,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
@@ -2720,7 +2720,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -3044,7 +3044,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -3089,7 +3089,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -3813,7 +3813,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -3858,7 +3858,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -3907,7 +3907,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness checking for the Cruise Control container.
                   readinessProbe:
                     type: object
@@ -3938,7 +3938,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness checking for the Cruise Control container.
                   jvmOptions:
                     type: object
@@ -5689,7 +5689,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness check.
                   readinessProbe:
                     type: object
@@ -5720,7 +5720,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness check.
                 description: Configuration of the Kafka Exporter. Kafka Exporter can
                   provide additional metrics, for example lag of consumer group at
@@ -7639,7 +7639,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
@@ -7670,7 +7670,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -7819,7 +7819,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -7864,7 +7864,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -9076,7 +9076,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
@@ -9107,7 +9107,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -9849,7 +9849,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -9894,7 +9894,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -10184,7 +10184,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -10229,7 +10229,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -10320,7 +10320,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
@@ -10351,7 +10351,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                 description: Configuration of the Topic Operator.
               entityOperator:
@@ -10404,7 +10404,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
@@ -10436,7 +10436,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -10554,7 +10554,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
@@ -10586,7 +10586,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -10910,7 +10910,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -10955,7 +10955,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -11679,7 +11679,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -11724,7 +11724,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -11773,7 +11773,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness checking for the Cruise Control container.
                   readinessProbe:
                     type: object
@@ -11804,7 +11804,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness checking for the Cruise Control container.
                   jvmOptions:
                     type: object
@@ -13559,7 +13559,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness check.
                   readinessProbe:
                     type: object
@@ -13590,7 +13590,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness check.
                 description: Configuration of the Kafka Exporter. Kafka Exporter can
                   provide additional metrics, for example lag of consumer group at
@@ -15509,7 +15509,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
@@ -15540,7 +15540,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -15689,7 +15689,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -15734,7 +15734,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -16946,7 +16946,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
@@ -16977,7 +16977,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -17719,7 +17719,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -17764,7 +17764,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -18054,7 +18054,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -18099,7 +18099,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -18190,7 +18190,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
@@ -18221,7 +18221,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness checking.
                 description: Configuration of the Topic Operator.
               entityOperator:
@@ -18274,7 +18274,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
@@ -18306,7 +18306,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -18424,7 +18424,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
@@ -18456,7 +18456,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -18780,7 +18780,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -18825,7 +18825,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -19549,7 +19549,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod liveness checking.
                       logLevel:
                         type: string
@@ -19594,7 +19594,7 @@ spec:
                             type: integer
                             minimum: 1
                             description: The timeout for each attempted health check.
-                              Default to 10 seconds. Minimum value is 1.
+                              Default to 5 seconds. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -19643,7 +19643,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness checking for the Cruise Control container.
                   readinessProbe:
                     type: object
@@ -19674,7 +19674,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness checking for the Cruise Control container.
                   jvmOptions:
                     type: object
@@ -21429,7 +21429,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod liveness check.
                   readinessProbe:
                     type: object
@@ -21460,7 +21460,7 @@ spec:
                         type: integer
                         minimum: 1
                         description: The timeout for each attempted health check.
-                          Default to 10 seconds. Minimum value is 1.
+                          Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness check.
                 description: Configuration of the Kafka Exporter. Kafka Exporter can
                   provide additional metrics, for example lag of consumer group at

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ProbeGenerator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ProbeGenerator.java
@@ -26,12 +26,18 @@ public class ProbeGenerator {
             throw new IllegalArgumentException();
         }
 
-        return new ProbeBuilder()
-                .withInitialDelaySeconds(probeConfig.getInitialDelaySeconds())
+
+        ProbeBuilder pb =  new ProbeBuilder()
                 .withTimeoutSeconds(probeConfig.getTimeoutSeconds())
                 .withPeriodSeconds(probeConfig.getPeriodSeconds())
                 .withSuccessThreshold(probeConfig.getSuccessThreshold())
                 .withFailureThreshold(probeConfig.getFailureThreshold());
+
+        if (probeConfig.getInitialDelaySeconds() > 0)   {
+            pb = pb.withInitialDelaySeconds(probeConfig.getInitialDelaySeconds());
+        }
+
+        return pb;
     }
 
     public static io.fabric8.kubernetes.api.model.Probe httpProbe(Probe probeConfig, String path, String port) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ProbeGeneratorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ProbeGeneratorTest.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ProbeGeneratorTest {
@@ -183,5 +184,17 @@ public class ProbeGeneratorTest {
                 .withTimeoutSeconds(5)
                 .build()
         ));
+    }
+
+    @Test
+    public void testZeroInitialDelayIsSetToNull() {
+        io.strimzi.api.kafka.model.Probe probeConfig = new io.strimzi.api.kafka.model.ProbeBuilder()
+                .withInitialDelaySeconds(0)
+                .build();
+
+        Probe probe = ProbeGenerator.defaultBuilder(probeConfig)
+                .build();
+
+        assertThat(probe.getInitialDelaySeconds(), is(nullValue()));
     }
 }

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -986,13 +986,13 @@ Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`], xref:type-E
 |Property                    |Description
 |failureThreshold     1.2+<.<|Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
 |integer
-|initialDelaySeconds  1.2+<.<|The initial delay before first the health is first checked.
+|initialDelaySeconds  1.2+<.<|The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
 |integer
 |periodSeconds        1.2+<.<|How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
 |integer
 |successThreshold     1.2+<.<|Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
 |integer
-|timeoutSeconds       1.2+<.<|The timeout for each attempted health check.
+|timeoutSeconds       1.2+<.<|The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
 |integer
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -992,7 +992,7 @@ Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`], xref:type-E
 |integer
 |successThreshold     1.2+<.<|Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
 |integer
-|timeoutSeconds       1.2+<.<|The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+|timeoutSeconds       1.2+<.<|The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
 |integer
 |====
 

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -1371,7 +1371,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
@@ -1395,7 +1395,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod readiness checking.
                 jvmOptions:
                   type: object
@@ -1525,7 +1525,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -1561,7 +1561,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -2627,7 +2627,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
@@ -2651,7 +2651,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod readiness checking.
                 jvmOptions:
                   type: object
@@ -3317,7 +3317,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -3353,7 +3353,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -3634,7 +3634,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -3670,7 +3670,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -3751,7 +3751,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
@@ -3775,7 +3775,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod readiness checking.
               description: Configuration of the Topic Operator.
             entityOperator:
@@ -3820,7 +3820,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     readinessProbe:
                       type: object
@@ -3844,7 +3844,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -3949,7 +3949,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     readinessProbe:
                       type: object
@@ -3973,7 +3973,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -4285,7 +4285,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -4321,7 +4321,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -4972,7 +4972,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -5008,7 +5008,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -5049,7 +5049,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod liveness checking for the Cruise Control container.
                 readinessProbe:
                   type: object
@@ -5073,7 +5073,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod readiness checking for the Cruise Control container.
                 jvmOptions:
                   type: object
@@ -6655,7 +6655,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod liveness check.
                 readinessProbe:
                   type: object
@@ -6679,7 +6679,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod readiness check.
               description: Configuration of the Kafka Exporter. Kafka Exporter can provide additional metrics, for example lag of consumer group at topic/partition.
             maintenanceTimeWindows:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -1354,42 +1354,48 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod readiness checking.
                 jvmOptions:
                   type: object
@@ -1502,21 +1508,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -1535,21 +1544,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -2598,42 +2610,48 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod readiness checking.
                 jvmOptions:
                   type: object
@@ -3282,21 +3300,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -3315,21 +3336,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -3593,21 +3617,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -3626,21 +3653,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -3704,42 +3734,48 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod readiness checking.
               description: Configuration of the Topic Operator.
             entityOperator:
@@ -3767,42 +3803,48 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -3890,42 +3932,48 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -4220,21 +4268,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -4253,21 +4304,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -4901,21 +4955,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -4934,21 +4991,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -4972,42 +5032,48 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod liveness checking for the Cruise Control container.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod readiness checking for the Cruise Control container.
                 jvmOptions:
                   type: object
@@ -6572,42 +6638,48 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod liveness check.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod readiness check.
               description: Configuration of the Kafka Exporter. Kafka Exporter can provide additional metrics, for example lag of consumer group at topic/partition.
             maintenanceTimeWindows:

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -236,7 +236,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
@@ -260,7 +260,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -219,42 +219,48 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -89,7 +89,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
@@ -113,7 +113,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -72,42 +72,48 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -1150,42 +1150,48 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod readiness checking.
             version:
               type: string

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -1167,7 +1167,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
@@ -1191,7 +1191,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod readiness checking.
             version:
               type: string

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -306,42 +306,48 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod readiness checking.
             template:
               type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -323,7 +323,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
@@ -347,7 +347,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod readiness checking.
             template:
               type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -301,42 +301,48 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -318,7 +318,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
@@ -342,7 +342,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1367,7 +1367,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
@@ -1391,7 +1391,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod readiness checking.
                 jvmOptions:
                   type: object
@@ -1521,7 +1521,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -1557,7 +1557,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -2623,7 +2623,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
@@ -2647,7 +2647,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod readiness checking.
                 jvmOptions:
                   type: object
@@ -3313,7 +3313,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -3349,7 +3349,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -3630,7 +3630,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -3666,7 +3666,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -3747,7 +3747,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
@@ -3771,7 +3771,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod readiness checking.
               description: Configuration of the Topic Operator.
             entityOperator:
@@ -3816,7 +3816,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     readinessProbe:
                       type: object
@@ -3840,7 +3840,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -3945,7 +3945,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     readinessProbe:
                       type: object
@@ -3969,7 +3969,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -4281,7 +4281,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -4317,7 +4317,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -4968,7 +4968,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -5004,7 +5004,7 @@ spec:
                         timeoutSeconds:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -5045,7 +5045,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod liveness checking for the Cruise Control container.
                 readinessProbe:
                   type: object
@@ -5069,7 +5069,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod readiness checking for the Cruise Control container.
                 jvmOptions:
                   type: object
@@ -6651,7 +6651,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod liveness check.
                 readinessProbe:
                   type: object
@@ -6675,7 +6675,7 @@ spec:
                     timeoutSeconds:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   description: Pod readiness check.
               description: Configuration of the Kafka Exporter. Kafka Exporter can provide additional metrics, for example lag of consumer group at topic/partition.
             maintenanceTimeWindows:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1350,42 +1350,48 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod readiness checking.
                 jvmOptions:
                   type: object
@@ -1498,21 +1504,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -1531,21 +1540,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -2594,42 +2606,48 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod readiness checking.
                 jvmOptions:
                   type: object
@@ -3278,21 +3296,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -3311,21 +3332,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -3589,21 +3613,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -3622,21 +3649,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -3700,42 +3730,48 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod readiness checking.
               description: Configuration of the Topic Operator.
             entityOperator:
@@ -3763,42 +3799,48 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -3886,42 +3928,48 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -4216,21 +4264,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -4249,21 +4300,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -4897,21 +4951,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -4930,21 +4987,24 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
-                          description: The initial delay before first the health is first checked.
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
-                          description: The timeout for each attempted health check.
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -4968,42 +5028,48 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod liveness checking for the Cruise Control container.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod readiness checking for the Cruise Control container.
                 jvmOptions:
                   type: object
@@ -6568,42 +6634,48 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod liveness check.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
-                      description: The initial delay before first the health is first checked.
+                      description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
                   description: Pod readiness check.
               description: Configuration of the Kafka Exporter. Kafka Exporter can provide additional metrics, for example lag of consumer group at topic/partition.
             maintenanceTimeWindows:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -215,42 +215,48 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -232,7 +232,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
@@ -256,7 +256,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -68,42 +68,48 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -85,7 +85,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
@@ -109,7 +109,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -1163,7 +1163,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
@@ -1187,7 +1187,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod readiness checking.
             version:
               type: string

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -1146,42 +1146,48 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod readiness checking.
             version:
               type: string

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -319,7 +319,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
@@ -343,7 +343,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod readiness checking.
             template:
               type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -302,42 +302,48 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod readiness checking.
             template:
               type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -314,7 +314,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
@@ -338,7 +338,7 @@ spec:
                 timeoutSeconds:
                   type: integer
                   minimum: 1
-                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
+                  description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -297,42 +297,48 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
-                  description: The initial delay before first the health is first checked.
+                  description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default to 10 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1828,6 +1828,7 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be
                         considered failed after having succeeded. Defaults to 3. Minimum
                         value is 1.
@@ -1835,26 +1836,30 @@ spec:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first
-                        checked.
+                        checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default
                         to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to
                         be considered successful after having failed. Defaults to
                         1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default
+                        to 10 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be
                         considered failed after having succeeded. Defaults to 3. Minimum
                         value is 1.
@@ -1862,20 +1867,23 @@ spec:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first
-                        checked.
+                        checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default
                         to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to
                         be considered successful after having failed. Defaults to
                         1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default
+                        to 10 seconds. Minimum value is 1.
                   description: Pod readiness checking.
                 jvmOptions:
                   type: object
@@ -1999,6 +2007,7 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe
                             to be considered failed after having succeeded. Defaults
                             to 3. Minimum value is 1.
@@ -2006,20 +2015,24 @@ spec:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is
-                            first checked.
+                            first checked. Default to 15 seconds. Minimum value is
+                            0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe.
                             Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe
                             to be considered successful after having failed. Defaults
                             to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
+                          minimum: 1
                           description: The timeout for each attempted health check.
+                            Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -2039,6 +2052,7 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe
                             to be considered failed after having succeeded. Defaults
                             to 3. Minimum value is 1.
@@ -2046,20 +2060,24 @@ spec:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is
-                            first checked.
+                            first checked. Default to 15 seconds. Minimum value is
+                            0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe.
                             Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe
                             to be considered successful after having failed. Defaults
                             to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
+                          minimum: 1
                           description: The timeout for each attempted health check.
+                            Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -3244,6 +3262,7 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be
                         considered failed after having succeeded. Defaults to 3. Minimum
                         value is 1.
@@ -3251,26 +3270,30 @@ spec:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first
-                        checked.
+                        checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default
                         to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to
                         be considered successful after having failed. Defaults to
                         1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default
+                        to 10 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be
                         considered failed after having succeeded. Defaults to 3. Minimum
                         value is 1.
@@ -3278,20 +3301,23 @@ spec:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first
-                        checked.
+                        checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default
                         to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to
                         be considered successful after having failed. Defaults to
                         1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default
+                        to 10 seconds. Minimum value is 1.
                   description: Pod readiness checking.
                 jvmOptions:
                   type: object
@@ -4008,6 +4034,7 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe
                             to be considered failed after having succeeded. Defaults
                             to 3. Minimum value is 1.
@@ -4015,20 +4042,24 @@ spec:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is
-                            first checked.
+                            first checked. Default to 15 seconds. Minimum value is
+                            0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe.
                             Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe
                             to be considered successful after having failed. Defaults
                             to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
+                          minimum: 1
                           description: The timeout for each attempted health check.
+                            Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -4048,6 +4079,7 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe
                             to be considered failed after having succeeded. Defaults
                             to 3. Minimum value is 1.
@@ -4055,20 +4087,24 @@ spec:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is
-                            first checked.
+                            first checked. Default to 15 seconds. Minimum value is
+                            0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe.
                             Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe
                             to be considered successful after having failed. Defaults
                             to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
+                          minimum: 1
                           description: The timeout for each attempted health check.
+                            Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -4333,6 +4369,7 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe
                             to be considered failed after having succeeded. Defaults
                             to 3. Minimum value is 1.
@@ -4340,20 +4377,24 @@ spec:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is
-                            first checked.
+                            first checked. Default to 15 seconds. Minimum value is
+                            0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe.
                             Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe
                             to be considered successful after having failed. Defaults
                             to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
+                          minimum: 1
                           description: The timeout for each attempted health check.
+                            Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -4373,6 +4414,7 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe
                             to be considered failed after having succeeded. Defaults
                             to 3. Minimum value is 1.
@@ -4380,20 +4422,24 @@ spec:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is
-                            first checked.
+                            first checked. Default to 15 seconds. Minimum value is
+                            0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe.
                             Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe
                             to be considered successful after having failed. Defaults
                             to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
+                          minimum: 1
                           description: The timeout for each attempted health check.
+                            Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -4460,6 +4506,7 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be
                         considered failed after having succeeded. Defaults to 3. Minimum
                         value is 1.
@@ -4467,26 +4514,30 @@ spec:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first
-                        checked.
+                        checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default
                         to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to
                         be considered successful after having failed. Defaults to
                         1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default
+                        to 10 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be
                         considered failed after having succeeded. Defaults to 3. Minimum
                         value is 1.
@@ -4494,20 +4545,23 @@ spec:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first
-                        checked.
+                        checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default
                         to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to
                         be considered successful after having failed. Defaults to
                         1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default
+                        to 10 seconds. Minimum value is 1.
                   description: Pod readiness checking.
               description: Configuration of the Topic Operator.
             entityOperator:
@@ -4535,6 +4589,7 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe
                             to be considered failed after having succeeded. Defaults
                             to 3. Minimum value is 1.
@@ -4542,26 +4597,31 @@ spec:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is
-                            first checked.
+                            first checked. Default to 15 seconds. Minimum value is
+                            0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe.
                             Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe
                             to be considered successful after having failed. Defaults
                             to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
+                          minimum: 1
                           description: The timeout for each attempted health check.
+                            Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe
                             to be considered failed after having succeeded. Defaults
                             to 3. Minimum value is 1.
@@ -4569,20 +4629,24 @@ spec:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is
-                            first checked.
+                            first checked. Default to 15 seconds. Minimum value is
+                            0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe.
                             Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe
                             to be considered successful after having failed. Defaults
                             to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
+                          minimum: 1
                           description: The timeout for each attempted health check.
+                            Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -4674,6 +4738,7 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe
                             to be considered failed after having succeeded. Defaults
                             to 3. Minimum value is 1.
@@ -4681,26 +4746,31 @@ spec:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is
-                            first checked.
+                            first checked. Default to 15 seconds. Minimum value is
+                            0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe.
                             Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe
                             to be considered successful after having failed. Defaults
                             to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
+                          minimum: 1
                           description: The timeout for each attempted health check.
+                            Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe
                             to be considered failed after having succeeded. Defaults
                             to 3. Minimum value is 1.
@@ -4708,20 +4778,24 @@ spec:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is
-                            first checked.
+                            first checked. Default to 15 seconds. Minimum value is
+                            0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe.
                             Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe
                             to be considered successful after having failed. Defaults
                             to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
+                          minimum: 1
                           description: The timeout for each attempted health check.
+                            Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -5019,6 +5093,7 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe
                             to be considered failed after having succeeded. Defaults
                             to 3. Minimum value is 1.
@@ -5026,20 +5101,24 @@ spec:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is
-                            first checked.
+                            first checked. Default to 15 seconds. Minimum value is
+                            0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe.
                             Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe
                             to be considered successful after having failed. Defaults
                             to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
+                          minimum: 1
                           description: The timeout for each attempted health check.
+                            Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -5059,6 +5138,7 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe
                             to be considered failed after having succeeded. Defaults
                             to 3. Minimum value is 1.
@@ -5066,20 +5146,24 @@ spec:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is
-                            first checked.
+                            first checked. Default to 15 seconds. Minimum value is
+                            0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe.
                             Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe
                             to be considered successful after having failed. Defaults
                             to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
+                          minimum: 1
                           description: The timeout for each attempted health check.
+                            Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -5775,6 +5859,7 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe
                             to be considered failed after having succeeded. Defaults
                             to 3. Minimum value is 1.
@@ -5782,20 +5867,24 @@ spec:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is
-                            first checked.
+                            first checked. Default to 15 seconds. Minimum value is
+                            0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe.
                             Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe
                             to be considered successful after having failed. Defaults
                             to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
+                          minimum: 1
                           description: The timeout for each attempted health check.
+                            Default to 10 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -5815,6 +5904,7 @@ spec:
                       properties:
                         failureThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive failures for the probe
                             to be considered failed after having succeeded. Defaults
                             to 3. Minimum value is 1.
@@ -5822,20 +5912,24 @@ spec:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is
-                            first checked.
+                            first checked. Default to 15 seconds. Minimum value is
+                            0.
                         periodSeconds:
                           type: integer
+                          minimum: 1
                           description: How often (in seconds) to perform the probe.
                             Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          minimum: 1
                           description: Minimum consecutive successes for the probe
                             to be considered successful after having failed. Defaults
                             to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
-                          minimum: 0
+                          minimum: 1
                           description: The timeout for each attempted health check.
+                            Default to 10 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -5860,6 +5954,7 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be
                         considered failed after having succeeded. Defaults to 3. Minimum
                         value is 1.
@@ -5867,26 +5962,30 @@ spec:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first
-                        checked.
+                        checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default
                         to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to
                         be considered successful after having failed. Defaults to
                         1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default
+                        to 10 seconds. Minimum value is 1.
                   description: Pod liveness checking for the Cruise Control container.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be
                         considered failed after having succeeded. Defaults to 3. Minimum
                         value is 1.
@@ -5894,20 +5993,23 @@ spec:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first
-                        checked.
+                        checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default
                         to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to
                         be considered successful after having failed. Defaults to
                         1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default
+                        to 10 seconds. Minimum value is 1.
                   description: Pod readiness checking for the Cruise Control container.
                 jvmOptions:
                   type: object
@@ -7635,6 +7737,7 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be
                         considered failed after having succeeded. Defaults to 3. Minimum
                         value is 1.
@@ -7642,26 +7745,30 @@ spec:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first
-                        checked.
+                        checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default
                         to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to
                         be considered successful after having failed. Defaults to
                         1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default
+                        to 10 seconds. Minimum value is 1.
                   description: Pod liveness check.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive failures for the probe to be
                         considered failed after having succeeded. Defaults to 3. Minimum
                         value is 1.
@@ -7669,20 +7776,23 @@ spec:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first
-                        checked.
+                        checked. Default to 15 seconds. Minimum value is 0.
                     periodSeconds:
                       type: integer
+                      minimum: 1
                       description: How often (in seconds) to perform the probe. Default
                         to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      minimum: 1
                       description: Minimum consecutive successes for the probe to
                         be considered successful after having failed. Defaults to
                         1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
-                      minimum: 0
-                      description: The timeout for each attempted health check.
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default
+                        to 10 seconds. Minimum value is 1.
                   description: Pod readiness check.
               description: Configuration of the Kafka Exporter. Kafka Exporter can
                 provide additional metrics, for example lag of consumer group at topic/partition.

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1852,7 +1852,7 @@ spec:
                       type: integer
                       minimum: 1
                       description: The timeout for each attempted health check. Default
-                        to 10 seconds. Minimum value is 1.
+                        to 5 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
@@ -1883,7 +1883,7 @@ spec:
                       type: integer
                       minimum: 1
                       description: The timeout for each attempted health check. Default
-                        to 10 seconds. Minimum value is 1.
+                        to 5 seconds. Minimum value is 1.
                   description: Pod readiness checking.
                 jvmOptions:
                   type: object
@@ -2032,7 +2032,7 @@ spec:
                           type: integer
                           minimum: 1
                           description: The timeout for each attempted health check.
-                            Default to 10 seconds. Minimum value is 1.
+                            Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -2077,7 +2077,7 @@ spec:
                           type: integer
                           minimum: 1
                           description: The timeout for each attempted health check.
-                            Default to 10 seconds. Minimum value is 1.
+                            Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -3286,7 +3286,7 @@ spec:
                       type: integer
                       minimum: 1
                       description: The timeout for each attempted health check. Default
-                        to 10 seconds. Minimum value is 1.
+                        to 5 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
@@ -3317,7 +3317,7 @@ spec:
                       type: integer
                       minimum: 1
                       description: The timeout for each attempted health check. Default
-                        to 10 seconds. Minimum value is 1.
+                        to 5 seconds. Minimum value is 1.
                   description: Pod readiness checking.
                 jvmOptions:
                   type: object
@@ -4059,7 +4059,7 @@ spec:
                           type: integer
                           minimum: 1
                           description: The timeout for each attempted health check.
-                            Default to 10 seconds. Minimum value is 1.
+                            Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -4104,7 +4104,7 @@ spec:
                           type: integer
                           minimum: 1
                           description: The timeout for each attempted health check.
-                            Default to 10 seconds. Minimum value is 1.
+                            Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -4394,7 +4394,7 @@ spec:
                           type: integer
                           minimum: 1
                           description: The timeout for each attempted health check.
-                            Default to 10 seconds. Minimum value is 1.
+                            Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -4439,7 +4439,7 @@ spec:
                           type: integer
                           minimum: 1
                           description: The timeout for each attempted health check.
-                            Default to 10 seconds. Minimum value is 1.
+                            Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -4530,7 +4530,7 @@ spec:
                       type: integer
                       minimum: 1
                       description: The timeout for each attempted health check. Default
-                        to 10 seconds. Minimum value is 1.
+                        to 5 seconds. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
@@ -4561,7 +4561,7 @@ spec:
                       type: integer
                       minimum: 1
                       description: The timeout for each attempted health check. Default
-                        to 10 seconds. Minimum value is 1.
+                        to 5 seconds. Minimum value is 1.
                   description: Pod readiness checking.
               description: Configuration of the Topic Operator.
             entityOperator:
@@ -4614,7 +4614,7 @@ spec:
                           type: integer
                           minimum: 1
                           description: The timeout for each attempted health check.
-                            Default to 10 seconds. Minimum value is 1.
+                            Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     readinessProbe:
                       type: object
@@ -4646,7 +4646,7 @@ spec:
                           type: integer
                           minimum: 1
                           description: The timeout for each attempted health check.
-                            Default to 10 seconds. Minimum value is 1.
+                            Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -4763,7 +4763,7 @@ spec:
                           type: integer
                           minimum: 1
                           description: The timeout for each attempted health check.
-                            Default to 10 seconds. Minimum value is 1.
+                            Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     readinessProbe:
                       type: object
@@ -4795,7 +4795,7 @@ spec:
                           type: integer
                           minimum: 1
                           description: The timeout for each attempted health check.
-                            Default to 10 seconds. Minimum value is 1.
+                            Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -5118,7 +5118,7 @@ spec:
                           type: integer
                           minimum: 1
                           description: The timeout for each attempted health check.
-                            Default to 10 seconds. Minimum value is 1.
+                            Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -5163,7 +5163,7 @@ spec:
                           type: integer
                           minimum: 1
                           description: The timeout for each attempted health check.
-                            Default to 10 seconds. Minimum value is 1.
+                            Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -5884,7 +5884,7 @@ spec:
                           type: integer
                           minimum: 1
                           description: The timeout for each attempted health check.
-                            Default to 10 seconds. Minimum value is 1.
+                            Default to 5 seconds. Minimum value is 1.
                       description: Pod liveness checking.
                     logLevel:
                       type: string
@@ -5929,7 +5929,7 @@ spec:
                           type: integer
                           minimum: 1
                           description: The timeout for each attempted health check.
-                            Default to 10 seconds. Minimum value is 1.
+                            Default to 5 seconds. Minimum value is 1.
                       description: Pod readiness checking.
                     resources:
                       type: object
@@ -5978,7 +5978,7 @@ spec:
                       type: integer
                       minimum: 1
                       description: The timeout for each attempted health check. Default
-                        to 10 seconds. Minimum value is 1.
+                        to 5 seconds. Minimum value is 1.
                   description: Pod liveness checking for the Cruise Control container.
                 readinessProbe:
                   type: object
@@ -6009,7 +6009,7 @@ spec:
                       type: integer
                       minimum: 1
                       description: The timeout for each attempted health check. Default
-                        to 10 seconds. Minimum value is 1.
+                        to 5 seconds. Minimum value is 1.
                   description: Pod readiness checking for the Cruise Control container.
                 jvmOptions:
                   type: object
@@ -7761,7 +7761,7 @@ spec:
                       type: integer
                       minimum: 1
                       description: The timeout for each attempted health check. Default
-                        to 10 seconds. Minimum value is 1.
+                        to 5 seconds. Minimum value is 1.
                   description: Pod liveness check.
                 readinessProbe:
                   type: object
@@ -7792,7 +7792,7 @@ spec:
                       type: integer
                       minimum: 1
                       description: The timeout for each attempted health check. Default
-                        to 10 seconds. Minimum value is 1.
+                        to 5 seconds. Minimum value is 1.
                   description: Pod readiness check.
               description: Configuration of the Kafka Exporter. Kafka Exporter can
                 provide additional metrics, for example lag of consumer group at topic/partition.

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -275,7 +275,7 @@ spec:
                   type: integer
                   minimum: 1
                   description: The timeout for each attempted health check. Default
-                    to 10 seconds. Minimum value is 1.
+                    to 5 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
@@ -306,7 +306,7 @@ spec:
                   type: integer
                   minimum: 1
                   description: The timeout for each attempted health check. Default
-                    to 10 seconds. Minimum value is 1.
+                    to 5 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -251,6 +251,7 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered
                     failed after having succeeded. Defaults to 3. Minimum value is
                     1.
@@ -258,26 +259,30 @@ spec:
                   type: integer
                   minimum: 0
                   description: The initial delay before first the health is first
-                    checked.
+                    checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default
                     to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered
                     successful after having failed. Defaults to 1. Must be 1 for liveness.
                     Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default
+                    to 10 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered
                     failed after having succeeded. Defaults to 3. Minimum value is
                     1.
@@ -285,20 +290,23 @@ spec:
                   type: integer
                   minimum: 0
                   description: The initial delay before first the health is first
-                    checked.
+                    checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default
                     to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered
                     successful after having failed. Defaults to 1. Must be 1 for liveness.
                     Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default
+                    to 10 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -67,6 +67,7 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered
                     failed after having succeeded. Defaults to 3. Minimum value is
                     1.
@@ -74,26 +75,30 @@ spec:
                   type: integer
                   minimum: 0
                   description: The initial delay before first the health is first
-                    checked.
+                    checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default
                     to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered
                     successful after having failed. Defaults to 1. Must be 1 for liveness.
                     Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default
+                    to 10 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered
                     failed after having succeeded. Defaults to 3. Minimum value is
                     1.
@@ -101,20 +106,23 @@ spec:
                   type: integer
                   minimum: 0
                   description: The initial delay before first the health is first
-                    checked.
+                    checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default
                     to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered
                     successful after having failed. Defaults to 1. Must be 1 for liveness.
                     Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default
+                    to 10 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -91,7 +91,7 @@ spec:
                   type: integer
                   minimum: 1
                   description: The timeout for each attempted health check. Default
-                    to 10 seconds. Minimum value is 1.
+                    to 5 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
@@ -122,7 +122,7 @@ spec:
                   type: integer
                   minimum: 1
                   description: The timeout for each attempted health check. Default
-                    to 10 seconds. Minimum value is 1.
+                    to 5 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -1301,7 +1301,7 @@ spec:
                   type: integer
                   minimum: 1
                   description: The timeout for each attempted health check. Default
-                    to 10 seconds. Minimum value is 1.
+                    to 5 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
@@ -1332,7 +1332,7 @@ spec:
                   type: integer
                   minimum: 1
                   description: The timeout for each attempted health check. Default
-                    to 10 seconds. Minimum value is 1.
+                    to 5 seconds. Minimum value is 1.
               description: Pod readiness checking.
             version:
               type: string

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -1277,6 +1277,7 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered
                     failed after having succeeded. Defaults to 3. Minimum value is
                     1.
@@ -1284,26 +1285,30 @@ spec:
                   type: integer
                   minimum: 0
                   description: The initial delay before first the health is first
-                    checked.
+                    checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default
                     to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered
                     successful after having failed. Defaults to 1. Must be 1 for liveness.
                     Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default
+                    to 10 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered
                     failed after having succeeded. Defaults to 3. Minimum value is
                     1.
@@ -1311,20 +1316,23 @@ spec:
                   type: integer
                   minimum: 0
                   description: The initial delay before first the health is first
-                    checked.
+                    checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default
                     to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered
                     successful after having failed. Defaults to 1. Must be 1 for liveness.
                     Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default
+                    to 10 seconds. Minimum value is 1.
               description: Pod readiness checking.
             version:
               type: string

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -367,7 +367,7 @@ spec:
                   type: integer
                   minimum: 1
                   description: The timeout for each attempted health check. Default
-                    to 10 seconds. Minimum value is 1.
+                    to 5 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
@@ -398,7 +398,7 @@ spec:
                   type: integer
                   minimum: 1
                   description: The timeout for each attempted health check. Default
-                    to 10 seconds. Minimum value is 1.
+                    to 5 seconds. Minimum value is 1.
               description: Pod readiness checking.
             template:
               type: object

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -343,6 +343,7 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered
                     failed after having succeeded. Defaults to 3. Minimum value is
                     1.
@@ -350,26 +351,30 @@ spec:
                   type: integer
                   minimum: 0
                   description: The initial delay before first the health is first
-                    checked.
+                    checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default
                     to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered
                     successful after having failed. Defaults to 1. Must be 1 for liveness.
                     Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default
+                    to 10 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered
                     failed after having succeeded. Defaults to 3. Minimum value is
                     1.
@@ -377,20 +382,23 @@ spec:
                   type: integer
                   minimum: 0
                   description: The initial delay before first the health is first
-                    checked.
+                    checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default
                     to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered
                     successful after having failed. Defaults to 1. Must be 1 for liveness.
                     Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default
+                    to 10 seconds. Minimum value is 1.
               description: Pod readiness checking.
             template:
               type: object

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -357,6 +357,7 @@ spec:
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered
                     failed after having succeeded. Defaults to 3. Minimum value is
                     1.
@@ -364,26 +365,30 @@ spec:
                   type: integer
                   minimum: 0
                   description: The initial delay before first the health is first
-                    checked.
+                    checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default
                     to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered
                     successful after having failed. Defaults to 1. Must be 1 for liveness.
                     Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default
+                    to 10 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive failures for the probe to be considered
                     failed after having succeeded. Defaults to 3. Minimum value is
                     1.
@@ -391,20 +396,23 @@ spec:
                   type: integer
                   minimum: 0
                   description: The initial delay before first the health is first
-                    checked.
+                    checked. Default to 15 seconds. Minimum value is 0.
                 periodSeconds:
                   type: integer
+                  minimum: 1
                   description: How often (in seconds) to perform the probe. Default
                     to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  minimum: 1
                   description: Minimum consecutive successes for the probe to be considered
                     successful after having failed. Defaults to 1. Must be 1 for liveness.
                     Minimum value is 1.
                 timeoutSeconds:
                   type: integer
-                  minimum: 0
-                  description: The timeout for each attempted health check.
+                  minimum: 1
+                  description: The timeout for each attempted health check. Default
+                    to 10 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -381,7 +381,7 @@ spec:
                   type: integer
                   minimum: 1
                   description: The timeout for each attempted health check. Default
-                    to 10 seconds. Minimum value is 1.
+                    to 5 seconds. Minimum value is 1.
               description: Pod liveness checking.
             readinessProbe:
               type: object
@@ -412,7 +412,7 @@ spec:
                   type: integer
                   minimum: 1
                   description: The timeout for each attempted health check. Default
-                    to 10 seconds. Minimum value is 1.
+                    to 5 seconds. Minimum value is 1.
               description: Pod readiness checking.
             jvmOptions:
               type: object


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In health check probes, when the `initialDelaySeconds` is set to 0, Kubernetes actually set it to `null`. This is causing never ending loop of rolling updates as described in #4041. This PR handles that in the `ProbeGenerator` and keeps it as `null` when set to `0`. It also updates the defaults and minimal values for the other options in the health check probes to make the CRD validation work properly etc.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging