### PR TITLE
Change images for example clients

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -68,6 +68,10 @@ public interface Constants {
     String ALWAYS_IMAGE_PULL_POLICY = "Always";
     String IF_NOT_PRESENT_IMAGE_PULL_POLICY = "IfNotPresent";
 
+    String STRIMZI_EXAMPLE_PRODUCER_NAME = "java-kafka-producer";
+    String STRIMZI_EXAMPLE_CONSUMER_NAME = "java-kafka-consumer";
+    String STRIMZI_EXAMPLE_STREAMS_NAME = "java-kafka-streams";
+
     /**
      * Constants for specific ports
      */

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -109,6 +109,7 @@ public class Environment {
     public static final String STRIMZI_ORG_DEFAULT = "strimzi";
     public static final String STRIMZI_TAG_DEFAULT = "latest";
     public static final String STRIMZI_REGISTRY_DEFAULT = "quay.io";
+    public static final String STRIMZI_CLIENTS_ORG_DEFAULT = "strimzi-examples";
     private static final String TEST_LOG_DIR_DEFAULT = TestUtils.USER_PATH + "/../systemtest/target/logs/";
     private static final String STRIMZI_LOG_LEVEL_DEFAULT = "DEBUG";
     static final String KUBERNETES_DOMAIN_DEFAULT = ".nip.io";

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaBasicExampleClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaBasicExampleClients.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.resources.crd.kafkaclients;
 import io.fabric8.kubernetes.api.model.batch.DoneableJob;
 import io.fabric8.kubernetes.api.model.batch.JobBuilder;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.utils.ClientUtils;
@@ -180,7 +181,7 @@ public class KafkaBasicExampleClients {
                             .addNewContainer()
                                 .withName(producerName)
                                 .withImagePullPolicy(Constants.IF_NOT_PRESENT_IMAGE_PULL_POLICY)
-                                .withImage("strimzi/hello-world-producer:latest")
+                                .withImage(Environment.STRIMZI_REGISTRY_DEFAULT + "/" + Environment.STRIMZI_CLIENTS_ORG_DEFAULT + "/" + Constants.STRIMZI_EXAMPLE_PRODUCER_NAME + ":latest")
                                 .addNewEnv()
                                     .withName("BOOTSTRAP_SERVERS")
                                     .withValue(bootstrapAddress)
@@ -248,7 +249,7 @@ public class KafkaBasicExampleClients {
                         .addNewContainer()
                             .withName(consumerName)
                             .withImagePullPolicy(Constants.IF_NOT_PRESENT_IMAGE_PULL_POLICY)
-                            .withImage("strimzi/hello-world-consumer:latest")
+                            .withImage(Environment.STRIMZI_REGISTRY_DEFAULT + "/" + Environment.STRIMZI_CLIENTS_ORG_DEFAULT + "/" + Constants.STRIMZI_EXAMPLE_CONSUMER_NAME + ":latest")
                             .addNewEnv()
                                 .withName("BOOTSTRAP_SERVERS")
                                 .withValue(bootstrapAddress)

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaTracingExampleClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaTracingExampleClients.java
@@ -6,6 +6,8 @@ package io.strimzi.systemtest.resources.crd.kafkaclients;
 
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DoneableDeployment;
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 
@@ -148,7 +150,7 @@ public class KafkaTracingExampleClients extends KafkaBasicExampleClients {
                                 .withContainers()
                                 .addNewContainer()
                                     .withName(consumerName)
-                                    .withImage("strimzi/" + consumerName + ":latest")
+                                    .withImage(Environment.STRIMZI_REGISTRY_DEFAULT + "/" + Environment.STRIMZI_CLIENTS_ORG_DEFAULT + "/" + Constants.STRIMZI_EXAMPLE_CONSUMER_NAME + ":latest")
                                     .addNewEnv()
                                         .withName("BOOTSTRAP_SERVERS")
                                         .withValue(bootstrapAddress)
@@ -221,7 +223,7 @@ public class KafkaTracingExampleClients extends KafkaBasicExampleClients {
                         .withContainers()
                         .addNewContainer()
                             .withName(producerName)
-                            .withImage("strimzi/" + producerName + ":latest")
+                            .withImage(Environment.STRIMZI_REGISTRY_DEFAULT + "/" + Environment.STRIMZI_CLIENTS_ORG_DEFAULT + "/" + Constants.STRIMZI_EXAMPLE_PRODUCER_NAME + ":latest")
                             .addNewEnv()
                                 .withName("BOOTSTRAP_SERVERS")
                                 .withValue(bootstrapAddress)
@@ -290,7 +292,7 @@ public class KafkaTracingExampleClients extends KafkaBasicExampleClients {
                         .withContainers()
                         .addNewContainer()
                             .withName(kafkaStreamsName)
-                            .withImage("strimzi/" + kafkaStreamsName + ":latest")
+                            .withImage(Environment.STRIMZI_REGISTRY_DEFAULT + "/" + Environment.STRIMZI_CLIENTS_ORG_DEFAULT + "/" + Constants.STRIMZI_EXAMPLE_STREAMS_NAME + ":latest")
                             .addNewEnv()
                                 .withName("BOOTSTRAP_SERVERS")
                                 .withValue(bootstrapAddress)


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Refactoring

### Description

In recent days, we changed the names of client-examples images and w also moved them from docker.io to quay.io. This PR reflects the changes in system tests.

### Checklist


- [x] Make sure all tests pass

