### PR TITLE
Remove owner referneces from ClusterRoleBindings

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1402,9 +1402,8 @@ public abstract class AbstractModel {
     protected ClusterRoleBinding getClusterRoleBinding(String name, Subject subject, RoleRef roleRef) {
         return new ClusterRoleBindingBuilder()
                 .withNewMetadata()
-                .withName(name)
-                .withOwnerReferences(createOwnerReference())
-                .withLabels(labels.toMap())
+                    .withName(name)
+                    .withLabels(labels.toMap())
                 .endMetadata()
                 .withSubjects(subject)
                 .withRoleRef(roleRef)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -97,5 +97,4 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
     protected Future<Boolean> delete(Reconciliation reconciliation) {
         return Future.succeededFuture(Boolean.FALSE);
     }
-
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -3712,6 +3712,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         return new KafkaStatus();
     }
 
+    @Override
     protected Future<Boolean> delete(Reconciliation reconciliation) {
         return clusterRoleBindingOperations.reconcile(KafkaResources.initContainerClusterRoleBindingName(reconciliation.name(), reconciliation.namespace()), null)
                 .recover(error -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1814,26 +1814,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
         Future<ReconciliationState> kafkaInitClusterRoleBinding() {
             ClusterRoleBinding desired = kafkaCluster.generateClusterRoleBinding(namespace);
-            Future<ReconcileResult<ClusterRoleBinding>> fut = clusterRoleBindingOperations.reconcile(
-                    KafkaResources.initContainerClusterRoleBindingName(name, namespace), desired);
 
-            Promise replacementPromise = Promise.promise();
-
-            fut.onComplete(res -> {
-                if (res.failed()) {
-                    if (desired == null && res.cause() != null && res.cause().getMessage() != null &&
-                            res.cause().getMessage().contains("Message: Forbidden!")) {
-                        log.debug("Ignoring forbidden access to ClusterRoleBindings which seems not needed while Kafka rack awareness is disabled.");
-                        replacementPromise.complete();
-                    } else {
-                        replacementPromise.fail(res.cause());
-                    }
-                } else {
-                    replacementPromise.complete();
-                }
-            });
-
-            return withVoid(replacementPromise.future());
+            return withVoid(withIgnoreRbacError(clusterRoleBindingOperations.reconcile(KafkaResources.initContainerClusterRoleBindingName(name, namespace), desired), desired));
         }
 
         Future<ReconciliationState> kafkaScaleDown() {
@@ -3712,19 +3694,15 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         return new KafkaStatus();
     }
 
+    /**
+     * Deletes the ClusterRoleBinding which as a cluster-scoped resource cannot be deleted by the ownerReference
+     *
+     * @param reconciliation    The Reconciliation identification
+     * @return                  Future indicating the result of the deletion
+     */
     @Override
     protected Future<Boolean> delete(Reconciliation reconciliation) {
-        return clusterRoleBindingOperations.reconcile(KafkaResources.initContainerClusterRoleBindingName(reconciliation.name(), reconciliation.namespace()), null)
-                .recover(error -> {
-                    if (error != null
-                            && error.getMessage() != null
-                            && error.getMessage().contains("Message: Forbidden!"))  {
-                        log.debug("Ignoring forbidden access to ClusterRoleBindings when attempting to delete resources.");
-                        return Future.succeededFuture();
-                    } else {
-                        return Future.failedFuture(error);
-                    }
-                })
+        return withIgnoreRbacError(clusterRoleBindingOperations.reconcile(KafkaResources.initContainerClusterRoleBindingName(reconciliation.name(), reconciliation.namespace()), null), null)
                 .map(Boolean.FALSE); // Return FALSE since other resources are still deleted by garbage collection
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -216,6 +216,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
         return replacementPromise.future();
     }
 
+    @Override
     protected Future<Boolean> delete(Reconciliation reconciliation) {
         return super.delete(reconciliation)
                 .compose(i -> clusterRoleBindingOperations.reconcile(KafkaConnectResources.initContainerClusterRoleBindingName(reconciliation.name(), reconciliation.namespace()), null))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -194,42 +194,20 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
      */
     Future<ReconcileResult<ClusterRoleBinding>> connectInitClusterRoleBinding(String namespace, String name, KafkaConnectCluster connectCluster) {
         ClusterRoleBinding desired = connectCluster.generateClusterRoleBinding();
-        Future<ReconcileResult<ClusterRoleBinding>> fut = clusterRoleBindingOperations.reconcile(
-                KafkaConnectResources.initContainerClusterRoleBindingName(name, namespace), desired);
 
-        Promise<ReconcileResult<ClusterRoleBinding>> replacementPromise = Promise.promise();
-
-        fut.onComplete(res -> {
-            if (res.failed()) {
-                if (desired == null && res.cause() != null && res.cause().getMessage() != null &&
-                        res.cause().getMessage().contains("Message: Forbidden!")) {
-                    log.debug("Ignoring forbidden access to ClusterRoleBindings which seems not needed while Kafka Connect rack awareness is disabled.");
-                    replacementPromise.complete();
-                } else {
-                    replacementPromise.fail(res.cause());
-                }
-            } else {
-                replacementPromise.complete(res.result());
-            }
-        });
-
-        return replacementPromise.future();
+        return withIgnoreRbacError(clusterRoleBindingOperations.reconcile(KafkaConnectResources.initContainerClusterRoleBindingName(name, namespace), desired), desired);
     }
 
+    /**
+     * Deletes the ClusterRoleBinding which as a cluster-scoped resource cannot be deleted by the ownerReference
+     *
+     * @param reconciliation    The Reconciliation identification
+     * @return                  Future indicating the result of the deletion
+     */
     @Override
     protected Future<Boolean> delete(Reconciliation reconciliation) {
         return super.delete(reconciliation)
-                .compose(i -> clusterRoleBindingOperations.reconcile(KafkaConnectResources.initContainerClusterRoleBindingName(reconciliation.name(), reconciliation.namespace()), null))
-                .recover(error -> {
-                    if (error != null
-                            && error.getMessage() != null
-                            && error.getMessage().contains("Message: Forbidden!"))  {
-                        log.debug("Ignoring forbidden access to ClusterRoleBindings when attempting to delete resources.");
-                        return Future.succeededFuture();
-                    } else {
-                        return Future.failedFuture(error);
-                    }
-                })
+                .compose(i -> withIgnoreRbacError(clusterRoleBindingOperations.reconcile(KafkaConnectResources.initContainerClusterRoleBindingName(reconciliation.name(), reconciliation.namespace()), null), null))
                 .map(Boolean.FALSE); // Return FALSE since other resources are still deleted by garbage collection
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -254,7 +254,7 @@ public abstract class AbstractOperator<
                     if (deleteResult) {
                         log.info("{}: {} {} deleted", reconciliation, kind, name);
                     } else {
-                        log.info("{}: Assembly {} should be deleted by garbage collection", reconciliation, name);
+                        log.info("{}: Assembly {} or some parts of it will be deleted by garbage collection", reconciliation, name);
                     }
                     return (Void) null;
                 }).recover(deleteResult -> {

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -535,7 +535,7 @@ public abstract class AbstractOperator<
                         && res.cause() != null
                         && res.cause().getMessage() != null
                         && res.cause().getMessage().contains("Message: Forbidden!")) {
-                    log.debug("Ignoring forbidden access to resource which does not seem to be required.");
+                    log.debug("Ignoring forbidden access to ClusterRoleBindings resource which does not seem to be required.");
                     replacementPromise.complete(ReconcileResult.noop(null));
                 } else {
                     replacementPromise.fail(res.cause());

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.common;
 
 import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
@@ -24,6 +25,7 @@ import io.strimzi.operator.common.model.NamespaceAndName;
 import io.strimzi.operator.common.model.ResourceVisitor;
 import io.strimzi.operator.common.model.ValidationVisitor;
 import io.strimzi.operator.common.operator.resource.AbstractWatchableStatusedResourceOperator;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.StatusUtils;
 import io.strimzi.operator.common.operator.resource.TimeoutException;
 import io.vertx.core.AsyncResult;
@@ -513,5 +515,36 @@ public abstract class AbstractOperator<
                 log.debug("{}: Removed metric " + METRICS_PREFIX + "resource.state{}", reconciliation, metricTags);
             }
         }
+    }
+
+    /**
+     * In some cases, when the ClusterRoleBinding reconciliation fails with RBAC error and the desired object is null,
+     * we want to ignore the error and return success. This is used to let Strimzi work without some Cluster-wide RBAC
+     * rights when the features they are needed for are not used by the user.
+     *
+     * @param reconcileFuture   The original reconciliation future
+     * @param desired           The desired state of the resource.
+     * @return                  A future which completes when the resource was reconciled.
+     */
+    public Future<ReconcileResult<ClusterRoleBinding>> withIgnoreRbacError(Future<ReconcileResult<ClusterRoleBinding>> reconcileFuture, ClusterRoleBinding desired) {
+        Promise<ReconcileResult<ClusterRoleBinding>> replacementPromise = Promise.promise();
+
+        reconcileFuture.onComplete(res -> {
+            if (res.failed()) {
+                if (desired == null
+                        && res.cause() != null
+                        && res.cause().getMessage() != null
+                        && res.cause().getMessage().contains("Message: Forbidden!")) {
+                    log.debug("Ignoring forbidden access to resource which does not seem to be required.");
+                    replacementPromise.complete(ReconcileResult.noop(null));
+                } else {
+                    replacementPromise.fail(res.cause());
+                }
+            } else {
+                replacementPromise.complete(res.result());
+            }
+        });
+
+        return replacementPromise.future();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/ClusterOperatorRbacST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/ClusterOperatorRbacST.java
@@ -47,14 +47,14 @@ public class ClusterOperatorRbacST extends AbstractST {
 
         LOGGER.info("CO log should contain some information about ignoring forbidden access to CRB for Kafka");
         String log = cmdKubeClient().execInCurrentNamespace(false, "logs", coPodName).out();
-        assertTrue(log.contains("Ignoring forbidden access to ClusterRoleBindings which seems not needed while Kafka rack awareness is disabled."));
+        assertTrue(log.contains("Ignoring forbidden access to ClusterRoleBindings resource which does not seem to be required."));
 
         LOGGER.info("Deploying KafkaConnect: {} without rack awareness, the CR should be deployed without error", CLUSTER_NAME);
         KafkaConnectResource.kafkaConnect(CLUSTER_NAME, 1, false).done();
 
         LOGGER.info("CO log should contain some information about ignoring forbidden access to CRB for KafkaConnect");
         log = cmdKubeClient().execInCurrentNamespace(false, "logs", coPodName, "--tail", "50").out();
-        assertTrue(log.contains("Ignoring forbidden access to ClusterRoleBindings which seems not needed while Kafka Connect rack awareness is disabled."));
+        assertTrue(log.contains("Ignoring forbidden access to ClusterRoleBindings resource which does not seem to be required."));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Strimzi is using ownerReferences to delete resources through Kubernetes garbage collection. The owner references should however be used only within the same scope as the the owner resource. E.g. be in the same namespace or be cluster scoped for cluster scoped resources.

This is not the case for ClusterRoleBindings resources and for RoleBindings created for TO/UO in case they watch different namespace. This PR removes the owner references from the first case and adds manual deletion of the ClusterRoleBindings in Kafka and KafkaConnect resources. The TO/UO is a bit more complicated and needs to be addressed in a different PR.

This is related to discussion in #3577 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging