### PR TITLE
Prometheus operator does not parse configuration

### DIFF
--- a/examples/metrics/prometheus-install/prometheus.yaml
+++ b/examples/metrics/prometheus-install/prometheus.yaml
@@ -58,9 +58,7 @@ spec:
   podMonitorSelector:
     matchLabels:
       app: strimzi
-  serviceMonitorSelector:
-    matchLabels:
-      prometheus: prometheus    
+  serviceMonitorSelector: {}    
   resources:
     requests:
       memory: 400Mi

--- a/examples/metrics/prometheus-install/prometheus.yaml
+++ b/examples/metrics/prometheus-install/prometheus.yaml
@@ -58,6 +58,9 @@ spec:
   podMonitorSelector:
     matchLabels:
       app: strimzi
+  serviceMonitorSelector:
+    matchLabels:
+      prometheus: prometheus    
   resources:
     requests:
       memory: 400Mi


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix


### Description
It seems the Prometheus operator v0.37 has a bug. If the `ServiceMonitor` property is not specified, no Prometheus configuration is generated at all. Having `ServiceMonitor` matcher in our CR does not make sense as we do not support `ServiceMonitors` but without it does not work :fearful: 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

