### PR TITLE
feat: Update Jackson version to 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,10 +94,10 @@
         <log4j.version>2.13.3</log4j.version>
         <hamcrest.version>2.2</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>
-        <fasterxml.jackson-core.version>2.10.5.1</fasterxml.jackson-core.version>
+        <fasterxml.jackson-core.version>2.10.5</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.10.5.1</fasterxml.jackson-databind.version>
-        <fasterxml.jackson-dataformat.version>2.10.5.1</fasterxml.jackson-dataformat.version>
-        <fasterxml.jackson-annotations.version>2.10.5.1</fasterxml.jackson-annotations.version>
+        <fasterxml.jackson-dataformat.version>2.10.5</fasterxml.jackson-dataformat.version>
+        <fasterxml.jackson-annotations.version>2.10.5</fasterxml.jackson-annotations.version>
         <kafka.version>2.6.0</kafka.version>
         <zkclient.version>0.11</zkclient.version>
         <scala-library.version>2.12.10</scala-library.version>

--- a/pom.xml
+++ b/pom.xml
@@ -94,10 +94,10 @@
         <log4j.version>2.13.3</log4j.version>
         <hamcrest.version>2.2</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>
-        <fasterxml.jackson-core.version>2.10.4</fasterxml.jackson-core.version>
-        <fasterxml.jackson-databind.version>2.10.4</fasterxml.jackson-databind.version>
-        <fasterxml.jackson-dataformat.version>2.10.4</fasterxml.jackson-dataformat.version>
-        <fasterxml.jackson-annotations.version>2.10.4</fasterxml.jackson-annotations.version>
+        <fasterxml.jackson-core.version>2.11.0</fasterxml.jackson-core.version>
+        <fasterxml.jackson-databind.version>2.11.0</fasterxml.jackson-databind.version>
+        <fasterxml.jackson-dataformat.version>2.11.0</fasterxml.jackson-dataformat.version>
+        <fasterxml.jackson-annotations.version>2.11.0</fasterxml.jackson-annotations.version>
         <kafka.version>2.6.0</kafka.version>
         <zkclient.version>0.11</zkclient.version>
         <scala-library.version>2.12.10</scala-library.version>

--- a/pom.xml
+++ b/pom.xml
@@ -94,10 +94,10 @@
         <log4j.version>2.13.3</log4j.version>
         <hamcrest.version>2.2</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>
-        <fasterxml.jackson-core.version>2.11.0</fasterxml.jackson-core.version>
-        <fasterxml.jackson-databind.version>2.11.0</fasterxml.jackson-databind.version>
-        <fasterxml.jackson-dataformat.version>2.11.0</fasterxml.jackson-dataformat.version>
-        <fasterxml.jackson-annotations.version>2.11.0</fasterxml.jackson-annotations.version>
+        <fasterxml.jackson-core.version>2.10.5.1</fasterxml.jackson-core.version>
+        <fasterxml.jackson-databind.version>2.10.5.1</fasterxml.jackson-databind.version>
+        <fasterxml.jackson-dataformat.version>2.10.5.1</fasterxml.jackson-dataformat.version>
+        <fasterxml.jackson-annotations.version>2.10.5.1</fasterxml.jackson-annotations.version>
         <kafka.version>2.6.0</kafka.version>
         <zkclient.version>0.11</zkclient.version>
         <scala-library.version>2.12.10</scala-library.version>


### PR DESCRIPTION
Update Jackson version from 2.10.2 to 2.11.0
to resolve security vulnerability CVE-2020-25649

Signed-off-by: Salma Saeed <salma.saeed@ibm.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

