### PR TITLE
Do not use ownerReference in UO and TO bindings into a different namespace

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -299,12 +299,16 @@ public class EntityTopicOperator extends AbstractModel {
                 .withNewMetadata()
                     .withName(roleBindingName(cluster))
                     .withNamespace(watchedNamespace)
-                    .withOwnerReferences(createOwnerReference())
                     .withLabels(labels.toMap())
                 .endMetadata()
                 .withRoleRef(roleRef)
                 .withSubjects(singletonList(ks))
                 .build();
+
+        // We set OwnerReference only within the same namespace since it does nto work cross-namespace
+        if (namespace.equals(watchedNamespace)) {
+            rb.getMetadata().setOwnerReferences(singletonList(createOwnerReference()));
+        }
 
         return rb;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -331,12 +331,16 @@ public class EntityUserOperator extends AbstractModel {
                 .withNewMetadata()
                     .withName(roleBindingName(cluster))
                     .withNamespace(watchedNamespace)
-                    .withOwnerReferences(createOwnerReference())
                     .withLabels(labels.toMap())
                 .endMetadata()
                 .withRoleRef(roleRef)
                 .withSubjects(singletonList(ks))
                 .build();
+
+        // We set OwnerReference only within the same namespace since it does nto work cross-namespace
+        if (namespace.equals(watchedNamespace)) {
+            rb.getMetadata().setOwnerReferences(singletonList(createOwnerReference()));
+        }
 
         return rb;
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -223,10 +223,20 @@ public class EntityTopicOperatorTest {
     }
 
     @Test
-    public void testRoleBinding()   {
+    public void testRoleBindingInOtherNamespace()   {
         RoleBinding binding = entityTopicOperator.generateRoleBinding(namespace, toWatchedNamespace);
 
         assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getNamespace(), is(toWatchedNamespace));
+        assertThat(binding.getMetadata().getOwnerReferences().size(), is(0));
+    }
+
+    @Test
+    public void testRoleBindingInTheSameNamespace()   {
+        RoleBinding binding = entityTopicOperator.generateRoleBinding(namespace, namespace);
+
+        assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
+        assertThat(binding.getMetadata().getNamespace(), is(namespace));
+        assertThat(binding.getMetadata().getOwnerReferences().size(), is(1));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -298,10 +298,20 @@ public class EntityUserOperatorTest {
     }
 
     @Test
-    public void testRoleBinding()   {
+    public void testRoleBindingInOtherNamespace()   {
         RoleBinding binding = entityUserOperator.generateRoleBinding(namespace, uoWatchedNamespace);
 
         assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getNamespace(), is(uoWatchedNamespace));
+        assertThat(binding.getMetadata().getOwnerReferences().size(), is(0));
+    }
+
+    @Test
+    public void testRoleBindingInTheSameNamespace()   {
+        RoleBinding binding = entityUserOperator.generateRoleBinding(namespace, namespace);
+
+        assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
+        assertThat(binding.getMetadata().getNamespace(), is(namespace));
+        assertThat(binding.getMetadata().getOwnerReferences().size(), is(1));
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Strimzi is using ownerReferences to delete resources through Kubernetes garbage collection. The owner references should however be used only within the same scope as the the owner resource. E.g. be in the same namespace or be cluster scoped for cluster scoped resources.

But when TO or UO are configured to watch different namespace, they are actually created in the other namespace. So we should not use there the owner reference. As a side-effect, without the owner reference the role bindings will never be deleted. We cannot delete them manually like the ClusterRoleBindings because we do not know in which namespace they might be once the Kafka CR is deleted. Tis is not a new problem. When the user changes the custom resource and changes the watched namespace, we also cannot delete it anymore. So I do not think it should be considered as a blocker.

The PR #4077 fixes similar issue with ClusterRoleBindings. Both PRs are related to the discussion in #3577.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging