### PR TITLE
[DOC] Fix version field in the sample Kafka YAML

### DIFF
--- a/documentation/modules/ref-sample-kafka-resource-config.adoc
+++ b/documentation/modules/ref-sample-kafka-resource-config.adoc
@@ -26,7 +26,7 @@ metadata:
 spec:
   kafka:
     replicas: 3 <1>
-    version: {ProductVersion} <2>
+    version: {DefaultKafkaVersion} <2>
     resources: <3>
       requests:
         memory: 64Gi
@@ -66,6 +66,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
+      log.message.format.version: {LogMsgVersHigher}
+      inter.broker.protocol.version: {LogMsgVersHigher}
       ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <17>
       ssl.enabled.protocols: "TLSv1.2"
       ssl.protocol: "TLSv1.2"


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The documentation chapter with sample Kafka YAML configuration (https://strimzi.io/docs/operators/latest/full/using.html#ref-sample-kafka-resource-config-deployment-configuration-kafka) contains a bug. It uses the operator version in the `version` field instead of Kafka version. This PR fixes it by using the right variable. 

It also adds to the sample config the default log message format and inter broker protocol versions tohave the fields from the examples.