### PR TITLE
CO should be more verbose when resource name is missing

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -114,17 +114,17 @@ public class ListenersValidator {
     private static void validateBrokerCertChainAndKey(Set<String> errors, GenericKafkaListener listener) {
         if (listener.getConfiguration().getBrokerCertChainAndKey().getSecretName() == null
                 || listener.getConfiguration().getBrokerCertChainAndKey().getSecretName().isEmpty()) {
-            errors.add("listener '" + listener.getName() + "' cannot have empty secret name in the brokerCertChainAndKey");
+            errors.add("listener '" + listener.getName() + "' cannot have an empty secret name in the brokerCertChainAndKey");
         }
 
         if (listener.getConfiguration().getBrokerCertChainAndKey().getKey() == null
                 || listener.getConfiguration().getBrokerCertChainAndKey().getKey().isEmpty()) {
-            errors.add("listener '" + listener.getName() + "' cannot have empty key in the brokerCertChainAndKey");
+            errors.add("listener '" + listener.getName() + "' cannot have an empty key in the brokerCertChainAndKey");
         }
 
         if (listener.getConfiguration().getBrokerCertChainAndKey().getCertificate() == null
                 || listener.getConfiguration().getBrokerCertChainAndKey().getCertificate().isEmpty()) {
-            errors.add("listener '" + listener.getName() + "' cannot have empty certificate in the brokerCertChainAndKey");
+            errors.add("listener '" + listener.getName() + "' cannot have an empty certificate in the brokerCertChainAndKey");
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -93,10 +93,8 @@ public class ListenersValidator {
                     }
                 }
 
-                if (listener.getConfiguration().getBrokerCertChainAndKey() != null
-                    && (listener.getConfiguration().getBrokerCertChainAndKey().getSecretName() == null
-                    || listener.getConfiguration().getBrokerCertChainAndKey().getSecretName().isEmpty())) {
-                    errors.add("listener '" + listener.getName() + "' cannot have empty secret name in the brokerCertChainAndKey");
+                if (listener.getConfiguration().getBrokerCertChainAndKey() != null) {
+                    validateBrokerCertChainAndKey(errors, listener);
                 }
             }
 
@@ -107,6 +105,29 @@ public class ListenersValidator {
 
         return errors;
     }
+    /**
+     * Validates that the listener has a BrokerCertChainAndKey with non-empty values
+     *
+     * @param errors    List where any found errors will be added
+     * @param listener  Listener which needs to be validated
+     */
+    private static void validateBrokerCertChainAndKey(Set<String> errors, GenericKafkaListener listener) {
+        if (listener.getConfiguration().getBrokerCertChainAndKey().getSecretName() == null
+                || listener.getConfiguration().getBrokerCertChainAndKey().getSecretName().isEmpty()) {
+            errors.add("listener '" + listener.getName() + "' cannot have empty secret name in the brokerCertChainAndKey");
+        }
+
+        if (listener.getConfiguration().getBrokerCertChainAndKey().getKey() == null
+                || listener.getConfiguration().getBrokerCertChainAndKey().getKey().isEmpty()) {
+            errors.add("listener '" + listener.getName() + "' cannot have empty key in the brokerCertChainAndKey");
+        }
+
+        if (listener.getConfiguration().getBrokerCertChainAndKey().getCertificate() == null
+                || listener.getConfiguration().getBrokerCertChainAndKey().getCertificate().isEmpty()) {
+            errors.add("listener '" + listener.getName() + "' cannot have empty certificate in the brokerCertChainAndKey");
+        }
+    }
+
 
     /**
      * Validates that the listener has an allowed port number

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -92,6 +92,12 @@ public class ListenersValidator {
                         validateBrokerDnsAnnotations(errors, listener, broker);
                     }
                 }
+
+                if (listener.getConfiguration().getBrokerCertChainAndKey() != null
+                    && listener.getConfiguration().getBrokerCertChainAndKey().getSecretName() == null
+                    || listener.getConfiguration().getBrokerCertChainAndKey().getSecretName().isEmpty()) {
+                    errors.add("listener '" + listener.getName() + "' cannot have empty secret name in the brokerCertChainAndKey");
+                }
             }
 
             if (KafkaListenerType.INGRESS.equals(listener.getType()))    {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -94,8 +94,8 @@ public class ListenersValidator {
                 }
 
                 if (listener.getConfiguration().getBrokerCertChainAndKey() != null
-                    && listener.getConfiguration().getBrokerCertChainAndKey().getSecretName() == null
-                    || listener.getConfiguration().getBrokerCertChainAndKey().getSecretName().isEmpty()) {
+                    && (listener.getConfiguration().getBrokerCertChainAndKey().getSecretName() == null
+                    || listener.getConfiguration().getBrokerCertChainAndKey().getSecretName().isEmpty())) {
                     errors.add("listener '" + listener.getName() + "' cannot have empty secret name in the brokerCertChainAndKey");
                 }
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -668,9 +668,9 @@ public class ListenersValidatorTest {
 
         Exception exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(3, listeners));
         assertThat(exception.getMessage(), allOf(
-                containsString("listener 'listener1' cannot have empty secret name in the brokerCertChainAndKey"),
-                containsString("listener 'listener1' cannot have empty key in the brokerCertChainAndKey"),
-                containsString("listener 'listener1' cannot have empty certificate in the brokerCertChainAndKey")));
+                containsString("listener 'listener1' cannot have an empty secret name in the brokerCertChainAndKey"),
+                containsString("listener 'listener1' cannot have an empty key in the brokerCertChainAndKey"),
+                containsString("listener 'listener1' cannot have an empty certificate in the brokerCertChainAndKey")));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -651,6 +651,29 @@ public class ListenersValidatorTest {
     }
 
     @Test
+    public void testValidateBrokerCertChainAndKey() {
+        GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
+                .withName("listener1")
+                .withPort(9900)
+                .withType(KafkaListenerType.INTERNAL)
+                .withNewConfiguration()
+                    .withNewBrokerCertChainAndKey()
+                        .withCertificate("")
+                        .withKey("")
+                    .endBrokerCertChainAndKey()
+                .endConfiguration()
+                .build();
+
+        List<GenericKafkaListener> listeners = asList(listener1);
+
+        Exception exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(3, listeners));
+        assertThat(exception.getMessage(), allOf(
+                containsString("listener 'listener1' cannot have empty secret name in the brokerCertChainAndKey"),
+                containsString("listener 'listener1' cannot have empty key in the brokerCertChainAndKey"),
+                containsString("listener 'listener1' cannot have empty certificate in the brokerCertChainAndKey")));
+    }
+
+    @Test
     public void testMinimalConfiguration() {
         GenericKafkaListener internal = new GenericKafkaListenerBuilder()
                 .withName("internal")

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
@@ -198,6 +198,9 @@ public abstract class AbstractNonNamespacedResourceOperator<C extends Kubernetes
      * @return The resource, or null if it doesn't exist.
      */
     public T get(String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException(resourceKind + " with an empty name cannot be configured. Please provide a name.");
+        }
         return operation().withName(name).get();
     }
 
@@ -207,6 +210,9 @@ public abstract class AbstractNonNamespacedResourceOperator<C extends Kubernetes
      * @return A Future for the result.
      */
     public Future<T> getAsync(String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException(resourceKind + " with an empty name cannot be configured. Please provide a name.");
+        }
         return resourceSupport.getAsync(operation().withName(name));
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -230,6 +230,9 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
      * @return The resource, or null if it doesn't exist.
      */
     public T get(String namespace, String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException(resourceKind + " with an empty name cannot be configured. Please provide a name.");
+        }
         return operation().inNamespace(namespace).withName(name).get();
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -231,7 +231,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
      */
     public T get(String namespace, String name) {
         if (name == null || name.isEmpty()) {
-            throw new IllegalArgumentException(resourceKind + " with an empty name cannot be configured. Please provide a name.");
+            throw new IllegalArgumentException(namespace + "/" + resourceKind + " with an empty name cannot be configured. Please provide a name.");
         }
         return operation().inNamespace(namespace).withName(name).get();
     }
@@ -244,7 +244,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
      */
     public Future<T> getAsync(String namespace, String name) {
         if (name == null || name.isEmpty()) {
-            throw new IllegalArgumentException(resourceKind + " with an empty name cannot be configured. Please provide a name.");
+            throw new IllegalArgumentException(namespace + "/" + resourceKind + " with an empty name cannot be configured. Please provide a name.");
         }
         return resourceSupport.getAsync(operation().inNamespace(namespace).withName(name));
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -240,6 +240,9 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
      * @return A Future for the result.
      */
     public Future<T> getAsync(String namespace, String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException(resourceKind + " with an empty name cannot be configured. Please provide a name.");
+        }
         return resourceSupport.getAsync(operation().inNamespace(namespace).withName(name));
     }
 


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement

### Description
When the resource name in the CR is not specified, `operation().inNamespace(namespace).withName(name)` returns an exception `Name must be provided.`(coming from the fabric8). In the large CR it can be tricky to find, what name is missing. This PR adds information, what resource does have an empty name specified. 

Output after these changes:
```
java.lang.IllegalArgumentException: Secret with an empty name cannot be configured. Please provide a name.
```

Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/4022
### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

