### PR TITLE
Connect default logging not expanded

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -412,9 +412,9 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
         defaultLogging.asMap().entrySet().forEach(entry -> {
             // set all logger levels to default
             if (entry.getKey().equals("log4j.rootLogger")) {
-                updateLoggers.put("root", entry.getValue());
+                updateLoggers.put("root", Util.expandVar(entry.getValue(), defaultLogging.asMap()));
             } else if (entry.getKey().startsWith("log4j.logger.")) {
-                updateLoggers.put(entry.getKey().substring("log4j.logger.".length()), entry.getValue());
+                updateLoggers.put(entry.getKey().substring("log4j.logger.".length()), Util.expandVar(entry.getValue(), defaultLogging.asMap()));
             }
         });
 
@@ -425,12 +425,12 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
             if (entry.getKey().equals("log4j.rootLogger")) {
                 if (fetchedLoggers.get("root") == null || fetchedLoggers.get("root").get("level") == null ||
                         !entry.getValue().equals(fetchedLoggers.get("root").get("level"))) {
-                    updateLoggers.put("root", entry.getValue());
+                    updateLoggers.put("root", Util.expandVar(entry.getValue(), ops.asMap()));
                 }
             } else if (entry.getKey().startsWith("log4j.logger.")) {
                 Map<String, String> fetchedLogger = fetchedLoggers.get(entry.getKey().substring("log4j.logger.".length()));
                 if (fetchedLogger == null || fetchedLogger.get("level") == null || !entry.getValue().equals(fetchedLogger.get("level"))) {
-                    updateLoggers.put(entry.getKey().substring("log4j.logger.".length()), entry.getValue());
+                    updateLoggers.put(entry.getKey().substring("log4j.logger.".length()), Util.expandVar(entry.getValue(), ops.asMap()));
                 }
             }
         });


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
Connect logging configuration has not been expanded. So in configuration `log4j.rootLogger=${connect.root.logger.level}, CONSOLE`, we tried to update `root` logger to level `${connect.root.logger.level}`. 

Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/4053
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

