### PR TITLE
[systemtest] Tests for NetworkPolicy enhancements

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
@@ -16,6 +16,7 @@ import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
 import java.util.List;
 
 public class BundleResource {
@@ -24,22 +25,30 @@ public class BundleResource {
     public static final String PATH_TO_CO_CONFIG = TestUtils.USER_PATH + "/../install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml";
 
     public static DoneableDeployment clusterOperator(String namespace, long operationTimeout) {
-        return KubernetesResource.deployNewDeployment(defaultClusterOperator(namespace, operationTimeout, Constants.RECONCILIATION_INTERVAL).build());
+        return KubernetesResource.deployNewDeployment(defaultClusterOperator(namespace, operationTimeout, Constants.RECONCILIATION_INTERVAL, Collections.emptyList()).build());
+    }
+
+    public static DoneableDeployment clusterOperator(String namespace, long operationTimeout, List<EnvVar> customEnvs) {
+        return KubernetesResource.deployNewDeployment(defaultClusterOperator(namespace, operationTimeout, Constants.RECONCILIATION_INTERVAL, customEnvs).build());
     }
 
     public static DoneableDeployment clusterOperator(String namespace, long operationTimeout, long reconciliationInterval) {
-        return KubernetesResource.deployNewDeployment(defaultClusterOperator(namespace, operationTimeout, reconciliationInterval).build());
+        return KubernetesResource.deployNewDeployment(defaultClusterOperator(namespace, operationTimeout, reconciliationInterval, Collections.emptyList()).build());
+    }
+
+    public static DoneableDeployment clusterOperator(String namespace, long operationTimeout, long reconciliationInterval, List<EnvVar> customEnvs) {
+        return KubernetesResource.deployNewDeployment(defaultClusterOperator(namespace, operationTimeout, reconciliationInterval, customEnvs).build());
     }
 
     public static DoneableDeployment clusterOperator(String namespace) {
-        return KubernetesResource.deployNewDeployment(defaultClusterOperator(namespace, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Constants.RECONCILIATION_INTERVAL).build());
+        return KubernetesResource.deployNewDeployment(defaultClusterOperator(namespace, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Constants.RECONCILIATION_INTERVAL, Collections.emptyList()).build());
     }
 
     public static DeploymentBuilder defaultClusterOperator(String namespace) {
-        return defaultClusterOperator(namespace, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Constants.RECONCILIATION_INTERVAL);
+        return defaultClusterOperator(namespace, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Constants.RECONCILIATION_INTERVAL, Collections.emptyList());
     }
 
-    private static DeploymentBuilder defaultClusterOperator(String namespace, long operationTimeout, long reconciliationInterval) {
+    private static DeploymentBuilder defaultClusterOperator(String namespace, long operationTimeout, long reconciliationInterval, List<EnvVar> customEnvs) {
 
         Deployment clusterOperator = KubernetesResource.getDeploymentFromYaml(PATH_TO_CO_CONFIG);
 
@@ -74,6 +83,10 @@ public class BundleResource {
 
         envVars.add(new EnvVar("STRIMZI_IMAGE_PULL_POLICY", Environment.COMPONENTS_IMAGE_PULL_POLICY, null));
         envVars.add(new EnvVar("STRIMZI_LOG_LEVEL", Environment.STRIMZI_LOG_LEVEL, null));
+
+        if (envVars.size() != 0) {
+            envVars.addAll(customEnvs);
+        }
         // Apply updated env variables
         clusterOperator.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(envVars);
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -214,6 +214,7 @@ public class KafkaUtils {
      */
     public static void  updateConfigurationWithStabilityWait(String clusterName, String brokerConfigName, Object value) {
         updateSpecificConfiguration(clusterName, brokerConfigName, value);
+        waitForClusterStability(clusterName);
     }
 
     /**

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -115,7 +115,7 @@ public abstract class AbstractST implements TestSeparator {
      * Don't use this method in tests, where specific configuration of CO is needed.
      * @param namespace namespace where CO should be installed into
      */
-    protected void installClusterOperator(String namespace, List<String> bindingsNamespaces, long operationTimeout, long reconciliationInterval) {
+    protected void installClusterOperator(String namespace, List<String> bindingsNamespaces, long operationTimeout, long reconciliationInterval, List<EnvVar> customEnvs) {
         if (Environment.isOlmInstall()) {
             LOGGER.info("Going to install ClusterOperator via OLM");
             cluster.setNamespace(namespace);
@@ -131,19 +131,27 @@ public abstract class AbstractST implements TestSeparator {
             prepareEnvForOperator(namespace, bindingsNamespaces);
             applyRoleBindings(namespace, bindingsNamespaces);
             // 060-Deployment
-            BundleResource.clusterOperator(namespace, operationTimeout, reconciliationInterval).done();
+            BundleResource.clusterOperator(namespace, operationTimeout, reconciliationInterval, customEnvs).done();
         }
     }
 
-    protected void installClusterOperator(String namespace, long operationTimeout, long reconciliationInterval) throws Exception {
-        installClusterOperator(namespace, Collections.singletonList(namespace), operationTimeout, reconciliationInterval);
+    protected void installClusterOperator(String namespace, long operationTimeout, long reconciliationInterval, List<EnvVar> customEnvs) {
+        installClusterOperator(namespace, Collections.singletonList(namespace), operationTimeout, reconciliationInterval, customEnvs);
     }
 
-    protected void installClusterOperator(String namespace, long operationTimeout) throws Exception {
-        installClusterOperator(namespace, operationTimeout, Constants.RECONCILIATION_INTERVAL);
+    protected void installClusterOperator(String namespace, long operationTimeout, long reconciliationInterval) {
+        installClusterOperator(namespace, operationTimeout, reconciliationInterval, Collections.emptyList());
     }
 
-    protected void installClusterOperator(String namespace) throws Exception {
+    protected void installClusterOperator(String namespace, long operationTimeout, List<EnvVar> customEnvs) {
+        installClusterOperator(namespace, operationTimeout, Constants.RECONCILIATION_INTERVAL, customEnvs);
+    }
+
+    protected void installClusterOperator(String namespace, long operationTimeout) {
+        installClusterOperator(namespace, operationTimeout, Constants.RECONCILIATION_INTERVAL, Collections.emptyList());
+    }
+
+    protected void installClusterOperator(String namespace) {
         installClusterOperator(namespace, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
@@ -984,7 +984,7 @@ class ConnectS2IST extends AbstractST {
     }
 
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT, Constants.RECONCILIATION_INTERVAL);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.security;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeerBuilder;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.strimzi.api.kafka.model.KafkaUser;
+import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
+import io.strimzi.systemtest.resources.KubernetesResource;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
+import io.strimzi.systemtest.resources.crd.KafkaUserResource;
+import io.strimzi.systemtest.resources.operator.BundleResource;
+import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.specific.MetricsUtils;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.Constants.NETWORKPOLICIES_SUPPORTED;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag(NETWORKPOLICIES_SUPPORTED)
+public class NetworkPoliciesST extends AbstractST {
+    public static final String NAMESPACE = "np-cluster-test";
+    private static final Logger LOGGER = LogManager.getLogger(NetworkPoliciesST.class);
+
+    @Test
+    @Tag(INTERNAL_CLIENTS_USED)
+    void testNetworkPoliciesWithPlainListener() {
+        installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
+
+        String allowedKafkaClientsName = CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS + "-allow";
+        String deniedKafkaClientsName = CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS + "-deny";
+        Map<String, String> matchLabelForPlain = new HashMap<>();
+        matchLabelForPlain.put("app", allowedKafkaClientsName);
+
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 1, 1)
+            .editSpec()
+                .editKafka()
+                    .withNewListeners()
+                        .addNewGenericKafkaListener()
+                            .withName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
+                            .withPort(9092)
+                            .withType(KafkaListenerType.INTERNAL)
+                            .withTls(false)
+                            .withNewKafkaListenerAuthenticationScramSha512Auth()
+                            .endKafkaListenerAuthenticationScramSha512Auth()
+                            .withNetworkPolicyPeers(
+                                new NetworkPolicyPeerBuilder()
+                                    .withNewPodSelector()
+                                    .withMatchLabels(matchLabelForPlain)
+                                    .endPodSelector()
+                                    .build())
+                        .endGenericKafkaListener()
+                    .endListeners()
+                .endKafka()
+                .withNewKafkaExporter()
+                .endKafkaExporter()
+            .endSpec()
+            .done();
+
+        String topic0 = "topic-example-0";
+        String topic1 = "topic-example-1";
+
+        String userName = "user-example";
+        KafkaUser kafkaUser = KafkaUserResource.scramShaUser(CLUSTER_NAME, userName).done();
+
+        KafkaTopicResource.topic(CLUSTER_NAME, topic0).done();
+        KafkaTopicResource.topic(CLUSTER_NAME, topic1).done();
+
+        KafkaClientsResource.deployKafkaClients(false, allowedKafkaClientsName, kafkaUser).done();
+
+        String allowedKafkaClientsPodName = kubeClient().listPodsByPrefixInName(allowedKafkaClientsName).get(0).getMetadata().getName();
+
+        LOGGER.info("Verifying that {} pod is able to exchange messages", allowedKafkaClientsPodName);
+
+        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
+            .withUsingPodName(allowedKafkaClientsPodName)
+            .withTopicName(topic0)
+            .withNamespaceName(NAMESPACE)
+            .withClusterName(CLUSTER_NAME)
+            .withMessageCount(MESSAGE_COUNT)
+            .withKafkaUsername(userName)
+            .withSecurityProtocol(SecurityProtocol.PLAINTEXT)
+            .withListenerName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
+            .build();
+
+        internalKafkaClient.checkProducedAndConsumedMessages(
+            internalKafkaClient.sendMessagesPlain(),
+            internalKafkaClient.receiveMessagesPlain()
+        );
+
+        KafkaClientsResource.deployKafkaClients(false, deniedKafkaClientsName, kafkaUser).done();
+
+        String deniedKafkaClientsPodName = kubeClient().listPodsByPrefixInName(deniedKafkaClientsName).get(0).getMetadata().getName();
+
+        InternalKafkaClient newInternalKafkaClient = internalKafkaClient.toBuilder()
+            .withUsingPodName(deniedKafkaClientsPodName)
+            .withTopicName(topic1)
+            .build();
+
+        LOGGER.info("Verifying that {} pod is not able to exchange messages", deniedKafkaClientsPodName);
+        assertThrows(AssertionError.class, () ->  {
+            newInternalKafkaClient.checkProducedAndConsumedMessages(
+                newInternalKafkaClient.sendMessagesPlain(),
+                newInternalKafkaClient.receiveMessagesPlain()
+            );
+        });
+
+        LOGGER.info("Check metrics exported by Kafka Exporter");
+        Map<String, String> kafkaExporterMetricsData = MetricsUtils.collectKafkaExporterPodsMetrics(CLUSTER_NAME);
+        assertThat("Kafka Exporter metrics should be non-empty", kafkaExporterMetricsData.size() > 0);
+        for (Map.Entry<String, String> entry : kafkaExporterMetricsData.entrySet()) {
+            assertThat("Value from collected metric should be non-empty", !entry.getValue().isEmpty());
+            assertThat("Metrics doesn't contain specific values", entry.getValue().contains("kafka_consumergroup_current_offset"));
+            assertThat("Metrics doesn't contain specific values", entry.getValue().contains("kafka_topic_partitions{topic=\"" + topic0 + "\"} 1"));
+            assertThat("Metrics doesn't contain specific values", entry.getValue().contains("kafka_topic_partitions{topic=\"" + topic1 + "\"} 1"));
+        }
+    }
+
+    @Test
+    @Tag(INTERNAL_CLIENTS_USED)
+    void testNetworkPoliciesWithTlsListener() {
+        installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
+
+        String allowedKafkaClientsName = CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS + "-allow";
+        String deniedKafkaClientsName = CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS + "-deny";
+        Map<String, String> matchLabelsForTls = new HashMap<>();
+        matchLabelsForTls.put("app", allowedKafkaClientsName);
+
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 1, 1)
+            .editSpec()
+                .editKafka()
+                    .withNewListeners()
+                        .addNewGenericKafkaListener()
+                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
+                            .withPort(9093)
+                            .withType(KafkaListenerType.INTERNAL)
+                            .withTls(true)
+                            .withNewKafkaListenerAuthenticationScramSha512Auth()
+                            .endKafkaListenerAuthenticationScramSha512Auth()
+                            .withNetworkPolicyPeers(
+                                new NetworkPolicyPeerBuilder()
+                                    .withNewPodSelector()
+                                    .withMatchLabels(matchLabelsForTls)
+                                    .endPodSelector()
+                                    .build())
+                        .endGenericKafkaListener()
+                    .endListeners()
+                .endKafka()
+            .endSpec()
+            .done();
+
+        String topic0 = "topic-example-0";
+        String topic1 = "topic-example-1";
+        KafkaTopicResource.topic(CLUSTER_NAME, topic0).done();
+        KafkaTopicResource.topic(CLUSTER_NAME, topic1).done();
+
+        String userName = "user-example";
+        KafkaUser kafkaUser = KafkaUserResource.scramShaUser(CLUSTER_NAME, userName).done();
+
+        KafkaClientsResource.deployKafkaClients(true, allowedKafkaClientsName, kafkaUser).done();
+
+        String allowedKafkaClientsPodName = kubeClient().listPodsByPrefixInName(allowedKafkaClientsName).get(0).getMetadata().getName();
+
+        LOGGER.info("Verifying that {} pod is able to exchange messages", allowedKafkaClientsPodName);
+
+        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
+            .withUsingPodName(allowedKafkaClientsPodName)
+            .withTopicName(topic0)
+            .withNamespaceName(NAMESPACE)
+            .withClusterName(CLUSTER_NAME)
+            .withMessageCount(MESSAGE_COUNT)
+            .withKafkaUsername(userName)
+            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+            .build();
+
+        internalKafkaClient.checkProducedAndConsumedMessages(
+            internalKafkaClient.sendMessagesTls(),
+            internalKafkaClient.receiveMessagesTls()
+        );
+
+        KafkaClientsResource.deployKafkaClients(true, deniedKafkaClientsName, kafkaUser).done();
+
+        String deniedKafkaClientsPodName = kubeClient().listPodsByPrefixInName(deniedKafkaClientsName).get(0).getMetadata().getName();
+
+        InternalKafkaClient newInternalKafkaClient = internalKafkaClient.toBuilder()
+            .withUsingPodName(deniedKafkaClientsPodName)
+            .withTopicName(topic1)
+            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+            .build();
+
+        LOGGER.info("Verifying that {} pod is  not able to exchange messages", deniedKafkaClientsPodName);
+
+        assertThrows(AssertionError.class, () -> {
+            newInternalKafkaClient.checkProducedAndConsumedMessages(
+                newInternalKafkaClient.sendMessagesTls(),
+                newInternalKafkaClient.receiveMessagesTls()
+            );
+        });
+    }
+
+    @Test
+    void testNPWhenOperatorIsInSameNamespaceAsOperand() {
+        EnvVar operatorNamespaceEnv = new EnvVarBuilder()
+            .withName("STRIMZI_OPERATOR_NAMESPACE")
+            .withValue(NAMESPACE)
+            .build();
+
+        installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Collections.singletonList(operatorNamespaceEnv));
+
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
+
+        checkNetworkPoliciesInNamespace(NAMESPACE);
+
+        changeKafkaConfigurationAndCheckObservedGeneration(NAMESPACE);
+    }
+
+    @Test
+    void testNPWhenOperatorIsInDifferentNamespaceThanOperand() {
+        String secondNamespace = "second-" + NAMESPACE;
+
+        Map<String, String> labels = new HashMap<>();
+        labels.put("my-label", "my-value");
+
+        EnvVar operatorLabelsEnv = new EnvVarBuilder()
+            .withName("STRIMZI_OPERATOR_NAMESPACE_LABELS")
+            .withValue(labels.toString().replaceAll("\\{|}", ""))
+            .build();
+
+        cluster.createNamespace(secondNamespace);
+
+        prepareEnvForOperator(NAMESPACE, Arrays.asList(NAMESPACE, secondNamespace));
+
+        // Apply role bindings in CO namespace
+        applyRoleBindings(NAMESPACE);
+
+        // Create ClusterRoleBindings that grant cluster-wide access to all OpenShift projects
+        List<ClusterRoleBinding> clusterRoleBindingList = KubernetesResource.clusterRoleBindingsForAllNamespaces(NAMESPACE);
+        clusterRoleBindingList.forEach(clusterRoleBinding ->
+            KubernetesResource.clusterRoleBinding(clusterRoleBinding, NAMESPACE));
+        // 060-Deployment
+        BundleResource.clusterOperator("*", Constants.CO_OPERATION_TIMEOUT_DEFAULT, Collections.singletonList(operatorLabelsEnv)).done();
+
+        kubeClient().getClient().namespaces().withName(NAMESPACE).edit()
+            .editMetadata()
+                .addToLabels(labels)
+            .endMetadata()
+            .done();
+
+        cluster.setNamespace(secondNamespace);
+
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3)
+            .editMetadata()
+                .addToLabels(labels)
+            .endMetadata()
+            .done();
+
+        checkNetworkPoliciesInNamespace(secondNamespace);
+
+        changeKafkaConfigurationAndCheckObservedGeneration(secondNamespace);
+    }
+
+    void checkNetworkPoliciesInNamespace(String namespace) {
+        List<NetworkPolicy> networkPolicyList = new ArrayList<>(kubeClient().getClient().network().networkPolicies().inNamespace(namespace).list().getItems());
+
+        String networkPolicyPrefix = CLUSTER_NAME + "-network-policy";
+
+        assertNotNull(networkPolicyList.stream().filter(networkPolicy ->  networkPolicy.getMetadata().getName().contains(networkPolicyPrefix + "-kafka")).findFirst());
+        assertNotNull(networkPolicyList.stream().filter(networkPolicy ->  networkPolicy.getMetadata().getName().contains(networkPolicyPrefix + "-zookeeper")).findFirst());
+    }
+
+    void changeKafkaConfigurationAndCheckObservedGeneration(String namespace) {
+        long observedGen = KafkaResource.kafkaClient().inNamespace(namespace).withName(CLUSTER_NAME).get().getStatus().getObservedGeneration();
+        KafkaUtils.updateConfigurationWithStabilityWait(CLUSTER_NAME, "log.message.timestamp.type", "LogAppendTime");
+
+        assertThat(KafkaResource.kafkaClient().inNamespace(namespace).withName(CLUSTER_NAME).get().getStatus().getObservedGeneration(), is(not(observedGen)));
+    }
+
+    @BeforeAll
+    void setup() {
+        ResourceManager.setClassResources();
+    }
+}


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New tests
- New ST

### Description

This PR gonna add new ST for NetworkPolicy tests. Other than that, I added two tests for the new enhancement to our NP (especially new envs for CO). 

First test trying to set `STRIMZI_OPERATOR_NAMESPACE` with actual namespace (which should be added by default) and tests, if the Kafka cluster is correctly created and we can replace the configuration (the dynamic one) which will do the request to Kafka API. It will ensure us that NP are correctly set. Also there is little check if the NP are created for `kafka` and `zookeeper`.

Second test is trying to deploy CO with custom labels in one namespace (also labeling that namespace), adding the `STRIMZI_OPERATOR_NAMESPACE_LABELS` to the CO and then creating Kafka cluster (with the same labels) in different namespace. Again, I'm replacing dynamic configuration and checking, if the observed generation will be higher and the request on API will be successful.

Also this PR edits our methods so we can use the custom envs on CO deployment.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass