### PR TITLE
[DOC] Clarify Kafka Connect dependencies when configuring MM2

### DIFF
--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -54,6 +54,8 @@ This procedure shows a configuration that uses TLS encryption and authentication
 ** link:{BookURLDeploying}#deploying-kafka-cluster-str[Kafka cluster^]
 * Source and target Kafka clusters must be available
 
+WARNING: To avoid conflicts between dependencies, MirrorMaker 2.0 and the underlying Kafka Connect deployment that supports it must be from the same Kafka version.
+
 .Procedure
 
 . Edit the `spec` properties for the `KafkaMirrorMaker2` resource.
@@ -178,9 +180,9 @@ spec:
             name: aws-creds
             key: awsSecretAccessKey
 ----
-<1> The Kafka Connect xref:type-KafkaConnectSpec-reference[version].
+<1> The Kafka Connect xref:type-KafkaConnectSpec-reference[version] used with the MirrorMaker 2.0 deployment, which must be from the same Kafka version as MirrorMaker 2.0.
 <2> xref:con-common-configuration-replicas-reference[The number of replica nodes].
-<3> xref:type-KafkaMirrorMaker2Spec-reference[Cluster alias] for Kafka Connect.
+<3> xref:type-KafkaMirrorMaker2Spec-reference[Kafka cluster alias] for Kafka Connect, which must specify the *target* Kafka cluster. The Kafka cluster is used by Kafka Connect for its internal topics.
 <4> xref:type-KafkaMirrorMaker2ClusterSpec-reference[Specification] for the Kafka clusters being synchronized.
 <5> xref:type-KafkaMirrorMaker2ClusterSpec-reference[Cluster alias] for the source Kafka cluster.
 <6> Authentication for the source cluster, using the xref:type-KafkaClientAuthenticationTls-reference[TLS mechanism], as shown here, using xref:type-KafkaClientAuthenticationOAuth-reference[OAuth bearer tokens], or a SASL-based xref:type-KafkaClientAuthenticationScramSha512-reference[SCRAM-SHA-512] or xref:type-KafkaClientAuthenticationPlain-reference[PLAIN] mechanism.

--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -54,8 +54,6 @@ This procedure shows a configuration that uses TLS encryption and authentication
 ** link:{BookURLDeploying}#deploying-kafka-cluster-str[Kafka cluster^]
 * Source and target Kafka clusters must be available
 
-WARNING: To avoid conflicts between dependencies, MirrorMaker 2.0 and the underlying Kafka Connect deployment that supports it must be from the same Kafka version.
-
 .Procedure
 
 . Edit the `spec` properties for the `KafkaMirrorMaker2` resource.
@@ -180,7 +178,7 @@ spec:
             name: aws-creds
             key: awsSecretAccessKey
 ----
-<1> The Kafka Connect xref:type-KafkaConnectSpec-reference[version] used with the MirrorMaker 2.0 deployment, which must be from the same Kafka version as MirrorMaker 2.0.
+<1> The Kafka Connect and Mirror Maker 2.0 xref:type-KafkaConnectSpec-reference[version], which will always be the same.
 <2> xref:con-common-configuration-replicas-reference[The number of replica nodes].
 <3> xref:type-KafkaMirrorMaker2Spec-reference[Kafka cluster alias] for Kafka Connect, which must specify the *target* Kafka cluster. The Kafka cluster is used by Kafka Connect for its internal topics.
 <4> xref:type-KafkaMirrorMaker2ClusterSpec-reference[Specification] for the Kafka clusters being synchronized.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Minor updates to the MM2 configuration procedure in the _Using Guide_ to clarify the dependencies between the MM2 and Kafka Connect versions used.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

