### PR TITLE
Integrate OAuth authentication custom claim check

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
@@ -58,6 +58,7 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     private boolean enablePlain = false;
     private String tokenEndpointUri;
     private boolean enableOauthBearer = true;
+    private String customClaimCheck;
 
     @Description("Must be `" + TYPE_OAUTH + "`")
     @Override
@@ -117,6 +118,17 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
 
     public void setCheckAudience(boolean checkAudience) {
         this.checkAudience = checkAudience;
+    }
+
+    @Description("JsonPath filter query to be applied to the JWT token or to the response of the introspection endpoint " +
+            "for additional token validation. Not set by default.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getCustomClaimCheck() {
+        return customClaimCheck;
+    }
+
+    public void setCustomClaimCheck(String customClaimCheck) {
+        this.customClaimCheck = customClaimCheck;
     }
 
     @Description("URI of the JWKS certificate endpoint, which can be used for local JWT validation.")

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
@@ -276,6 +276,12 @@ spec:
                                 OAuth client secret which the Kafka broker can use
                                 to authenticate against the authorization server and
                                 use the introspect endpoint URI.
+                            customClaimCheck:
+                              type: string
+                              description: JsonPath filter query to be applied to
+                                the JWT token or to the response of the introspection
+                                endpoint for additional token validation. Not set
+                                by default.
                             disableTlsHostnameVerification:
                               type: boolean
                               description: Enable or disable TLS hostname verification.

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
@@ -274,6 +274,12 @@ spec:
                                 OAuth client secret which the Kafka broker can use
                                 to authenticate against the authorization server and
                                 use the introspect endpoint URI.
+                            customClaimCheck:
+                              type: string
+                              description: JsonPath filter query to be applied to
+                                the JWT token or to the response of the introspection
+                                endpoint for additional token validation. Not set
+                                by default.
                             disableTlsHostnameVerification:
                               type: boolean
                               description: Enable or disable TLS hostname verification.
@@ -6362,6 +6368,12 @@ spec:
                                   the OAuth client secret which the Kafka broker can
                                   use to authenticate against the authorization server
                                   and use the introspect endpoint URI.
+                              customClaimCheck:
+                                type: string
+                                description: JsonPath filter query to be applied to
+                                  the JWT token or to the response of the introspection
+                                  endpoint for additional token validation. Not set
+                                  by default.
                               disableTlsHostnameVerification:
                                 type: boolean
                                 description: Enable or disable TLS hostname verification.
@@ -6809,6 +6821,12 @@ spec:
                                     the OAuth client secret which the Kafka broker
                                     can use to authenticate against the authorization
                                     server and use the introspect endpoint URI.
+                                customClaimCheck:
+                                  type: string
+                                  description: JsonPath filter query to be applied
+                                    to the JWT token or to the response of the introspection
+                                    endpoint for additional token validation. Not
+                                    set by default.
                                 disableTlsHostnameVerification:
                                   type: boolean
                                   description: Enable or disable TLS hostname verification.
@@ -7063,6 +7081,12 @@ spec:
                                     the OAuth client secret which the Kafka broker
                                     can use to authenticate against the authorization
                                     server and use the introspect endpoint URI.
+                                customClaimCheck:
+                                  type: string
+                                  description: JsonPath filter query to be applied
+                                    to the JWT token or to the response of the introspection
+                                    endpoint for additional token validation. Not
+                                    set by default.
                                 disableTlsHostnameVerification:
                                   type: boolean
                                   description: Enable or disable TLS hostname verification.
@@ -7340,6 +7364,12 @@ spec:
                                     the OAuth client secret which the Kafka broker
                                     can use to authenticate against the authorization
                                     server and use the introspect endpoint URI.
+                                customClaimCheck:
+                                  type: string
+                                  description: JsonPath filter query to be applied
+                                    to the JWT token or to the response of the introspection
+                                    endpoint for additional token validation. Not
+                                    set by default.
                                 disableTlsHostnameVerification:
                                   type: boolean
                                   description: Enable or disable TLS hostname verification.
@@ -14695,6 +14725,12 @@ spec:
                                   the OAuth client secret which the Kafka broker can
                                   use to authenticate against the authorization server
                                   and use the introspect endpoint URI.
+                              customClaimCheck:
+                                type: string
+                                description: JsonPath filter query to be applied to
+                                  the JWT token or to the response of the introspection
+                                  endpoint for additional token validation. Not set
+                                  by default.
                               disableTlsHostnameVerification:
                                 type: boolean
                                 description: Enable or disable TLS hostname verification.
@@ -15142,6 +15178,12 @@ spec:
                                     the OAuth client secret which the Kafka broker
                                     can use to authenticate against the authorization
                                     server and use the introspect endpoint URI.
+                                customClaimCheck:
+                                  type: string
+                                  description: JsonPath filter query to be applied
+                                    to the JWT token or to the response of the introspection
+                                    endpoint for additional token validation. Not
+                                    set by default.
                                 disableTlsHostnameVerification:
                                   type: boolean
                                   description: Enable or disable TLS hostname verification.
@@ -15396,6 +15438,12 @@ spec:
                                     the OAuth client secret which the Kafka broker
                                     can use to authenticate against the authorization
                                     server and use the introspect endpoint URI.
+                                customClaimCheck:
+                                  type: string
+                                  description: JsonPath filter query to be applied
+                                    to the JWT token or to the response of the introspection
+                                    endpoint for additional token validation. Not
+                                    set by default.
                                 disableTlsHostnameVerification:
                                   type: boolean
                                   description: Enable or disable TLS hostname verification.
@@ -15673,6 +15721,12 @@ spec:
                                     the OAuth client secret which the Kafka broker
                                     can use to authenticate against the authorization
                                     server and use the introspect endpoint URI.
+                                customClaimCheck:
+                                  type: string
+                                  description: JsonPath filter query to be applied
+                                    to the JWT token or to the response of the introspection
+                                    endpoint for additional token validation. Not
+                                    set by default.
                                 disableTlsHostnameVerification:
                                   type: boolean
                                   description: Enable or disable TLS hostname verification.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -355,6 +355,7 @@ public class KafkaBrokerConfigurationBuilder {
         addOption(options, ServerConfig.OAUTH_VALID_ISSUER_URI, oauth.getValidIssuerUri());
         addBooleanOptionIfFalse(options, ServerConfig.OAUTH_CHECK_ISSUER, oauth.isCheckIssuer());
         addBooleanOptionIfTrue(options, ServerConfig.OAUTH_CHECK_AUDIENCE, oauth.isCheckAudience());
+        addOption(options, ServerConfig.OAUTH_CUSTOM_CLAIM_CHECK, oauth.getCustomClaimCheck());
         addOption(options, ServerConfig.OAUTH_JWKS_ENDPOINT_URI, oauth.getJwksEndpointUri());
         if (oauth.getJwksRefreshSeconds() != null && oauth.getJwksRefreshSeconds() > 0) {
             addOption(options, ServerConfig.OAUTH_JWKS_REFRESH_SECONDS, String.valueOf(oauth.getJwksRefreshSeconds()));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBroker;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.kafka.oauth.jsonpath.JsonPathFilterQuery;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -439,6 +440,15 @@ public class ListenersValidator {
 
             if (oAuth.isCheckAudience() && oAuth.getClientId() == null) {
                 errors.add("listener " + listenerName + ": 'clientId' has to be configured when 'checkAudience' is 'true'");
+            }
+
+            String customCheckQuery = oAuth.getCustomClaimCheck();
+            if (customCheckQuery != null) {
+                try {
+                    JsonPathFilterQuery.parse(customCheckQuery);
+                } catch (Exception e) {
+                    errors.add("listener " + listenerName + ": 'customClaimCheck' value not a valid JsonPath filter query - " + e.getMessage());
+                }
             }
 
             if (oAuth.getIntrospectionEndpointUri() != null && (oAuth.getClientId() == null || oAuth.getClientSecret() == null)) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -1031,6 +1031,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                     .withNewValidIssuerUri("https://valid-issuer")
                     .withNewIntrospectionEndpointUri("https://intro")
                     .withCheckAudience(true)
+                    .withCustomClaimCheck("'kafka-user' in @.roles.client-roles.kafka")
                     .withNewClientId("my-oauth-client")
                     .withNewClientSecret()
                         .withNewSecretName("my-secret")
@@ -1058,7 +1059,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "ssl.secure.random.implementation=SHA1PRNG",
                 "ssl.endpoint.identification.algorithm=HTTPS",
                 "listener.name.plain-9092.oauthbearer.sasl.server.callback.handler.class=io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler",
-                "listener.name.plain-9092.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub=\"thePrincipalName\" oauth.client.id=\"my-oauth-client\" oauth.valid.issuer.uri=\"https://valid-issuer\" oauth.check.audience=\"true\" oauth.introspection.endpoint.uri=\"https://intro\" oauth.client.secret=\"${STRIMZI_PLAIN_9092_OAUTH_CLIENT_SECRET}\";",
+                "listener.name.plain-9092.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub=\"thePrincipalName\" oauth.client.id=\"my-oauth-client\" oauth.valid.issuer.uri=\"https://valid-issuer\" oauth.check.audience=\"true\" oauth.custom.claim.check=\"'kafka-user' in @.roles.client-roles.kafka\" oauth.introspection.endpoint.uri=\"https://intro\" oauth.client.secret=\"${STRIMZI_PLAIN_9092_OAUTH_CLIENT_SECRET}\";",
                 "listener.name.plain-9092.sasl.enabled.mechanisms=OAUTHBEARER",
                 "principal.builder.class=io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder"));
     }

--- a/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
@@ -28,6 +28,26 @@
         </repository>
     </repositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <!--
+            Override version 1.1.1 dependency of net.logstash.log4j:jsonevent-layout
+            Tests with updated version pass using sources at https://github.com/logstash/log4j-jsonevent-layout
+            -->
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>2.3</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- https://mvnrepository.com/artifact/io.prometheus.jmx/jmx_prometheus_javaagent -->
         <dependency>
@@ -102,10 +122,6 @@
                 <exclusion>
                     <groupId>com.sun.activation</groupId>
                     <artifactId>jakarta.activation</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.jayway.jsonpath</groupId>
-                    <artifactId>json-path</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
@@ -28,6 +28,26 @@
         </repository>
     </repositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <!--
+            Override version 1.1.1 dependency of net.logstash.log4j:jsonevent-layout
+            Tests with updated version pass using sources at https://github.com/logstash/log4j-jsonevent-layout
+            -->
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>2.3</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- https://mvnrepository.com/artifact/io.prometheus.jmx/jmx_prometheus_javaagent -->
         <dependency>
@@ -102,10 +122,6 @@
                 <exclusion>
                     <groupId>com.sun.activation</groupId>
                     <artifactId>jakarta.activation</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.jayway.jsonpath</groupId>
-                    <artifactId>json-path</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
@@ -28,6 +28,26 @@
         </repository>
     </repositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <!--
+            Override version 1.1.1 dependency of net.logstash.log4j:jsonevent-layout
+            Tests with updated version pass using sources at https://github.com/logstash/log4j-jsonevent-layout
+            -->
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>2.3</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- https://mvnrepository.com/artifact/io.prometheus.jmx/jmx_prometheus_javaagent -->
         <dependency>
@@ -102,10 +122,6 @@
                 <exclusion>
                     <groupId>com.sun.activation</groupId>
                     <artifactId>jakarta.activation</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.jayway.jsonpath</groupId>
-                    <artifactId>json-path</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -283,6 +283,8 @@ It must have the value `oauth` for the type `KafkaListenerAuthenticationOAuth`.
 |string
 |clientSecret                       1.2+<.<|Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
 |xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
+|customClaimCheck                   1.2+<.<|JsonPath filter query to be applied to the JWT token or to the response of the introspection endpoint for additional token validation. Not set by default.
+|string
 |disableTlsHostnameVerification     1.2+<.<|Enable or disable TLS hostname verification. Default value is `false`.
 |boolean
 |enableECDSA                        1.2+<.<|Enable or disable ECDSA support by installing BouncyCastle crypto provider. Default value is `false`.

--- a/documentation/modules/oauth/proc-oauth-authentication-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authentication-broker-config.adoc
@@ -136,7 +136,7 @@ Depending on how you apply OAuth 2.0 authentication, and the type of authorizati
 <7> Set this to `false` in order to disable the SASL_OAUTHBEARER mechanism on the listener. At least one of SASL_PLAIN or SASL_OAUTHBEARER has to be enabled. Default is `true`.
 <8> Set this to `true` in order to enable the SASL_PLAIN mechanism on the listener, which is supported by all clients on all platforms. The Kafka client has to enable the SASL_PLAIN mechanism and set the `username` and the `password`. This mechanism can be used to authenticate either by using the OAuth access token, or by using the OAuth clientId and secret (client credentials). If the client sets `username` to `access-token` then the password is interpreted as access token on the server, otherwise the user is interpreted as the clientId, and password as the client secret. Default is `false`.
 <9> This has to be set to support the client credentials authentication when `enablePlain` is set to true, as described in previous point.
-<10> Additional custom rules can be imposed on the JWT access token during validation by setting this to a JsonPath filter query. If matching fails, the access token is rejected. When using `introspectionEndpointUri` the custom check is applied to the introspection endpoint response JSON.
+<10> Additional custom rules can be imposed on the JWT access token during validation by setting this to a JsonPath filter query. If the access token does not contain the necessary data, it is rejected. When using the `introspectionEndpointUri`, the custom check is applied to the introspection endpoint response JSON.
 
 . Save and exit the editor, then wait for rolling updates to complete.
 

--- a/documentation/modules/oauth/proc-oauth-authentication-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authentication-broker-config.adoc
@@ -125,6 +125,7 @@ Depending on how you apply OAuth 2.0 authentication, and the type of authorizati
     enableOauthBearer: false <7>
     enablePlain: true <8>
     tokenEndpointUri: __https://OAUTH-SERVER-ADDRESS/auth/realms/external/protocol/openid-connect/token__ <9>
+    customClaimCheck: "@.custom == 'custom-value'" <10>
 ----
 <1> If your authorization server does not provide an `iss` claim, it is not possible to perform an issuer check. In this situation, set `checkIssuer` to `false` and do not specify a `validIssuerUri`. Default is `true`.
 <2> If your authorization server provides an `aud` (audience) claim, and you want to enforce an audience check, set `checkAudience` to `true`. Audience checks identify the intended recipients of tokens. As a result, the Kafka broker will reject tokens that do not have its `clientId` in their `aud` claim. Default is `false`.
@@ -135,6 +136,7 @@ Depending on how you apply OAuth 2.0 authentication, and the type of authorizati
 <7> Set this to `false` in order to disable the SASL_OAUTHBEARER mechanism on the listener. At least one of SASL_PLAIN or SASL_OAUTHBEARER has to be enabled. Default is `true`.
 <8> Set this to `true` in order to enable the SASL_PLAIN mechanism on the listener, which is supported by all clients on all platforms. The Kafka client has to enable the SASL_PLAIN mechanism and set the `username` and the `password`. This mechanism can be used to authenticate either by using the OAuth access token, or by using the OAuth clientId and secret (client credentials). If the client sets `username` to `access-token` then the password is interpreted as access token on the server, otherwise the user is interpreted as the clientId, and password as the client secret. Default is `false`.
 <9> This has to be set to support the client credentials authentication when `enablePlain` is set to true, as described in previous point.
+<10> Additional custom rules can be imposed on the JWT access token during validation by setting this to a JsonPath filter query. If matching fails, the access token is rejected. When using `introspectionEndpointUri` the custom check is applied to the introspection endpoint response JSON.
 
 . Save and exit the editor, then wait for rolling updates to complete.
 

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -212,6 +212,9 @@ spec:
                                   - key
                                   - secretName
                                 description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
+                              customClaimCheck:
+                                type: string
+                                description: JsonPath filter query to be applied to the JWT token or to the response of the introspection endpoint for additional token validation. Not set by default.
                               disableTlsHostnameVerification:
                                 type: boolean
                                 description: Enable or disable TLS hostname verification. Default value is `false`.
@@ -494,6 +497,9 @@ spec:
                                     - key
                                     - secretName
                                   description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
+                                customClaimCheck:
+                                  type: string
+                                  description: JsonPath filter query to be applied to the JWT token or to the response of the introspection endpoint for additional token validation. Not set by default.
                                 disableTlsHostnameVerification:
                                   type: boolean
                                   description: Enable or disable TLS hostname verification. Default value is `false`.
@@ -659,6 +665,9 @@ spec:
                                     - key
                                     - secretName
                                   description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
+                                customClaimCheck:
+                                  type: string
+                                  description: JsonPath filter query to be applied to the JWT token or to the response of the introspection endpoint for additional token validation. Not set by default.
                                 disableTlsHostnameVerification:
                                   type: boolean
                                   description: Enable or disable TLS hostname verification. Default value is `false`.
@@ -845,6 +854,9 @@ spec:
                                     - key
                                     - secretName
                                   description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
+                                customClaimCheck:
+                                  type: string
+                                  description: JsonPath filter query to be applied to the JWT token or to the response of the introspection endpoint for additional token validation. Not set by default.
                                 disableTlsHostnameVerification:
                                   type: boolean
                                   description: Enable or disable TLS hostname verification. Default value is `false`.

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -277,6 +277,12 @@ spec:
                                 OAuth client secret which the Kafka broker can use
                                 to authenticate against the authorization server and
                                 use the introspect endpoint URI.
+                            customClaimCheck:
+                              type: string
+                              description: JsonPath filter query to be applied to
+                                the JWT token or to the response of the introspection
+                                endpoint for additional token validation. Not set
+                                by default.
                             disableTlsHostnameVerification:
                               type: boolean
                               description: Enable or disable TLS hostname verification.
@@ -722,6 +728,12 @@ spec:
                                   the OAuth client secret which the Kafka broker can
                                   use to authenticate against the authorization server
                                   and use the introspect endpoint URI.
+                              customClaimCheck:
+                                type: string
+                                description: JsonPath filter query to be applied to
+                                  the JWT token or to the response of the introspection
+                                  endpoint for additional token validation. Not set
+                                  by default.
                               disableTlsHostnameVerification:
                                 type: boolean
                                 description: Enable or disable TLS hostname verification.
@@ -970,6 +982,12 @@ spec:
                                   the OAuth client secret which the Kafka broker can
                                   use to authenticate against the authorization server
                                   and use the introspect endpoint URI.
+                              customClaimCheck:
+                                type: string
+                                description: JsonPath filter query to be applied to
+                                  the JWT token or to the response of the introspection
+                                  endpoint for additional token validation. Not set
+                                  by default.
                               disableTlsHostnameVerification:
                                 type: boolean
                                 description: Enable or disable TLS hostname verification.
@@ -1242,6 +1260,12 @@ spec:
                                   the OAuth client secret which the Kafka broker can
                                   use to authenticate against the authorization server
                                   and use the introspect endpoint URI.
+                              customClaimCheck:
+                                type: string
+                                description: JsonPath filter query to be applied to
+                                  the JWT token or to the response of the introspection
+                                  endpoint for additional token validation. Not set
+                                  by default.
                               disableTlsHostnameVerification:
                                 type: boolean
                                 description: Enable or disable TLS hostname verification.

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <scala-library.version>2.12.12</scala-library.version>
         <zookeeper.version>3.5.8</zookeeper.version>
         <mockito.version>2.28.2</mockito.version>
-        <jsonpath.version>2.4.0</jsonpath.version>
+        <jsonpath.version>2.5.0</jsonpath.version>
         <slf4j.version>1.7.25</slf4j.version>
         <quartz.version>2.3.2</quartz.version>
         <debezium.version>1.3.1.Final</debezium.version>
@@ -694,12 +694,6 @@
                 <groupId>io.strimzi</groupId>
                 <artifactId>kafka-oauth-common</artifactId>
                 <version>${strimzi-oauth.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.jayway.jsonpath</groupId>
-                        <artifactId>json-path</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.strimzi</groupId>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds ability to add custom validation of JWT token during authentication by specifying a JsonPath filter query to pass or fail the access token based on its content. If introspection endpoint is used, the filter query is applied to the response of the introspection endpoint. 

The following configuration option is added to the 'authentication' section of type 'oauth' of the Kafka CR:

```
  authentication:
    type: oauth
    customClaimCheck: "FILTER QUERY"
```

This PR depends on https://github.com/strimzi/strimzi-kafka-oauth/pull/87.
This PR is based on top of https://github.com/strimzi/strimzi-kafka-operator/pull/4027.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards
