### PR TITLE
[DOC] Add the guide for running multiple Connect instances also to the deploying guide

### DIFF
--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
@@ -18,6 +18,7 @@ Kafka Connect is typically used to integrate Kafka with external databases and s
 The procedures in this section show how to:
 
 * xref:deploying-kafka-connect-{context}[Deploy a Kafka Connect cluster using a `KafkaConnect` resource]
+* xref:con-kafka-connect-multiple-instances-{context}[Running multiple Kafka Connect instances]
 * xref:using-kafka-connect-with-plug-ins-{context}[Create a Kafka Connect image containing the connectors you need to make your connection]
 * xref:con-creating-managing-connectors-{context}[Create and manage connectors using a `KafkaConnector` resource or the Kafka Connect REST API]
 * xref:proc-deploying-kafkaconnector-{context}[Deploy a `KafkaConnector` resource to Kafka Connect]
@@ -27,6 +28,8 @@ In this guide, the term _connector_ is used when the meaning is clear from the c
 
 //Procedure to deploy a Kafka Connect cluster
 include::modules/proc-deploy-kafka-connect.adoc[leveloffset=+1]
+//Procedure to deploy a Kafka Connect cluster
+include::../../modules/configuring/con-config-kafka-connect-multiple-instances.adoc[leveloffset=+1]
 //Options to deploy Kafka Connect with new container image
 include::assembly-deploy-kafka-connect-with-plugins.adoc[leveloffset=+1]
 //Overview of creating connectors through API

--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
@@ -28,7 +28,7 @@ In this guide, the term _connector_ is used when the meaning is clear from the c
 
 //Procedure to deploy a Kafka Connect cluster
 include::modules/proc-deploy-kafka-connect.adoc[leveloffset=+1]
-//Procedure to deploy a Kafka Connect cluster
+//Running multiple Kafka Connect instances
 include::../../modules/configuring/con-config-kafka-connect-multiple-instances.adoc[leveloffset=+1]
 //Options to deploy Kafka Connect with new container image
 include::assembly-deploy-kafka-connect-with-plugins.adoc[leveloffset=+1]

--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
@@ -18,7 +18,7 @@ Kafka Connect is typically used to integrate Kafka with external databases and s
 The procedures in this section show how to:
 
 * xref:deploying-kafka-connect-{context}[Deploy a Kafka Connect cluster using a `KafkaConnect` resource]
-* xref:con-kafka-connect-multiple-instances-{context}[Running multiple Kafka Connect instances]
+* xref:con-kafka-connect-multiple-instances-{context}[Run multiple Kafka Connect instances]
 * xref:using-kafka-connect-with-plug-ins-{context}[Create a Kafka Connect image containing the connectors you need to make your connection]
 * xref:con-creating-managing-connectors-{context}[Create and manage connectors using a `KafkaConnector` resource or the Kafka Connect REST API]
 * xref:proc-deploying-kafkaconnector-{context}[Deploy a `KafkaConnector` resource to Kafka Connect]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The guide about running multiple Kafka Connect instances is currently only hidden among the Kafka Connect details in the Using guide. It needs to be more visible also in the Deploying guide, where users deploy Connect for the first time. This PR keeps it in the original place, but also adds it to the Deploying guide, to the chapter 4.2.