### PR TITLE
Bring the -server field back among living

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
@@ -61,7 +61,7 @@ public class JvmOptions implements UnknownPropertyPreserving, Serializable {
 
     @JsonProperty("-server")
     @Description("-server option to to the JVM")
-    public Boolean isServer() {
+    public Boolean getServer() {
         return server;
     }
 

--- a/api/src/test/java/io/strimzi/api/kafka/model/JvmOptionsTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/JvmOptionsTest.java
@@ -35,29 +35,29 @@ public class JvmOptionsTest {
                 "  \"-server\": \"true\"" +
                 "}", JvmOptions.class);
 
-        assertThat(opts.isServer(), is(true));
+        assertThat(opts.getServer(), is(true));
 
         opts = TestUtils.fromJson("{" +
                 "  \"-server\": true" +
                 "}", JvmOptions.class);
 
-        assertThat(opts.isServer(), is(true));
+        assertThat(opts.getServer(), is(true));
 
         opts = TestUtils.fromJson("{" +
                 "  \"-server\": \"false\"" +
                 "}", JvmOptions.class);
 
-        assertThat(opts.isServer(), is(false));
+        assertThat(opts.getServer(), is(false));
 
         opts = TestUtils.fromJson("{" +
                 "  \"-server\": false" +
                 "}", JvmOptions.class);
 
-        assertThat(opts.isServer(), is(false));
+        assertThat(opts.getServer(), is(false));
 
         opts = TestUtils.fromJson("{}", JvmOptions.class);
 
-        assertThat(opts.isServer(), is(nullValue()));
+        assertThat(opts.getServer(), is(nullValue()));
     }
 
     @Test

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
@@ -838,6 +838,9 @@ spec:
                         type: string
                         pattern: '[0-9]+[mMgG]?'
                         description: -Xmx option to to the JVM.
+                      "-server":
+                        type: boolean
+                        description: -server option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging
@@ -1917,6 +1920,9 @@ spec:
                         type: string
                         pattern: '[0-9]+[mMgG]?'
                         description: -Xmx option to to the JVM.
+                      "-server":
+                        type: boolean
+                        description: -server option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging
@@ -2685,6 +2691,9 @@ spec:
                             type: string
                             pattern: '[0-9]+[mMgG]?'
                             description: -Xmx option to to the JVM.
+                          "-server":
+                            type: boolean
+                            description: -server option to to the JVM.
                           gcLoggingEnabled:
                             type: boolean
                             description: Specifies whether the Garbage Collection
@@ -2835,6 +2844,9 @@ spec:
                             type: string
                             pattern: '[0-9]+[mMgG]?'
                             description: -Xmx option to to the JVM.
+                          "-server":
+                            type: boolean
+                            description: -server option to to the JVM.
                           gcLoggingEnabled:
                             type: boolean
                             description: Specifies whether the Garbage Collection
@@ -4044,6 +4056,9 @@ spec:
                         type: string
                         pattern: '[0-9]+[mMgG]?'
                         description: -Xmx option to to the JVM.
+                      "-server":
+                        type: boolean
+                        description: -server option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
@@ -830,6 +830,9 @@ spec:
                         type: string
                         pattern: '[0-9]+[mMgG]?'
                         description: -Xmx option to to the JVM.
+                      "-server":
+                        type: boolean
+                        description: -server option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging
@@ -1873,6 +1876,9 @@ spec:
                         type: string
                         pattern: '[0-9]+[mMgG]?'
                         description: -Xmx option to to the JVM.
+                      "-server":
+                        type: boolean
+                        description: -server option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging
@@ -2618,6 +2624,9 @@ spec:
                             type: string
                             pattern: '[0-9]+[mMgG]?'
                             description: -Xmx option to to the JVM.
+                          "-server":
+                            type: boolean
+                            description: -server option to to the JVM.
                           gcLoggingEnabled:
                             type: boolean
                             description: Specifies whether the Garbage Collection
@@ -2764,6 +2773,9 @@ spec:
                             type: string
                             pattern: '[0-9]+[mMgG]?'
                             description: -Xmx option to to the JVM.
+                          "-server":
+                            type: boolean
+                            description: -server option to to the JVM.
                           gcLoggingEnabled:
                             type: boolean
                             description: Specifies whether the Garbage Collection
@@ -3954,6 +3966,9 @@ spec:
                         type: string
                         pattern: '[0-9]+[mMgG]?'
                         description: -Xmx option to to the JVM.
+                      "-server":
+                        type: boolean
+                        description: -server option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging
@@ -7686,6 +7701,9 @@ spec:
                         type: string
                         pattern: '[0-9]+[mMgG]?'
                         description: -Xmx option to to the JVM.
+                      "-server":
+                        type: boolean
+                        description: -server option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging
@@ -9123,6 +9141,9 @@ spec:
                         type: string
                         pattern: '[0-9]+[mMgG]?'
                         description: -Xmx option to to the JVM.
+                      "-server":
+                        type: boolean
+                        description: -server option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging
@@ -10273,6 +10294,9 @@ spec:
                         type: string
                         pattern: '[0-9]+[mMgG]?'
                         description: -Xmx option to to the JVM.
+                      "-server":
+                        type: boolean
+                        description: -server option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging
@@ -10484,6 +10508,9 @@ spec:
                             type: string
                             pattern: '[0-9]+[mMgG]?'
                             description: -Xmx option to to the JVM.
+                          "-server":
+                            type: boolean
+                            description: -server option to to the JVM.
                           gcLoggingEnabled:
                             type: boolean
                             description: Specifies whether the Garbage Collection
@@ -10630,6 +10657,9 @@ spec:
                             type: string
                             pattern: '[0-9]+[mMgG]?'
                             description: -Xmx option to to the JVM.
+                          "-server":
+                            type: boolean
+                            description: -server option to to the JVM.
                           gcLoggingEnabled:
                             type: boolean
                             description: Specifies whether the Garbage Collection
@@ -11820,6 +11850,9 @@ spec:
                         type: string
                         pattern: '[0-9]+[mMgG]?'
                         description: -Xmx option to to the JVM.
+                      "-server":
+                        type: boolean
+                        description: -server option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging
@@ -15556,6 +15589,9 @@ spec:
                         type: string
                         pattern: '[0-9]+[mMgG]?'
                         description: -Xmx option to to the JVM.
+                      "-server":
+                        type: boolean
+                        description: -server option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging
@@ -16993,6 +17029,9 @@ spec:
                         type: string
                         pattern: '[0-9]+[mMgG]?'
                         description: -Xmx option to to the JVM.
+                      "-server":
+                        type: boolean
+                        description: -server option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging
@@ -18143,6 +18182,9 @@ spec:
                         type: string
                         pattern: '[0-9]+[mMgG]?'
                         description: -Xmx option to to the JVM.
+                      "-server":
+                        type: boolean
+                        description: -server option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging
@@ -18354,6 +18396,9 @@ spec:
                             type: string
                             pattern: '[0-9]+[mMgG]?'
                             description: -Xmx option to to the JVM.
+                          "-server":
+                            type: boolean
+                            description: -server option to to the JVM.
                           gcLoggingEnabled:
                             type: boolean
                             description: Specifies whether the Garbage Collection
@@ -18500,6 +18545,9 @@ spec:
                             type: string
                             pattern: '[0-9]+[mMgG]?'
                             description: -Xmx option to to the JVM.
+                          "-server":
+                            type: boolean
+                            description: -server option to to the JVM.
                           gcLoggingEnabled:
                             type: boolean
                             description: Specifies whether the Garbage Collection
@@ -19690,6 +19738,9 @@ spec:
                         type: string
                         pattern: '[0-9]+[mMgG]?'
                         description: -Xmx option to to the JVM.
+                      "-server":
+                        type: boolean
+                        description: -server option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1233,7 +1233,7 @@ public abstract class AbstractModel {
     protected void jvmPerformanceOptions(List<EnvVar> envVars) {
         StringBuilder jvmPerformanceOpts = new StringBuilder();
 
-        Boolean isServer = jvmOptions != null ? jvmOptions.isServer() : null;
+        Boolean isServer = jvmOptions != null ? jvmOptions.getServer() : null;
         if (isServer != null && isServer) {
             jvmPerformanceOpts.append("-server");
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -360,7 +360,7 @@ public class EntityOperator extends AbstractModel {
             strimziJavaOpts.append(" -Xmx").append(xmx);
         }
 
-        Boolean server = jvmOptions != null ? jvmOptions.isServer() : null;
+        Boolean server = jvmOptions != null ? jvmOptions.getServer() : null;
 
         if (server != null && server) {
             strimziJavaOpts.append(' ').append(" -server");

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1011,6 +1011,8 @@ Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`], xref:type-E
 |string
 |-Xmx                  1.2+<.<|-Xmx option to to the JVM.
 |string
+|-server               1.2+<.<|-server option to to the JVM.
+|boolean
 |gcLoggingEnabled      1.2+<.<|Specifies whether the Garbage Collection logging is enabled. The default is false.
 |boolean
 |javaSystemProperties  1.2+<.<|A map of additional system properties which will be passed using the `-D` option to the JVM.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -1411,6 +1411,9 @@ spec:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
                       description: -Xmx option to to the JVM.
+                    "-server":
+                      type: boolean
+                      description: -server option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -2667,6 +2670,9 @@ spec:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
                       description: -Xmx option to to the JVM.
+                    "-server":
+                      type: boolean
+                      description: -server option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -3713,6 +3719,9 @@ spec:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
                       description: -Xmx option to to the JVM.
+                    "-server":
+                      type: boolean
+                      description: -server option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -3890,6 +3899,9 @@ spec:
                           type: string
                           pattern: '[0-9]+[mMgG]?'
                           description: -Xmx option to to the JVM.
+                        "-server":
+                          type: boolean
+                          description: -server option to to the JVM.
                         gcLoggingEnabled:
                           type: boolean
                           description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -4015,6 +4027,9 @@ spec:
                           type: string
                           pattern: '[0-9]+[mMgG]?'
                           description: -Xmx option to to the JVM.
+                        "-server":
+                          type: boolean
+                          description: -server option to to the JVM.
                         gcLoggingEnabled:
                           type: boolean
                           description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -5089,6 +5104,9 @@ spec:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
                       description: -Xmx option to to the JVM.
+                    "-server":
+                      type: boolean
+                      description: -server option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging is enabled. The default is false.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -276,6 +276,9 @@ spec:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
                   description: -Xmx option to to the JVM.
+                "-server":
+                  type: boolean
+                  description: -server option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is enabled. The default is false.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -129,6 +129,9 @@ spec:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
                   description: -Xmx option to to the JVM.
+                "-server":
+                  type: boolean
+                  description: -server option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is enabled. The default is false.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -634,6 +634,9 @@ spec:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
                   description: -Xmx option to to the JVM.
+                "-server":
+                  type: boolean
+                  description: -server option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is enabled. The default is false.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -264,6 +264,9 @@ spec:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
                   description: -Xmx option to to the JVM.
+                "-server":
+                  type: boolean
+                  description: -server option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is enabled. The default is false.

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -358,6 +358,9 @@ spec:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
                   description: -Xmx option to to the JVM.
+                "-server":
+                  type: boolean
+                  description: -server option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is enabled. The default is false.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1407,6 +1407,9 @@ spec:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
                       description: -Xmx option to to the JVM.
+                    "-server":
+                      type: boolean
+                      description: -server option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -2663,6 +2666,9 @@ spec:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
                       description: -Xmx option to to the JVM.
+                    "-server":
+                      type: boolean
+                      description: -server option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -3709,6 +3715,9 @@ spec:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
                       description: -Xmx option to to the JVM.
+                    "-server":
+                      type: boolean
+                      description: -server option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -3886,6 +3895,9 @@ spec:
                           type: string
                           pattern: '[0-9]+[mMgG]?'
                           description: -Xmx option to to the JVM.
+                        "-server":
+                          type: boolean
+                          description: -server option to to the JVM.
                         gcLoggingEnabled:
                           type: boolean
                           description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -4011,6 +4023,9 @@ spec:
                           type: string
                           pattern: '[0-9]+[mMgG]?'
                           description: -Xmx option to to the JVM.
+                        "-server":
+                          type: boolean
+                          description: -server option to to the JVM.
                         gcLoggingEnabled:
                           type: boolean
                           description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -5085,6 +5100,9 @@ spec:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
                       description: -Xmx option to to the JVM.
+                    "-server":
+                      type: boolean
+                      description: -server option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging is enabled. The default is false.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -272,6 +272,9 @@ spec:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
                   description: -Xmx option to to the JVM.
+                "-server":
+                  type: boolean
+                  description: -server option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is enabled. The default is false.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -125,6 +125,9 @@ spec:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
                   description: -Xmx option to to the JVM.
+                "-server":
+                  type: boolean
+                  description: -server option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is enabled. The default is false.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -630,6 +630,9 @@ spec:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
                   description: -Xmx option to to the JVM.
+                "-server":
+                  type: boolean
+                  description: -server option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is enabled. The default is false.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -260,6 +260,9 @@ spec:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
                   description: -Xmx option to to the JVM.
+                "-server":
+                  type: boolean
+                  description: -server option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is enabled. The default is false.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -354,6 +354,9 @@ spec:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
                   description: -Xmx option to to the JVM.
+                "-server":
+                  type: boolean
+                  description: -server option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is enabled. The default is false.

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1899,6 +1899,9 @@ spec:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
                       description: -Xmx option to to the JVM.
+                    "-server":
+                      type: boolean
+                      description: -server option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging
@@ -3333,6 +3336,9 @@ spec:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
                       description: -Xmx option to to the JVM.
+                    "-server":
+                      type: boolean
+                      description: -server option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging
@@ -4483,6 +4489,9 @@ spec:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
                       description: -Xmx option to to the JVM.
+                    "-server":
+                      type: boolean
+                      description: -server option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging
@@ -4693,6 +4702,9 @@ spec:
                           type: string
                           pattern: '[0-9]+[mMgG]?'
                           description: -Xmx option to to the JVM.
+                        "-server":
+                          type: boolean
+                          description: -server option to to the JVM.
                         gcLoggingEnabled:
                           type: boolean
                           description: Specifies whether the Garbage Collection logging
@@ -4838,6 +4850,9 @@ spec:
                           type: string
                           pattern: '[0-9]+[mMgG]?'
                           description: -Xmx option to to the JVM.
+                        "-server":
+                          type: boolean
+                          description: -server option to to the JVM.
                         gcLoggingEnabled:
                           type: boolean
                           description: Specifies whether the Garbage Collection logging
@@ -6025,6 +6040,9 @@ spec:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
                       description: -Xmx option to to the JVM.
+                    "-server":
+                      type: boolean
+                      description: -server option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -322,6 +322,9 @@ spec:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
                   description: -Xmx option to to the JVM.
+                "-server":
+                  type: boolean
+                  description: -server option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -138,6 +138,9 @@ spec:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
                   description: -Xmx option to to the JVM.
+                "-server":
+                  type: boolean
+                  description: -server option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -711,6 +711,9 @@ spec:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
                   description: -Xmx option to to the JVM.
+                "-server":
+                  type: boolean
+                  description: -server option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -298,6 +298,9 @@ spec:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
                   description: -Xmx option to to the JVM.
+                "-server":
+                  type: boolean
+                  description: -server option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -428,6 +428,9 @@ spec:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
                   description: -Xmx option to to the JVM.
+                "-server":
+                  type: boolean
+                  description: -server option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `jvmOptions` API field has for a long time supported the `-server` option. But at some point, it was changed from `boolean` to `Boolean`. But the getter was not changed and remained as `isServer` instead of changing to `getServer`. As a result, the field disappeared from the CRDs and from the API docs. This PR changes the `isServer` to `getServer` and brings it back among the living.

I guess the question is ... assuming it was missing for more then two years since the change from `boolean` to `Boolean` and nobody missed it ... should we really resurrect it? Or should we instead rather remove it from the code? WDYT @strimzi/maintainers 