### PR TITLE
Remove Java 8 support from our shell scripts

### DIFF
--- a/docker-images/kafka/scripts/set_kafka_gc_options.sh
+++ b/docker-images/kafka/scripts/set_kafka_gc_options.sh
@@ -4,12 +4,7 @@ set -e
 # expand gc options based upon java version
 function get_gc_opts {
   # The first segment of the version number is '1' for releases < 9; then '9', '10', '11', ...
-  JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
-  if [ "$JAVA_MAJOR_VERSION" -ge "9" ] ; then
-    echo "-Xlog:gc*:stdout:time"
-  else
-    echo "-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps"
-  fi
+  echo "-Xlog:gc*:stdout:time"
 }
 
 if [ "${STRIMZI_KAFKA_GC_LOG_ENABLED}" == "true" ]; then

--- a/docker-images/operator/scripts/launch_java.sh
+++ b/docker-images/operator/scripts/launch_java.sh
@@ -5,13 +5,7 @@ set -x
 # expand gc options based upon java version
 function get_gc_opts {
   if [ "${STRIMZI_GC_LOG_ENABLED}" == "true" ]; then
-    # The first segment of the version number is '1' for releases < 9; then '9', '10', '11', ...
-    JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
-    if [ "$JAVA_MAJOR_VERSION" -ge "9" ] ; then
-      echo "-Xlog:gc*:stdout:time -XX:NativeMemoryTracking=summary"
-    else
-      echo "-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:NativeMemoryTracking=summary"
-    fi
+    echo "-Xlog:gc*:stdout:time -XX:NativeMemoryTracking=summary"
   else
     # no gc options
     echo ""
@@ -27,10 +21,7 @@ JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp -Djava.security.egd=file:/dev/
 JAVA_OPTS="${JAVA_OPTS} $(get_gc_opts)"
 
 # Deny illegal access option is supported only on Java 9 and higher
-JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
-if [ "$JAVA_MAJOR_VERSION" -ge "9" ] ; then
-  JAVA_OPTS="${JAVA_OPTS} --illegal-access=deny"
-fi
+JAVA_OPTS="${JAVA_OPTS} --illegal-access=deny"
 
 # shellcheck disable=SC2086
 exec /usr/bin/tini -w -e 143 -- java $JAVA_OPTS -classpath "$JAVA_CLASSPATH" "$JAVA_MAIN" "$@"

--- a/docker-images/test-client/scripts/launch_java.sh
+++ b/docker-images/test-client/scripts/launch_java.sh
@@ -8,13 +8,7 @@ shift
 # expand gc options based upon java version
 function get_gc_opts {
   if [ "${STRIMZI_GC_LOG_ENABLED}" == "true" ]; then
-    # The first segment of the version number is '1' for releases < 9; then '9', '10', '11', ...
-    JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
-    if [ "$JAVA_MAJOR_VERSION" -ge "9" ] ; then
-      echo "-Xlog:gc*:stdout:time -XX:NativeMemoryTracking=summary"
-    else
-      echo "-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:NativeMemoryTracking=summary"
-    fi
+    echo "-Xlog:gc*:stdout:time -XX:NativeMemoryTracking=summary"
   else
     # no gc options
     echo ""
@@ -35,9 +29,6 @@ JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp -Djava.security.egd=file:/dev/
 JAVA_OPTS="${JAVA_OPTS} $(get_gc_opts)"
 
 # Deny illegal access option is supported only on Java 9 and higher
-JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
-if [ "$JAVA_MAJOR_VERSION" -ge "9" ] ; then
-  JAVA_OPTS="${JAVA_OPTS} --illegal-access=deny"
-fi
+JAVA_OPTS="${JAVA_OPTS} --illegal-access=deny"
 
 exec java $JAVA_OPTS -jar $JAR $@


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We now use only Java 11 for all our container images. But I found out some of our scripts still contained Java 8 support. This PR removes it to make them a bit cleaner.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally