### PR TITLE
#4035: Patch Rancher Cattle annotations when reconciling services

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -9,7 +9,10 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Integer.parseInt;
@@ -35,6 +38,14 @@ public class Annotations {
     public static final String ANNO_OP_STRIMZI_IO_MANUAL_ROLLING_UPDATE = "operator." + Annotations.STRIMZI_DOMAIN + "manual-rolling-update";
 
     public static final String ANNO_DEP_KUBE_IO_REVISION = "deployment.kubernetes.io/revision";
+
+    /**
+     * Whitelist of predicates that allows existing load balancer service annotations to be retained while reconciling the resources.
+     */
+    public static final List<Predicate<String>> LOADBALANCER_ANNOTATION_WHITELIST = List.of(
+            Pattern.compile("cattle\\.io/.*").asMatchPredicate(),
+            Pattern.compile("field\\.cattle\\.io.*").asMatchPredicate()
+    );
 
     private static Map<String, String> annotations(ObjectMeta metadata) {
         Map<String, String> annotations = metadata.getAnnotations();

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -43,8 +43,8 @@ public class Annotations {
      * Whitelist of predicates that allows existing load balancer service annotations to be retained while reconciling the resources.
      */
     public static final List<Predicate<String>> LOADBALANCER_ANNOTATION_WHITELIST = List.of(
-            Pattern.compile("cattle\\.io/.*").asMatchPredicate(),
-            Pattern.compile("field\\.cattle\\.io.*").asMatchPredicate()
+            annotation -> annotation.startsWith("cattle.io/"),
+            annotation -> annotation.startsWith("field.cattle.io")
     );
 
     private static Map<String, String> annotations(ObjectMeta metadata) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
-import java.util.regex.Pattern;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Integer.parseInt;
@@ -43,8 +42,8 @@ public class Annotations {
      * Whitelist of predicates that allows existing load balancer service annotations to be retained while reconciling the resources.
      */
     public static final List<Predicate<String>> LOADBALANCER_ANNOTATION_WHITELIST = List.of(
-            annotation -> annotation.startsWith("cattle.io/"),
-            annotation -> annotation.startsWith("field.cattle.io")
+        annotation -> annotation.startsWith("cattle.io/"),
+        annotation -> annotation.startsWith("field.cattle.io")
     );
 
     private static Map<String, String> annotations(ObjectMeta metadata) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Should fix #4035, by whitelisting all "cattle.io" annotations, and patching them into the desired spec for Services of the type LoadBalancer or NodePort.

- Is it better to make the "cattle.io" seed configurable?

### Checklist

- [X] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

