### PR TITLE
feat: Add annotations to perform connector/task restart operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # CHANGELOG
 
+## 0.22.0
+
+* Add annotations that enable the operator to restart Kafka Connect connectors or tasks. The annotations can be applied to the KafkaConnector and the KafkaMirrorMaker2 custom resources.
+
 ## 0.21.0
 
 * Add support for declarative management of connector plugins in Kafka Connect CR 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -41,6 +41,7 @@ import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectorSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
+import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.status.HasStatus;
 import io.strimzi.api.kafka.model.status.KafkaConnectS2IStatus;
 import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
@@ -77,6 +78,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -481,7 +483,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
      * @param resource The resource that defines the connector.
      * @return A Future whose result, when successfully completed, is a map of the current connector state.
      */
-    protected Future<Map<String, Object>> maybeCreateOrUpdateConnector(Reconciliation reconciliation, String host, KafkaConnectApi apiClient,
+    protected Future<ConnectorStatusAndConditions> maybeCreateOrUpdateConnector(Reconciliation reconciliation, String host, KafkaConnectApi apiClient,
                                                                        String connectorName, KafkaConnectorSpec connectorSpec, CustomResource resource) {
         return apiClient.getConnectorConfig(new BackOff(200L, 2, 6), host, port, connectorName).compose(
             config -> {
@@ -489,21 +491,23 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                     log.debug("{}: Connector {} exists and has desired config, {}=={}", reconciliation, connectorName, connectorSpec.getConfig(), config);
                     return apiClient.status(host, port, connectorName)
                         .compose(status -> pauseResume(reconciliation, host, apiClient, connectorName, connectorSpec, status))
-                        .compose(ignored -> maybeRestartConnector(reconciliation, host, apiClient, connectorName, resource))
-                        .compose(ignored -> maybeRestartConnectorTask(reconciliation, host, apiClient, connectorName, resource))
-                        .compose(ignored ->
-                            apiClient.statusWithBackOff(new BackOff(200L, 2, 10), host, port,
-                                connectorName));
+                        .compose(ignored -> maybeRestartConnector(reconciliation, host, apiClient, connectorName, resource, new ArrayList<>()))
+                        .compose(conditions -> maybeRestartConnectorTask(reconciliation, host, apiClient, connectorName, resource, conditions))
+                        .compose(conditions ->
+                            apiClient.statusWithBackOff(new BackOff(200L, 2, 10), host, port, connectorName)
+                                .compose(createConnectorStatusAndConditions(conditions)));
                 } else {
                     log.debug("{}: Connector {} exists but does not have desired config, {}!={}", reconciliation, connectorName, connectorSpec.getConfig(), config);
-                    return createOrUpdateConnector(reconciliation, host, apiClient, connectorName, connectorSpec);
+                    return createOrUpdateConnector(reconciliation, host, apiClient, connectorName, connectorSpec)
+                        .compose(createConnectorStatusAndConditions());
                 }
             },
             error -> {
                 if (error instanceof ConnectRestException
                         && ((ConnectRestException) error).getStatusCode() == 404) {
                     log.debug("{}: Connector {} does not exist", reconciliation, connectorName);
-                    return createOrUpdateConnector(reconciliation, host, apiClient, connectorName, connectorSpec);
+                    return createOrUpdateConnector(reconciliation, host, apiClient, connectorName, connectorSpec)
+                        .compose(createConnectorStatusAndConditions());
                 } else {
                     return Future.failedFuture(error);
                 }
@@ -559,34 +563,40 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         }
     }
 
-    private Future<Void> maybeRestartConnector(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, String connectorName, CustomResource resource) {
+    private Future<List<Condition>> maybeRestartConnector(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, String connectorName, CustomResource resource, List<Condition> conditions) {
         if (hasRestartAnnotation(resource, connectorName)) {
             log.debug("{}: Restarting connector {}", reconciliation, connectorName);
             return apiClient.restart(host, port, connectorName)
-                    .compose(ignored -> removeRestartAnnotation(reconciliation, resource),
+                    .compose(ignored -> removeRestartAnnotation(reconciliation, resource)
+                        .compose(v -> Future.succeededFuture(conditions)),
                         throwable -> {
-                            // Ignore restart failures - just try again on the next reconcile
-                            log.warn("{}: Failed to restart connector {}. {}", reconciliation, connectorName, throwable.getMessage());
-                            return Future.succeededFuture();
+                            // Ignore restart failures - add a warning and try again on the next reconcile
+                            String message = "Failed to restart connector " + connectorName + ". " + throwable.getMessage();
+                            log.warn("{}: {}", reconciliation, message);
+                            conditions.add(StatusUtils.buildWarningCondition("RestartConnector", message));
+                            return Future.succeededFuture(conditions);
                         });
         } else {
-            return Future.succeededFuture();
+            return Future.succeededFuture(conditions);
         }
     }
 
-    private Future<Void> maybeRestartConnectorTask(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, String connectorName, CustomResource resource) {
+    private Future<List<Condition>> maybeRestartConnectorTask(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, String connectorName, CustomResource resource, List<Condition> conditions) {
         int taskID = getRestartTaskAnnotationTaskID(resource, connectorName);
         if (taskID >= 0) {
             log.debug("{}: Restarting connector task {}:{}", reconciliation, connectorName, taskID);
             return apiClient.restartTask(host, port, connectorName, taskID)
-                    .compose(ignored -> removeRestartTaskAnnotation(reconciliation, resource),
+                    .compose(ignored -> removeRestartTaskAnnotation(reconciliation, resource)
+                        .compose(v -> Future.succeededFuture(conditions)),
                         throwable -> {
-                            // Ignore restart failures - just try again on the next reconcile
-                            log.warn("{}: Failed to restart connector task {}:{}. {}", reconciliation, connectorName, taskID, throwable.getMessage());
-                            return Future.succeededFuture();
+                            // Ignore restart failures - add a warning and try again on the next reconcile
+                            String message = "Failed to restart connector task " + connectorName + ":" + taskID + ". " + throwable.getMessage();
+                            log.warn("{}: {}", reconciliation, message);
+                            conditions.add(StatusUtils.buildWarningCondition("RestartConnectorTask", message));
+                            return Future.succeededFuture(conditions);
                         });
         } else {
-            return Future.succeededFuture();
+            return Future.succeededFuture(conditions);
         }
     }
 
@@ -653,15 +663,45 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         }
     }
 
-    Future<Void> maybeUpdateConnectorStatus(Reconciliation reconciliation, KafkaConnector connector, Map<String, Object> statusResult, Throwable error) {
+    protected class ConnectorStatusAndConditions {
+        Map<String, Object> statusResult;
+        List<Condition> conditions;
+
+        ConnectorStatusAndConditions(Map<String, Object> statusResult, List<Condition> conditions) {
+            this.statusResult = statusResult;
+            this.conditions = conditions;
+        }
+
+        ConnectorStatusAndConditions(Map<String, Object> statusResult) {
+            this(statusResult, Collections.emptyList());
+        }
+    }
+
+    Function<Map<String, Object>, Future<ConnectorStatusAndConditions>> createConnectorStatusAndConditions() {
+        return statusResult -> Future.succeededFuture(new ConnectorStatusAndConditions(statusResult));
+    }
+
+    Function<Map<String, Object>, Future<ConnectorStatusAndConditions>> createConnectorStatusAndConditions(List<Condition> conditions) {
+        return statusResult -> Future.succeededFuture(new ConnectorStatusAndConditions(statusResult, conditions));
+    }
+
+    Future<Void> maybeUpdateConnectorStatus(Reconciliation reconciliation, KafkaConnector connector, ConnectorStatusAndConditions connectorStatus, Throwable error) {
         KafkaConnectorStatus status = new KafkaConnectorStatus();
         if (error != null) {
             log.warn("{}: Error reconciling connector {}", reconciliation, connector.getMetadata().getName(), error);
+        }
+
+        Map<String, Object> statusResult = null;
+        List<Condition> conditions = Collections.emptyList();
+        if (connectorStatus != null) {
+            statusResult = connectorStatus.statusResult;
+            conditions = connectorStatus.conditions;
         }
         StatusUtils.setStatusConditionAndObservedGeneration(connector, status, error != null ? Future.failedFuture(error) : Future.succeededFuture());
         status.setConnectorStatus(statusResult);
 
         status.setTasksMax(getActualTaskCount(connector, statusResult));
+        status.addConditions(conditions);
 
         return maybeUpdateStatusCommon(connectorOperator, connector, reconciliation, status,
             (connector1, status1) -> {
@@ -795,4 +835,6 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                 Future.succeededFuture(null);
         return CompositeFuture.join(metricsCmFut, loggingCmFut).map(res -> new MetricsAndLoggingCm(res.resultAt(0), res.resultAt(1)));
     }
+
+
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -481,7 +481,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
      * @param connectorName The connector name.
      * @param connectorSpec The desired connector spec.
      * @param resource The resource that defines the connector.
-     * @return A Future whose result, when successfully completed, is a map of the current connector state.
+     * @return A Future whose result, when successfully completed, is a ConnectorStatusAndConditions object containing the map of the current connector state plus any conditions that have arisen.
      */
     protected Future<ConnectorStatusAndConditions> maybeCreateOrUpdateConnector(Reconciliation reconciliation, String host, KafkaConnectApi apiClient,
                                                                        String connectorName, KafkaConnectorSpec connectorSpec, CustomResource resource) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -147,6 +147,25 @@ public interface KafkaConnectApi {
      * this returns the list of connect loggers.
      */
     Future<Map<String, Map<String, String>>> listConnectLoggers(String host, int port);
+
+    /**
+     * Make a {@code POST} request to {@code /connectors/${connectorName}/restart}.
+     * @param host The host to make the request to.
+     * @param port The port to make the request to.
+     * @param connectorName The name of the connector to restart.
+     * @return A Future which completes with the result of the request.
+     */
+    Future<Void> restart(String host, int port, String connectorName);
+
+    /**
+     * Make a {@code POST} request to {@code /connectors/${connectorName}/tasks/${taskID}/restart}.
+     * @param host The host to make the request to.
+     * @param port The port to make the request to.
+     * @param connectorName The name of the connector.
+     * @param taskID The ID of the connector task to restart.
+     * @return A Future which completes with the result of the request.
+     */
+    Future<Void> restartTask(String host, int port, String connectorName, int taskID);
 }
 
 class ConnectRestException extends RuntimeException {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -468,7 +468,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
      * the restart action specified by user has been completed.
      */
     @Override
-    protected Future<? extends CustomResource> removeRestartAnnotation(Reconciliation reconciliation, CustomResource resource) {
+    protected Future<Void> removeRestartAnnotation(Reconciliation reconciliation, CustomResource resource) {
         return removeAnnotation(reconciliation, (KafkaMirrorMaker2) resource, ANNO_STRIMZI_IO_RESTART_CONNECTOR);
     }
 
@@ -478,21 +478,22 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
      * the restart action specified by user has been completed.
      */
     @Override
-    protected Future<? extends CustomResource> removeRestartTaskAnnotation(Reconciliation reconciliation, CustomResource resource) {
+    protected Future<Void> removeRestartTaskAnnotation(Reconciliation reconciliation, CustomResource resource) {
         return removeAnnotation(reconciliation, (KafkaMirrorMaker2) resource, ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK);
     }
 
     /**
      * Patches the KafkaMirrorMaker2 CR to remove the supplied annotation
      */
-    protected Future<? extends CustomResource> removeAnnotation(Reconciliation reconciliation, KafkaMirrorMaker2 resource, String annotationKey) {
+    protected Future<Void> removeAnnotation(Reconciliation reconciliation, KafkaMirrorMaker2 resource, String annotationKey) {
         log.debug("{}: Removing annotation {}", reconciliation, annotationKey);
         KafkaMirrorMaker2 patchedKafkaMirrorMaker2 = new KafkaMirrorMaker2Builder(resource)
             .editMetadata()
             .removeFromAnnotations(annotationKey)
             .endMetadata()
             .build();
-        return resourceOperator.patchAsync(patchedKafkaMirrorMaker2);
+        return resourceOperator.patchAsync(patchedKafkaMirrorMaker2)
+            .compose(ignored -> Future.succeededFuture());
     }
 
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -146,6 +146,48 @@ public class ConnectorMockTest {
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_11);
 
+        setupMockConnectAPI();
+
+        ResourceOperatorSupplier ros = new ResourceOperatorSupplier(vertx, client,
+                new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, client),
+                    // Retry up to 3 times (4 attempts), with overall max delay of 35000ms
+                    () -> new BackOff(5_000, 2, 4)),
+                new DefaultAdminClientProvider(),
+                new DefaultZookeeperScalerProvider(),
+                ResourceUtils.metricsProvider(),
+                pfa, 10_000);
+        ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(map(
+            ClusterOperatorConfig.STRIMZI_KAFKA_IMAGES, KafkaVersionTestUtils.getKafkaImagesEnvVarString(),
+            ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_IMAGES, KafkaVersionTestUtils.getKafkaConnectImagesEnvVarString(),
+            ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_S2I_IMAGES, KafkaVersionTestUtils.getKafkaConnectS2iImagesEnvVarString(),
+            ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMaker2ImagesEnvVarString(),
+            ClusterOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, Long.toString(Long.MAX_VALUE)),
+                KafkaVersionTestUtils.getKafkaVersionLookup());
+        kafkaConnectOperator = new KafkaConnectAssemblyOperator(vertx,
+            pfa,
+            ros,
+            config,
+            x -> api);
+
+        Checkpoint async = testContext.checkpoint();
+        // Fail test if watcher closes for any reason
+        kafkaConnectOperator.createWatch(NAMESPACE, e -> testContext.failNow(e))
+            .onComplete(testContext.succeeding())
+            .compose(watch -> {
+                kafkaConnectS2iOperator = new KafkaConnectS2IAssemblyOperator(vertx,
+                    pfa,
+                    ros,
+                    config,
+                    x -> api);
+                // Fail test if watcher closes for any reason
+                return kafkaConnectS2iOperator.createWatch(NAMESPACE, e -> testContext.failNow(e));
+            })
+            .onComplete(testContext.succeeding())
+            .compose(watch -> AbstractConnectOperator.createConnectorWatch(kafkaConnectOperator, kafkaConnectS2iOperator, NAMESPACE))
+            .onComplete(testContext.succeeding(v -> async.flag()));
+    }
+
+    private void setupMockConnectAPI() {
         api = mock(KafkaConnectApi.class);
         runningConnectors = new HashMap<>();
 
@@ -171,9 +213,12 @@ public class ConnectorMockTest {
             String connectorName = invocation.getArgument(3);
             ConnectorState connectorState = runningConnectors.get(key(host, connectorName));
             if (connectorState != null) {
-                Map<String, Object> map = new HashMap<>();
+                Map<String, String> map = new HashMap<>();
+                map.put("name", connectorName);
                 for (Map.Entry<String, Object> entry : connectorState.config) {
-                    map.put(entry.getKey(), entry.getValue());
+                    if (entry.getValue() != null) {
+                        map.put(entry.getKey(), entry.getValue().toString());
+                    }
                 }
                 return Future.succeededFuture(map);
             } else {
@@ -244,44 +289,24 @@ public class ConnectorMockTest {
             }
             return Future.succeededFuture();
         });
-
-        ResourceOperatorSupplier ros = new ResourceOperatorSupplier(vertx, client,
-                new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, client),
-                    // Retry up to 3 times (4 attempts), with overall max delay of 35000ms
-                    () -> new BackOff(5_000, 2, 4)),
-                new DefaultAdminClientProvider(),
-                new DefaultZookeeperScalerProvider(),
-                ResourceUtils.metricsProvider(),
-                pfa, 10_000);
-        ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(map(
-            ClusterOperatorConfig.STRIMZI_KAFKA_IMAGES, KafkaVersionTestUtils.getKafkaImagesEnvVarString(),
-            ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_IMAGES, KafkaVersionTestUtils.getKafkaConnectImagesEnvVarString(),
-            ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_S2I_IMAGES, KafkaVersionTestUtils.getKafkaConnectS2iImagesEnvVarString(),
-            ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMaker2ImagesEnvVarString(),
-            ClusterOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, Long.toString(Long.MAX_VALUE)),
-                KafkaVersionTestUtils.getKafkaVersionLookup());
-        kafkaConnectOperator = new KafkaConnectAssemblyOperator(vertx,
-            pfa,
-            ros,
-            config,
-            x -> api);
-
-        Checkpoint async = testContext.checkpoint();
-        // Fail test if watcher closes for any reason
-        kafkaConnectOperator.createWatch(NAMESPACE, e -> testContext.failNow(e))
-            .onComplete(testContext.succeeding())
-            .compose(watch -> {
-                kafkaConnectS2iOperator = new KafkaConnectS2IAssemblyOperator(vertx,
-                    pfa,
-                    ros,
-                    config,
-                    x -> api);
-                // Fail test if watcher closes for any reason
-                return kafkaConnectS2iOperator.createWatch(NAMESPACE, e -> testContext.failNow(e));
-            })
-            .onComplete(testContext.succeeding())
-            .compose(watch -> AbstractConnectOperator.createConnectorWatch(kafkaConnectOperator, kafkaConnectS2iOperator, NAMESPACE))
-            .onComplete(testContext.succeeding(v -> async.flag()));
+        when(api.restart(any(), anyInt(), anyString())).thenAnswer(invocation -> {
+            String host = invocation.getArgument(0);
+            String connectorName = invocation.getArgument(2);
+            ConnectorState connectorState = runningConnectors.get(key(host, connectorName));
+            if (connectorState == null) {
+                return Future.failedFuture(new ConnectRestException("PUT", "", 404, "Not found", "Connector name " + connectorName));
+            }
+            return Future.succeededFuture();
+        });
+        when(api.restartTask(any(), anyInt(), anyString(), anyInt())).thenAnswer(invocation -> {
+            String host = invocation.getArgument(0);
+            String connectorName = invocation.getArgument(2);
+            ConnectorState connectorState = runningConnectors.get(key(host, connectorName));
+            if (connectorState == null) {
+                return Future.failedFuture(new ConnectRestException("PUT", "", 404, "Not found", "Connector name " + connectorName));
+            }
+            return Future.succeededFuture();
+        });
     }
 
     @AfterEach
@@ -363,6 +388,21 @@ public class ConnectorMockTest {
                     && state.equals(connectorState);
             } else {
                 return false;
+            }
+        });
+    }
+
+    public void waitForRemovedAnnotation(String connectorName, String annotation) {
+        Resource<KafkaConnector, DoneableKafkaConnector> resource = Crds.kafkaConnectorOperation(client)
+            .inNamespace(NAMESPACE)
+            .withName(connectorName);
+        waitForStatus(resource, connectorName, s -> {
+            Map<String, String> annotations = s.getMetadata().getAnnotations();
+            if (annotations != null) {
+                System.out.println("Annotation: {" + annotation + ":" + annotations.get(annotation) + "}");
+                return !annotations.containsKey(annotation);
+            } else {
+                return true;
             }
         });
     }
@@ -517,7 +557,7 @@ public class ConnectorMockTest {
 
         verify(api, times(2)).list(
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, times(2)).createOrUpdatePutRequest(
+        verify(api, times(1)).createOrUpdatePutRequest(
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
@@ -638,7 +678,7 @@ public class ConnectorMockTest {
         verify(api, times(2)).list(
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         // triggered twice (Connect creation, Connector Status update)
-        verify(api, times(2)).createOrUpdatePutRequest(
+        verify(api, times(1)).createOrUpdatePutRequest(
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
@@ -767,7 +807,7 @@ public class ConnectorMockTest {
         waitForConnectorReady(connectorName);
 
         // triggered twice (Connect creation, Connector Status update) for the first cluster
-        verify(api, times(2)).createOrUpdatePutRequest(
+        verify(api, times(1)).createOrUpdatePutRequest(
                 eq(KafkaConnectResources.qualifiedServiceName(oldConnectClusterName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         // never triggered for the second cluster as connector's Strimzi cluster label does not match cluster 2
@@ -794,7 +834,7 @@ public class ConnectorMockTest {
         verify(api, never()).delete(
                 eq(KafkaConnectResources.qualifiedServiceName(oldConnectClusterName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
-        verify(api, times(2)).createOrUpdatePutRequest(
+        verify(api, times(1)).createOrUpdatePutRequest(
                 eq(KafkaConnectResources.qualifiedServiceName(newConnectClusterName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
 
@@ -905,7 +945,7 @@ public class ConnectorMockTest {
 
         verify(api, times(2)).list(
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, times(2)).createOrUpdatePutRequest(
+        verify(api, times(1)).createOrUpdatePutRequest(
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
@@ -946,6 +986,153 @@ public class ConnectorMockTest {
         verify(api, times(1)).resume(
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
+    }
+
+    /** Create connect, create connector, restart connector */
+    @Test
+    public void testConnectorRestart() {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
+            .withNewMetadata()
+            .withNamespace(NAMESPACE)
+            .withName(connectName)
+            .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(1)
+            .endSpec()
+            .done();
+        waitForConnectReady(connectName);
+
+        // triggered twice (Connect creation, Connector Status update)
+        verify(api, times(2)).list(
+            eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, never()).createOrUpdatePutRequest(
+            eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+            eq(connectorName), any());
+
+        // Create KafkaConnector and wait till it's ready
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
+            .withNewMetadata()
+            .withName(connectorName)
+            .withNamespace(NAMESPACE)
+            .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+            .endMetadata()
+            .withNewSpec()
+            .withTasksMax(1)
+            .withClassName("Dummy")
+            .endSpec()
+            .done();
+        waitForConnectorReady(connectorName);
+        waitForConnectorState(connectorName, "RUNNING");
+
+        verify(api, times(2)).list(
+            eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, times(1)).createOrUpdatePutRequest(
+            eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+            eq(connectorName), any());
+        assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+
+        verify(api, never()).restart(
+            eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+            eq(connectorName));
+        verify(api, never()).restartTask(
+            eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+            eq(connectorName), eq(0));
+
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).edit()
+            .editMetadata()
+            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_RESTART, "true")
+            .endMetadata()
+            .done();
+
+        waitForConnectorReady(connectorName);
+        waitForConnectorState(connectorName, "RUNNING");
+        waitForRemovedAnnotation(connectorName, Annotations.ANNO_STRIMZI_IO_RESTART);
+
+        verify(api, times(1)).restart(
+            eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+            eq(connectorName));
+        verify(api, never()).restartTask(
+            eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+            eq(connectorName), eq(0));
+    }
+
+
+    /** Create connect, create connector, restart connector task */
+    @Test
+    public void testConnectorRestartTask() {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
+            .withNewMetadata()
+            .withNamespace(NAMESPACE)
+            .withName(connectName)
+            .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(1)
+            .endSpec()
+            .done();
+        waitForConnectReady(connectName);
+
+        // triggered twice (Connect creation, Connector Status update)
+        verify(api, times(2)).list(
+            eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, never()).createOrUpdatePutRequest(
+            eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+            eq(connectorName), any());
+
+        // Create KafkaConnector and wait till it's ready
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
+            .withNewMetadata()
+            .withName(connectorName)
+            .withNamespace(NAMESPACE)
+            .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+            .endMetadata()
+            .withNewSpec()
+            .withTasksMax(1)
+            .withClassName("Dummy")
+            .endSpec()
+            .done();
+        waitForConnectorReady(connectorName);
+        waitForConnectorState(connectorName, "RUNNING");
+
+        verify(api, times(2)).list(
+            eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, times(1)).createOrUpdatePutRequest(
+            eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+            eq(connectorName), any());
+        assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+
+        verify(api, never()).restart(
+            eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+            eq(connectorName));
+        verify(api, never()).restartTask(
+            eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+            eq(connectorName), eq(0));
+
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).edit()
+            .editMetadata()
+            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_RESTART_TASK, "0")
+            .endMetadata()
+            .done();
+
+        waitForConnectorReady(connectorName);
+        waitForConnectorState(connectorName, "RUNNING");
+        waitForRemovedAnnotation(connectorName, Annotations.ANNO_STRIMZI_IO_RESTART_TASK);
+
+        verify(api, times(0)).restart(
+            eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+            eq(connectorName));
+        verify(api, times(1)).restartTask(
+            eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+            eq(connectorName), eq(0));
     }
 
     /** Create connect, create connector, Scale to 0 */
@@ -991,7 +1178,7 @@ public class ConnectorMockTest {
 
         verify(api, times(2)).list(
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, times(2)).createOrUpdatePutRequest(
+        verify(api, times(1)).createOrUpdatePutRequest(
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
@@ -1055,7 +1242,7 @@ public class ConnectorMockTest {
 
         verify(api, times(2)).list(
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, times(2)).createOrUpdatePutRequest(
+        verify(api, times(1)).createOrUpdatePutRequest(
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -207,6 +207,12 @@ public class KafkaConnectApiTest {
             .compose(ignored -> client.resume("localhost", PORT, "test"))
             .onComplete(context.succeeding())
 
+            .compose(ignored -> client.restart("localhost", PORT, "test"))
+            .onComplete(context.succeeding())
+
+            .compose(ignored -> client.restartTask("localhost", PORT, "test", 0))
+            .onComplete(context.succeeding())
+
             .compose(ignored -> {
                 JsonObject o = new JsonObject()
                         .put("connector.class", "ThisConnectorDoesNotExist")

--- a/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
+++ b/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
@@ -21,6 +21,9 @@ Use the `KafkaConnectS2I` resource if you are using the {docs-okd-s2i} framework
 
 * link:{BookURLDeploying}#con-creating-managing-connectors-str[Creating and managing connectors^]
 * link:{BookURLDeploying}#proc-deploying-kafkaconnector-str[Deploying a `KafkaConnector` resource to Kafka Connect^]
+* link:{BookURLDeploying}#proc-manual-restart-connector-str[Restart a Kafka connector by annotating a `KafkaConnector` resource]
+* link:{BookURLDeploying}#proc-manual-restart-connector-task-str[Restart a Kafka connector task by annotating a `KafkaConnector` resource]
+
 
 //procedure to configure Kafka Connect
 include::../../modules/configuring/proc-config-kafka-connect.adoc[leveloffset=+1]
@@ -28,6 +31,10 @@ include::../../modules/configuring/proc-config-kafka-connect.adoc[leveloffset=+1
 include::../../modules/configuring/con-config-kafka-connect-multiple-instances.adoc[leveloffset=+1]
 //If authorization is enabled, configure the Kafka Connect user for read/write access rights
 include::../../modules/configuring/proc-config-kafka-connect-user-authorization.adoc[leveloffset=+1]
+//Procedure to restart a Kafka connector
+include::../../modules/proc-manual-restart-connector.adoc[leveloffset=+1]
+//Procedure to restart a Kafka connector task
+include::../../modules/proc-manual-restart-connector-task.adoc[leveloffset=+1]
 //Resources created for Kafka Connect
 include::../../modules/configuring/ref-config-list-of-kafka-connect-resources.adoc[leveloffset=+1]
 //Resources created for Kafka Connect S2I

--- a/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
+++ b/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
@@ -21,8 +21,8 @@ Use the `KafkaConnectS2I` resource if you are using the {docs-okd-s2i} framework
 
 * link:{BookURLDeploying}#con-creating-managing-connectors-str[Creating and managing connectors^]
 * link:{BookURLDeploying}#proc-deploying-kafkaconnector-str[Deploying a `KafkaConnector` resource to Kafka Connect^]
-* link:{BookURLDeploying}#proc-manual-restart-connector-str[Restart a Kafka connector by annotating a `KafkaConnector` resource]
-* link:{BookURLDeploying}#proc-manual-restart-connector-task-str[Restart a Kafka connector task by annotating a `KafkaConnector` resource]
+* link:{BookURLDeploying}#proc-manual-restart-connector-str[Restart a Kafka connector by annotating a `KafkaConnector` resource^]
+* link:{BookURLDeploying}#proc-manual-restart-connector-task-str[Restart a Kafka connector task by annotating a `KafkaConnector` resource^]
 
 
 //procedure to configure Kafka Connect

--- a/documentation/assemblies/configuring/assembly-config-mirrormaker2.adoc
+++ b/documentation/assemblies/configuring/assembly-config-mirrormaker2.adoc
@@ -41,3 +41,9 @@ include::../../modules/configuring/con-config-mirrormaker2-acls.adoc[leveloffset
 
 //Procedure to set up the configuration
 include::../../modules/configuring/proc-config-mirrormaker2-replication.adoc[leveloffset=+1]
+
+//Procedure to restart a connector
+include::../../modules/proc-manual-restart-mirrormaker2-connector.adoc[leveloffset=+1]
+
+//Procedure to restart a connector task
+include::../../modules/proc-manual-restart-mirrormaker2-connector-task.adoc[leveloffset=+1]

--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
@@ -22,6 +22,8 @@ The procedures in this section show how to:
 * xref:using-kafka-connect-with-plug-ins-{context}[Create a Kafka Connect image containing the connectors you need to make your connection]
 * xref:con-creating-managing-connectors-{context}[Create and manage connectors using a `KafkaConnector` resource or the Kafka Connect REST API]
 * xref:proc-deploying-kafkaconnector-{context}[Deploy a `KafkaConnector` resource to Kafka Connect]
+* xref:proc-manual-restart-connector-{context}[Restart a Kafka connector by annotating a `KafkaConnector` resource]
+* xref:proc-manual-restart-connector-task-{context}[Restart a Kafka connector task by annotating a `KafkaConnector` resource]
 
 NOTE: The term _connector_ is used interchangeably to mean a connector instance running within a Kafka Connect cluster, or a connector class.
 In this guide, the term _connector_ is used when the meaning is clear from the context.
@@ -34,5 +36,7 @@ include::../../modules/configuring/con-config-kafka-connect-multiple-instances.a
 include::assembly-deploy-kafka-connect-with-plugins.adoc[leveloffset=+1]
 //Overview of creating connectors through API
 include::modules/con-deploy-kafka-connect-managing-connectors.adoc[leveloffset=+1]
-//Procedure to deploy a KafkaConnector resource
-include::modules/proc-deploying-kafkaconnector.adoc[leveloffset=+1]
+//Procedure to restart a Kafka connector
+include::../../modules/proc-manual-restart-connector.adoc[leveloffset=+1]
+//Procedure to restart a Kafka connector task
+include::../../modules/proc-manual-restart-connector-task.adoc[leveloffset=+1]

--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
@@ -36,6 +36,8 @@ include::../../modules/configuring/con-config-kafka-connect-multiple-instances.a
 include::assembly-deploy-kafka-connect-with-plugins.adoc[leveloffset=+1]
 //Overview of creating connectors through API
 include::modules/con-deploy-kafka-connect-managing-connectors.adoc[leveloffset=+1]
+//Procedure to deploy a KafkaConnector resource
+include::modules/proc-deploying-kafkaconnector.adoc[leveloffset=+1]
 //Procedure to restart a Kafka connector
 include::../../modules/proc-manual-restart-connector.adoc[leveloffset=+1]
 //Procedure to restart a Kafka connector task

--- a/documentation/modules/proc-manual-restart-connector-task.adoc
+++ b/documentation/modules/proc-manual-restart-connector-task.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+//
+
+[id='proc-manual-restart-connector-{context}']
+= Performing a restart of a Kafka connector task
+
+This procedure describes how to manually trigger a restart of a Kafka connector task by using a Kubernetes annotation.
+
+.Prerequisites
+
+* The Cluster Operator is running.
+
+.Procedure
+
+. Find the name of the `KafkaConnector` custom resource that controls the Kafka connector task you want to restart:
+[source,shell,subs=+quotes]
+kubectl get KafkaConnector
+
+. Find the ID of the task to be restarted from the `KafkaConnector` custom resource.
+Task IDs are non-negative integers, starting from 0:
+[source,shell,subs=+quotes]
+kubectl describe KafkaConnector _KafkaConnector-name_
+
+. To restart the connector task, annotate the `KafkaConnector` resource in Kubernetes.
+For example, using `kubectl annotate` to restart task 0:
+[source,shell,subs=+quotes]
+kubectl annotate KafkaConnector _KafkaConnector-name_ strimzi.io/restart-task=0
+
+
+. Wait for the next reconciliation to occur (every two minutes by default).
+The Kafka connector task is restarted, as long as the annotation was detected by the reconciliation process.
+When Kafka Connect accepts the restart request, the annotation is removed from the `KafkaConnector` custom resource.

--- a/documentation/modules/proc-manual-restart-connector-task.adoc
+++ b/documentation/modules/proc-manual-restart-connector-task.adoc
@@ -2,7 +2,7 @@
 //
 //
 
-[id='proc-manual-restart-connector-{context}']
+[id='proc-manual-restart-connector-task-{context}']
 = Performing a restart of a Kafka connector task
 
 This procedure describes how to manually trigger a restart of a Kafka connector task by using a Kubernetes annotation.

--- a/documentation/modules/proc-manual-restart-connector.adoc
+++ b/documentation/modules/proc-manual-restart-connector.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+//
+
+[id='proc-manual-restart-connector-{context}']
+= Performing a restart of a Kafka connector
+
+This procedure describes how to manually trigger a restart of a Kafka connector by using a Kubernetes annotation.
+
+.Prerequisites
+
+* The Cluster Operator is running.
+
+.Procedure
+
+. Find the name of the `KafkaConnector` custom resource that controls the Kafka connector you want to restart:
+[source,shell,subs=+quotes]
+kubectl get KafkaConnector
+
+. To restart the connector, annotate the `KafkaConnector` resource in Kubernetes.
+For example, using `kubectl annotate`:
+[source,shell,subs=+quotes]
+kubectl annotate KafkaConnector _KafkaConnector-name_ strimzi.io/restart=true
+
+. Wait for the next reconciliation to occur (every two minutes by default).
+The Kafka connector is restarted, as long as the annotation was detected by the reconciliation process.
+When Kafka Connect accepts the restart request, the annotation is removed from the `KafkaConnector` custom resource.

--- a/documentation/modules/proc-manual-restart-mirrormaker2-connector-task.adoc
+++ b/documentation/modules/proc-manual-restart-mirrormaker2-connector-task.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+//
+
+[id='proc-manual-restart-connector-{context}']
+= Performing a restart of a Kafka MirrorMaker 2.0 connector task
+
+This procedure describes how to manually trigger a restart of a Kafka MirrorMaker 2.0 connector task by using a Kubernetes annotation.
+
+.Prerequisites
+
+* The Cluster Operator is running.
+
+.Procedure
+
+. Find the name of the `KafkaMirrorMaker2` custom resource that controls the Kafka MirrorMaker 2.0 connector you want to restart:
+[source,shell,subs=+quotes]
+kubectl get KafkaMirrorMaker2
+
+. Find the name of the Kafka MirrorMaker 2.0 connector and the ID of the task to be restarted from the `KafkaMirrorMaker2` custom resource.
+Task IDs are non-negative integers, starting from 0:
+[source,shell,subs=+quotes]
+kubectl describe KafkaMirrorMaker2 _KafkaMirrorMaker2-name_
+
+. To restart the connector task, annotate the `KafkaMirrorMaker2` resource in Kubernetes.
+For example, using `kubectl annotate` to restart task 0 of the connector named `my-source->my-target.MirrorSourceConnector`:
+[source,shell,subs=+quotes]
+kubectl annotate KafkaMirrorMaker2 _KafkaMirrorMaker2-name_ "strimzi.io/restart-connector-task=my-source->my-target.MirrorSourceConnector:0"
+
+. Wait for the next reconciliation to occur (every two minutes by default).
+The Kafka MirrorMaker 2.0 connector task is restarted, as long as the annotation was detected by the reconciliation process.
+When the restart task request is accepted, the annotation is removed from the `KafkaMirrorMaker2` custom resource.

--- a/documentation/modules/proc-manual-restart-mirrormaker2-connector-task.adoc
+++ b/documentation/modules/proc-manual-restart-mirrormaker2-connector-task.adoc
@@ -2,7 +2,7 @@
 //
 //
 
-[id='proc-manual-restart-connector-{context}']
+[id='proc-manual-restart-mirrormaker2-connector-task-{context}']
 = Performing a restart of a Kafka MirrorMaker 2.0 connector task
 
 This procedure describes how to manually trigger a restart of a Kafka MirrorMaker 2.0 connector task by using a Kubernetes annotation.

--- a/documentation/modules/proc-manual-restart-mirrormaker2-connector.adoc
+++ b/documentation/modules/proc-manual-restart-mirrormaker2-connector.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+//
+
+[id='proc-manual-restart-connector-{context}']
+= Performing a restart of a Kafka MirrorMaker 2.0 connector
+
+This procedure describes how to manually trigger a restart of a Kafka MirrorMaker 2.0 connector by using a Kubernetes annotation.
+
+.Prerequisites
+
+* The Cluster Operator is running.
+
+.Procedure
+
+. Find the name of the `KafkaMirrorMaker2` custom resource that controls the Kafka MirrorMaker 2.0 connector you want to restart:
+[source,shell,subs=+quotes]
+kubectl get KafkaMirrorMaker2
+
+. Find the name of the Kafka MirrorMaker 2.0 connector to be restarted from the `KafkaMirrorMaker2` custom resource.
+[source,shell,subs=+quotes]
+kubectl describe KafkaMirrorMaker2 _KafkaMirrorMaker2-name_
+
+. To restart the connector, annotate the `KafkaMirrorMaker2` resource in Kubernetes. For example, using `kubectl annotate` to restart the connector named `my-source->my-target.MirrorSourceConnector`:
+[source,shell,subs=+quotes]
+kubectl annotate KafkaMirrorMaker2 _KafkaMirrorMaker2-name_ "strimzi.io/restart-connector=my-source->my-target.MirrorSourceConnector"
+
+. Wait for the next reconciliation to occur (every two minutes by default).
+The Kafka MirrorMaker 2.0 connector is restarted, as long as the annotation was detected by the reconciliation process.
+When the restart request is accepted, the annotation is removed from the `KafkaMirrorMaker2` custom resource.

--- a/documentation/modules/proc-manual-restart-mirrormaker2-connector.adoc
+++ b/documentation/modules/proc-manual-restart-mirrormaker2-connector.adoc
@@ -2,7 +2,7 @@
 //
 //
 
-[id='proc-manual-restart-connector-{context}']
+[id='proc-manual-restart-mirrormaker2-connector-{context}']
 = Performing a restart of a Kafka MirrorMaker 2.0 connector
 
 This procedure describes how to manually trigger a restart of a Kafka MirrorMaker 2.0 connector by using a Kubernetes annotation.

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Integer.parseInt;
@@ -39,6 +40,21 @@ public class Annotations {
     public static final String ANNO_STRIMZI_IO_REBALANCE = STRIMZI_DOMAIN + "rebalance";
     @Deprecated
     public static final String ANNO_OP_STRIMZI_IO_MANUAL_ROLLING_UPDATE = "operator." + Annotations.STRIMZI_DOMAIN + "manual-rolling-update";
+
+    /**
+     * Annotations for restarting KafkaConnector and KafkaMirrorMaker2 connectors or tasks
+     */
+    public static final String ANNO_STRIMZI_IO_RESTART = STRIMZI_DOMAIN + "restart";
+    public static final String ANNO_STRIMZI_IO_RESTART_CONNECTOR = STRIMZI_DOMAIN + "restart-connector";
+    public static final String ANNO_STRIMZI_IO_RESTART_TASK = STRIMZI_DOMAIN + "restart-task";
+    public static final String ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK = STRIMZI_DOMAIN + "restart-connector-task";
+    public static final String ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK_PATTERN_CONNECTOR = "connector";
+    public static final String ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK_PATTERN_TASK = "task";
+    public static final Pattern ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK_PATTERN = Pattern.compile("^(?<" +
+        ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK_PATTERN_CONNECTOR +
+        ">.+):(?<" +
+        ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK_PATTERN_TASK +
+        ">\\d+)$");
 
     public static final String ANNO_DEP_KUBE_IO_REVISION = "deployment.kubernetes.io/revision";
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR implements the first part of the 'Restarting Kafka Connect connectors and tasks' proposal (https://github.com/strimzi/proposals/blob/master/007-restarting-kafka-connect-connectors-and-tasks.md), 
adding new annotations that cause the operator to restart connectors or tasks. The annotations can be applied to the KafkaConnector, and the KafkaMirrorMaker2 custom resources. The annotation acts as a trigger for a single restart call
by the operator, and is removed from the CR when the restart REST API call is successfully called.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

