### PR TITLE
Add check for inter.broker.protocol.version and warning to status conditions

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -533,7 +533,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          * practice to the status.
          */
         Future<ReconciliationState> checkKafkaSpec() {
-            KafkaSpecChecker checker = new KafkaSpecChecker(kafkaAssembly.getSpec(), kafkaCluster, zkCluster);
+            KafkaSpecChecker checker = new KafkaSpecChecker(kafkaAssembly.getSpec(), versions, kafkaCluster, zkCluster);
             List<Condition> warnings = checker.run();
             kafkaStatus.addConditions(warnings);
             return Future.succeededFuture(this);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecChecker.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecChecker.java
@@ -8,6 +8,7 @@ import io.strimzi.api.kafka.model.KafkaSpec;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaConfiguration;
+import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.StorageUtils;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.common.operator.resource.StatusUtils;
@@ -29,11 +30,13 @@ public class KafkaSpecChecker {
     private KafkaSpec spec;
     private KafkaCluster kafkaCluster;
     private ZookeeperCluster zkCluster;
+    private String kafkaBrokerVersion;
 
     private final static Pattern VERSION_REGEX = Pattern.compile("(\\d\\.\\d+).*");
 
     /**
      * @param spec The spec requested by the user in the CR
+     * @param versions List of versions supported by the Operator. Used to detect the default version.
      * @param kafkaCluster The model generated based on the spec. This is requested so that default
      *                     values not included in the spec can be taken into account, without needing
      *                     this class to include awareness of what defaults are applied.
@@ -41,15 +44,22 @@ public class KafkaSpecChecker {
      *                     values not included in the spec can be taken into account, without needing
      *                     this class to include awareness of what defaults are applied.
      */
-    public KafkaSpecChecker(KafkaSpec spec, KafkaCluster kafkaCluster, ZookeeperCluster zkCluster) {
+    public KafkaSpecChecker(KafkaSpec spec, KafkaVersion.Lookup versions, KafkaCluster kafkaCluster, ZookeeperCluster zkCluster) {
         this.spec = spec;
         this.kafkaCluster = kafkaCluster;
         this.zkCluster = zkCluster;
+
+        if (spec.getKafka().getVersion() != null) {
+            this.kafkaBrokerVersion = spec.getKafka().getVersion();
+        } else {
+            this.kafkaBrokerVersion = versions.defaultVersion().version();
+        }
     }
 
     public List<Condition> run() {
         List<Condition> warnings = new ArrayList<>();
         checkKafkaLogMessageFormatVersion(warnings);
+        checkKafkaInterBrokerProtocolVersion(warnings);
         checkKafkaStorage(warnings);
         checkZooKeeperStorage(warnings);
         checkZooKeeperReplicas(warnings);
@@ -67,12 +77,33 @@ public class KafkaSpecChecker {
      */
     private void checkKafkaLogMessageFormatVersion(List<Condition> warnings) {
         String logMsgFormatVersion = kafkaCluster.getConfiguration().getConfigOption(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION);
-        String kafkaBrokerVersion = spec.getKafka().getVersion();
-        if (logMsgFormatVersion != null && kafkaBrokerVersion != null) {
+
+        if (logMsgFormatVersion != null) {
             Matcher m = VERSION_REGEX.matcher(logMsgFormatVersion);
             if (m.find() && !kafkaBrokerVersion.startsWith(m.group(0))) {
                 warnings.add(StatusUtils.buildWarningCondition("KafkaLogMessageFormatVersion",
                         "log.message.format.version does not match the Kafka cluster version, which suggests that an upgrade is incomplete."));
+            }
+        }
+    }
+
+    /**
+     * Checks if the version of the Kafka brokers matches any custom inter.broker.protocol.version config.
+     *
+     * Updating this is the final step in upgrading Kafka version, so if this doesn't match it is possibly an
+     * indication that a user has updated their Kafka cluster and is unaware that they also should update
+     * their format version to match.
+     *
+     * @param warnings List to add a warning to, if appropriate.
+     */
+    private void checkKafkaInterBrokerProtocolVersion(List<Condition> warnings) {
+        String interBrokerProtocolVersion = kafkaCluster.getConfiguration().getConfigOption(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION);
+
+        if (interBrokerProtocolVersion != null) {
+            Matcher m = VERSION_REGEX.matcher(interBrokerProtocolVersion);
+            if (m.find() && !kafkaBrokerVersion.startsWith(m.group(0))) {
+                warnings.add(StatusUtils.buildWarningCondition("KafkaInterBrokerProtocolVersion",
+                        "inter.broker.protocol.version does not match the Kafka cluster version, which suggests that an upgrade is incomplete."));
             }
         }
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecChecker.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecChecker.java
@@ -26,11 +26,9 @@ import java.util.regex.Pattern;
  * lead to problems.
  */
 public class KafkaSpecChecker {
-
-    private KafkaSpec spec;
-    private KafkaCluster kafkaCluster;
-    private ZookeeperCluster zkCluster;
-    private String kafkaBrokerVersion;
+    private final KafkaCluster kafkaCluster;
+    private final ZookeeperCluster zkCluster;
+    private final String kafkaBrokerVersion;
 
     private final static Pattern VERSION_REGEX = Pattern.compile("(\\d\\.\\d+).*");
 
@@ -45,7 +43,6 @@ public class KafkaSpecChecker {
      *                     this class to include awareness of what defaults are applied.
      */
     public KafkaSpecChecker(KafkaSpec spec, KafkaVersion.Lookup versions, KafkaCluster kafkaCluster, ZookeeperCluster zkCluster) {
-        this.spec = spec;
         this.kafkaCluster = kafkaCluster;
         this.zkCluster = zkCluster;
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecChecker.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecChecker.java
@@ -30,7 +30,7 @@ public class KafkaSpecChecker {
     private final ZookeeperCluster zkCluster;
     private final String kafkaBrokerVersion;
 
-    private final static Pattern VERSION_REGEX = Pattern.compile("(\\d\\.\\d+).*");
+    private final static Pattern VERSION_REGEX = Pattern.compile("(\\d+\\.\\d+).*");
 
     /**
      * @param spec The spec requested by the user in the CR
@@ -77,7 +77,7 @@ public class KafkaSpecChecker {
 
         if (logMsgFormatVersion != null) {
             Matcher m = VERSION_REGEX.matcher(logMsgFormatVersion);
-            if (m.find() && !kafkaBrokerVersion.startsWith(m.group(0))) {
+            if (m.matches() && !kafkaBrokerVersion.startsWith(m.group(1))) {
                 warnings.add(StatusUtils.buildWarningCondition("KafkaLogMessageFormatVersion",
                         "log.message.format.version does not match the Kafka cluster version, which suggests that an upgrade is incomplete."));
             }
@@ -98,7 +98,7 @@ public class KafkaSpecChecker {
 
         if (interBrokerProtocolVersion != null) {
             Matcher m = VERSION_REGEX.matcher(interBrokerProtocolVersion);
-            if (m.find() && !kafkaBrokerVersion.startsWith(m.group(0))) {
+            if (m.matches() && !kafkaBrokerVersion.startsWith(m.group(1))) {
                 warnings.add(StatusUtils.buildWarningCondition("KafkaInterBrokerProtocolVersion",
                         "inter.broker.protocol.version does not match the Kafka cluster version, which suggests that an upgrade is incomplete."));
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecChecker.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecChecker.java
@@ -30,7 +30,8 @@ public class KafkaSpecChecker {
     private final ZookeeperCluster zkCluster;
     private final String kafkaBrokerVersion;
 
-    private final static Pattern VERSION_REGEX = Pattern.compile("(\\d+\\.\\d+).*");
+    // This pattern is used to extract the MAJOR.MINOR version from the protocol or format version fields
+    private final static Pattern MAJOR_MINOR_REGEX = Pattern.compile("(\\d+\\.\\d+).*");
 
     /**
      * @param spec The spec requested by the user in the CR
@@ -76,7 +77,7 @@ public class KafkaSpecChecker {
         String logMsgFormatVersion = kafkaCluster.getConfiguration().getConfigOption(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION);
 
         if (logMsgFormatVersion != null) {
-            Matcher m = VERSION_REGEX.matcher(logMsgFormatVersion);
+            Matcher m = MAJOR_MINOR_REGEX.matcher(logMsgFormatVersion);
             if (m.matches() && !kafkaBrokerVersion.startsWith(m.group(1))) {
                 warnings.add(StatusUtils.buildWarningCondition("KafkaLogMessageFormatVersion",
                         "log.message.format.version does not match the Kafka cluster version, which suggests that an upgrade is incomplete."));
@@ -97,7 +98,7 @@ public class KafkaSpecChecker {
         String interBrokerProtocolVersion = kafkaCluster.getConfiguration().getConfigOption(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION);
 
         if (interBrokerProtocolVersion != null) {
-            Matcher m = VERSION_REGEX.matcher(interBrokerProtocolVersion);
+            Matcher m = MAJOR_MINOR_REGEX.matcher(interBrokerProtocolVersion);
             if (m.matches() && !kafkaBrokerVersion.startsWith(m.group(1))) {
                 warnings.add(StatusUtils.buildWarningCondition("KafkaInterBrokerProtocolVersion",
                         "inter.broker.protocol.version does not match the Kafka cluster version, which suggests that an upgrade is incomplete."));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecCheckerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecCheckerTest.java
@@ -19,9 +19,6 @@ import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import org.junit.jupiter.api.Test;
 
 import java.io.StringReader;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -262,9 +259,5 @@ public class KafkaSpecCheckerTest {
         KafkaSpecChecker checker = generateChecker(kafka);
         List<Condition> warnings = checker.run();
         assertThat(warnings, hasSize(2));
-    }
-
-    private Date dateSupplier() {
-        return Date.from(LocalDateTime.of(2018, 11, 26, 9, 12, 0).atZone(ZoneId.of("GMT")).toInstant());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecCheckerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecCheckerTest.java
@@ -186,7 +186,21 @@ public class KafkaSpecCheckerTest {
     @Test
     public void checkLogMessageFormatWithRightVersion() {
         Map<String, Object> kafkaOptions = new HashMap<>();
-        kafkaOptions.put(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_VERSION);
+        kafkaOptions.put(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION, KafkaVersionTestUtils.LATEST_FORMAT_VERSION);
+        Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+            emptyMap(), null, kafkaOptions, emptyMap(),
+            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
+                .build();
+
+        KafkaSpecChecker checker = generateChecker(kafka);
+        List<Condition> warnings = checker.run();
+        assertThat(warnings, hasSize(0));
+    }
+
+    @Test
+    public void checkLogMessageFormatWithRightLongVersion() {
+        Map<String, Object> kafkaOptions = new HashMap<>();
+        kafkaOptions.put(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION, KafkaVersionTestUtils.LATEST_FORMAT_VERSION + "-IV0");
         Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
             emptyMap(), null, kafkaOptions, emptyMap(),
             new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
@@ -241,6 +255,20 @@ public class KafkaSpecCheckerTest {
     public void checkInterBrokerProtocolWithCorrectVersion() {
         Map<String, Object> kafkaOptions = new HashMap<>();
         kafkaOptions.put(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION, KafkaVersionTestUtils.LATEST_PROTOCOL_VERSION);
+        Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+            emptyMap(), null, kafkaOptions, emptyMap(),
+            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
+                .build();
+
+        KafkaSpecChecker checker = generateChecker(kafka);
+        List<Condition> warnings = checker.run();
+        assertThat(warnings, hasSize(0));
+    }
+
+    @Test
+    public void checkInterBrokerProtocolWithCorrectLongVersion() {
+        Map<String, Object> kafkaOptions = new HashMap<>();
+        kafkaOptions.put(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION, KafkaVersionTestUtils.LATEST_PROTOCOL_VERSION + "-IV0");
         Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
             emptyMap(), null, kafkaOptions, emptyMap(),
             new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecCheckerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecCheckerTest.java
@@ -50,7 +50,7 @@ public class KafkaSpecCheckerTest {
                 emptyMap()) { };
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, versions);
         ZookeeperCluster zkCluster = ZookeeperCluster.fromCrd(kafka, versions);
-        return new KafkaSpecChecker(kafka.getSpec(), kafkaCluster, zkCluster);
+        return new KafkaSpecChecker(kafka.getSpec(), versions, kafkaCluster, zkCluster);
     }
 
     @Test
@@ -147,7 +147,7 @@ public class KafkaSpecCheckerTest {
     }
 
     @Test
-    public void checkKafkaVersion() {
+    public void checkLogMessageFormatVersion() {
         Map<String, Object> kafkaOptions = new HashMap<>();
         kafkaOptions.put(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION, KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION);
         Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
@@ -166,6 +166,92 @@ public class KafkaSpecCheckerTest {
         assertThat(warning.getReason(), is("KafkaLogMessageFormatVersion"));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("log.message.format.version does not match the Kafka cluster version, which suggests that an upgrade is incomplete."));
+    }
+
+    @Test
+    public void checkLogMessageFormatWithoutVersion() {
+        Map<String, Object> kafkaOptions = new HashMap<>();
+        kafkaOptions.put(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION, KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION);
+        Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+            emptyMap(), null, kafkaOptions, emptyMap(),
+            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
+                .build();
+
+        KafkaSpecChecker checker = generateChecker(kafka);
+        List<Condition> warnings = checker.run();
+        assertThat(warnings, hasSize(1));
+        Condition warning = warnings.get(0);
+        assertThat(warning.getReason(), is("KafkaLogMessageFormatVersion"));
+        assertThat(warning.getStatus(), is("True"));
+        assertThat(warning.getMessage(), is("log.message.format.version does not match the Kafka cluster version, which suggests that an upgrade is incomplete."));
+    }
+
+    @Test
+    public void checkLogMessageFormatWithRightVersion() {
+        Map<String, Object> kafkaOptions = new HashMap<>();
+        kafkaOptions.put(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_VERSION);
+        Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+            emptyMap(), null, kafkaOptions, emptyMap(),
+            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
+                .build();
+
+        KafkaSpecChecker checker = generateChecker(kafka);
+        List<Condition> warnings = checker.run();
+        assertThat(warnings, hasSize(0));
+    }
+
+    @Test
+    public void checkInterBrokerProtocolVersion() {
+        Map<String, Object> kafkaOptions = new HashMap<>();
+        kafkaOptions.put(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION, KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION);
+        Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+            emptyMap(), null, kafkaOptions, emptyMap(),
+            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
+                .editSpec()
+                    .editKafka()
+                        .withVersion(KafkaVersionTestUtils.LATEST_KAFKA_VERSION)
+                    .endKafka()
+                .endSpec()
+            .build();
+        KafkaSpecChecker checker = generateChecker(kafka);
+        List<Condition> warnings = checker.run();
+        assertThat(warnings, hasSize(1));
+        Condition warning = warnings.get(0);
+        assertThat(warning.getReason(), is("KafkaInterBrokerProtocolVersion"));
+        assertThat(warning.getStatus(), is("True"));
+        assertThat(warning.getMessage(), is("inter.broker.protocol.version does not match the Kafka cluster version, which suggests that an upgrade is incomplete."));
+    }
+
+    @Test
+    public void checkInterBrokerProtocolWithoutVersion() {
+        Map<String, Object> kafkaOptions = new HashMap<>();
+        kafkaOptions.put(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION, KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION);
+        Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+            emptyMap(), null, kafkaOptions, emptyMap(),
+            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
+                .build();
+
+        KafkaSpecChecker checker = generateChecker(kafka);
+        List<Condition> warnings = checker.run();
+        assertThat(warnings, hasSize(1));
+        Condition warning = warnings.get(0);
+        assertThat(warning.getReason(), is("KafkaInterBrokerProtocolVersion"));
+        assertThat(warning.getStatus(), is("True"));
+        assertThat(warning.getMessage(), is("inter.broker.protocol.version does not match the Kafka cluster version, which suggests that an upgrade is incomplete."));
+    }
+
+    @Test
+    public void checkInterBrokerProtocolWithCorrectVersion() {
+        Map<String, Object> kafkaOptions = new HashMap<>();
+        kafkaOptions.put(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION, KafkaVersionTestUtils.LATEST_PROTOCOL_VERSION);
+        Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+            emptyMap(), null, kafkaOptions, emptyMap(),
+            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
+                .build();
+
+        KafkaSpecChecker checker = generateChecker(kafka);
+        List<Condition> warnings = checker.run();
+        assertThat(warnings, hasSize(0));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In #4044 we added `inter.broker.protocol.version` to the YAML files used by users. After upgrades, users will be responsible for updating this value. this PR checks the version and adds a warning if it lacks behind the Kafka version to make sure users are aware of this limitation. This follows the same principle as the existing check of `log.message.format.version`.

In addition, the `.spec.kafka.version` is not specified, the check is done against the default version to make sure users get this warning even when they just use the default version.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally