### PR TITLE
Kafka connect: add jmxOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,8 @@
 * Support passing metrics configuration as an external ConfigMap
 * Enable CORS configuration for Cruise Control
 * Add support for rolling individual Kafka or ZooKeeper pods through the Cluster Operator using an annotation
-<<<<<<< HEAD
 * Add support for Topology Spread Constraints in Pod templates
 * Make Kafka `cluster-id` (KIP-78) available on Kafka CRD status
-
-=======
->>>>>>> refactor jmx for kafka_*_run
 
 ### Deprecations and removals
 * The `metrics` field in the Strimzi custom resources has been deprecated and will be removed in the future. For configuring metrics, use the new `metricsConfig` field and pass the configuration via ConfigMap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 0.22.0
 
 * Add annotations that enable the operator to restart Kafka Connect connectors or tasks. The annotations can be applied to the KafkaConnector and the KafkaMirrorMaker2 custom resources.
+* Add support for JMX options configuration of all Kafka Connect (KC, KC2SI, MM2)
 
 ### Deprecations and removals
 
@@ -27,6 +28,7 @@
 * Add support for rolling individual Kafka or ZooKeeper pods through the Cluster Operator using an annotation
 * Add support for Topology Spread Constraints in Pod templates
 * Make Kafka `cluster-id` (KIP-78) available on Kafka CRD status
+
 
 ### Deprecations and removals
 * The `metrics` field in the Strimzi custom resources has been deprecated and will be removed in the future. For configuring metrics, use the new `metricsConfig` field and pass the configuration via ConfigMap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,12 @@
 * Support passing metrics configuration as an external ConfigMap
 * Enable CORS configuration for Cruise Control
 * Add support for rolling individual Kafka or ZooKeeper pods through the Cluster Operator using an annotation
+<<<<<<< HEAD
 * Add support for Topology Spread Constraints in Pod templates
 * Make Kafka `cluster-id` (KIP-78) available on Kafka CRD status
 
+=======
+>>>>>>> refactor jmx for kafka_*_run
 
 ### Deprecations and removals
 * The `metrics` field in the Strimzi custom resources has been deprecated and will be removed in the future. For configuring metrics, use the new `metricsConfig` field and pass the configuration via ConfigMap.

--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -29,7 +30,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "replicas", "version", "image", "resources", 
-        "livenessProbe", "readinessProbe", "jvmOptions",
+        "livenessProbe", "readinessProbe", "jvmOptions",  "jmxOptions",
         "affinity", "tolerations", "logging", "metrics", "metricsConfig", "tracing",
         "template", "externalConfiguration"})
 @EqualsAndHashCode(doNotUseGetters = true)
@@ -44,6 +45,7 @@ public abstract class AbstractKafkaConnectSpec extends Spec {
     private ResourceRequirements resources;
     private Probe livenessProbe;
     private Probe readinessProbe;
+    private KafkaJmxOptions jmxOptions;
     private JvmOptions jvmOptions;
     private MetricsConfig metricsConfig;
     private Map<String, Object> metrics;
@@ -132,6 +134,17 @@ public abstract class AbstractKafkaConnectSpec extends Spec {
 
     public void setJvmOptions(JvmOptions jvmOptions) {
         this.jvmOptions = jvmOptions;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Description("JMX Options")
+    @JsonProperty("jmxOptions")
+    public KafkaJmxOptions getJmxOptions() {
+        return jmxOptions;
+    }
+
+    public void setJmxOptions(KafkaJmxOptions jmxOptions) {
+        this.jmxOptions = jmxOptions;
     }
 
     @Description("Metrics configuration.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2ISpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2ISpec.java
@@ -20,7 +20,7 @@ import lombok.EqualsAndHashCode;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "replicas", "image", "buildResources",
-        "livenessProbe", "readinessProbe", "jvmOptions",
+        "livenessProbe", "readinessProbe", "jvmOptions",  "jmxOptions",
         "affinity", "logging", "metrics", "template"})
 @EqualsAndHashCode(callSuper = true)
 public class KafkaConnectS2ISpec extends KafkaConnectSpec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
@@ -25,7 +25,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "replicas", "version", "image",
         "bootstrapServers", "tls", "authentication", "config", "resources",
-        "livenessProbe", "readinessProbe", "jvmOptions",
+        "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions",
         "affinity", "tolerations", "logging", "metrics", "tracing",
         "template", "externalConfiguration"})
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaJmxOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaJmxOptions.java
@@ -25,7 +25,7 @@ public class KafkaJmxOptions implements UnknownPropertyPreserving, Serializable 
     private KafkaJmxAuthentication authentication;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-    @Description("Authentication configuration for connecting to the Kafka JMX port")
+    @Description("Authentication configuration for connecting to the JMX port")
     @JsonProperty("authentication")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public KafkaJmxAuthentication getAuthentication() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2Spec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2Spec.java
@@ -21,7 +21,7 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"replicas", "version", "image", "connectCluster", 
         "clusters", "mirrors", "resources", 
-        "livenessProbe", "readinessProbe", "jvmOptions",
+        "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions",
         "affinity", "tolerations", "logging", "metrics", "tracing", 
         "template", "externalConfiguration"})
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
@@ -872,7 +872,7 @@ spec:
                         required:
                         - type
                         description: Authentication configuration for connecting to
-                          the Kafka JMX port.
+                          the JMX port.
                     description: JMX Options for Kafka brokers.
                   resources:
                     type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
@@ -864,7 +864,7 @@ spec:
                         required:
                         - type
                         description: Authentication configuration for connecting to
-                          the Kafka JMX port.
+                          the JMX port.
                     description: JMX Options for Kafka brokers.
                   resources:
                     type: object
@@ -7905,7 +7905,7 @@ spec:
                         required:
                         - type
                         description: Authentication configuration for connecting to
-                          the Kafka JMX port.
+                          the JMX port.
                     description: JMX Options for Kafka brokers.
                   resources:
                     type: object
@@ -15960,7 +15960,7 @@ spec:
                         required:
                         - type
                         description: Authentication configuration for connecting to
-                          the Kafka JMX port.
+                          the JMX port.
                     description: JMX Options for Kafka brokers.
                   resources:
                     type: object

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
@@ -341,9 +341,9 @@ public class AuthenticationUtils {
     }
 
     /**
-     * Generates the necessary resources that the Kafka Cluster needs to secure the Kafka Jmx Port
+     * Generates the necessary resources that the Kafka Cluster needs to secure the Jmx Port
      *
-     * @param authentication the Authentication Configuration for the Kafka Jmx Port
+     * @param authentication the Authentication Configuration for the Jmx Port
      * @param kafkaCluster the current state of the kafka Cluster CR
      */
     public static void configureKafkaJmxOptions(KafkaJmxAuthentication authentication, KafkaCluster kafkaCluster)   {
@@ -353,6 +353,23 @@ public class AuthenticationUtils {
             }
         } else {
             kafkaCluster.setJmxAuthenticated(false);
+        }
+    }
+
+
+    /**
+     * Generates the necessary resources that the KafkaConnect Cluster needs to secure the Jmx Port
+     *
+     * @param authentication the Authentication Configuration for the Jmx Port
+     * @param kafkaConnectCluster the current state of the kafkaConnect Cluster CR
+     */
+    public static void configureKafkaConnectJmxOptions(KafkaJmxAuthentication authentication, KafkaConnectCluster kafkaConnectCluster)   {
+        if (authentication != null) {
+            if (authentication instanceof KafkaJmxAuthenticationPassword) {
+                kafkaConnectCluster.setJmxAuthenticated(true);
+            }
+        } else {
+            kafkaConnectCluster.setJmxAuthenticated(false);
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -68,7 +68,13 @@ import io.strimzi.operator.common.model.Labels;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Base64;
+
 
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 public class KafkaConnectCluster extends AbstractModel {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -4,7 +4,32 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.Affinity;
+import io.fabric8.kubernetes.api.model.AffinityBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarSource;
+import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
+import io.fabric8.kubernetes.api.model.SecretVolumeSource;
+import io.fabric8.kubernetes.api.model.SecurityContext;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.Toleration;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyBuilder;
@@ -42,6 +67,7 @@ import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 
 import java.nio.charset.StandardCharsets;
+
 import java.util.*;
 
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
@@ -316,6 +342,10 @@ public class KafkaConnectCluster extends AbstractModel {
         portList.add(createContainerPort(REST_API_PORT_NAME, REST_API_PORT, "TCP"));
         if (isMetricsEnabled) {
             portList.add(createContainerPort(METRICS_PORT_NAME, METRICS_PORT, "TCP"));
+        }
+
+        if (isJmxEnabled()) {
+            portList.add(createContainerPort(JMX_PORT_NAME, JMX_PORT, "TCP"));
         }
 
         return portList;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -771,7 +771,7 @@ public class KafkaConnectCluster extends AbstractModel {
     }
 
     /**
-     * Generate the Secret containing the username and password to secure the jmx port on the kafka brokers
+     * Generate the Secret containing the username and password to secure the jmx port on the kafka connect workers
      *
      * @return The generated Secret
      */

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -4,31 +4,7 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import io.fabric8.kubernetes.api.model.Affinity;
-import io.fabric8.kubernetes.api.model.AffinityBuilder;
-import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
-import io.fabric8.kubernetes.api.model.ContainerPort;
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.EnvVarBuilder;
-import io.fabric8.kubernetes.api.model.EnvVarSource;
-import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.IntOrString;
-import io.fabric8.kubernetes.api.model.LocalObjectReference;
-import io.fabric8.kubernetes.api.model.Quantity;
-import io.fabric8.kubernetes.api.model.ResourceRequirements;
-import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
-import io.fabric8.kubernetes.api.model.SecretVolumeSource;
-import io.fabric8.kubernetes.api.model.SecurityContext;
-import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServicePort;
-import io.fabric8.kubernetes.api.model.Toleration;
-import io.fabric8.kubernetes.api.model.Volume;
-import io.fabric8.kubernetes.api.model.VolumeBuilder;
-import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyBuilder;
@@ -61,13 +37,12 @@ import io.strimzi.api.kafka.model.connect.ExternalConfigurationVolumeSource;
 import io.strimzi.api.kafka.model.template.KafkaConnectTemplate;
 import io.strimzi.api.kafka.model.tracing.Tracing;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 public class KafkaConnectCluster extends AbstractModel {
@@ -90,6 +65,12 @@ public class KafkaConnectCluster extends AbstractModel {
             .withInitialDelaySeconds(DEFAULT_HEALTHCHECK_DELAY).build();
     protected static final boolean DEFAULT_KAFKA_CONNECT_METRICS_ENABLED = false;
 
+    private static final String NAME_SUFFIX = "-" + APPLICATION_NAME;
+    protected static final String KAFKA_CONNECT_JMX_SECRET_SUFFIX = NAME_SUFFIX + "-jmx";
+    protected static final String SECRET_JMX_USERNAME_KEY = "jmx-username";
+    protected static final String SECRET_JMX_PASSWORD_KEY = "jmx-password";
+
+
     // Kafka Connect configuration keys (EnvVariables)
     protected static final String ENV_VAR_PREFIX = "KAFKA_CONNECT_";
     protected static final String ENV_VAR_KAFKA_CONNECT_CONFIGURATION = "KAFKA_CONNECT_CONFIGURATION";
@@ -108,6 +89,9 @@ public class KafkaConnectCluster extends AbstractModel {
     protected static final String ENV_VAR_KAFKA_CONNECT_OAUTH_REFRESH_TOKEN = "KAFKA_CONNECT_OAUTH_REFRESH_TOKEN";
     protected static final String OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT = "/opt/kafka/oauth-certs/";
     protected static final String ENV_VAR_STRIMZI_TRACING = "STRIMZI_TRACING";
+    protected static final String ENV_VAR_KAFKA_CONNECT_JMX_ENABLED = "KAFKA_CONNECT_JMX_ENABLED";
+    protected static final String ENV_VAR_KAFKA_CONNECT_JMX_USERNAME = "KAFKA_CONNECT_JMX_USERNAME";
+    protected static final String ENV_VAR_KAFKA_CONNECT_JMX_PASSWORD = "KAFKA_CONNECT_JMX_PASSWORD";
 
     private Rack rack;
     private String initImage;
@@ -123,6 +107,9 @@ public class KafkaConnectCluster extends AbstractModel {
 
     private KafkaConnectTls tls;
     private KafkaClientAuthentication authentication;
+
+    private boolean isJmxEnabled;
+    private boolean isJmxAuthenticated;
 
     /**
      * Constructor
@@ -203,6 +190,12 @@ public class KafkaConnectCluster extends AbstractModel {
         }
 
         kafkaConnect.setJvmOptions(spec.getJvmOptions());
+
+        if (spec.getJmxOptions() != null) {
+            kafkaConnect.setJmxEnabled(Boolean.TRUE);
+            AuthenticationUtils.configureKafkaConnectJmxOptions(spec.getJmxOptions().getAuthentication(), kafkaConnect);
+        }
+
         if (spec.getReadinessProbe() != null) {
             kafkaConnect.setReadinessProbe(spec.getReadinessProbe());
         }
@@ -310,6 +303,10 @@ public class KafkaConnectCluster extends AbstractModel {
     public Service generateService() {
         List<ServicePort> ports = new ArrayList<>(1);
         ports.add(createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, "TCP"));
+
+        if (isJmxEnabled()) {
+            ports.add(createServicePort(JMX_PORT_NAME, JMX_PORT, JMX_PORT, "TCP"));
+        }
 
         return createService("ClusterIP", ports, Util.mergeLabelsOrAnnotations(templateServiceAnnotations));
     }
@@ -579,6 +576,14 @@ public class KafkaConnectCluster extends AbstractModel {
             varList.add(buildEnvVar(ENV_VAR_STRIMZI_TRACING, tracing.getType()));
         }
 
+        if (isJmxEnabled()) {
+            varList.add(buildEnvVar(ENV_VAR_KAFKA_CONNECT_JMX_ENABLED, "true"));
+            if (isJmxAuthenticated) {
+                varList.add(buildEnvVarFromSecret(ENV_VAR_KAFKA_CONNECT_JMX_USERNAME, jmxSecretName(cluster), SECRET_JMX_USERNAME_KEY));
+                varList.add(buildEnvVarFromSecret(ENV_VAR_KAFKA_CONNECT_JMX_PASSWORD, jmxSecretName(cluster), SECRET_JMX_PASSWORD_KEY));
+            }
+        }
+
         // Add shared environment variables used for all containers
         varList.addAll(getRequiredEnvVars());
 
@@ -696,6 +701,56 @@ public class KafkaConnectCluster extends AbstractModel {
     public String getServiceAccountName() {
         return KafkaConnectResources.serviceAccountName(cluster);
     }
+
+    /**
+     * @return Return if the jmx has been enabled
+     */
+    public boolean isJmxEnabled() {
+        return isJmxEnabled;
+    }
+
+    /**
+     * Sets the object with jmx options enabled
+     *
+     * @param jmxEnabled if jmx is enabled
+     */
+    public void setJmxEnabled(boolean jmxEnabled) {
+        isJmxEnabled = jmxEnabled;
+    }
+
+    public boolean isJmxAuthenticated() {
+        return isJmxAuthenticated;
+    }
+
+    public void setJmxAuthenticated(boolean jmxAuthenticated) {
+        isJmxAuthenticated = jmxAuthenticated;
+    }
+
+    /**
+     * @param cluster The name of the cluster.
+     * @return The name of the jmx Secret.
+     */
+    public static String jmxSecretName(String cluster) {
+        return cluster + KafkaConnectCluster.KAFKA_CONNECT_JMX_SECRET_SUFFIX;
+    }
+
+    /**
+     * Generate the Secret containing the username and password to secure the jmx port on the kafka brokers
+     *
+     * @return The generated Secret
+     */
+    public Secret generateJmxSecret() {
+        Map<String, String> data = new HashMap<>(2);
+        String[] keys = {SECRET_JMX_USERNAME_KEY, SECRET_JMX_PASSWORD_KEY};
+        PasswordGenerator passwordGenerator = new PasswordGenerator(16);
+        for (String key : keys) {
+            data.put(key, Base64.getEncoder().encodeToString(passwordGenerator.generate().getBytes(StandardCharsets.US_ASCII)));
+        }
+
+        return createSecret(KafkaConnectCluster.jmxSecretName(cluster), data);
+    }
+
+
 
     /**
      * Generates the NetworkPolicies relevant for Kafka Connect nodes

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -125,6 +125,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
                 .withLivenessProbe(spec.getLivenessProbe())
                 .withReadinessProbe(spec.getReadinessProbe())
                 .withJvmOptions(spec.getJvmOptions())
+                .withJmxOptions(spec.getJmxOptions())
                 .withMetrics(spec.getMetrics())
                 .withMetricsConfig(spec.getMetricsConfig())
                 .withTracing(spec.getTracing())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
@@ -174,6 +175,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                     desiredLogging.set(logAndMetricsConfigMap.getData().get(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG));
                     return configMapOperations.reconcile(namespace, connect.getAncillaryConfigMapName(), logAndMetricsConfigMap);
                 })
+                .compose(i -> kafkaConnectJmxSecret(namespace, kafkaConnect.getMetadata().getName(), connect))
                 .compose(i -> podDisruptionBudgetOperator.reconcile(namespace, connect.getName(), connect.generatePodDisruptionBudget()))
                 .compose(i -> {
                     if (buildState.desiredBuildRevision != null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -150,6 +150,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<Ope
                     desiredLogging.set(logAndMetricsConfigMap.getData().get(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG));
                     return configMapOperations.reconcile(namespace, connect.getAncillaryConfigMapName(), logAndMetricsConfigMap);
                 })
+                .compose(i -> kafkaConnectJmxSecret(namespace, connect.getName(), connect))
                 .compose(i -> deploymentConfigOperations.reconcile(namespace, connect.getName(), connect.generateDeploymentConfig(annotations, pfa.isOpenshift(), imagePullPolicy, imagePullSecrets)))
                 .compose(i -> imagesStreamOperations.reconcile(namespace, KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster()), connect.generateSourceImageStream()))
                 .compose(i -> imagesStreamOperations.reconcile(namespace, KafkaConnectS2IResources.targetImageStreamName(connect.getCluster()), connect.generateTargetImageStream()))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -160,6 +160,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                     desiredLogging.set(logAndMetricsConfigMap.getData().get(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG));
                     return configMapOperations.reconcile(namespace, mirrorMaker2Cluster.getAncillaryConfigMapName(), logAndMetricsConfigMap);
                 })
+                .compose(i -> kafkaConnectJmxSecret(namespace, mirrorMaker2Cluster.getName(), mirrorMaker2Cluster))
                 .compose(i -> podDisruptionBudgetOperator.reconcile(namespace, mirrorMaker2Cluster.getName(), mirrorMaker2Cluster.generatePodDisruptionBudget()))
                 .compose(i -> deploymentOperations.reconcile(namespace, mirrorMaker2Cluster.getName(), mirrorMaker2Cluster.generateDeployment(annotations, pfa.isOpenshift(), imagePullPolicy, imagePullSecrets)))
                 .compose(i -> deploymentOperations.scaleUp(namespace, mirrorMaker2Cluster.getName(), mirrorMaker2Cluster.getReplicas()))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -20,6 +21,7 @@ import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
+import io.strimzi.operator.cluster.model.KafkaConnectCluster;
 import io.strimzi.operator.cluster.model.KafkaMirrorMakerCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -5,10 +5,8 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.KafkaMirrorMakerList;
 import io.strimzi.api.kafka.model.DoneableKafkaMirrorMaker;
 import io.strimzi.api.kafka.model.ExternalLogging;
@@ -21,7 +19,6 @@ import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
-import io.strimzi.operator.cluster.model.KafkaConnectCluster;
 import io.strimzi.operator.cluster.model.KafkaMirrorMakerCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.KafkaMirrorMakerList;
 import io.strimzi.api.kafka.model.DoneableKafkaMirrorMaker;
 import io.strimzi.api.kafka.model.ExternalLogging;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -638,12 +638,10 @@ public class KafkaConnectAssemblyOperatorTest {
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         ServiceOperator mockServiceOps = supplier.serviceOperations;
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
-<<<<<<< HEAD
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
-=======
         SecretOperator mockSecretOps = supplier.secretOperations;
->>>>>>> fix test
+
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         String kcName = "foo";
@@ -778,12 +776,9 @@ public class KafkaConnectAssemblyOperatorTest {
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         ServiceOperator mockServiceOps = supplier.serviceOperations;
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
-<<<<<<< HEAD
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
-=======
         SecretOperator mockSecretOps = supplier.secretOperations;
->>>>>>> fix test
 
         String kcName = "foo";
         String kcNamespace = "test";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -122,6 +122,7 @@ public class KafkaConnectAssemblyOperatorTest {
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
@@ -142,6 +143,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
 
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         when(mockPodOps.reconcile(eq(kc.getMetadata().getNamespace()), eq(KafkaConnectResources.buildPodName(kc.getMetadata().getName())), eq(null))).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
 
@@ -262,6 +264,7 @@ public class KafkaConnectAssemblyOperatorTest {
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         String kcName = "foo";
@@ -278,6 +281,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockDcOps.getAsync(kcNamespace, connect.getName())).thenReturn(Future.succeededFuture(connect.generateDeployment(new HashMap<String, String>(), true, null, null)));
         when(mockDcOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
@@ -359,6 +363,7 @@ public class KafkaConnectAssemblyOperatorTest {
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         String kcName = "foo";
@@ -376,6 +381,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockDcOps.getAsync(kcNamespace, connect.getName())).thenReturn(Future.succeededFuture(connect.generateDeployment(new HashMap<String, String>(), true, null, null)));
         when(mockDcOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
@@ -492,6 +498,7 @@ public class KafkaConnectAssemblyOperatorTest {
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         ServiceOperator mockServiceOps = supplier.serviceOperations;
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        SecretOperator mockSecretOps = supplier.secretOperations;
 
         String kcName = "foo";
         String kcNamespace = "test";
@@ -508,6 +515,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockDcOps.getAsync(kcNamespace, connect.getName())).thenReturn(Future.succeededFuture(connect.generateDeployment(new HashMap<String, String>(), true, null, null)));
         when(mockDcOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         ArgumentCaptor<String> serviceNamespaceCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
@@ -556,6 +564,7 @@ public class KafkaConnectAssemblyOperatorTest {
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         String kcName = "foo";
@@ -574,6 +583,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockDcOps.getAsync(kcNamespace, connect.getName())).thenReturn(Future.succeededFuture(connect.generateDeployment(new HashMap<String, String>(), true, null, null)));
         when(mockDcOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         when(mockServiceOps.reconcile(eq(kcNamespace), any(), any())).thenReturn(Future.succeededFuture());
 
@@ -626,8 +636,12 @@ public class KafkaConnectAssemblyOperatorTest {
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         ServiceOperator mockServiceOps = supplier.serviceOperations;
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+<<<<<<< HEAD
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+=======
+        SecretOperator mockSecretOps = supplier.secretOperations;
+>>>>>>> fix test
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         String kcName = "foo";
@@ -646,6 +660,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockDcOps.getAsync(kcNamespace, connect.getName())).thenReturn(Future.succeededFuture(connect.generateDeployment(new HashMap<String, String>(), true, null, null)));
         when(mockDcOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         when(mockServiceOps.reconcile(eq(kcNamespace), any(), any())).thenReturn(Future.succeededFuture());
 
@@ -761,8 +776,12 @@ public class KafkaConnectAssemblyOperatorTest {
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         ServiceOperator mockServiceOps = supplier.serviceOperations;
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+<<<<<<< HEAD
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+=======
+        SecretOperator mockSecretOps = supplier.secretOperations;
+>>>>>>> fix test
 
         String kcName = "foo";
         String kcNamespace = "test";
@@ -786,6 +805,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPodOps.reconcile(eq(kc.getMetadata().getNamespace()), eq(KafkaConnectResources.buildPodName(kc.getMetadata().getName())), eq(null))).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
         when(mockBcOps.reconcile(eq(kc.getMetadata().getNamespace()), eq(KafkaConnectResources.buildConfigName(kc.getMetadata().getName())), eq(null))).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
         when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
         when(mockConnectOps.updateStatusAsync(connectCaptor.capture())).thenReturn(Future.succeededFuture());
@@ -819,6 +839,7 @@ public class KafkaConnectAssemblyOperatorTest {
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         kc.getMetadata().setCreationTimestamp("2020-01-27T19:31:12Z");
@@ -845,6 +866,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
 
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         when(mockNetPolOps.reconcile(eq(kc.getMetadata().getNamespace()), eq(KafkaConnectResources.deploymentName(kc.getMetadata().getName())), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
 
@@ -1010,6 +1032,7 @@ public class KafkaConnectAssemblyOperatorTest {
         ServiceOperator mockServiceOps = supplier.serviceOperations;
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
         ClusterRoleBindingOperator mockCrbOps = supplier.clusterRoleBindingOperator;
+        SecretOperator mockSecretOps = supplier.secretOperations;
 
         String kcName = "foo";
         String kcNamespace = "test";
@@ -1025,6 +1048,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockServiceOps.get(kcNamespace, connect.getName())).thenReturn(connect.generateService());
         when(mockDcOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         when(mockCrbOps.reconcile(any(), any())).thenReturn(Future.failedFuture("Message: Forbidden!"));
         when(mockServiceOps.reconcile(any(), any(), any())).thenReturn(Future.succeededFuture());
@@ -1061,6 +1085,7 @@ public class KafkaConnectAssemblyOperatorTest {
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
         ClusterRoleBindingOperator mockCrbOps = supplier.clusterRoleBindingOperator;
+        SecretOperator mockSecretOps = supplier.secretOperations;
 
         String kcName = "foo";
         String kcNamespace = "test";
@@ -1076,6 +1101,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockDcOps.getAsync(kcNamespace, connect.getName())).thenReturn(Future.succeededFuture(connect.generateDeployment(new HashMap<String, String>(), true, null, null)));
         when(mockDcOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         when(mockCrbOps.reconcile(any(), any())).thenReturn(Future.failedFuture("Message: Forbidden!"));
         when(mockServiceOps.reconcile(any(), any(), any())).thenReturn(Future.succeededFuture());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorTest.java
@@ -158,6 +158,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -449,7 +450,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
-        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -570,7 +571,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
-        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -710,7 +711,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
-        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -860,7 +861,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
-        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -991,7 +992,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
-        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -1156,7 +1157,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
-        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -1310,7 +1311,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
-        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -1436,7 +1437,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
-        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -1449,9 +1450,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockBcOps.reconcile(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)), buildConfigCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
 
         Build builder = new BuildBuilder()
-                .withNewMetadata()
-                    .withNamespace(NAMESPACE)
-                    .withName("build-1")
+                .withNewMetadata().withNamespace(NAMESPACE).withName("build-1")
                 .endMetadata()
                 .withNewSpec()
                 .endSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorTest.java
@@ -46,6 +46,7 @@ import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -132,6 +133,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
@@ -275,6 +277,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
         BuildOperator mockBuildOps = supplier.buildOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
@@ -299,6 +302,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -420,6 +424,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
@@ -443,6 +448,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleUp(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
@@ -539,6 +545,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
         BuildOperator mockBuildOps = supplier.buildOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
@@ -562,6 +569,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleUp(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
@@ -672,6 +680,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
@@ -700,6 +709,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleUp(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
@@ -820,6 +830,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
@@ -848,6 +859,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleUp(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
@@ -948,6 +960,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
@@ -977,6 +990,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleUp(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
@@ -1112,6 +1126,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
         BuildOperator mockBuildOps = supplier.buildOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
@@ -1140,6 +1155,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleUp(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
@@ -1264,6 +1280,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
         BuildOperator mockBuildOps = supplier.buildOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
@@ -1292,6 +1309,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleUp(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
@@ -1387,6 +1405,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
         BuildOperator mockBuildOps = supplier.buildOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
@@ -1416,6 +1435,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         when(mockDepOps.scaleUp(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -6,8 +6,6 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
-import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
@@ -24,17 +22,15 @@ import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.api.kafka.model.connect.ConnectorPluginBuilder;
 import io.strimzi.api.kafka.model.status.KafkaConnectS2IStatus;
+import io.strimzi.api.kafka.model.KafkaJmxOptionsBuilder;
+import io.strimzi.api.kafka.model.KafkaJmxAuthenticationPasswordBuilder;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
-import io.strimzi.operator.cluster.model.KafkaConnectCluster;
 import io.strimzi.operator.cluster.model.KafkaConnectS2ICluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
-import io.strimzi.api.kafka.model.KafkaJmxAuthenticationPasswordBuilder;
-import io.strimzi.api.kafka.model.KafkaJmxOptions;
-import io.strimzi.api.kafka.model.KafkaJmxOptionsBuilder;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
@@ -63,9 +59,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
@@ -102,6 +102,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         ServiceOperator mockServiceOps = supplier.serviceOperations;
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        SecretOperator mockSecretOps = supplier.secretOperations;
 
         String kmm2Name = "foo";
         String kmm2Namespace = "test";
@@ -121,6 +122,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
         when(mockNetPolOps.reconcile(eq(kmm2.getMetadata().getNamespace()), eq(KafkaMirrorMaker2Resources.deploymentName(kmm2.getMetadata().getName())), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
+        when(mockSecretOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture());
 
         ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
         when(mockPdbOps.reconcile(anyString(), any(), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
@@ -189,6 +191,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         ServiceOperator mockServiceOps = supplier.serviceOperations;
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        SecretOperator mockSecretOps = supplier.secretOperations;
 
         String kmm2Name = "foo";
         String kmm2Namespace = "test";
@@ -202,6 +205,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockDcOps.get(kmm2Namespace, mirrorMaker2.getName())).thenReturn(mirrorMaker2.generateDeployment(new HashMap<String, String>(), true, null, null));
         when(mockDcOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture());
 
         ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
@@ -268,6 +272,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         ServiceOperator mockServiceOps = supplier.serviceOperations;
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        SecretOperator mockSecretOps = supplier.secretOperations;
 
         String kmm2Name = "foo";
         String kmm2Namespace = "test";
@@ -283,6 +288,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                 .thenReturn(mirrorMaker2.generateDeployment(new HashMap<String, String>(), true, null, null));
         when(mockDcOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture());
 
         ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
@@ -387,6 +393,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         ServiceOperator mockServiceOps = supplier.serviceOperations;
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        SecretOperator mockSecretOps = supplier.secretOperations;
 
         String kmm2Name = "foo";
         String kmm2Namespace = "test";
@@ -402,6 +409,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockDcOps.get(kmm2Namespace, mirrorMaker2.getName())).thenReturn(mirrorMaker2.generateDeployment(new HashMap<String, String>(), true, null, null));
         when(mockDcOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture());
 
         ArgumentCaptor<String> serviceNamespaceCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
@@ -447,6 +455,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         ServiceOperator mockServiceOps = supplier.serviceOperations;
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        SecretOperator mockSecretOps = supplier.secretOperations;
 
         String kmm2Name = "foo";
         String kmm2Namespace = "test";
@@ -462,6 +471,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockDcOps.get(kmm2Namespace, mirrorMaker2.getName())).thenReturn(mirrorMaker2.generateDeployment(new HashMap<String, String>(), true, null, null));
         when(mockDcOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture());
 
         when(mockServiceOps.reconcile(eq(kmm2Namespace), any(), any())).thenReturn(Future.succeededFuture());
 
@@ -504,6 +514,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         ServiceOperator mockServiceOps = supplier.serviceOperations;
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        SecretOperator mockSecretOps = supplier.secretOperations;
 
         String kmm2Name = "foo";
         String kmm2Namespace = "test";
@@ -521,7 +532,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
 
         when(mockServiceOps.reconcile(eq(kmm2Namespace), any(), any())).thenReturn(Future.succeededFuture());
-
+        when(mockSecretOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture());
         when(mockDcOps.reconcile(eq(kmm2Namespace), any(), any())).thenReturn(Future.succeededFuture());
 
         doAnswer(i -> Future.succeededFuture(scaleTo))
@@ -616,6 +627,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         ServiceOperator mockServiceOps = supplier.serviceOperations;
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        SecretOperator mockSecretOps = supplier.secretOperations;
 
         String kmm2Name = "foo";
         String kmm2Namespace = "test";
@@ -633,6 +645,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
         when(mockNetPolOps.reconcile(eq(kmm2.getMetadata().getNamespace()), eq(KafkaMirrorMaker2Resources.deploymentName(kmm2.getMetadata().getName())), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
         when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(eq(kmm2Namespace), any(), any())).thenReturn(Future.succeededFuture());
 
         ArgumentCaptor<KafkaMirrorMaker2> mirrorMaker2Captor = ArgumentCaptor.forClass(KafkaMirrorMaker2.class);
         when(mockMirrorMaker2Ops.updateStatusAsync(mirrorMaker2Captor.capture())).thenReturn(Future.succeededFuture());
@@ -663,6 +676,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         ServiceOperator mockServiceOps = supplier.serviceOperations;
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        SecretOperator mockSecretOps = supplier.secretOperations;
 
         String kmm2Name = "foo";
         String kmm2Namespace = "test";
@@ -681,6 +695,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockDcOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
         when(mockNetPolOps.reconcile(eq(kmm2.getMetadata().getNamespace()), eq(KafkaMirrorMaker2Resources.deploymentName(kmm2.getMetadata().getName())), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
+        when(mockSecretOps.reconcile(eq(kmm2Namespace), any(), any())).thenReturn(Future.succeededFuture());
 
         ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
         when(mockPdbOps.reconcile(anyString(), any(), pdbCaptor.capture())).thenReturn(Future.succeededFuture());

--- a/docker-images/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka/scripts/kafka_connect_run.sh
@@ -45,28 +45,7 @@ if [ "$KAFKA_CONNECT_METRICS_ENABLED" = "true" ]; then
     export KAFKA_OPTS
 fi
 
-if [ "$KAFKA_CONNECT_JMX_ENABLED" = "true" ]; then
-  KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote=true -Djava.rmi.server.hostname=$(hostname -i) -Djava.net.preferIPv4Stack=true"
-
-  if [ -n "$KAFKA_CONNECT_JMX_USERNAME" ]; then
-    # Secure JMX port on 9999 with username and password
-    JMX_ACCESS_FILE="/tmp/access.file"
-    JMX_PASSWORD_FILE="/tmp/password.file"
-
-    cat << EOF > "${JMX_ACCESS_FILE}"
-${KAFKA_CONNECT_JMX_USERNAME} readonly
-EOF
-
-    cat << EOF > "${JMX_PASSWORD_FILE}"
-$KAFKA_CONNECT_JMX_USERNAME $KAFKA_CONNECT_JMX_PASSWORD
-EOF
-    chmod 400 "${JMX_PASSWORD_FILE}"
-    KAFKA_JMX_OPTS="${KAFKA_JMX_OPTS} -Dcom.sun.management.jmxremote.access.file=${JMX_ACCESS_FILE} -Dcom.sun.management.jmxremote.password.file=${JMX_PASSWORD_FILE}  -Dcom.sun.management.jmxremote.authenticate=true"
-  else
-    # expose the port insecurely
-    KAFKA_JMX_OPTS="${KAFKA_JMX_OPTS} -Dcom.sun.management.jmxremote.authenticate=false"
-  fi
-fi
+. ./set_kafka_jmx_options.sh ${KAFKA_CONNECT_JMX_ENABLED} ${KAFKA_CONNECT_JMX_USERNAME} ${KAFKA_CONNECT_JMX_PASSWORD}
 
 # enabling Tracing agent (initializes Jaeger tracing) as Java agent
 if [ "$STRIMZI_TRACING" = "jaeger" ]; then

--- a/docker-images/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka/scripts/kafka_connect_run.sh
@@ -45,6 +45,29 @@ if [ "$KAFKA_CONNECT_METRICS_ENABLED" = "true" ]; then
     export KAFKA_OPTS
 fi
 
+if [ "$KAFKA_CONNECT_JMX_ENABLED" = "true" ]; then
+  KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote=true -Djava.rmi.server.hostname=$(hostname -i) -Djava.net.preferIPv4Stack=true"
+
+  if [ -n "$KAFKA_CONNECT_JMX_USERNAME" ]; then
+    # Secure JMX port on 9999 with username and password
+    JMX_ACCESS_FILE="/tmp/access.file"
+    JMX_PASSWORD_FILE="/tmp/password.file"
+
+    cat << EOF > "${JMX_ACCESS_FILE}"
+${KAFKA_CONNECT_JMX_USERNAME} readonly
+EOF
+
+    cat << EOF > "${JMX_PASSWORD_FILE}"
+$KAFKA_CONNECT_JMX_USERNAME $KAFKA_CONNECT_JMX_PASSWORD
+EOF
+    chmod 400 "${JMX_PASSWORD_FILE}"
+    KAFKA_JMX_OPTS="${KAFKA_JMX_OPTS} -Dcom.sun.management.jmxremote.access.file=${JMX_ACCESS_FILE} -Dcom.sun.management.jmxremote.password.file=${JMX_PASSWORD_FILE}  -Dcom.sun.management.jmxremote.authenticate=true"
+  else
+    # expose the port insecurely
+    KAFKA_JMX_OPTS="${KAFKA_JMX_OPTS} -Dcom.sun.management.jmxremote.authenticate=false"
+  fi
+fi
+
 # enabling Tracing agent (initializes Jaeger tracing) as Java agent
 if [ "$STRIMZI_TRACING" = "jaeger" ]; then
     KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls "$KAFKA_HOME"/libs/tracing-agent*.jar)=jaeger"

--- a/docker-images/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka/scripts/kafka_connect_run.sh
@@ -45,7 +45,7 @@ if [ "$KAFKA_CONNECT_METRICS_ENABLED" = "true" ]; then
     export KAFKA_OPTS
 fi
 
-. ./set_kafka_jmx_options.sh ${KAFKA_CONNECT_JMX_ENABLED} ${KAFKA_CONNECT_JMX_USERNAME} ${KAFKA_CONNECT_JMX_PASSWORD}
+. ./set_kafka_jmx_options.sh "${KAFKA_CONNECT_JMX_ENABLED}" "${KAFKA_CONNECT_JMX_USERNAME}" "${KAFKA_CONNECT_JMX_PASSWORD}"
 
 # enabling Tracing agent (initializes Jaeger tracing) as Java agent
 if [ "$STRIMZI_TRACING" = "jaeger" ]; then

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -17,7 +17,7 @@ rm -f /var/opt/kafka/kafka-ready /var/opt/kafka/zk-connected 2> /dev/null
 KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls "$KAFKA_HOME"/libs/kafka-agent*.jar)=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected"
 export KAFKA_OPTS
 
-. ./set_kafka_jmx_options.sh ${KAFKA_JMX_ENABLED} ${KAFKA_JMX_USERNAME} ${KAFKA_JMX_PASSWORD}
+. ./set_kafka_jmx_options.sh "${KAFKA_JMX_ENABLED}" "${KAFKA_JMX_USERNAME}" "${KAFKA_JMX_PASSWORD}"
 
 if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
     export KAFKA_OPTS="${KAFKA_OPTS} ${STRIMZI_JAVA_SYSTEM_PROPERTIES}"

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -17,28 +17,7 @@ rm -f /var/opt/kafka/kafka-ready /var/opt/kafka/zk-connected 2> /dev/null
 KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls "$KAFKA_HOME"/libs/kafka-agent*.jar)=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected"
 export KAFKA_OPTS
 
-if [ "$KAFKA_JMX_ENABLED" = "true" ]; then
-  KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote=true -Djava.rmi.server.hostname=$(hostname -i) -Djava.net.preferIPv4Stack=true"
-
-  if [ -n "$KAFKA_JMX_USERNAME" ]; then
-    # Secure JMX port on 9999 with username and password
-    JMX_ACCESS_FILE="/tmp/access.file"
-    JMX_PASSWORD_FILE="/tmp/password.file"
-
-    cat << EOF > "${JMX_ACCESS_FILE}"
-${KAFKA_JMX_USERNAME} readonly
-EOF
-
-    cat << EOF > "${JMX_PASSWORD_FILE}"
-$KAFKA_JMX_USERNAME $KAFKA_JMX_PASSWORD
-EOF
-    chmod 400 "${JMX_PASSWORD_FILE}"
-    KAFKA_JMX_OPTS="${KAFKA_JMX_OPTS} -Dcom.sun.management.jmxremote.access.file=${JMX_ACCESS_FILE} -Dcom.sun.management.jmxremote.password.file=${JMX_PASSWORD_FILE}  -Dcom.sun.management.jmxremote.authenticate=true"
-  else
-    # expose the port insecurely
-    KAFKA_JMX_OPTS="${KAFKA_JMX_OPTS} -Dcom.sun.management.jmxremote.authenticate=false"
-  fi
-fi
+. ./set_kafka_jmx_options.sh ${KAFKA_JMX_ENABLED} ${KAFKA_JMX_USERNAME} ${KAFKA_JMX_PASSWORD}
 
 if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
     export KAFKA_OPTS="${KAFKA_OPTS} ${STRIMZI_JAVA_SYSTEM_PROPERTIES}"

--- a/docker-images/kafka/scripts/set_kafka_jmx_options.sh
+++ b/docker-images/kafka/scripts/set_kafka_jmx_options.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+
+JMX_ENABLED="$1"
+JMX_USERNAME="$2"
+JMX_PASSWORD="$3"
+
+echo "${JMX_ENABLED}, ${JMX_USERNAME}, ${JMX_PASSWORD}"
+
+if [ "$JMX_ENABLED" = "true" ]; then
+  export KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote=true -Djava.rmi.server.hostname=$(hostname -i) -Djava.net.preferIPv4Stack=true"
+
+  if [ -n "$JMX_USERNAME" ]; then
+    # Secure JMX port on 9999 with username and password
+    JMX_ACCESS_FILE="/tmp/access.file"
+    JMX_PASSWORD_FILE="/tmp/password.file"
+
+    cat << EOF > "${JMX_ACCESS_FILE}"
+${JMX_USERNAME} readonly
+EOF
+
+    cat << EOF > "${JMX_PASSWORD_FILE}"
+$JMX_USERNAME $JMX_PASSWORD
+EOF
+    chmod 400 "${JMX_PASSWORD_FILE}"
+    export KAFKA_JMX_OPTS="${KAFKA_JMX_OPTS} -Dcom.sun.management.jmxremote.access.file=${JMX_ACCESS_FILE} -Dcom.sun.management.jmxremote.password.file=${JMX_PASSWORD_FILE}  -Dcom.sun.management.jmxremote.authenticate=true"
+  else
+    # expose the port insecurely
+    export KAFKA_JMX_OPTS="${KAFKA_JMX_OPTS} -Dcom.sun.management.jmxremote.authenticate=false"
+  fi
+fi

--- a/docker-images/kafka/scripts/set_kafka_jmx_options.sh
+++ b/docker-images/kafka/scripts/set_kafka_jmx_options.sh
@@ -5,10 +5,8 @@ JMX_ENABLED="$1"
 JMX_USERNAME="$2"
 JMX_PASSWORD="$3"
 
-echo "${JMX_ENABLED}, ${JMX_USERNAME}, ${JMX_PASSWORD}"
-
 if [ "$JMX_ENABLED" = "true" ]; then
-  export KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote=true -Djava.rmi.server.hostname=$(hostname -i) -Djava.net.preferIPv4Stack=true"
+  KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote=true -Djava.rmi.server.hostname=$(hostname -i) -Djava.net.preferIPv4Stack=true"
 
   if [ -n "$JMX_USERNAME" ]; then
     # Secure JMX port on 9999 with username and password
@@ -23,9 +21,11 @@ EOF
 $JMX_USERNAME $JMX_PASSWORD
 EOF
     chmod 400 "${JMX_PASSWORD_FILE}"
-    export KAFKA_JMX_OPTS="${KAFKA_JMX_OPTS} -Dcom.sun.management.jmxremote.access.file=${JMX_ACCESS_FILE} -Dcom.sun.management.jmxremote.password.file=${JMX_PASSWORD_FILE}  -Dcom.sun.management.jmxremote.authenticate=true"
+    KAFKA_JMX_OPTS="${KAFKA_JMX_OPTS} -Dcom.sun.management.jmxremote.access.file=${JMX_ACCESS_FILE} -Dcom.sun.management.jmxremote.password.file=${JMX_PASSWORD_FILE}  -Dcom.sun.management.jmxremote.authenticate=true"
+    export KAFKA_JMX_OPTS
   else
     # expose the port insecurely
-    export KAFKA_JMX_OPTS="${KAFKA_JMX_OPTS} -Dcom.sun.management.jmxremote.authenticate=false"
+    KAFKA_JMX_OPTS="${KAFKA_JMX_OPTS} -Dcom.sun.management.jmxremote.authenticate=false"
+    export KAFKA_JMX_OPTS
   fi
 fi

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1035,13 +1035,13 @@ Used in: xref:type-JvmOptions-{context}[`JvmOptions`]
 [id='type-KafkaJmxOptions-{context}']
 ### `KafkaJmxOptions` schema reference
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
+Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`]
 
 
 [options="header"]
 |====
 |Property               |Description
-|authentication  1.2+<.<|Authentication configuration for connecting to the Kafka JMX port. The type depends on the value of the `authentication.type` property within the given object, which must be one of [password].
+|authentication  1.2+<.<|Authentication configuration for connecting to the JMX port. The type depends on the value of the `authentication.type` property within the given object, which must be one of [password].
 |xref:type-KafkaJmxAuthenticationPassword-{context}[`KafkaJmxAuthenticationPassword`]
 |====
 
@@ -1975,6 +1975,8 @@ include::../api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc[leveloffset=+1]
 |xref:type-Probe-{context}[`Probe`]
 |jvmOptions             1.2+<.<|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
+|jmxOptions             1.2+<.<|JMX Options.
+|xref:type-KafkaJmxOptions-{context}[`KafkaJmxOptions`]
 |affinity               1.2+<.<|*The property `affinity` has been deprecated. This feature should now be configured at path `spec.template.pod.affinity`.* The pod's affinity rules. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core[external documentation for core/v1 affinity].
 
 
@@ -2470,6 +2472,8 @@ include::../api/io.strimzi.api.kafka.model.KafkaConnectS2ISpec.adoc[leveloffset=
 |xref:type-Probe-{context}[`Probe`]
 |jvmOptions                1.2+<.<|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
+|jmxOptions                1.2+<.<|JMX Options.
+|xref:type-KafkaJmxOptions-{context}[`KafkaJmxOptions`]
 |affinity                  1.2+<.<|*The property `affinity` has been deprecated. This feature should now be configured at path `spec.template.pod.affinity`.* The pod's affinity rules. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core[external documentation for core/v1 affinity].
 
 
@@ -3285,6 +3289,8 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |xref:type-Probe-{context}[`Probe`]
 |jvmOptions             1.2+<.<|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
+|jmxOptions             1.2+<.<|JMX Options.
+|xref:type-KafkaJmxOptions-{context}[`KafkaJmxOptions`]
 |affinity               1.2+<.<|*The property `affinity` has been deprecated. This feature should now be configured at path `spec.template.pod.affinity`.* The pod's affinity rules. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core[external documentation for core/v1 affinity].
 
 

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1436,7 +1436,7 @@ spec:
                           description: Authentication type. Currently the only supported types are `password`.`password` type creates a username and protected port with no TLS.
                       required:
                         - type
-                      description: Authentication configuration for connecting to the Kafka JMX port.
+                      description: Authentication configuration for connecting to the JMX port.
                   description: JMX Options for Kafka brokers.
                 resources:
                   type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -288,6 +288,21 @@ spec:
                         description: The system property value.
                   description: A map of additional system properties which will be passed using the `-D` option to the JVM.
               description: JVM Options for pods.
+            jmxOptions:
+              type: object
+              properties:
+                authentication:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - password
+                      description: Authentication type. Currently the only supported types are `password`.`password` type creates a username and protected port with no TLS.
+                  required:
+                    - type
+                  description: Authentication configuration for connecting to the JMX port.
+              description: JMX Options.
             affinity:
               type: object
               properties:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -141,6 +141,21 @@ spec:
                         description: The system property value.
                   description: A map of additional system properties which will be passed using the `-D` option to the JVM.
               description: JVM Options for pods.
+            jmxOptions:
+              type: object
+              properties:
+                authentication:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - password
+                      description: Authentication type. Currently the only supported types are `password`.`password` type creates a username and protected port with no TLS.
+                  required:
+                    - type
+                  description: Authentication configuration for connecting to the JMX port.
+              description: JMX Options.
             affinity:
               type: object
               properties:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -370,6 +370,21 @@ spec:
                         description: The system property value.
                   description: A map of additional system properties which will be passed using the `-D` option to the JVM.
               description: JVM Options for pods.
+            jmxOptions:
+              type: object
+              properties:
+                authentication:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - password
+                      description: Authentication type. Currently the only supported types are `password`.`password` type creates a username and protected port with no TLS.
+                  required:
+                    - type
+                  description: Authentication configuration for connecting to the JMX port.
+              description: JMX Options.
             affinity:
               type: object
               properties:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1933,7 +1933,7 @@ spec:
                       required:
                       - type
                       description: Authentication configuration for connecting to
-                        the Kafka JMX port.
+                        the JMX port.
                   description: JMX Options for Kafka brokers.
                 resources:
                   type: object

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -340,6 +340,24 @@ spec:
                   description: A map of additional system properties which will be
                     passed using the `-D` option to the JVM.
               description: JVM Options for pods.
+            jmxOptions:
+              type: object
+              properties:
+                authentication:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                      - password
+                      description: Authentication type. Currently the only supported
+                        types are `password`.`password` type creates a username and
+                        protected port with no TLS.
+                  required:
+                  - type
+                  description: Authentication configuration for connecting to the
+                    JMX port.
+              description: JMX Options.
             affinity:
               type: object
               properties:

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -156,6 +156,24 @@ spec:
                   description: A map of additional system properties which will be
                     passed using the `-D` option to the JVM.
               description: JVM Options for pods.
+            jmxOptions:
+              type: object
+              properties:
+                authentication:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                      - password
+                      description: Authentication type. Currently the only supported
+                        types are `password`.`password` type creates a username and
+                        protected port with no TLS.
+                  required:
+                  - type
+                  description: Authentication configuration for connecting to the
+                    JMX port.
+              description: JMX Options.
             affinity:
               type: object
               properties:

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -446,6 +446,24 @@ spec:
                   description: A map of additional system properties which will be
                     passed using the `-D` option to the JVM.
               description: JVM Options for pods.
+            jmxOptions:
+              type: object
+              properties:
+                authentication:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                      - password
+                      description: Authentication type. Currently the only supported
+                        types are `password`.`password` type creates a username and
+                        protected port with no TLS.
+                  required:
+                  - type
+                  description: Authentication configuration for connecting to the
+                    JMX port.
+              description: JMX Options.
             affinity:
               type: object
               properties:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature


### Description

add jmxOptions to KafkaConnect 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

