### PR TITLE
[DOC] kafka config assembly update for Using Guide

### DIFF
--- a/documentation/assemblies/configuring/assembly-config-kafka.adoc
+++ b/documentation/assemblies/configuring/assembly-config-kafka.adoc
@@ -1,0 +1,56 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-deployment-configuration.adoc
+
+[id='assembly-config-kafka-{context}']
+= Kafka cluster configuration
+
+This section describes how to configure a Kafka deployment in your Strimzi cluster.
+
+You configure Kafka using the `Kafka` resource.
+Configuration options are also available for ZooKeeper and the Entity Operator.
+
+The full schema of the `Kafka` resource is described in xref:type-Kafka-reference[].
+
+.Listener configuration
+You configure listeners for connecting to Kafka brokers.
+For more information on configuring listeners for connecting brokers, see xref:configuration-points-listeners-{context}[Listener configuration]
+
+.Authorizing access to Kafka
+You can configure your Kafka cluster to allow or decline actions executed by users.
+For more information on securing access to Kafka brokers, see xref:assembly-securing-kafka-str[Managing access to Kafka].
+
+.Managing TLS certificates
+When deploying Kafka, the Cluster Operator automatically sets up and renews TLS certificates to enable encryption and authentication within your cluster.
+If required, you can manually renew the cluster and client CA certificates before their renewal period ends.
+You can also replace the keys used by the cluster and client CA certificates.
+For more information, see xref:proc-renewing-ca-certs-manually-{context}[Renewing CA certificates manually] and xref:proc-replacing-private-keys-{context}[Replacing private keys].
+
+.Additional resources
+
+* For more information about Apache Kafka, see the http://kafka.apache.org[Apache Kafka website^].
+
+//procedure to configure Kafka
+include::../../modules/configuring/proc-config-kafka.adoc[leveloffset=+1]
+//entity operator config
+include::assembly-kafka-entity-operator.adoc[leveloffset=+1]
+//storage considerations
+include::assembly-storage.adoc[leveloffset=+1]
+//scaling Kafka clusters
+include::assembly-scaling-clusters.adoc[leveloffset=+1]
+//incorporating jmxtrans metrics
+ifdef::Metrics[]
+include::assembly-jmxtrans.adoc[leveloffset=+1]
+endif::Metrics[]
+//windows (time) for maintenance
+include::assembly-maintenance-time-windows.adoc[leveloffset=+1]
+//connecting to ZooKeeper from terminal
+include::../../modules/configuring/proc-connecting-to-zookeeper.adoc[leveloffset=+1]
+//steps for manual rolling updates
+include::../../modules/configuring/proc-manual-rolling-update-kafka.adoc[leveloffset=+1]
+include::../../modules/configuring/proc-manual-rolling-update-zookeeper.adoc[leveloffset=+1]
+//steps to delete kafka, zookeeper nodes
+include::../../modules/configuring/proc-manual-delete-pod-pvc-kafka.adoc[leveloffset=+1]
+include::../../modules/configuring/proc-manual-delete-pod-pvc-zookeeper.adoc[leveloffset=+1]
+//Kafka cluster resources created
+include::../../modules/configuring/ref-list-of-kafka-cluster-resources.adoc[leveloffset=+1]

--- a/documentation/assemblies/configuring/assembly-config-kafka.adoc
+++ b/documentation/assemblies/configuring/assembly-config-kafka.adoc
@@ -6,15 +6,17 @@
 = Kafka cluster configuration
 
 This section describes how to configure a Kafka deployment in your Strimzi cluster.
+A Kafka cluster is deployed with a ZooKeeper cluster. The deployment can also include the Topic Operator and User Operator, which manage Kafka topics and users.
 
 You configure Kafka using the `Kafka` resource.
-Configuration options are also available for ZooKeeper and the Entity Operator.
+Configuration options are also available for ZooKeeper and the Entity Operator within the `Kafka` resource.
+The Entity Operator comprises the Topic Operator and User Operator.
 
-The full schema of the `Kafka` resource is described in xref:type-Kafka-reference[].
+The full schema of the `Kafka` resource is described in the xref:type-Kafka-reference[].
 
 .Listener configuration
-You configure listeners for connecting to Kafka brokers.
-For more information on configuring listeners for connecting brokers, see xref:configuration-points-listeners-{context}[Listener configuration]
+You configure listeners for connecting clients to Kafka brokers.
+For more information on configuring listeners for connecting brokers, see xref:configuration-points-listeners-{context}[Listener configuration].
 
 .Authorizing access to Kafka
 You can configure your Kafka cluster to allow or decline actions executed by users.

--- a/documentation/assemblies/configuring/assembly-customizing-kubernetes-resources.adoc
+++ b/documentation/assemblies/configuring/assembly-customizing-kubernetes-resources.adoc
@@ -1,0 +1,56 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-deployment-configuration.adoc
+
+[id='assembly-customizing-kubernetes-resources-{context}']
+= Customizing Kubernetes resources
+
+Strimzi creates several Kubernetes resources, such as `Deployments`, `StatefulSets`, `Pods`, and `Services`, which are managed by Strimzi operators.
+Only the operator that is responsible for managing a particular Kubernetes resource can change that resource.
+If you try to manually change an operator-managed Kubernetes resource, the operator will revert your changes back.
+
+However, changing an operator-managed Kubernetes resource can be useful if you want to perform certain tasks, such as:
+
+- Adding custom labels or annotations that control how `Pods` are treated by Istio or other services
+- Managing how `Loadbalancer`-type Services are created by the cluster
+
+You can make such changes using the `template` property in the Strimzi custom resources.
+The `template` property is supported in the following resources.
+The API reference provides more details about the customizable fields.
+
+`Kafka.spec.kafka`:: See xref:type-KafkaClusterTemplate-reference[]
+`Kafka.spec.zookeeper`:: See xref:type-ZookeeperClusterTemplate-reference[]
+`Kafka.spec.entityOperator`:: See xref:type-EntityOperatorTemplate-reference[]
+`Kafka.spec.kafkaExporter`:: See xref:type-KafkaExporterTemplate-reference[]
+`Kafka.spec.cruiseControl`:: See xref:type-CruiseControlTemplate-reference[]
+`Kafka.spec.jmxTrans`:: See xref:type-JmxTransTemplate-reference[]
+`KafkaConnect.spec`:: See xref:type-KafkaConnectTemplate-reference[]
+`KafkaConnectS2I.spec`:: See xref:type-KafkaConnectTemplate-reference[]
+`KafkaMirrorMaker.spec`:: See xref:type-KafkaMirrorMakerTemplate-reference[]
+`KafkaMirrorMaker2.spec`:: See xref:type-KafkaConnectTemplate-reference[]
+`KafkaBridge.spec`:: See xref:type-KafkaBridgeTemplate-reference[]
+`KafkaUser.spec`:: See xref:type-KafkaUserTemplate-reference[]
+
+In the following example, the `template` property is used to modify the labels in a Kafka broker's `StatefulSet`:
+
+.Example template customization
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+  labels:
+    app: my-cluster
+spec:
+  kafka:
+    # ...
+    template:
+      statefulset:
+        metadata:
+          labels:
+            mylabel: myvalue
+    # ...
+----
+
+include::../../modules/configuring/con-customizing-image-pull-policy.adoc[leveloffset=+1]

--- a/documentation/assemblies/configuring/assembly-deployment-configuration.adoc
+++ b/documentation/assemblies/configuring/assembly-deployment-configuration.adoc
@@ -1,0 +1,37 @@
+// This assembly is included in the following assemblies:
+//
+// master.adoc
+
+[id='assembly-deployment-configuration-{context}']
+
+= Deployment configuration
+
+This chapter describes how to configure different aspects of the supported deployments using custom resources:
+
+* Kafka clusters
+* Kafka Connect clusters
+* Kafka Connect clusters with _Source2Image_ support
+* Kafka MirrorMaker
+* Kafka Bridge
+* Cruise Control
+
+NOTE: Labels applied to a custom resource are also applied to the Kubernetes resources comprising Kafka MirrorMaker.
+This provides a convenient mechanism for resources to be labeled as required.
+
+The _Deploying and Upgrading Strimzi_ guide describes how to link:{BookURLDeploying}#assembly-metrics-str[monitor your Strimzi deployment^].
+
+include::assembly-config-kafka.adoc[leveloffset=+1]
+
+include::assembly-config-kafka-connect.adoc[leveloffset=+1]
+
+include::assembly-config-mirrormaker.adoc[leveloffset=+1]
+
+include::assembly-config-mirrormaker2.adoc[leveloffset=+1]
+
+include::assembly-config-kafka-bridge.adoc[leveloffset=+1]
+
+include::assembly-customizing-kubernetes-resources.adoc[leveloffset=+1]
+
+include::assembly-scheduling.adoc[leveloffset=+1]
+
+include::assembly-external-logging.adoc[leveloffset=+1]

--- a/documentation/assemblies/configuring/assembly-external-logging.adoc
+++ b/documentation/assemblies/configuring/assembly-external-logging.adoc
@@ -1,0 +1,36 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-deployment-configuration.adoc
+
+[id='external-logging_{context}']
+= External logging
+
+When setting the logging levels for a resource, you can specify them _inline_ directly in the `spec.logging` property of the resource YAML:
+
+[source,shell,subs="+quotes,attributes"]
+----
+spec:
+  # ...
+  logging:
+    type: inline
+    loggers:
+      kafka.root.logger.level: "INFO"
+----
+
+Or you can specify _external_ logging:
+
+[source,shell,subs="+quotes,attributes"]
+----
+spec:
+  # ...
+  logging:
+    type: external
+    name: _customConfigMap_
+----
+
+With external logging, logging properties are defined in a ConfigMap.
+The name of the ConfigMap is referenced in the `spec.logging.name` property.
+
+The advantages of using a ConfigMap are that the logging properties are maintained in one place and are accessible to more than one resource.
+
+include::../../modules/configuring/proc-creating-configmap.adoc[leveloffset=+1]

--- a/documentation/assemblies/configuring/assembly-jmxtrans.adoc
+++ b/documentation/assemblies/configuring/assembly-jmxtrans.adoc
@@ -1,0 +1,20 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-config-kafka.adoc
+
+[id='assembly-jmxtrans-{context}']
+= Retrieving JMX metrics with JmxTrans
+
+link:https://github.com/jmxtrans/jmxtrans[JmxTrans^] is a tool for retrieving JMX metrics data from Java processes and pushing that data, in various formats, to remote sinks inside or outside the cluster.
+JmxTrans can communicate with a secure JMX port.
+
+Strimzi supports using JmxTrans to read JMX metrics from Kafka brokers.
+
+JmxTrans reads JMX metrics data from secure or insecure Kafka brokers and pushes the data to remote sinks in various data formats.
+For example, JmxTrans can obtain JMX metrics about the request rate of each Kafka broker's network and then push the data to a Logstash database outside the Kubernetes cluster.
+
+include::../../modules/configuring/proc-jmxtrans-deployment.adoc[leveloffset=+1]
+
+== Additional resources
+
+For more information about JmxTrans, see the link:https://github.com/jmxtrans/jmxtrans[JmxTrans github^].

--- a/documentation/assemblies/configuring/assembly-kafka-entity-operator.adoc
+++ b/documentation/assemblies/configuring/assembly-kafka-entity-operator.adoc
@@ -1,0 +1,27 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-config-kafka.adoc
+
+[id='assembly-kafka-entity-operator-{context}']
+
+= Configuring the Entity Operator
+
+The Entity Operator is responsible for managing Kafka-related entities in a running Kafka cluster.
+
+The Entity Operator comprises the:
+
+* xref:overview-concepts-topic-operator-str[Topic Operator] to manage Kafka topics
+* xref:overview-concepts-user-operator-str[User Operator] to manage Kafka users
+
+Through `Kafka` resource configuration, the Cluster Operator can deploy the Entity Operator, including one or both operators, when deploying a Kafka cluster.
+
+NOTE: When deployed, the Entity Operator contains the operators according to the deployment configuration.
+
+The operators are automatically configured to manage the topics and users of the Kafka cluster.
+
+include::../../modules/configuring/ref-kafka-entity-operator.adoc[leveloffset=+1]
+
+//topic operator config
+include::../../modules/configuring/con-configuring-topic-operator.adoc[leveloffset=+1]
+//user operator config
+include::../../modules/configuring/con-configuring-user-operator.adoc[leveloffset=+1]

--- a/documentation/assemblies/configuring/assembly-maintenance-time-windows.adoc
+++ b/documentation/assemblies/configuring/assembly-maintenance-time-windows.adoc
@@ -1,0 +1,15 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-config-kafka.adoc
+
+[id='assembly-maintenance-time-windows-{context}']
+
+= Maintenance time windows for rolling updates
+
+Maintenance time windows allow you to schedule certain rolling updates of your Kafka and ZooKeeper clusters to start at a convenient time.
+
+include::../../modules/configuring/con-maintenance-time-windows-overview.adoc[leveloffset=+1]
+
+include::../../modules/configuring/con-maintenance-time-window-definition.adoc[leveloffset=+1]
+
+include::../../modules/configuring/proc-configuring-maintenance-time-windows.adoc[leveloffset=+1]

--- a/documentation/assemblies/configuring/assembly-scaling-clusters.adoc
+++ b/documentation/assemblies/configuring/assembly-scaling-clusters.adoc
@@ -1,0 +1,22 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-config-kafka.adoc
+
+[id='scaling-clusters-{context}']
+= Scaling clusters
+
+include::../../modules/configuring/con-scaling-kafka-clusters.adoc[leveloffset=+1]
+
+include::../../modules/configuring/con-partition-reassignment.adoc[leveloffset=+1]
+
+include::../../modules/configuring/proc-generating-reassignment-json-files.adoc[leveloffset=+1]
+
+== Creating reassignment JSON files manually
+
+You can manually create the reassignment JSON file if you want to move specific partitions.
+
+include::../../modules/configuring/con-reassignment-throttles.adoc[leveloffset=+1]
+
+include::../../modules/configuring/proc-scaling-up-a-kafka-cluster.adoc[leveloffset=+1]
+
+include::../../modules/configuring/proc-scaling-down-a-kafka-cluster.adoc[leveloffset=+1]

--- a/documentation/assemblies/configuring/assembly-scheduling.adoc
+++ b/documentation/assemblies/configuring/assembly-scheduling.adoc
@@ -1,0 +1,18 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-deployment-configuration.adoc
+
+[id='assembly-scheduling-{context}']
+= Configuring pod scheduling
+
+When two applications are scheduled to the same Kubernetes node, both applications might use the same resources like disk I/O and impact performance.
+That can lead to performance degradation.
+Scheduling Kafka pods in a way that avoids sharing nodes with other critical workloads, using the right nodes or dedicated a set of nodes only for Kafka are the best ways how to avoid such problems.
+
+include::../../modules/configuring/ref-affinity.adoc[leveloffset=+1]
+
+include::../../modules/configuring/proc-scheduling-based-on-other-pods.adoc[leveloffset=+1]
+
+include::../../modules/configuring/proc-scheduling-deployment-to-node-using-node-affinity.adoc[leveloffset=+1]
+
+include::../../modules/configuring/proc-dedicated-nodes.adoc[leveloffset=+1]

--- a/documentation/assemblies/configuring/assembly-storage.adoc
+++ b/documentation/assemblies/configuring/assembly-storage.adoc
@@ -1,0 +1,44 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-config-kafka.adoc
+
+[id='assembly-storage-{context}']
+= Kafka and ZooKeeper storage types
+
+As stateful applications, Kafka and ZooKeeper need to store data on disk. Strimzi supports three storage types for this data:
+
+* Ephemeral
+* Persistent
+* JBOD storage
+
+NOTE: JBOD storage is supported only for Kafka, not for ZooKeeper.
+
+When configuring a `Kafka` resource, you can specify the type of storage used by the Kafka broker and its corresponding ZooKeeper node. You configure the storage type using the `storage` property in the following resources:
+
+* `Kafka.spec.kafka`
+* `Kafka.spec.zookeeper`
+
+The storage type is configured in the `type` field.
+
+WARNING: The storage type cannot be changed after a Kafka cluster is deployed.
+
+.Additional resources
+
+* For more information about ephemeral storage, see xref:type-EphemeralStorage-reference[ephemeral storage schema reference].
+* For more information about persistent storage, see xref:type-PersistentClaimStorage-reference[persistent storage schema reference].
+* For more information about JBOD storage, see xref:type-JbodStorage-reference[JBOD schema reference].
+* For more information about the schema for `Kafka`, see xref:type-Kafka-reference[`Kafka` schema reference].
+
+include::../../modules/configuring/con-considerations-for-data-storage.adoc[leveloffset=+1]
+
+include::../../modules/configuring/ref-storage-ephemeral.adoc[leveloffset=+1]
+
+include::../../modules/configuring/ref-storage-persistent.adoc[leveloffset=+1]
+
+include::../../modules/configuring/proc-resizing-persistent-volumes.adoc[leveloffset=+1]
+
+include::../../modules/configuring/ref-storage-jbod.adoc[leveloffset=+1]
+
+include::../../modules/configuring/proc-adding-volumes-to-jbod-storage.adoc[leveloffset=+1]
+
+include::../../modules/configuring/proc-removing-volumes-from-jbod-storage.adoc[leveloffset=+1]

--- a/documentation/modules/configuring/con-configuring-topic-operator.adoc
+++ b/documentation/modules/configuring/con-configuring-topic-operator.adoc
@@ -23,7 +23,7 @@ Default `20`.
 `topicMetadataMaxAttempts`::
 The number of attempts at getting topic metadata from Kafka.
 The time between each attempt is defined as an exponential back-off.
-Consider increasing this value when topic creation could take more time due to the number of partitions or replicas.
+Consider increasing this value when topic creation might take more time due to the number of partitions or replicas.
 Default `6`.
 
 `image`::

--- a/documentation/modules/configuring/con-configuring-topic-operator.adoc
+++ b/documentation/modules/configuring/con-configuring-topic-operator.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// assembly-kafka-entity-operator.adoc
+
+[id='topic-operator-{context}']
+= Topic Operator configuration properties
+
+Topic Operator deployment can be configured using additional options inside the `topicOperator` object.
+The following properties are supported:
+
+`watchedNamespace`::
+The Kubernetes namespace in which the topic operator watches for `KafkaTopics`.
+Default is the namespace where the Kafka cluster is deployed.
+
+`reconciliationIntervalSeconds`::
+The interval between periodic reconciliations in seconds.
+Default `90`.
+
+`zookeeperSessionTimeoutSeconds`::
+The ZooKeeper session timeout in seconds.
+Default `20`.
+
+`topicMetadataMaxAttempts`::
+The number of attempts at getting topic metadata from Kafka.
+The time between each attempt is defined as an exponential back-off.
+Consider increasing this value when topic creation could take more time due to the number of partitions or replicas.
+Default `6`.
+
+`image`::
+The `image` property can be used to configure the container image which will be used.
+For more details about configuring custom container images, see xref:con-common-configuration-images-reference[].
+
+`resources`::
+The `resources` property configures the amount of resources allocated to the Topic Operator.
+For more details about resource request and limit configuration, see xref:con-common-configuration-resources-reference[].
+
+`logging`::
+The `logging` property configures the logging of the Topic Operator.
+For more details, see xref:property-topic-operator-logging-reference[].
+
+.Example Topic Operator configuration
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    # ...
+  zookeeper:
+    # ...
+  entityOperator:
+    # ...
+    topicOperator:
+      watchedNamespace: my-topic-namespace
+      reconciliationIntervalSeconds: 60
+    # ...
+----

--- a/documentation/modules/configuring/con-configuring-user-operator.adoc
+++ b/documentation/modules/configuring/con-configuring-user-operator.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// assembly-kafka-entity-operator.adoc
+
+[id='user-operator-{context}']
+= User Operator configuration properties
+
+User Operator deployment can be configured using additional options inside the `userOperator` object.
+The following properties are supported:
+
+`watchedNamespace`::
+The Kubernetes namespace in which the user operator watches for `KafkaUsers`.
+Default is the namespace where the Kafka cluster is deployed.
+
+`reconciliationIntervalSeconds`::
+The interval between periodic reconciliations in seconds.
+Default `120`.
+
+`zookeeperSessionTimeoutSeconds`::
+The ZooKeeper session timeout in seconds.
+Default `6`.
+
+`image`::
+The `image` property can be used to configure the container image which will be used.
+For more details about configuring custom container images, see xref:con-common-configuration-images-reference[].
+
+`resources`::
+The `resources` property configures the amount of resources allocated to the User Operator.
+For more details about resource request and limit configuration, see xref:con-common-configuration-resources-reference[].
+
+`logging`::
+The `logging` property configures the logging of the User Operator.
+For more details, see xref:property-topic-operator-logging-reference[].
+
+`secretPrefix`::
+The `secretPrefix` property adds a prefix to the name of all Secrets created from the KafkaUser resource. For example, `STRIMZI_SECRET_PREFIX=kafka-` would prefix all Secret names with `kafka-`. So a KafkaUser named `my-user` would create a Secret named `kafka-my-user`.
+
+.Example User Operator configuration
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    # ...
+  zookeeper:
+    # ...
+  entityOperator:
+    # ...
+    userOperator:
+      watchedNamespace: my-user-namespace
+      reconciliationIntervalSeconds: 60
+    # ...
+----

--- a/documentation/modules/configuring/con-considerations-for-data-storage.adoc
+++ b/documentation/modules/configuring/con-considerations-for-data-storage.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// assembly-deployment-configuration-kafka.adoc
+
+[id='considerations-for-data-storage-{context}']
+
+= Data storage considerations
+
+An efficient data storage infrastructure is essential to the optimal performance of Strimzi.
+
+Block storage is required.
+File storage, such as NFS, does not work with Kafka.
+
+For your block storage, you can choose, for example:
+
+* Cloud-based block storage solutions, such as {aws-ebs}
+* {K8sLocalPersistentVolumes}
+* Storage Area Network (SAN) volumes accessed by a protocol such as _Fibre Channel_ or _iSCSI_
+
+NOTE: Strimzi does not require Kubernetes raw block volumes.
+
+== File systems
+
+It is recommended that you configure your storage system to use the _XFS_ file system.
+Strimzi is also compatible with the _ext4_ file system, but this might require additional configuration for best results.
+
+== Apache Kafka and ZooKeeper storage
+Use separate disks for Apache Kafka and ZooKeeper.
+
+Three types of data storage are supported:
+
+* Ephemeral (Recommended for development only)
+* Persistent
+* JBOD  (Just a Bunch of Disks, suitable for Kafka only)
+
+For more information, see xref:assembly-storage-{context}[Kafka and ZooKeeper storage].
+
+Solid-state drives (SSDs), though not essential, can improve the performance of Kafka in large clusters where data is sent to and received from multiple topics asynchronously. SSDs are particularly effective with ZooKeeper, which requires fast, low latency data access.
+
+NOTE: You do not need to provision replicated storage because Kafka and ZooKeeper both have built-in data replication.

--- a/documentation/modules/configuring/con-customizing-image-pull-policy.adoc
+++ b/documentation/modules/configuring/con-customizing-image-pull-policy.adoc
@@ -1,0 +1,27 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-customizing-kubernetes-resources.adoc
+
+[id='con-customizing-image-pull-policy-{context}']
+= Customizing the image pull policy
+
+Strimzi allows you to customize the image pull policy for containers in all pods deployed by the Cluster Operator.
+The image pull policy is configured using the environment variable `STRIMZI_IMAGE_PULL_POLICY` in the Cluster Operator deployment.
+The `STRIMZI_IMAGE_PULL_POLICY` environment variable can be set to three different values:
+
+`Always`::
+Container images are pulled from the registry every time the pod is started or restarted.
+
+`IfNotPresent`::
+Container images are pulled from the registry only when they were not pulled before.
+
+`Never`::
+Container images are never pulled from the registry.
+
+The image pull policy can be currently customized only for all Kafka, Kafka Connect, and Kafka MirrorMaker clusters at once.
+Changing the policy will result in a rolling update of all your Kafka, Kafka Connect, and Kafka MirrorMaker clusters.
+
+.Additional resources
+
+* For more information about Cluster Operator configuration, see xref:using-the-cluster-operator-{context}[].
+* For more information about Image Pull Policies, see {K8sImagePullPolicies}.

--- a/documentation/modules/configuring/con-maintenance-time-window-definition.adoc
+++ b/documentation/modules/configuring/con-maintenance-time-window-definition.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// assembly-maintenance-time-windows.adoc
+
+[id='con-maintenance-time-window-definition-{context}']
+= Maintenance time window definition
+
+You configure maintenance time windows by entering an array of strings in the `Kafka.spec.maintenanceTimeWindows` property.
+Each string is a {CronExpression} interpreted as being in UTC (Coordinated Universal Time, which for practical purposes is the same as Greenwich Mean Time).
+
+The following example configures a single maintenance time window that starts at midnight and ends at 01:59am (UTC), on Sundays, Mondays, Tuesdays, Wednesdays, and Thursdays:
+
+[source,yaml,subs="attributes+"]
+----
+# ...
+maintenanceTimeWindows:
+  - "* * 0-1 ? * SUN,MON,TUE,WED,THU *"
+# ...
+----
+
+In practice, maintenance windows should be set in conjunction with the `Kafka.spec.clusterCa.renewalDays` and `Kafka.spec.clientsCa.renewalDays` properties of the `Kafka` resource, to ensure that the necessary CA certificate renewal can be completed in the configured maintenance time windows.
+
+NOTE: Strimzi does not schedule maintenance operations exactly according to the given windows. Instead, for each reconciliation, it checks whether a maintenance window is currently "open".
+This means that the start of maintenance operations within a given time window can be delayed by up to the Cluster Operator reconciliation interval.
+Maintenance time windows must therefore be at least this long.
+
+.Additional resources
+
+* For more information about the Cluster Operator configuration, see xref:ref-operator-cluster-str[].

--- a/documentation/modules/configuring/con-maintenance-time-windows-overview.adoc
+++ b/documentation/modules/configuring/con-maintenance-time-windows-overview.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// assembly-maintenance-time-windows.adoc
+
+[id='con-maintenance-time-windows-overview-{context}']
+= Maintenance time windows overview
+
+In most cases, the Cluster Operator only updates your Kafka or ZooKeeper clusters in response to changes to the corresponding `Kafka` resource.
+This enables you to plan when to apply changes to a `Kafka` resource to minimize the impact on Kafka client applications.
+
+However, some updates to your Kafka and ZooKeeper clusters can happen without any corresponding change to the `Kafka` resource.
+For example, the Cluster Operator will need to perform a rolling restart if a CA (Certificate Authority) certificate that it manages is close to expiry.
+
+While a rolling restart of the pods should not affect _availability_ of the service (assuming correct broker and topic configurations), it could affect _performance_ of the Kafka client applications.
+Maintenance time windows allow you to schedule such spontaneous rolling updates of your Kafka and ZooKeeper clusters to start at a convenient time.
+If maintenance time windows are not configured for a cluster then it is possible that such spontaneous rolling updates will happen at an inconvenient time, such as during a predictable period of high load.
+

--- a/documentation/modules/configuring/con-partition-reassignment.adoc
+++ b/documentation/modules/configuring/con-partition-reassignment.adoc
@@ -1,0 +1,112 @@
+// Module included in the following assemblies:
+//
+// assembly-scaling-clusters.adoc
+
+[id='con-partition-reassignment-{context}']
+
+= Partition reassignment
+
+The Topic Operator does not currently support reassigning replicas to different brokers, so it is necessary to connect directly to broker pods to reassign replicas to brokers.
+
+Within a broker pod, the `kafka-reassign-partitions.sh` utility allows you to reassign partitions to different brokers.
+
+It has three different modes:
+
+`--generate`::
+Takes a set of topics and brokers and generates a _reassignment JSON file_ which will result in the partitions of those topics being assigned to those brokers.
+Because this operates on whole topics, it cannot be used when you just need to reassign some of the partitions of some topics.
+
+`--execute`::
+Takes a _reassignment JSON file_ and applies it to the partitions and brokers in the cluster.
+Brokers that gain partitions as a result become followers of the partition leader.
+For a given partition, once the new broker has caught up and joined the ISR (in-sync replicas) the old broker will stop being a follower and will delete its replica.
+
+`--verify`::
+Using the same _reassignment JSON file_ as the `--execute` step, `--verify` checks whether all of the partitions in the file have been moved to their intended brokers.
+If the reassignment is complete, --verify also removes any xref:con-reassignment-throttles-{context}[throttles] that are in effect.
+Unless removed, throttles will continue to affect the cluster even after the reassignment has finished.
+
+It is only possible to have one reassignment running in a cluster at any given time, and it is not possible to cancel a running reassignment.
+If you need to cancel a reassignment, wait for it to complete and then perform another reassignment to revert the effects of the first reassignment.
+The `kafka-reassign-partitions.sh` will print the reassignment JSON for this reversion as part of its output.
+Very large reassignments should be broken down into a number of smaller reassignments in case there is a need to stop in-progress reassignment.
+
+== Reassignment JSON file
+
+The _reassignment JSON file_ has a specific structure:
+
+[source,subs=+quotes]
+----
+{
+  "version": 1,
+  "partitions": [
+    _<PartitionObjects>_
+  ]
+}
+----
+
+Where _<PartitionObjects>_ is a comma-separated list of objects like:
+
+[source,subs=+quotes]
+----
+{
+  "topic": _<TopicName>_,
+  "partition": _<Partition>_,
+  "replicas": [ _<AssignedBrokerIds>_ ]
+}
+----
+
+NOTE: Although Kafka also supports a `"log_dirs"` property this should not be used in Strimzi.
+
+The following is an example reassignment JSON file that assigns topic `topic-a`, partition `4` to brokers `2`, `4` and `7`, and topic `topic-b` partition `2` to brokers `1`, `5` and `7`:
+
+[source,json]
+----
+{
+  "version": 1,
+  "partitions": [
+    {
+      "topic": "topic-a",
+      "partition": 4,
+      "replicas": [2,4,7]
+    },
+    {
+      "topic": "topic-b",
+      "partition": 2,
+      "replicas": [1,5,7]
+    }
+  ]
+}
+----
+
+Partitions not included in the JSON are not changed.
+
+== Reassigning partitions between JBOD volumes
+
+When using JBOD storage in your Kafka cluster, you can choose to reassign the partitions between specific volumes and their log directories (each volume has a single log directory).
+To reassign a partition to a specific volume, add the `log_dirs` option to _<PartitionObjects>_ in the reassignment JSON file.
+
+[source,subs=+quotes]
+----
+{
+  "topic": _<TopicName>_,
+  "partition": _<Partition>_,
+  "replicas": [ _<AssignedBrokerIds>_ ],
+  "log_dirs": [ _<AssignedLogDirs>_ ]
+}
+----
+
+The `log_dirs` object should contain the same number of log directories as the number of replicas specified in the `replicas` object.
+The value should be either an absolute path to the log directory, or the `any` keyword.
+
+For example:
+
+[source,subs=+quotes]
+----
+{
+      "topic": "topic-a",
+      "partition": 4,
+      "replicas": [2,4,7].
+      "log_dirs": [ "/var/lib/kafka/data-0/kafka-log2", "/var/lib/kafka/data-0/kafka-log4", "/var/lib/kafka/data-0/kafka-log7" ]
+}
+----

--- a/documentation/modules/configuring/con-reassignment-throttles.adoc
+++ b/documentation/modules/configuring/con-reassignment-throttles.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// assembly-scaling-clusters.adoc
+
+[id='con-reassignment-throttles-{context}']
+
+= Reassignment throttles
+
+Partition reassignment can be a slow process because it involves transferring large amounts of data between brokers.
+To avoid a detrimental impact on clients, you can throttle the reassignment process.
+This might cause the reassignment to take longer to complete.
+
+* If the throttle is too low then the newly assigned brokers will not be able to keep up with records being published and the reassignment will never complete.
+
+* If the throttle is too high then clients will be impacted.
+
+For example, for producers, this could manifest as higher than normal latency waiting for acknowledgement. For consumers, this could manifest as a drop in throughput caused by higher latency between polls.
+

--- a/documentation/modules/configuring/con-scaling-kafka-clusters.adoc
+++ b/documentation/modules/configuring/con-scaling-kafka-clusters.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// assembly-scaling-clusters.adoc
+
+[id='con-scaling-kafka-clusters-{context}']
+
+= Scaling Kafka clusters
+
+== Adding brokers to a cluster
+
+The primary way of increasing throughput for a topic is to increase the number of partitions for that topic. 
+That works because the extra partitions allow the load of the topic to be shared between the different brokers in the cluster.
+However, in situations where every broker is constrained by a particular resource (typically I/O) using more partitions will not result in increased throughput.
+Instead, you need to add brokers to the cluster.
+
+When you add an extra broker to the cluster, Kafka does not assign any partitions to it automatically.
+You must decide which partitions to move from the existing brokers to the new broker.
+
+Once the partitions have been redistributed between all the brokers, the resource utilization of each broker should be reduced.
+
+== Removing brokers from a cluster
+
+Because Strimzi uses `StatefulSets` to manage broker pods, you cannot remove _any_ pod from the cluster. 
+You can only remove one or more of the highest numbered pods from the cluster. 
+For example, in a cluster of 12 brokers the pods are named `_cluster-name_-kafka-0` up to `_cluster-name_-kafka-11`.
+If you decide to scale down by one broker, the `_cluster-name_-kafka-11` will be removed.
+
+Before you remove a broker from a cluster, ensure that it is not assigned to any partitions.
+You should also decide which of the remaining brokers will be responsible for each of the partitions on the broker being decommissioned.
+Once the broker has no assigned partitions, you can scale the cluster down safely.
+
+

--- a/documentation/modules/configuring/proc-adding-volumes-to-jbod-storage.adoc
+++ b/documentation/modules/configuring/proc-adding-volumes-to-jbod-storage.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// assembly-storage.adoc
+
+[id='proc-adding-volumes-to-jbod-storage-{context}']
+= Adding volumes to JBOD storage
+
+This procedure describes how to add volumes to a Kafka cluster configured to use JBOD storage.
+It cannot be applied to Kafka clusters configured to use any other storage type.
+
+NOTE: When adding a new volume under an `id` which was already used in the past and removed, you have to make sure that the previously used `PersistentVolumeClaims` have been deleted.
+
+.Prerequisites
+
+* A Kubernetes cluster
+* A running Cluster Operator
+* A Kafka cluster with JBOD storage
+
+.Procedure
+
+. Edit the `spec.kafka.storage.volumes` property in the `Kafka` resource.
+Add the new volumes to the `volumes` array.
+For example, add the new volume with id `2`:
++
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    # ...
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+      - id: 1
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+      - id: 2
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+    # ...
+  zookeeper:
+    # ...
+----
+
+. Create or update the resource:
++
+[source,shell,subs=+quotes]
+kubectl apply -f _KAFKA-CONFIG-FILE_
+
+. Create new topics or reassign existing partitions to the new disks.
+
+.Additional resources
+
+For more information about reassigning topics, see xref:con-partition-reassignment-{context}[].

--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -14,19 +14,19 @@ This procedure shows only some of the possible configuration options, but those 
 
 * Resource requests (CPU / Memory)
 * JVM options for maximum and minimum memory allocation
-* Listeners (and authentication)
+* Listeners (and authentication of clients)
 * Authentication
 * Storage
 * Rack awareness
 * Metrics
-* Cruise Control
+* Cruise Control for cluster rebalancing
 
 .Prerequisites
 
 * An OpenShift cluster
 * A running Cluster Operator
 
-See the _Deploying and Upgrading Strimzi_ guide for instructions on running a:
+See the _Deploying and Upgrading Strimzi_ guide for instructions on deploying a:
 
 * link:{BookURLDeploying}#cluster-operator-str[Cluster Operator^]
 * link:{BookURLDeploying}#deploying-kafka-cluster-str[Kafka cluster^]
@@ -185,15 +185,15 @@ spec:
     tlsSidecar: <36>
     # ...
 ----
-<1> xref:con-common-configuration-replicas-reference[The number of broker nodes]. If your cluster already has topics defined, you can
+<1> xref:con-common-configuration-replicas-reference[The number of replica nodes]. If your cluster already has topics defined, you can
 xref:scaling-clusters-{context}[scale clusters].
-<2> Kafka version, which can be changed by following link:{BookURLDeploying}#assembly-upgrade-str[the upgrade procedure].
+<2> Kafka version, which can be changed to a supported version by following link:{BookURLDeploying}#assembly-upgrade-str[the upgrade procedure].
 <3> Specified xref:property-kafka-logging-reference[Kafka loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` key. For the Kafka `kafka.root.logger.level` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
 <4> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
 <5> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
 <6> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka.
 <7> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
-<8> Listeners configure how clients connect to the Kafka cluster via bootstrap addresses. Listeners are xref:assembly-securing-kafka-brokers-str[configured as _internal_ or _external_ listeners for connection inside or outside the Kubernetes cluster].
+<8> Listeners configure how clients connect to the Kafka cluster via bootstrap addresses. Listeners are xref:assembly-securing-kafka-brokers-str[configured as _internal_ or _external_ listeners for connection from inside or outside the Kubernetes cluster].
 <9> Name to identify the listener. Must be unique within the Kafka cluster.
 <10> Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
 <11> Listener type specified as `internal`, or for external listeners, as `route`, `loadbalancer`, `nodeport` or `ingress`.
@@ -201,16 +201,16 @@ xref:scaling-clusters-{context}[scale clusters].
 <13> Defines whether the fully-qualified DNS names including the cluster service suffix (usually `.cluster.local`) are assigned.
 <14> Listener authentication mechanism xref:assembly-securing-kafka-brokers-str[specified as mutual TLS, SCRAM-SHA-512 or token-based OAuth 2.0].
 <15> External listener configuration specifies xref:assembly-configuring-external-listeners-str[how the Kafka cluster is exposed outside Kubernetes, such as through a `route`, `loadbalancer` or `nodeport`].
-<16> Optional configuration for a xref:kafka-listener-certificates-str[Kafka listener certificate] managed by an external Certificate Authority. The `brokerCertChainAndKey` property specifies a `Secret` that holds a server certificate and a private key. Kafka listener certificates can also be configured for TLS listeners.
-<17> Authorization xref:con-securing-kafka-authorization-str[enables simple, OAUTH 2.0 or OPA authorization on the Kafka broker.] Simple authorization uses the `AclAuthorizer` Kafka plugin.
-<18> Config specifies the broker configuration. xref:property-kafka-config-reference[Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi].
+<16> Optional configuration for a xref:kafka-listener-certificates-str[Kafka listener certificate] managed by an external Certificate Authority. The `brokerCertChainAndKey` specifies a `Secret` that contains a server certificate and a private key. You can configure Kafka listener certificates for both `tls` and `external` listeners.
+<17> Authorization xref:con-securing-kafka-authorization-str[enables simple, OAUTH 2.0, or OPA authorization on the Kafka broker.] Simple authorization uses the `AclAuthorizer` Kafka plugin.
+<18> The `config` specifies the broker configuration. xref:property-kafka-config-reference[Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi].
 <19> xref:con-common-configuration-ssl-reference[SSL properties for external listeners to run with a specific _cipher suite_ for a TLS version].
-<20> Storage is xref:assembly-storage-{context}[configured as `ephemeral`, `persistent-claim` or `jbod`].
+<20> xref:assembly-storage-{context}[Storage] is configured as `ephemeral`, `persistent-claim` or `jbod`.
 <21> Storage size for xref:proc-resizing-persistent-volumes-{context}[persistent volumes may be increased] and additional xref:proc-adding-volumes-to-jbod-storage-{context}[volumes may be added to JBOD storage].
 <22> Persistent storage has xref:ref-persistent-storage-{context}[additional configuration options], such as a storage `id` and `class` for dynamic volume provisioning.
 <23> xref:type-Rack-reference[Rack awareness] is configured to spread replicas across different racks. A `topologykey` must match the label of a cluster node.
-<24> xref:con-common-configuration-prometheus-reference[Prometheus metrics], which are enabled with configuration for the Prometheus JMX exporter in this example. You can enable metrics without further configuration using `metrics: {}`.
-<25> Kafka rules for exporting metrics to a Grafana dashboard through the JMX Exporter. A set of rules provided with Strimzi may be copied to your Kafka resource configuration.
+<24> xref:con-common-configuration-prometheus-reference[Prometheus metrics] enabled. In this example, metrics are configured for the Prometheus JMX Exporter (the default metrics exporter). You can enable metrics without further configuration using `metrics: {}`.
+<25> Prometheus rules for exporting metrics to a Grafana dashboard through the Prometheus JMX Exporter. A set of Prometheus rules provided with Strimzi may be copied to your Kafka resource configuration.
 <26> xref:property-kafka-jmx-reference[JMX options] to open JMX port 9999 to obtain JMX metrics, which is configured for password protection in this example. You can open the port without protection using `jmxOptions: {}`.
 <27> ZooKeeper-specific configuration, which contains properties similar to the Kafka configuration.
 <28> xref:con-common-configuration-replicas-reference[The number of ZooKeeper nodes]. ZooKeeper clusters or ensembles usually run with an odd number of nodes, typically three, five, or seven. The majority of nodes must be available in order to maintain an effective quorum.
@@ -219,11 +219,10 @@ Having a stable and highly available ZooKeeper cluster is crucial for Strimzi.
 <29> Specified xref:property-zookeeper-logging-reference[ZooKeeper loggers and log levels].
 <30> Entity Operator configuration, which xref:assembly-kafka-entity-operator-{context}[specifies the configuration for the Topic Operator and User Operator].
 <31> Entity Operator xref:type-TlsSidecar-reference[TLS sidecar configuration]. Entity Operator uses the TLS sidecar for secure communication with ZooKeeper.
-<32> Specified xref:property-topic-operator-logging-reference[Topic Operator loggers and log levels].
+<32> Specified xref:property-topic-operator-logging-reference[Topic Operator loggers and log levels]. This example uses `inline` logging.
 <33> Specified xref:property-user-operator-logging-reference[User Operator loggers and log levels].
-<34> Kafka Exporter configuration, to deploy Kafka Exporter in your cluster and expose data as Prometheus metrics. Kafka Exporter extracts data for analysis as Prometheus metrics, primarily data relating to offsets, consumer groups, consumer lag and topics.
-For information on setting up Kafka Exporter and why it is important to monitor consumer lag for performance, see link:{BookURLDeploying}#assembly-metrics-kafka-exporter-str[Kafka Exporter] in the _Deploying and Upgrading Strimzi_ guide.
-<35> Cruise Control configuration, which is used xref:cruise-control-concepts-str[to rebalance the Kafka cluster].
+<34> Kafka Exporter configuration. link:{BookURLDeploying}#assembly-metrics-kafka-exporter-str[Kafka Exporter] is an optional component for extracting metrics data from Kafka brokers, in particular consumer lag data.
+<35> Optional configuration for Cruise Control, which is used to xref:cruise-control-concepts-str[rebalance the Kafka cluster].
 <36> Cruise Control xref:type-TlsSidecar-reference[TLS sidecar configuration]. Cruise Control uses the TLS sidecar for secure communication with ZooKeeper.
 
 . Create or update the resource:

--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -1,0 +1,232 @@
+// Module included in the following assemblies:
+//
+// assembly-config-kafka.adoc
+
+[id='proc-config-kafka-{context}']
+= Configuring Kafka
+
+Use the properties of the `Kafka` resource to configure your Kafka deployment.
+
+As well as configuring Kafka, you can add configuration for ZooKeeper and the Strimzi Operators.
+Common configuration properties, such as logging and healthchecks, are configured independently for each component.
+
+This procedure shows only some of the possible configuration options, but those that are particularly important include:
+
+* Resource requests (CPU / Memory)
+* JVM options for maximum and minimum memory allocation
+* Listeners (and authentication)
+* Authentication
+* Storage
+* Rack awareness
+* Metrics
+* Cruise Control
+
+.Prerequisites
+
+* An OpenShift cluster
+* A running Cluster Operator
+
+See the _Deploying and Upgrading Strimzi_ guide for instructions on running a:
+
+* link:{BookURLDeploying}#cluster-operator-str[Cluster Operator^]
+* link:{BookURLDeploying}#deploying-kafka-cluster-str[Kafka cluster^]
+
+.Procedure
+
+. Edit the `spec` properties for the `Kafka` resource.
++
+The properties you can configure are shown in this example configuration:
++
+[source,shell,subs="+attributes"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    replicas: 3 <1>
+    version: {ProductVersion} <2>
+    logging: <3>
+      type: inline
+      loggers:
+        kafka.root.logger.level: "INFO"
+    resources: <4>
+      requests:
+        memory: 64Gi
+        cpu: "8"
+      limits:
+        memory: 64Gi
+        cpu: "12"
+    readinessProbe: <5>
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    livenessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    jvmOptions: <6>
+      -Xms: 8192m
+      -Xmx: 8192m
+    image: my-org/my-image:latest <7>
+    listeners: <8>
+      - name: plain <9>
+        port: 9092 <10>
+        type: internal <11>
+        tls: false <12>
+        configuration:
+          useServiceDnsDomain: true <13>
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+        authentication: <14>
+          type: tls
+      - name: external <15>
+        port: 9094
+        type: route
+        tls: true
+        configuration:
+          brokerCertChainAndKey: <16>
+            secretName: my-secret
+            certificate: my-certificate.crt
+            key: my-key.key
+    authorization: <17>
+      type: simple
+    config: <18>
+      auto.create.topics.enable: "false"
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <19>
+      ssl.enabled.protocols: "TLSv1.2"
+      ssl.protocol: "TLSv1.2"
+    storage: <20>
+      type: persistent-claim <21>
+      size: 10000Gi <22>
+    rack: <23>
+      topologyKey: topology.kubernetes.io/zone
+    metrics: <24>
+      lowercaseOutputName: true
+      rules: <25>
+      # Special cases and very specific rules
+      - pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
+        name: kafka_server_$1_$2
+        type: GAUGE
+        labels:
+          clientId: "$3"
+          topic: "$4"
+          partition: "$5"
+    jmxOptions: <26>
+      authentication:
+        type: "password"
+    # ...
+  zookeeper: <27>
+    replicas: 3 <28>
+    logging: <29>
+      type: inline
+      loggers:
+        zookeeper.root.logger: "INFO"
+    resources:
+      requests:
+        memory: 8Gi
+        cpu: "2"
+      limits:
+        memory: 8Gi
+        cpu: "2"
+    jvmOptions:
+      -Xms: 4096m
+      -Xmx: 4096m
+    storage:
+      type: persistent-claim
+      size: 1000Gi
+    metrics:
+      # ...
+  entityOperator: <30>
+    tlsSidecar: <31>
+      resources:
+        requests:
+          cpu: 200m
+          memory: 64Mi
+        limits:
+          cpu: 500m
+          memory: 128Mi
+    topicOperator:
+      watchedNamespace: my-topic-namespace
+      reconciliationIntervalSeconds: 60
+      logging: <32>
+        type: inline
+        loggers:
+          rootLogger.level: "INFO"
+      resources:
+        requests:
+          memory: 512Mi
+          cpu: "1"
+        limits:
+          memory: 512Mi
+          cpu: "1"
+    userOperator:
+      watchedNamespace: my-topic-namespace
+      reconciliationIntervalSeconds: 60
+      logging: <33>
+        type: inline
+        loggers:
+          rootLogger.level: INFO
+      resources:
+        requests:
+          memory: 512Mi
+          cpu: "1"
+        limits:
+          memory: 512Mi
+          cpu: "1"
+  kafkaExporter: <34>
+    # ...
+  cruiseControl: <35>
+    # ...
+    tlsSidecar: <36>
+    # ...
+----
+<1> xref:con-common-configuration-replicas-reference[The number of broker nodes]. If your cluster already has topics defined, you can
+xref:scaling-clusters-{context}[scale clusters].
+<2> Kafka version, which can be changed by following link:{BookURLDeploying}#assembly-upgrade-str[the upgrade procedure].
+<3> Specified xref:property-kafka-logging-reference[Kafka loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` key. For the Kafka `kafka.root.logger.level` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<4> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
+<5> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
+<6> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka.
+<7> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
+<8> Listeners configure how clients connect to the Kafka cluster via bootstrap addresses. Listeners are xref:assembly-securing-kafka-brokers-str[configured as _internal_ or _external_ listeners for connection inside or outside the Kubernetes cluster].
+<9> Name to identify the listener. Must be unique within the Kafka cluster.
+<10> Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
+<11> Listener type specified as `internal`, or for external listeners, as `route`, `loadbalancer`, `nodeport` or `ingress`.
+<12> Enables TLS encryption for each listener. Default is `false`. TLS encryption is not required for `route` listeners.
+<13> Defines whether the fully-qualified DNS names including the cluster service suffix (usually `.cluster.local`) are assigned.
+<14> Listener authentication mechanism xref:assembly-securing-kafka-brokers-str[specified as mutual TLS, SCRAM-SHA-512 or token-based OAuth 2.0].
+<15> External listener configuration specifies xref:assembly-configuring-external-listeners-str[how the Kafka cluster is exposed outside Kubernetes, such as through a `route`, `loadbalancer` or `nodeport`].
+<16> Optional configuration for a xref:kafka-listener-certificates-str[Kafka listener certificate] managed by an external Certificate Authority. The `brokerCertChainAndKey` property specifies a `Secret` that holds a server certificate and a private key. Kafka listener certificates can also be configured for TLS listeners.
+<17> Authorization xref:con-securing-kafka-authorization-str[enables simple, OAUTH 2.0 or OPA authorization on the Kafka broker.] Simple authorization uses the `AclAuthorizer` Kafka plugin.
+<18> Config specifies the broker configuration. xref:property-kafka-config-reference[Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi].
+<19> xref:con-common-configuration-ssl-reference[SSL properties for external listeners to run with a specific _cipher suite_ for a TLS version].
+<20> Storage is xref:assembly-storage-{context}[configured as `ephemeral`, `persistent-claim` or `jbod`].
+<21> Storage size for xref:proc-resizing-persistent-volumes-{context}[persistent volumes may be increased] and additional xref:proc-adding-volumes-to-jbod-storage-{context}[volumes may be added to JBOD storage].
+<22> Persistent storage has xref:ref-persistent-storage-{context}[additional configuration options], such as a storage `id` and `class` for dynamic volume provisioning.
+<23> xref:type-Rack-reference[Rack awareness] is configured to spread replicas across different racks. A `topologykey` must match the label of a cluster node.
+<24> xref:con-common-configuration-prometheus-reference[Prometheus metrics], which are enabled with configuration for the Prometheus JMX exporter in this example. You can enable metrics without further configuration using `metrics: {}`.
+<25> Kafka rules for exporting metrics to a Grafana dashboard through the JMX Exporter. A set of rules provided with Strimzi may be copied to your Kafka resource configuration.
+<26> xref:property-kafka-jmx-reference[JMX options] to open JMX port 9999 to obtain JMX metrics, which is configured for password protection in this example. You can open the port without protection using `jmxOptions: {}`.
+<27> ZooKeeper-specific configuration, which contains properties similar to the Kafka configuration.
+<28> xref:con-common-configuration-replicas-reference[The number of ZooKeeper nodes]. ZooKeeper clusters or ensembles usually run with an odd number of nodes, typically three, five, or seven. The majority of nodes must be available in order to maintain an effective quorum.
+If the ZooKeeper cluster loses its quorum, it will stop responding to clients and the Kafka brokers will stop working.
+Having a stable and highly available ZooKeeper cluster is crucial for Strimzi.
+<29> Specified xref:property-zookeeper-logging-reference[ZooKeeper loggers and log levels].
+<30> Entity Operator configuration, which xref:assembly-kafka-entity-operator-{context}[specifies the configuration for the Topic Operator and User Operator].
+<31> Entity Operator xref:type-TlsSidecar-reference[TLS sidecar configuration]. Entity Operator uses the TLS sidecar for secure communication with ZooKeeper.
+<32> Specified xref:property-topic-operator-logging-reference[Topic Operator loggers and log levels].
+<33> Specified xref:property-user-operator-logging-reference[User Operator loggers and log levels].
+<34> Kafka Exporter configuration, to deploy Kafka Exporter in your cluster and expose data as Prometheus metrics. Kafka Exporter extracts data for analysis as Prometheus metrics, primarily data relating to offsets, consumer groups, consumer lag and topics.
+For information on setting up Kafka Exporter and why it is important to monitor consumer lag for performance, see link:{BookURLDeploying}#assembly-metrics-kafka-exporter-str[Kafka Exporter] in the _Deploying and Upgrading Strimzi_ guide.
+<35> Cruise Control configuration, which is used xref:cruise-control-concepts-str[to rebalance the Kafka cluster].
+<36> Cruise Control xref:type-TlsSidecar-reference[TLS sidecar configuration]. Cruise Control uses the TLS sidecar for secure communication with ZooKeeper.
+
+. Create or update the resource:
++
+[source,shell,subs=+quotes]
+kubectl apply -f _KAFKA-CONFIG-FILE_

--- a/documentation/modules/configuring/proc-configuring-maintenance-time-windows.adoc
+++ b/documentation/modules/configuring/proc-configuring-maintenance-time-windows.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// assembly-maintenance-time-windows.adoc
+
+[id='proc-configuring-maintenance-time-windows-{context}']
+= Configuring a maintenance time window
+
+You can configure a maintenance time window for rolling updates triggered by supported processes.
+
+.Prerequisites
+
+* A Kubernetes cluster.
+* The Cluster Operator is running.
+
+.Procedure
+
+. Add or edit the `maintenanceTimeWindows` property in the `Kafka` resource.
+For example to allow maintenance between 0800 and 1059 and between 1400 and 1559 you would set the `maintenanceTimeWindows` as shown below:
++
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    # ...
+  zookeeper:
+    # ...
+  maintenanceTimeWindows:
+    - "* * 8-10 * * ?"
+    - "* * 14-15 * * ?"
+----
+
+. Create or update the resource:
++
+[source,shell,subs=+quotes]
+kubectl apply -f _KAFKA-CONFIG-FILE_
+
+.Additional resources
+
+Performing rolling updates:
+
+* xref:proc-manual-rolling-update-kafka-{context}[]
+* xref:proc-manual-rolling-update-zookeeper-{context}[]

--- a/documentation/modules/configuring/proc-connecting-to-zookeeper.adoc
+++ b/documentation/modules/configuring/proc-connecting-to-zookeeper.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// assembly-config-kafka.adoc
+
+[id='proc-connnecting-to-zookeeper-{context}']
+= Connecting to ZooKeeper from a terminal
+
+Most Kafka CLI tools can connect directly to Kafka, so under normal circumstances you should not need to connect to ZooKeeper.
+ZooKeeper services are secured with encryption and authentication and are not intended to be used by external applications that are not part of Strimzi.
+
+However, if you want to use Kafka CLI tools that require a connection to ZooKeeper, such as the `kafka-topics` tool, you can open a terminal inside a Kafka container and connect to the local end of the TLS tunnel to ZooKeeper by using `localhost:2181` as the ZooKeeper address.
+
+.Prerequisites
+
+* A Kubernetes cluster is available.
+* A Kafka cluster is running.
+* The Cluster Operator is running.
+
+.Procedure
+
+. Open the terminal using the Kubernetes console or run the `exec` command from your CLI.
++
+For example:
++
+[source,shell,subs="+quotes,attributes"]
+----
+kubectl exec -it _my-cluster_-zookeeper-0 -- bin/kafka-topics.sh --list --zookeeper localhost:12181
+----
++
+Be sure to use `localhost:12181`.
++
+You can now run Kafka commands to ZooKeeper.

--- a/documentation/modules/configuring/proc-connecting-to-zookeeper.adoc
+++ b/documentation/modules/configuring/proc-connecting-to-zookeeper.adoc
@@ -8,7 +8,7 @@
 Most Kafka CLI tools can connect directly to Kafka, so under normal circumstances you should not need to connect to ZooKeeper.
 ZooKeeper services are secured with encryption and authentication and are not intended to be used by external applications that are not part of Strimzi.
 
-However, if you want to use Kafka CLI tools that require a connection to ZooKeeper, such as the `kafka-topics` tool, you can open a terminal inside a Kafka container and connect to the local end of the TLS tunnel to ZooKeeper by using `localhost:2181` as the ZooKeeper address.
+However, if you want to use Kafka CLI tools that require a connection to ZooKeeper, such as the `kafka-topics.sh` tool, you can open a terminal inside a Kafka container and connect to the local end of the TLS tunnel to ZooKeeper by using `localhost:2181` as the ZooKeeper address.
 
 .Prerequisites
 

--- a/documentation/modules/configuring/proc-creating-configmap.adoc
+++ b/documentation/modules/configuring/proc-creating-configmap.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// assembly-external-logging.adoc
+
+[id='creating-configmap_{context}']
+= Creating a ConfigMap for logging
+
+To use a ConfigMap to define logging properties, you create the ConfigMap and then reference it as part of the logging definition in the `spec` of a resource.
+
+The ConfigMap must contain the appropriate logging configuration.
+
+* `log4j.properties` for Kafka components, ZooKeeper, and the Kafka Bridge
+* `log4j2.properties` for the Topic Operator and User Operator
+
+The configuration must be placed under these properties.
+
+Here we demonstrate how a ConfigMap defines a root logger for a Kafka resource.
+
+.Procedure
+
+. Create the ConfigMap.
++
+You can create the ConfigMap as a YAML file or from a properties file using `kubectl` at the command line.
++
+ConfigMap example with a root logger definition for Kafka:
++
+[source,yaml,subs="+attributes"]
+----
+kind: ConfigMap
+apiVersion: {KafkaApiVersion}
+metadata:
+  name: logging-configmap
+data:
+  log4j.properties:
+    kafka.root.logger.level="INFO"
+----
++
+From the command line, using a properties file:
++
+[source,shell]
+----
+kubectl create configmap logging-configmap --from-file=log4j.properties
+----
++
+The properties file defines the logging configuration:
++
+[source,text]
+----
+# Define the logger
+kafka.root.logger.level="INFO"
+# ...
+----
+
+. Define _external_ logging in the `spec` of the resource, setting the `logging.name` to the name of the ConfigMap.
++
+[source,shell,subs="+quotes,attributes"]
+----
+spec:
+  # ...
+  logging:
+    type: external
+    name: logging-configmap
+----
+
+. Create or update the resource.
++
+[source,shell,subs=+quotes]
+----
+kubectl apply -f kafka.yaml
+----

--- a/documentation/modules/configuring/proc-dedicated-nodes.adoc
+++ b/documentation/modules/configuring/proc-dedicated-nodes.adoc
@@ -1,0 +1,65 @@
+// Module included in the following assemblies:
+//
+// assembly-scheduling.adoc
+
+[id='proc-dedicated-nodes-{context}']
+= Setting up dedicated nodes and scheduling pods on them
+
+.Prerequisites
+
+* A Kubernetes cluster
+* A running Cluster Operator
+
+.Procedure
+
+. Select the nodes which should be used as dedicated.
+. Make sure there are no workloads scheduled on these nodes.
+. Set the taints on the selected nodes:
++
+This can be done using `kubectl taint`:
+[source,shell,subs=+quotes]
+kubectl taint node _NAME-OF-NODE_ dedicated=Kafka:NoSchedule
++
+. Additionally, add a label to the selected nodes as well.
++
+This can be done using `kubectl label`:
+[source,shell,subs=+quotes]
+kubectl label node _NAME-OF-NODE_ dedicated=Kafka
++
+. Edit the `affinity` and `tolerations` properties in the resource specifying the cluster deployment.
++
+For example:
++
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+spec:
+  kafka:
+    # ...
+    template:
+      pod:
+        tolerations:
+          - key: "dedicated"
+            operator: "Equal"
+            value: "Kafka"
+            effect: "NoSchedule"
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: dedicated
+                  operator: In
+                  values:
+                  - Kafka
+    # ...
+  zookeeper:
+    # ...
+----
+
+. Create or update the resource.
++
+This can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl apply -f _KAFKA-CONFIG-FILE_

--- a/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
+++ b/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
@@ -1,0 +1,79 @@
+
+[id='proc-generating-reassignment-json-files-{context}']
+= Generating reassignment JSON files
+
+This procedure describes how to generate a reassignment JSON file that reassigns all the partitions for a given set of topics using the `kafka-reassign-partitions.sh` tool.
+
+.Prerequisites
+
+* A running Cluster Operator
+* A `Kafka` resource
+* A set of topics to reassign the partitions of
+
+.Procedure
+
+. Prepare a JSON file named `_topics.json_` that lists the topics to move.
+It must have the following structure:
++
+[source,subs=+quotes]
+----
+{
+  "version": 1,
+  "topics": [
+    _<TopicObjects>_
+  ]
+}
+----
++
+where _<TopicObjects>_ is a comma-separated list of objects like:
++
+[source,subs=+quotes]
+----
+{
+  "topic": _<TopicName>_
+}
+----
++
+For example if you want to reassign all the partitions of `topic-a` and `topic-b`, you would need to prepare a `_topics.json_` file like this:
++
+[source,json]
+----
+{
+  "version": 1,
+  "topics": [
+    { "topic": "topic-a"},
+    { "topic": "topic-b"}
+  ]
+}
+----
+
+. Copy the `_topics.json_` file to one of the broker pods:
++
+[source,subs=+quotes]
+----
+cat _topics.json_ | kubectl exec -c kafka _<BrokerPod>_ -i -- \
+  /bin/bash -c \
+  'cat > /tmp/topics.json'
+----
+
+. Use the `kafka-reassign-partitions.sh` command to generate the reassignment JSON.
++
+[source,subs=+quotes]
+----
+kubectl exec _<BrokerPod>_ -c kafka -it -- \
+  bin/kafka-reassign-partitions.sh --bootstrap-server localhost:9092 \
+  --topics-to-move-json-file /tmp/topics.json \
+  --broker-list _<BrokerList>_ \
+  --generate
+----
++
+For example, to move all the partitions of `topic-a` and `topic-b` to brokers `4` and `7`
++
+[source,shell,subs=+quotes]
+----
+kubectl exec _<BrokerPod>_ -c kafka -it -- \
+  bin/kafka-reassign-partitions.sh --bootstrap-server localhost:9092 \
+  --topics-to-move-json-file /tmp/topics.json \
+  --broker-list 4,7 \
+  --generate
+----

--- a/documentation/modules/configuring/proc-jmxtrans-deployment.adoc
+++ b/documentation/modules/configuring/proc-jmxtrans-deployment.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+//
+// assembly-deployment-configuration-kafka.adoc
+// assembly-jmxtrans.adoc.
+
+[id='proc-jmxtrans-deployment-{context}']
+= Configuring a JmxTrans deployment
+
+.Prerequisites
+* A running Kubernetes cluster
+
+You can configure a JmxTrans deployment by using the `Kafka.spec.jmxTrans` property.
+A JmxTrans deployment can read from a secure or insecure Kafka broker.
+To configure a JmxTrans deployment, define the following properties:
+
+* `Kafka.spec.jmxTrans.outputDefinitions`
+* `Kafka.spec.jmxTrans.kafkaQueries`
+
+For more information on these properties, see the xref:type-JmxTransSpec-reference[`JmxTransSpec` schema reference].
+
+NOTE: To use JMXTrans, xref:proc-config-kafka-{context}[`jmxOptions` must be configured on the Kafka broker].
+
+[discrete]
+== Configuring JmxTrans output definitions
+
+Output definitions specify where JMX metrics are pushed to, and in which data format.
+For information about supported data formats, see link:https://github.com/jmxtrans/jmxtrans/wiki/OutputWriters[Data formats^].
+How many seconds JmxTrans agent waits for before pushing new data can be configured through the `flushDelay` property.
+The `host` and `port` properties define the target host address and target port the data is pushed to.
+The `name` property is a required property that is referenced by the `Kafka.spec.jmxTrans.kafkaQueries` property.
+
+Here is an example configuration pushing JMX data in the Graphite format every 5 seconds to a Logstash database on \http://myLogstash:9999, and another pushing to `standardOut` (standard output):
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  jmxTrans:
+    outputDefinitions:
+      - outputType: "com.googlecode.jmxtrans.model.output.GraphiteWriter"
+        host: "http://myLogstash"
+        port: 9999
+        flushDelay: 5
+        name: "logstash"
+      - outputType: "com.googlecode.jmxtrans.model.output.StdOutWriter"
+        name: "standardOut"
+        # ...
+    # ...
+  zookeeper:
+    # ...
+----
+
+[discrete]
+== Configuring JmxTrans queries
+JmxTrans queries specify what JMX metrics are read from the Kafka brokers.
+Currently JmxTrans queries can only be sent to the Kafka Brokers.
+Configure the `targetMBean` property to specify which target MBean on the Kafka broker is addressed.
+Configuring the `attributes` property specifies which MBean attribute is read as JMX metrics from the target MBean.
+JmxTrans supports wildcards to read from target MBeans, and filter by specifying the `typenames`.
+The `outputs` property defines where the metrics are pushed to by specifying the name of the output definitions.
+
+The following JmxTrans deployment reads from all MBeans that match the pattern `kafka.server:type=BrokerTopicMetrics,name=*` and have `name` in the target MBean's name.
+From those Mbeans, it obtains JMX metrics about the `Count` attribute and pushes the metrics to standard output as defined by `outputs`.
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  # ...
+  jmxTrans:
+    kafkaQueries:
+      - targetMBean: "kafka.server:type=BrokerTopicMetrics,*"
+        typeNames: ["name"]
+        attributes:  ["Count"]
+        outputs: ["standardOut"]
+  zookeeper:
+    # ...
+----

--- a/documentation/modules/configuring/proc-manual-delete-pod-pvc-kafka.adoc
+++ b/documentation/modules/configuring/proc-manual-delete-pod-pvc-kafka.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// assembly-config-kafka.adoc
+
+[id='proc-manual-delete-pod-pvc-kafka-{context}']
+= Deleting Kafka nodes manually
+
+This procedure describes how to delete an existing Kafka node by using a Kubernetes annotation.
+Deleting a Kafka node consists of deleting both the `Pod` on which the Kafka broker is running and the related `PersistentVolumeClaim` (if the cluster was deployed with persistent storage).
+After deletion, the `Pod` and its related `PersistentVolumeClaim` are recreated automatically.
+
+WARNING: Deleting a `PersistentVolumeClaim` can cause permanent data loss. The following procedure should only be performed if you have encountered storage issues.
+
+.Prerequisites
+
+See the _Deploying and Upgrading Strimzi_ guide for instructions on running a:
+
+* link:{BookURLDeploying}#cluster-operator-str[Cluster Operator^]
+* link:{BookURLDeploying}#deploying-kafka-cluster-str[Kafka cluster^]
+
+.Procedure
+
+. Find the name of the `Pod` that you want to delete.
++
+For example, if the cluster is named _cluster-name_, the pods are named _cluster-name_-kafka-_index_, where _index_ starts at zero and ends at the total number of replicas.
+
+. Annotate the `Pod` resource in Kubernetes.
++
+Use `kubectl annotate`:
+[source,shell,subs="+quotes,attributes+"]
+kubectl annotate pod _cluster-name_-kafka-_index_ strimzi.io/delete-pod-and-pvc=true
+
+. Wait for the next reconciliation, when the annotated pod with the underlying persistent volume claim will be deleted and then recreated.

--- a/documentation/modules/configuring/proc-manual-delete-pod-pvc-zookeeper.adoc
+++ b/documentation/modules/configuring/proc-manual-delete-pod-pvc-zookeeper.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// assembly-config-kafka.adoc
+
+[id='proc-manual-delete-pod-pvc-zookeeper-{context}']
+= Deleting ZooKeeper nodes manually
+
+This procedure describes how to delete an existing ZooKeeper node by using a Kubernetes annotation.
+Deleting a ZooKeeper node consists of deleting both the `Pod` on which ZooKeeper is running and the related `PersistentVolumeClaim` (if the cluster was deployed with persistent storage).
+After deletion, the `Pod` and its related `PersistentVolumeClaim` are recreated automatically.
+
+WARNING: Deleting a `PersistentVolumeClaim` can cause permanent data loss. The following procedure should only be performed if you have encountered storage issues.
+
+.Prerequisites
+
+See the _Deploying and Upgrading Strimzi_ guide for instructions on running a:
+
+* link:{BookURLDeploying}#cluster-operator-str[Cluster Operator^]
+* link:{BookURLDeploying}#deploying-kafka-cluster-str[Kafka cluster^]
+
+.Procedure
+
+. Find the name of the `Pod` that you want to delete.
++
+For example, if the cluster is named _cluster-name_, the pods are named _cluster-name_-zookeeper-_index_, where _index_ starts at zero and ends at the total number of replicas.
+
+. Annotate the `Pod` resource in Kubernetes.
++
+Use `kubectl annotate`:
+[source,shell,subs="+quotes,attributes+"]
+kubectl annotate pod _cluster-name_-zookeeper-_index_ strimzi.io/delete-pod-and-pvc=true
+
+. Wait for the next reconciliation, when the annotated pod with the underlying persistent volume claim will be deleted and then recreated.

--- a/documentation/modules/configuring/proc-manual-rolling-update-kafka.adoc
+++ b/documentation/modules/configuring/proc-manual-rolling-update-kafka.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// assembly-config-kafka.adoc
+
+[id='proc-manual-rolling-update-kafka-{context}']
+= Performing a rolling update of a Kafka cluster
+
+This procedure describes how to manually trigger a rolling update of an existing Kafka cluster by using a Kubernetes annotation.
+
+.Prerequisites
+
+See the _Deploying and Upgrading Strimzi_ guide for instructions on running a:
+
+* link:{BookURLDeploying}#cluster-operator-str[Cluster Operator^]
+* link:{BookURLDeploying}#deploying-kafka-cluster-str[Kafka cluster^]
+
+.Procedure
+
+. Find the name of the `StatefulSet` that controls the Kafka pods you want to manually update.
++
+For example, if your Kafka cluster is named _my-cluster_, the corresponding `StatefulSet` is named _my-cluster-kafka_.
+
+. Annotate the `StatefulSet` resource in Kubernetes. For example, using `kubectl annotate`:
+[source,shell,subs=+quotes]
+kubectl annotate statefulset _cluster-name_-kafka strimzi.io/manual-rolling-update=true
+
+. Wait for the next reconciliation to occur (every two minutes by default).
+A rolling update of all pods within the annotated `StatefulSet` is triggered, as long as the annotation was detected by the reconciliation process.
+When the rolling update of all the pods is complete, the annotation is removed from the `StatefulSet`.

--- a/documentation/modules/configuring/proc-manual-rolling-update-zookeeper.adoc
+++ b/documentation/modules/configuring/proc-manual-rolling-update-zookeeper.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// assembly-config-kafka.adoc
+
+[id='proc-manual-rolling-update-zookeeper-{context}']
+= Performing a rolling update of a ZooKeeper cluster
+
+This procedure describes how to manually trigger a rolling update of an existing ZooKeeper cluster by using a Kubernetes annotation.
+
+.Prerequisites
+
+See the _Deploying and Upgrading Strimzi_ guide for instructions on running a:
+
+* link:{BookURLDeploying}#cluster-operator-str[Cluster Operator^]
+* link:{BookURLDeploying}#deploying-kafka-cluster-str[Kafka cluster^]
+
+.Procedure
+
+. Find the name of the `StatefulSet` that controls the ZooKeeper pods you want to manually update.
++
+For example, if your Kafka cluster is named _my-cluster_, the corresponding `StatefulSet` is named _my-cluster-zookeeper_.
+
+. Annotate the `StatefulSet` resource in Kubernetes. For example, using `kubectl annotate`:
+[source,shell,subs=+quotes]
+kubectl annotate statefulset _cluster-name_-zookeeper strimzi.io/manual-rolling-update=true
+
+. Wait for the next reconciliation to occur (every two minutes by default).
+A rolling update of all pods within the annotated `StatefulSet` is triggered, as long as the annotation was detected by the reconciliation process.
+When the rolling update of all the pods is complete, the annotation is removed from the `StatefulSet`.

--- a/documentation/modules/configuring/proc-removing-volumes-from-jbod-storage.adoc
+++ b/documentation/modules/configuring/proc-removing-volumes-from-jbod-storage.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// assembly-storage.adoc
+
+[id='proc-removing-volumes-from-jbod-storage-{context}']
+= Removing volumes from JBOD storage
+
+This procedure describes how to remove volumes from Kafka cluster configured to use JBOD storage.
+It cannot be applied to Kafka clusters configured to use any other storage type.
+The JBOD storage always has to contain at least one volume.
+
+IMPORTANT: To avoid data loss, you have to move all partitions before removing the volumes.
+
+.Prerequisites
+
+* A Kubernetes cluster
+* A running Cluster Operator
+* A Kafka cluster with JBOD storage with two or more volumes
+
+.Procedure
+
+. Reassign all partitions from the disks which are you going to remove.
+Any data in partitions still assigned to the disks which are going to be removed might be lost.
+
+. Edit the `spec.kafka.storage.volumes` property in the `Kafka` resource.
+Remove one or more volumes from the `volumes` array.
+For example, remove the volumes with ids `1` and `2`:
++
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    # ...
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+    # ...
+  zookeeper:
+    # ...
+----
+
+. Create or update the resource:
++
+[source,shell,subs=+quotes]
+kubectl apply -f _KAFKA-CONFIG-FILE_
+
+.Additional resources
+
+For more information about reassigning topics, see xref:con-partition-reassignment-{context}[].

--- a/documentation/modules/configuring/proc-resizing-persistent-volumes.adoc
+++ b/documentation/modules/configuring/proc-resizing-persistent-volumes.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// assembly-storage.adoc
+
+[id='proc-resizing-persistent-volumes-{context}']
+= Resizing persistent volumes
+
+You can provision increased storage capacity by increasing the size of the persistent volumes used by an existing Strimzi cluster.
+Resizing persistent volumes is supported in clusters that use either a single persistent volume or multiple persistent volumes in a JBOD storage configuration.
+
+NOTE: You can increase but not decrease the size of persistent volumes.
+Decreasing the size of persistent volumes is not currently supported in Kubernetes.
+
+.Prerequisites
+
+* A Kubernetes cluster with support for volume resizing.
+* The Cluster Operator is running.
+* A Kafka cluster using persistent volumes created using a storage class that supports volume expansion.
+
+.Procedure
+
+. In a `Kafka` resource, increase the size of the persistent volume allocated to the Kafka cluster, the ZooKeeper cluster, or both.
+
+* To increase the volume size allocated to the Kafka cluster, edit the `spec.kafka.storage` property.
+* To increase the volume size allocated to the ZooKeeper cluster, edit the `spec.zookeeper.storage` property.
++
+For example, to increase the volume size from `1000Gi` to `2000Gi`:
++
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    # ...
+    storage:
+      type: persistent-claim
+      size: 2000Gi
+      class: my-storage-class
+    # ...
+  zookeeper:
+    # ...
+----
+
+. Create or update the resource:
++
+[source,shell,subs=+quotes]
+kubectl apply -f _KAFKA-CONFIG-FILE_
++
+Kubernetes increases the capacity of the selected persistent volumes in response to a request from the Cluster Operator.
+When the resizing is complete, the Cluster Operator restarts all pods that use the resized persistent volumes.
+This happens automatically.
+
+.Additional resources
+
+For more information about resizing persistent volumes in Kubernetes, see {K8sResizingPersistentVolumesUsingKubernetes}.

--- a/documentation/modules/configuring/proc-scaling-down-a-kafka-cluster.adoc
+++ b/documentation/modules/configuring/proc-scaling-down-a-kafka-cluster.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// ???
+
+[id='proc-scaling-down-a-kafka-cluster-{context}']
+
+= Scaling down a Kafka cluster
+
+This procedure describes how to decrease the number of brokers in a Kafka cluster.
+
+.Prerequisites
+
+* An existing Kafka cluster.
+* A _reassignment JSON file_ named `_reassignment.json_` describing how partitions should be reassigned to brokers in the cluster once the broker(s) in the highest numbered `Pod(s)` have been removed.
+
+.Procedure
+
+include::snip-reassign-partitions.adoc[]
+
+. Once all the partition reassignments have finished, the broker(s) being removed should not have responsibility for any of the partitions in the cluster.
+You can verify this by checking that the broker's data log directory does not contain any live partition logs.
+If the log directory on the broker contains a directory that does not match the extended regular expression `[a-zA-Z0-9.-]+\.[a-z0-9]+-delete$` then the broker still has live partitions and it should not be stopped.
++
+You can check this by executing the command:
++
+[source,shell,subs=+quotes]
+kubectl exec my-cluster-kafka-0 -c kafka -it -- \
+  /bin/bash -c \
+  "ls -l /var/lib/kafka/kafka-log_<N>_ | grep -E '^d' | grep -vE '[a-zA-Z0-9.-]+\.[a-z0-9]+-delete$'"
++
+where _N_ is the number of the `Pod(s)` being deleted.
++
+If the above command prints any output then the broker still has live partitions.
+In this case, either the reassignment has not finished, or the reassignment JSON file was incorrect.
+
+. Once you have confirmed that the broker has no live partitions you can edit the `Kafka.spec.kafka.replicas` of your `Kafka` resource, which will scale down the `StatefulSet`, deleting the highest numbered broker `Pod(s)`.

--- a/documentation/modules/configuring/proc-scaling-up-a-kafka-cluster.adoc
+++ b/documentation/modules/configuring/proc-scaling-up-a-kafka-cluster.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// ???
+
+[id='proc-scaling-up-a-kafka-cluster-{context}']
+
+= Scaling up a Kafka cluster
+
+This procedure describes how to increase the number of brokers in a Kafka cluster.
+
+.Prerequisites
+
+* An existing Kafka cluster.
+* A _reassignment JSON file_ named `_reassignment.json_` that describes how partitions should be reassigned to brokers in the enlarged cluster.
+
+.Procedure
+
+. Add as many new brokers as you need by increasing the `Kafka.spec.kafka.replicas` configuration option.
+
+. Verify that the new broker pods have started.
+
+include::snip-reassign-partitions.adoc[]

--- a/documentation/modules/configuring/proc-scheduling-based-on-other-pods.adoc
+++ b/documentation/modules/configuring/proc-scheduling-based-on-other-pods.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// assembly-scheduling.adoc
+
+[id='configuring-pod-anti-affinity-in-kafka-components-{context}']
+= Configuring pod anti-affinity in Kafka components
+
+.Prerequisites
+
+* A Kubernetes cluster
+* A running Cluster Operator
+
+.Procedure
+
+. Edit the `affinity` property in the resource specifying the cluster deployment.
+Use labels to specify the pods which should not be scheduled on the same nodes.
+The `topologyKey` should be set to `kubernetes.io/hostname` to specify that the selected pods should not be scheduled on nodes with the same hostname.
+For example:
++
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+spec:
+  kafka:
+    # ...
+    template:
+      pod:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                    - key: application
+                      operator: In
+                      values:
+                        - postgresql
+                        - mongodb
+                topologyKey: "kubernetes.io/hostname"
+    # ...
+  zookeeper:
+    # ...
+----
+
+. Create or update the resource.
++
+This can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl apply -f _KAFKA-CONFIG-FILE_

--- a/documentation/modules/configuring/proc-scheduling-deployment-to-node-using-node-affinity.adoc
+++ b/documentation/modules/configuring/proc-scheduling-deployment-to-node-using-node-affinity.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// assembly-scheduling.adoc
+
+[id='proc-configuring-node-affinity-{context}']
+= Configuring node affinity in Kafka components
+
+.Prerequisites
+
+* A Kubernetes cluster
+* A running Cluster Operator
+
+.Procedure
+
+. Label the nodes where Strimzi components should be scheduled.
++
+This can be done using `kubectl label`:
+[source,shell,subs="+quotes,attributes+"]
+kubectl label node _NAME-OF-NODE_ node-type=fast-network
++
+Alternatively, some of the existing labels might be reused.
+. Edit the `affinity` property in the resource specifying the cluster deployment.
+For example:
++
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+spec:
+  kafka:
+    # ...
+    template:
+      pod:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                  - key: node-type
+                    operator: In
+                    values:
+                    - fast-network
+    # ...
+  zookeeper:
+    # ...
+----
+
+. Create or update the resource.
++
+This can be done using `kubectl apply`:
+[source,shell,subs="+quotes,attributes+"]
+kubectl apply -f _KAFKA-CONFIG-FILE_

--- a/documentation/modules/configuring/ref-affinity.adoc
+++ b/documentation/modules/configuring/ref-affinity.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// assembly-scheduling.adoc
+
+[id='affinity-{context}']
+= Specifying affinity and tolerations
+
+Use affinity and tolerations to schedule the pods of kafka resources onto nodes.
+Affinity and tolerations are configured using the `affinity` and `tolerations` properties in following resources:
+
+* `Kafka.spec.kafka.template.pod`
+* `Kafka.spec.zookeeper.template.pod`
+* `Kafka.spec.entityOperator.template.pod`
+* `KafkaConnect.spec.template.pod`
+* `KafkaConnectS2I.spec.template.pod`
+* `KafkaBridge.spec.template.pod`
+
+The format of the `affinity` and `tolerations` properties follows the Kubernetes specification.
+The affinity configuration can include different types of affinity:
+
+* Pod affinity and anti-affinity
+* Node affinity
+
+.Additional resources
+
+* {K8sAffinity}
+* {K8sTolerations}
+
+[id='con-scheduling-based-on-other-pods-{context}']
+== Use pod anti-affinity to avoid critical applications sharing nodes
+
+Use pod anti-affinity to ensure that critical applications are never scheduled on the same disk.
+When running a Kafka cluster, it is recommended to use pod anti-affinity to ensure that the Kafka brokers do not share nodes with other workloads, such as databases.
+
+[id='con-scheduling-to-specific-nodes-{context}']
+== Use node affinity to schedule workloads onto specific nodes
+
+The Kubernetes cluster usually consists of many different types of worker nodes.
+Some are optimized for CPU heavy workloads, some for memory, while other might be optimized for storage (fast local SSDs) or network.
+Using different nodes helps to optimize both costs and performance.
+To achieve the best possible performance, it is important to allow scheduling of Strimzi components to use the right nodes.
+
+Kubernetes uses node affinity to schedule workloads onto specific nodes.
+Node affinity allows you to create a scheduling constraint for the node on which the pod will be scheduled.
+The constraint is specified as a label selector.
+You can specify the label using either the built-in node label like `beta.kubernetes.io/instance-type` or custom labels to select the right node.
+
+[id='con-dedicated-nodes-{context}']
+== Use node affinity and tolerations for dedicated nodes
+
+Use taints to create dedicated nodes, then schedule Kafka pods on the dedicated nodes by configuring node affinity and tolerations.
+
+Cluster administrators can mark selected Kubernetes nodes as tainted.
+Nodes with taints are excluded from regular scheduling and normal pods will not be scheduled to run on them.
+Only services which can tolerate the taint set on the node can be scheduled on it.
+The only other services running on such nodes will be system services such as log collectors or software defined networks.
+
+Running Kafka and its components on dedicated nodes can have many advantages.
+There will be no other applications running on the same nodes which could cause disturbance or consume the resources needed for Kafka.
+That can lead to improved performance and stability.

--- a/documentation/modules/configuring/ref-kafka-entity-operator.adoc
+++ b/documentation/modules/configuring/ref-kafka-entity-operator.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// assembly-kafka-entity-operator.adoc
+
+[id='ref-kafka-entity-operator-{context}']
+= Entity Operator configuration properties
+
+Use the `entityOperator` property in `Kafka.spec` to configure the Entity Operator.
+
+The `entityOperator` property supports several sub-properties:
+
+* `tlsSidecar`
+* `topicOperator`
+* `userOperator`
+* `template`
+
+The `tlsSidecar` property contains the configuration of the TLS sidecar container, which is used to communicate with ZooKeeper.
+
+The `template` property contains the configuration of the Entity Operator pod, such as labels, annotations, affinity, and tolerations.
+For more information on configuring templates, see xref:assembly-customizing-kubernetes-resources-str[].
+
+The `topicOperator` property contains the configuration of the Topic Operator.
+When this option is missing, the Entity Operator is deployed without the Topic Operator.
+
+The `userOperator` property contains the configuration of the User Operator.
+When this option is missing, the Entity Operator is deployed without the User Operator.
+
+For more information on the properties to configure the Entity Operator, see the xref:type-EntityUserOperatorSpec-reference[`EntityUserOperatorSpec` schema reference].
+
+.Example of basic configuration enabling both operators
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    # ...
+  zookeeper:
+    # ...
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+----
+
+If an empty object (`{}`) is used for the `topicOperator` and `userOperator`, all properties use their default values.
+
+When both `topicOperator` and `userOperator` properties are missing, the Entity Operator is not deployed.

--- a/documentation/modules/configuring/ref-kafka-entity-operator.adoc
+++ b/documentation/modules/configuring/ref-kafka-entity-operator.adoc
@@ -25,7 +25,7 @@ When this option is missing, the Entity Operator is deployed without the Topic O
 The `userOperator` property contains the configuration of the User Operator.
 When this option is missing, the Entity Operator is deployed without the User Operator.
 
-For more information on the properties to configure the Entity Operator, see the xref:type-EntityUserOperatorSpec-reference[`EntityUserOperatorSpec` schema reference].
+For more information on the properties used to configure the Entity Operator, see the xref:type-EntityUserOperatorSpec-reference[`EntityUserOperatorSpec` schema reference].
 
 .Example of basic configuration enabling both operators
 [source,yaml,subs=attributes+]

--- a/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
+++ b/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
@@ -1,0 +1,92 @@
+// Module included in the following assemblies:
+//
+// assembly-config-kafka.adoc
+
+[id='ref-list-of-kafka-cluster-resources-{context}']
+= List of Kafka cluster resources
+
+The following resources are created by the Cluster Operator in the Kubernetes cluster:
+
+.Shared resources
+
+`_cluster-name_-cluster-ca`:: Secret with the Cluster CA used to encrypt the cluster communication.
+`_cluster-name_-cluster-ca-cert`:: Secret with the Cluster CA public key. This key can be used to verify the identity of the Kafka brokers.
+`_cluster-name_-clients-ca`::  Secret with the Clients CA private key used to sign user certiticates
+`_cluster-name_-clients-ca-cert`:: Secret with the Clients CA public key. This key can be used to verify the identity of the Kafka users.
+`_cluster-name_-cluster-operator-certs`:: Secret with Cluster operators keys for communication with Kafka and ZooKeeper.
+
+.Zookeeper nodes
+
+`_cluster-name_-zookeeper`:: StatefulSet which is in charge of managing the ZooKeeper node pods.
+`_cluster-name_-zookeeper-_idx_`:: Pods created by the Zookeeper StatefulSet.
+`_cluster-name_-zookeeper-nodes`:: Headless Service needed to have DNS resolve the ZooKeeper pods IP addresses directly.
+`_cluster-name_-zookeeper-client`:: Service used by Kafka brokers to connect to ZooKeeper nodes as clients.
+`_cluster-name_-zookeeper-config`:: ConfigMap that contains the ZooKeeper ancillary configuration, and is mounted as a volume by the ZooKeeper node pods.
+`_cluster-name_-zookeeper-nodes`:: Secret with ZooKeeper node keys.
+`_cluster-name_-zookeeper`:: Service account used by the Zookeeper nodes.
+`_cluster-name_-zookeeper`:: Pod Disruption Budget configured for the ZooKeeper nodes.
+`_cluster-name_-network-policy-zookeeper`:: Network policy managing access to the ZooKeeper services.
+`data-_cluster-name_-zookeeper-_idx_`:: Persistent Volume Claim for the volume used for storing data for the ZooKeeper node pod `_idx_`. This resource will be created only if persistent storage is selected for provisioning persistent volumes to store data.
+
+.Kafka brokers
+
+`_cluster-name_-kafka`:: StatefulSet which is in charge of managing the Kafka broker pods.
+`_cluster-name_-kafka-_idx_`:: Pods created by the Kafka StatefulSet.
+`_cluster-name_-kafka-brokers`:: Service needed to have DNS resolve the Kafka broker pods IP addresses directly.
+`_cluster-name_-kafka-bootstrap`:: Service can be used as bootstrap servers for Kafka clients.
+`_cluster-name_-kafka-external-bootstrap`:: Bootstrap service for clients connecting from outside of the Kubernetes cluster. This resource will be created only when external listener is enabled.
+`_cluster-name_-kafka-_pod-id_`:: Service used to route traffic from outside of the Kubernetes cluster to individual pods. This resource will be created only when external listener is enabled.
+`_cluster-name_-kafka-external-bootstrap`:: Bootstrap route for clients connecting from outside of the Kubernetes cluster. This resource will be created only when external listener is enabled and set to type `route`.
+`_cluster-name_-kafka-_pod-id_`:: Route for traffic from outside of the Kubernetes cluster to individual pods. This resource will be created only when external listener is enabled and set to type `route`.
+`_cluster-name_-kafka-config`:: ConfigMap which contains the Kafka ancillary configuration and is mounted as a volume by the Kafka broker pods.
+`_cluster-name_-kafka-brokers`:: Secret with Kafka broker keys.
+`_cluster-name_-kafka`:: Service account used by the Kafka brokers.
+`_cluster-name_-kafka`:: Pod Disruption Budget configured for the Kafka brokers.
+`_cluster-name_-network-policy-kafka`:: Network policy managing access to the Kafka services.
+`strimzi-_namespace-name_-_cluster-name_-kafka-init`:: Cluster role binding used by the Kafka brokers.
+`_cluster-name_-jmx`:: Secret with JMX username and password used to secure the Kafka broker port. This resource will be created only when JMX is enabled in Kafka.
+`data-_cluster-name_-kafka-_idx_`:: Persistent Volume Claim for the volume used for storing data for the Kafka broker pod `_idx_`. This resource will be created only if persistent storage is selected for provisioning persistent volumes to store data.
+`data-_id_-_cluster-name_-kafka-_idx_`:: Persistent Volume Claim for the volume `_id_` used for storing data for the Kafka broker pod `_idx_`. This resource is only created if persistent storage is selected for JBOD volumes when provisioning persistent volumes to store data.
+
+.Entity Operator
+
+These resources are only created if the Entity Operator is deployed using the Cluster Operator.
+
+`_cluster-name_-entity-operator`:: Deployment with Topic and User Operators.
+`_cluster-name_-entity-operator-_random-string_`:: Pod created by the Entity Operator deployment.
+`_cluster-name_-entity-topic-operator-config`:: ConfigMap with ancillary configuration for Topic Operators.
+`_cluster-name_-entity-user-operator-config`:: ConfigMap with ancillary configuration for User Operators.
+`_cluster-name_-entity-operator-certs`:: Secret with Entity Operator keys for communication with Kafka and ZooKeeper.
+`_cluster-name_-entity-operator`:: Service account used by the Entity Operator.
+`strimzi-_cluster-name_-topic-operator`:: Role binding used by the Entity Operator.
+`strimzi-_cluster-name_-user-operator`:: Role binding used by the Entity Operator.
+
+.Kafka Exporter
+
+These resources are only created if the Kafka Exporter is deployed using the Cluster Operator.
+
+`_cluster-name_-kafka-exporter`:: Deployment with Kafka Exporter.
+`_cluster-name_-kafka-exporter-_random-string_`:: Pod created by the Kafka Exporter deployment.
+`_cluster-name_-kafka-exporter`:: Service used to collect consumer lag metrics.
+`_cluster-name_-kafka-exporter`:: Service account used by the Kafka Exporter.
+
+.Cruise Control
+
+These resources are only created only if Cruise Control was deployed using the Cluster Operator.
+
+`_cluster-name_-cruise-control`:: Deployment with Cruise Control.
+`_cluster-name_-cruise-control-_random-string_`:: Pod created by the Cruise Control deployment.
+`_cluster-name_-cruise-control-config`:: ConfigMap that contains the Cruise Control ancillary configuration, and is mounted as a volume by the Cruise Control pods.
+`_cluster-name_-cruise-control-certs`:: Secret with Cruise Control keys for communication with Kafka and ZooKeeper.
+`_cluster-name_-cruise-control`:: Service used to communicate with Cruise Control.
+`_cluster-name_-cruise-control`:: Service account used by Cruise Control.
+`_cluster-name_-network-policy-cruise-control`:: Network policy managing access to the Cruise Control service.
+
+.JMXTrans
+
+These resources are only created if JMXTrans is deployed using the Cluster Operator.
+
+`_cluster-name_-jmxtrans`:: Deployment with JMXTrans.
+`_cluster-name_-jmxtrans-_random-string_`:: Pod created by the JMXTrans deployment.
+`_cluster-name_-jmxtrans-config`:: ConfigMap that contains the JMXTrans ancillary configuration, and is mounted as a volume by the JMXTrans pods.
+`_cluster-name_-jmxtrans`:: Service account used by JMXTrans.

--- a/documentation/modules/configuring/ref-storage-ephemeral.adoc
+++ b/documentation/modules/configuring/ref-storage-ephemeral.adoc
@@ -5,12 +5,12 @@
 [id='ref-ephemeral-storage-{context}']
 = Ephemeral storage
 
-Ephemeral storage uses the `{K8sEmptyDir}` volumes to store data.
-To use ephemeral storage, the `type` field should be set to `ephemeral`.
+Ephemeral storage uses `{K8sEmptyDir}` volumes to store data.
+To use ephemeral storage, set the `type` field to `ephemeral`.
 
-IMPORTANT: `emptyDir` volumes are not persistent and the data stored in them will be lost when the Pod is restarted.
-After the new pod is started, it has to recover all data from other nodes of the cluster.
-Ephemeral storage is not suitable for use with single node ZooKeeper clusters and for Kafka topics with replication factor 1, because it will lead to data loss.
+IMPORTANT: `emptyDir` volumes are not persistent and the data stored in them is lost when the pod is restarted.
+After the new pod is started, it must recover all data from the other nodes of the cluster.
+Ephemeral storage is not suitable for use with single-node ZooKeeper clusters or for Kafka topics with a replication factor of 1. This configuration will cause data loss.
 
 .An example of Ephemeral storage
 [source,yaml,subs="attributes+"]
@@ -34,7 +34,11 @@ spec:
 
 == Log directories
 
-The ephemeral volume will be used by the Kafka brokers as log directories mounted into the following path:
+The ephemeral volume is used by the Kafka brokers as log directories mounted into the following path:
 
-`/var/lib/kafka/data/kafka-log_idx_`::
-Where `_idx_` is the Kafka broker pod index. For example `/var/lib/kafka/data/kafka-log0`.
+[source,shell,subs="+quotes,attributes"]
+----
+/var/lib/kafka/data/kafka-log__IDX__
+----
+
+Where `_IDX_` is the Kafka broker pod index. For example `/var/lib/kafka/data/kafka-log0`.

--- a/documentation/modules/configuring/ref-storage-ephemeral.adoc
+++ b/documentation/modules/configuring/ref-storage-ephemeral.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// assembly-storage.adoc
+
+[id='ref-ephemeral-storage-{context}']
+= Ephemeral storage
+
+Ephemeral storage uses the `{K8sEmptyDir}` volumes to store data.
+To use ephemeral storage, the `type` field should be set to `ephemeral`.
+
+IMPORTANT: `emptyDir` volumes are not persistent and the data stored in them will be lost when the Pod is restarted.
+After the new pod is started, it has to recover all data from other nodes of the cluster.
+Ephemeral storage is not suitable for use with single node ZooKeeper clusters and for Kafka topics with replication factor 1, because it will lead to data loss.
+
+.An example of Ephemeral storage
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    # ...
+    storage:
+      type: ephemeral
+    # ...
+  zookeeper:
+    # ...
+    storage:
+      type: ephemeral
+    # ...
+----
+
+== Log directories
+
+The ephemeral volume will be used by the Kafka brokers as log directories mounted into the following path:
+
+`/var/lib/kafka/data/kafka-log_idx_`::
+Where `_idx_` is the Kafka broker pod index. For example `/var/lib/kafka/data/kafka-log0`.

--- a/documentation/modules/configuring/ref-storage-jbod.adoc
+++ b/documentation/modules/configuring/ref-storage-jbod.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// assembly-storage.adoc
+
+[id='ref-jbod-storage-{context}']
+= JBOD storage overview
+
+You can configure Strimzi to use JBOD, a data storage configuration of multiple disks or volumes. JBOD is one approach to providing increased data storage for Kafka brokers. It can also improve performance.
+
+A JBOD configuration is described by one or more volumes, each of which can be either xref:ref-ephemeral-storage-{context}[ephemeral] or xref:ref-persistent-storage-{context}[persistent]. The rules and constraints for JBOD volume declarations are the same as those for ephemeral and persistent storage. For example, you cannot change the size of a persistent storage volume after it has been provisioned.
+
+== JBOD configuration
+
+To use JBOD with Strimzi, the storage `type` must be set to `jbod`. The `volumes` property allows you to describe the disks that make up your JBOD storage array or configuration. The following fragment shows an example JBOD configuration:
+
+[source,yaml]
+----
+# ...
+storage:
+  type: jbod
+  volumes:
+  - id: 0
+    type: persistent-claim
+    size: 100Gi
+    deleteClaim: false
+  - id: 1
+    type: persistent-claim
+    size: 100Gi
+    deleteClaim: false
+# ...
+----
+
+The ids cannot be changed once the JBOD volumes are created.
+
+Users can add or remove volumes from the JBOD configuration.
+
+[[jbod-pvc]]
+== JBOD and Persistent Volume Claims
+
+When persistent storage is used to declare JBOD volumes, the naming scheme of the resulting Persistent Volume Claims is as follows:
+
+`data-_id_-_cluster-name_-kafka-_idx_`::
+
+Where `_id_` is the ID of the volume used for storing data for Kafka broker pod `_idx_`.
+
+== Log directories
+
+The JBOD volumes will be used by the Kafka brokers as log directories mounted into the following path:
+
+`/var/lib/kafka/data-_id_/kafka-log_idx_`::
+Where `_id_` is the ID of the volume used for storing data for Kafka broker pod `_idx_`. For example `/var/lib/kafka/data-0/kafka-log0`.

--- a/documentation/modules/configuring/ref-storage-persistent.adoc
+++ b/documentation/modules/configuring/ref-storage-persistent.adoc
@@ -1,0 +1,155 @@
+// Module included in the following assemblies:
+//
+// assembly-storage.adoc
+
+[id='ref-persistent-storage-{context}']
+= Persistent storage
+
+Persistent storage uses {K8sPersistentVolumeClaims} to provision persistent volumes for storing data.
+Persistent Volume Claims can be used to provision volumes of many different types, depending on the {K8SStorageClass} which will provision the volume.
+The data types which can be used with persistent volume claims include many types of SAN storage as well as {K8sLocalPersistentVolumes}.
+
+To use persistent storage, the `type` has to be set to `persistent-claim`.
+Persistent storage supports additional configuration options:
+
+`id` (optional)::
+Storage identification number. This option is mandatory for storage volumes defined in a JBOD storage declaration.
+Default is `0`.
+
+`size` (required)::
+Defines the size of the persistent volume claim, for example, "1000Gi".
+
+`class` (optional)::
+The Kubernetes {K8SStorageClass} to use for dynamic volume provisioning.
+
+`selector` (optional)::
+Allows selecting a specific persistent volume to use.
+It contains key:value pairs representing labels for selecting such a volume.
+
+`deleteClaim` (optional)::
+Boolean value which specifies if the Persistent Volume Claim has to be deleted when the cluster is undeployed.
+Default is `false`.
+
+WARNING: Increasing the size of persistent volumes in an existing Strimzi cluster is only supported in Kubernetes versions that support persistent volume resizing. The persistent volume to be resized must use a storage class that supports volume expansion.
+For other versions of Kubernetes and storage classes which do not support volume expansion, you must decide the necessary storage size before deploying the cluster.
+Decreasing the size of existing persistent volumes is not possible.
+
+.Example fragment of persistent storage configuration with 1000Gi `size`
+[source,yaml]
+----
+# ...
+storage:
+  type: persistent-claim
+  size: 1000Gi
+# ...
+----
+
+The following example demonstrates the use of a storage class.
+
+.Example fragment of persistent storage configuration with specific Storage Class
+[source,yaml,subs="attributes+"]
+----
+# ...
+storage:
+  type: persistent-claim
+  size: 1Gi
+  class: my-storage-class
+# ...
+----
+
+Finally, a `selector` can be used to select a specific labeled persistent volume to provide needed features such as an SSD.
+
+.Example fragment of persistent storage configuration with selector
+[source,yaml,subs="attributes+"]
+----
+# ...
+storage:
+  type: persistent-claim
+  size: 1Gi
+  selector:
+    hdd-type: ssd
+  deleteClaim: true
+# ...
+----
+
+== Storage class overrides
+
+You can specify a different storage class for one or more Kafka brokers or ZooKeeper nodes, instead of using the default storage class.
+This is useful if, for example, storage classes are restricted to different availability zones or data centers.
+You can use the `overrides` field for this purpose.
+
+In this example, the default storage class is named `my-storage-class`:
+
+.Example Strimzi cluster using storage class overrides
+[source,yaml,subs="attributes+"]
+----
+apiVersion: kafka.strimzi.io/v1beta1
+kind: Kafka
+metadata:
+  labels:
+    app: my-cluster
+  name: my-cluster
+  namespace: myproject
+spec:
+  # ...
+  kafka:
+    replicas: 3
+    storage:
+      deleteClaim: true
+      size: 100Gi
+      type: persistent-claim
+      class: my-storage-class
+      overrides:
+        - broker: 0
+          class: my-storage-class-zone-1a
+        - broker: 1
+          class: my-storage-class-zone-1b
+        - broker: 2
+          class: my-storage-class-zone-1c
+  # ...
+  zookeeper:
+    replicas: 3
+    storage:
+      deleteClaim: true
+      size: 100Gi
+      type: persistent-claim
+      class: my-storage-class
+      overrides:
+        - broker: 0
+          class: my-storage-class-zone-1a
+        - broker: 1
+          class: my-storage-class-zone-1b
+        - broker: 2
+          class: my-storage-class-zone-1c
+  # ...
+----
+
+As a result of the configured `overrides` property, the volumes use the following storage classes:
+
+* The persistent volumes of ZooKeeper node 0 will use `my-storage-class-zone-1a`.
+* The persistent volumes of ZooKeeper node 1 will use `my-storage-class-zone-1b`.
+* The persistent volumes of ZooKeeepr node 2 will use `my-storage-class-zone-1c`.
+* The persistent volumes of Kafka broker 0 will use `my-storage-class-zone-1a`.
+* The persistent volumes of Kafka broker 1 will use `my-storage-class-zone-1b`.
+* The persistent volumes of Kafka broker 2 will use `my-storage-class-zone-1c`.
+
+The `overrides` property is currently used only to override storage class configurations. Overriding other storage configuration fields is not currently supported.
+Other fields from the storage configuration are currently not supported.
+
+[[pvc-naming]]
+== Persistent Volume Claim naming
+
+When persistent storage is used, it creates Persistent Volume Claims with the following names:
+
+`data-_cluster-name_-kafka-_idx_`::
+Persistent Volume Claim for the volume used for storing data for the Kafka broker pod `_idx_`.
+
+`data-_cluster-name_-zookeeper-_idx_`::
+Persistent Volume Claim for the volume used for storing data for the ZooKeeper node pod `_idx_`.
+
+== Log directories
+
+The persistent volume will be used by the Kafka brokers as log directories mounted into the following path:
+
+`/var/lib/kafka/data/kafka-log_idx_`::
+Where `_idx_` is the Kafka broker pod index. For example `/var/lib/kafka/data/kafka-log0`.

--- a/documentation/modules/configuring/ref-storage-persistent.adoc
+++ b/documentation/modules/configuring/ref-storage-persistent.adoc
@@ -149,7 +149,11 @@ Persistent Volume Claim for the volume used for storing data for the ZooKeeper n
 
 == Log directories
 
-The persistent volume will be used by the Kafka brokers as log directories mounted into the following path:
+The persistent volume is used by the Kafka brokers as log directories mounted into the following path:
 
-`/var/lib/kafka/data/kafka-log_idx_`::
-Where `_idx_` is the Kafka broker pod index. For example `/var/lib/kafka/data/kafka-log0`.
+[source,shell,subs="+quotes,attributes"]
+----
+/var/lib/kafka/data/kafka-log__IDX__
+----
+
+Where `_IDX_` is the Kafka broker pod index. For example `/var/lib/kafka/data/kafka-log0`.

--- a/documentation/modules/configuring/snip-reassign-partitions.adoc
+++ b/documentation/modules/configuring/snip-reassign-partitions.adoc
@@ -1,0 +1,78 @@
+. Copy the `_reassignment.json_` file to the broker pod on which you will later execute the commands:
++
+[source,shell,subs=+quotes]
+----
+cat _reassignment.json_ | \
+  kubectl exec _broker-pod_ -c kafka -i -- /bin/bash -c \
+  'cat > /tmp/reassignment.json'
+----
++
+For example:
++
+[source,shell,subs=+quotes]
+----
+cat _reassignment.json_ | \
+  kubectl exec my-cluster-kafka-0 -c kafka -i -- /bin/bash -c \
+  'cat > /tmp/reassignment.json'
+----
+
+. Execute the partition reassignment using the `kafka-reassign-partitions.sh` command line tool from the same broker pod.
++
+[source,shell,subs=+quotes]
+----
+kubectl exec _broker-pod_ -c kafka -it -- \
+  bin/kafka-reassign-partitions.sh --bootstrap-server localhost:9092 \
+  --reassignment-json-file /tmp/reassignment.json \
+  --execute
+----
++
+If you are going to throttle replication you can also pass the `--throttle` option with an inter-broker throttled rate in bytes per second. For example:
++
+[source,shell,subs=+quotes]
+----
+kubectl exec my-cluster-kafka-0 -c kafka -it -- \
+  bin/kafka-reassign-partitions.sh --bootstrap-server localhost:9092 \
+  --reassignment-json-file /tmp/reassignment.json \
+  --throttle 5000000 \
+  --execute
+----
++
+This command will print out two reassignment JSON objects. 
+The first records the current assignment for the partitions being moved. 
+You should save this to a local file (not a file in the pod) in case you need to revert the reassignment later on. 
+The second JSON object is the target reassignment you have passed in your reassignment JSON file.
+
+. If you need to change the throttle during reassignment you can use the same command line with a different throttled rate. For example:
++
+[source,shell,subs=+quotes]
+----
+kubectl exec my-cluster-kafka-0 -c kafka -it -- \
+  bin/kafka-reassign-partitions.sh --bootstrap-server localhost:9092 \
+  --reassignment-json-file /tmp/reassignment.json \
+  --throttle 10000000 \
+  --execute
+----
+
+. Periodically verify whether the reassignment has completed using the `kafka-reassign-partitions.sh` command line tool from any of the broker pods. This is the same command as the previous step but with the `--verify` option instead of the `--execute` option.
++
+[source,shell,subs=+quotes]
+----
+kubectl exec _broker-pod_ -c kafka -it -- \
+  bin/kafka-reassign-partitions.sh --bootstrap-server localhost:9092 \
+  --reassignment-json-file /tmp/reassignment.json \
+  --verify
+----
++
+For example,
++
+[source,shell,subs=+quotes]
+----
+kubectl exec my-cluster-kafka-0 -c kafka -it -- \
+  bin/kafka-reassign-partitions.sh --bootstrap-server localhost:9092 \
+  --reassignment-json-file /tmp/reassignment.json \
+  --verify
+----
+
+. The reassignment has finished when the `--verify` command reports each of  the partitions being moved as completed successfully. 
+This final `--verify` will also have the effect of removing any reassignment throttles.
+You can now delete the revert file if you saved the JSON for reverting the assignment to their original brokers.

--- a/documentation/using/master.adoc
+++ b/documentation/using/master.adoc
@@ -7,7 +7,7 @@ include::shared/attributes.adoc[]
 
 include::assemblies/assembly-overview.adoc[leveloffset=+1]
 
-include::assemblies/assembly-deployment-configuration.adoc[leveloffset=+1]
+include::assemblies/configuring/assembly-deployment-configuration.adoc[leveloffset=+1]
 
 include::assemblies/assembly-securing-external-listeners.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Procedures describing how to configure Kafka have been consolidated into a single procedure in the Using Guide. Examples have been moved into the schema appendix. 

NEW FILES
configuring/assembly-config-kafka.adoc
configuring/proc-config-kafka.adoc (replaces /modules/ref-sample-kafka-resource-config.adoc)

**Restructure of chapter** 
Minimal updates to the content retained that follows _Configuring Kafka_. 

![image](https://user-images.githubusercontent.com/47596553/101478623-dcd04f80-3948-11eb-938b-e8dd3452440c.png)

* Scheduling section streamlined and moved up a level out of the Kafka config, as it applies to all components (moved to assembly-customizing-kubernetes-resources.adoc.)
* JMXtrans content reduced and conditionalised
* Removed duplication of proc-renewing-ca-certs-manually.adoc and proc-replacing-private-keys.adoc
added a paragraph on renewing to kafka config assembly
* ./modules/con-considerations-for-data-storage.adoc moves to assembly-storage.adoc

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

