### PR TITLE
Avoid changing custom resource status because of HashSet ordering

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -34,9 +34,9 @@ import io.vertx.core.shareddata.Lock;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -390,7 +390,7 @@ public abstract class AbstractOperator<
      */
     /*test*/ Set<Condition> validate(T resource) {
         if (resource != null) {
-            Set<Condition> warningConditions = new HashSet<>(0);
+            Set<Condition> warningConditions = new LinkedHashSet<>(0);
 
             ResourceVisitor.visit(resource, new ValidationVisitor(resource, log, warningConditions));
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When adding the warnings about deprecated fields in custom resources to conditions, we use currently HashSet to store them. But with multiple warnings, HashSet does give unpredictable ordering and that results in the status of the custom resource constantly changing.  This PR changes from `HashSet` to `LinkedHashSet` which has predictable ordering.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally