### PR TITLE
Fix Zip Slip vulnerability in STs

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/FileUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/FileUtils.java
@@ -43,6 +43,10 @@ public class FileUtils {
             while (entry != null) {
                 File file = new File(dir, entry.getName());
 
+                if (!file.toPath().normalize().startsWith(dir.toPath())) {
+                    throw new RuntimeException("Invalid zip entry - unpacks outside of the destination path");
+                }
+
                 if (entry.isDirectory()) {
                     if (file.exists()) {
                         if (!file.isDirectory()) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes the Zip Slip vulnerability found in system tests by CodeQL (https://github.com/strimzi/strimzi-kafka-operator/security/code-scanning/1?query=ref%3Arefs%2Fheads%2Fmaster). It is only in system tests where it downloads our own ZIP files. But better fix it in case we copy the code in the future and to not cause false positives in the scanning tools.

### Checklist

- [x] Make sure all tests pass