### PR TITLE
Replace use of withNewConfigMapKeyRef with withConfigMapKeyRef

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/TestUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/TestUtils.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.cluster;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMapKeySelectorBuilder;
 import io.strimzi.api.kafka.model.JmxPrometheusExporterMetrics;
 import io.strimzi.api.kafka.model.JmxPrometheusExporterMetricsBuilder;
 import io.strimzi.operator.cluster.model.AbstractModel;
@@ -16,7 +17,11 @@ public class TestUtils {
     public static JmxPrometheusExporterMetrics getJmxPrometheusExporterMetrics(String key, String name) {
         JmxPrometheusExporterMetrics metricsConfig = new JmxPrometheusExporterMetricsBuilder()
                 .withNewValueFrom()
-                .withNewConfigMapKeyRef(key, name, true)
+                    .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder()
+                            .withName(name)
+                            .withKey(key)
+                            .withOptional(true)
+                            .build())
                 .endValueFrom()
                 .build();
         return metricsConfig;

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -664,7 +664,7 @@ class RollingUpdateST extends AbstractST {
         JmxPrometheusExporterMetrics zkMetricsConfig = new JmxPrometheusExporterMetricsBuilder()
                 .withNewValueFrom()
                     .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder()
-                            .withName(metricsCMNameK)
+                            .withName(metricsCMNameZk)
                             .withKey("metrics-config.yml")
                             .withOptional(true)
                             .build())

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMapKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
@@ -631,7 +632,11 @@ class RollingUpdateST extends AbstractST {
 
         JmxPrometheusExporterMetrics kafkaMetricsConfig = new JmxPrometheusExporterMetricsBuilder()
                 .withNewValueFrom()
-                .withNewConfigMapKeyRef("metrics-config.yml", metricsCMNameK, true)
+                    .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder()
+                            .withName(metricsCMNameK)
+                            .withKey("metrics-config.yml")
+                            .withOptional(true)
+                            .build())
                 .endValueFrom()
                 .build();
 
@@ -658,7 +663,11 @@ class RollingUpdateST extends AbstractST {
 
         JmxPrometheusExporterMetrics zkMetricsConfig = new JmxPrometheusExporterMetricsBuilder()
                 .withNewValueFrom()
-                .withNewConfigMapKeyRef("metrics-config.yml", metricsCMNameZk, true)
+                    .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder()
+                            .withName(metricsCMNameK)
+                            .withKey("metrics-config.yml")
+                            .withOptional(true)
+                            .build())
                 .endValueFrom()
                 .build();
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

For whatever reason, on some JDK versions, the method `withNewConfigMapKeyRef` in `JmxPrometheusExporterMetricsBuilder` is not generated. And that is causing compilation failures (see #4038 as an example).

This PR replaces its use with `withConfigMapKeyRef` which does not seem to suffer with this problem to be able to move forward with it.