### PR TITLE
Kafka cluster Id in status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Enable CORS configuration for Cruise Control
 * Add support for rolling individual Kafka or ZooKeeper pods through the Cluster Operator using an annotation
 * Add support for Topology Spread Constraints in Pod templates
+* Make Kafka `cluster-id` (KIP-78) available on Kafka CRD status
 
 ### Deprecations and removals
 * The `metrics` field in the Strimzi custom resources has been deprecated and will be removed in the future. For configuring metrics, use the new `metricsConfig` field and pass the configuration via ConfigMap.

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaStatus.java
@@ -29,6 +29,8 @@ public class KafkaStatus extends Status {
     private static final long serialVersionUID = 1L;
 
     private List<ListenerStatus> listeners;
+    
+    private String clusterId;
 
     @Description("Addresses of the internal and external listeners")
     public List<ListenerStatus> getListeners() {
@@ -37,5 +39,14 @@ public class KafkaStatus extends Status {
 
     public void setListeners(List<ListenerStatus> listeners) {
         this.listeners = listeners;
+    }
+    
+    @Description("Kafka cluster Id")
+    public String getClusterId() {
+        return clusterId;
+    }
+
+    public void setClusterId(String clusterId) {
+        this.clusterId = clusterId;
     }
 }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
@@ -6118,5 +6118,8 @@ spec:
                         verify the identity of the server when connecting to the given
                         listener. Set only for `tls` and `external` listeners.
                 description: Addresses of the internal and external listeners.
+              clusterId:
+                type: string
+                description: Kafka cluster Id.
             description: The status of the Kafka and ZooKeeper clusters, and Topic
               Operator.

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
@@ -5986,6 +5986,9 @@ spec:
                         verify the identity of the server when connecting to the given
                         listener. Set only for `tls` and `external` listeners.
                 description: Addresses of the internal and external listeners.
+              clusterId:
+                type: string
+                description: Kafka cluster Id.
             description: The status of the Kafka and ZooKeeper clusters, and Topic
               Operator.
   - name: v1beta1
@@ -14038,6 +14041,9 @@ spec:
                         verify the identity of the server when connecting to the given
                         listener. Set only for `tls` and `external` listeners.
                 description: Addresses of the internal and external listeners.
+              clusterId:
+                type: string
+                description: Kafka cluster Id.
             description: The status of the Kafka and ZooKeeper clusters, and Topic
               Operator.
   - name: v1alpha1
@@ -22090,5 +22096,8 @@ spec:
                         verify the identity of the server when connecting to the given
                         listener. Set only for `tls` and `external` listeners.
                 description: Addresses of the internal and external listeners.
+              clusterId:
+                type: string
+                description: Kafka cluster Id.
             description: The status of the Kafka and ZooKeeper clusters, and Topic
               Operator.

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -646,7 +646,8 @@ public class ResourceUtils {
                     Constructor<DescribeClusterResult> declaredConstructor = DescribeClusterResult.class.getDeclaredConstructor(KafkaFuture.class, KafkaFuture.class, KafkaFuture.class, KafkaFuture.class);
                     declaredConstructor.setAccessible(true);
                     KafkaFuture<Node> objectKafkaFuture = KafkaFutureImpl.completedFuture(new Node(0, "localhost", 9091));
-                    dcr = declaredConstructor.newInstance(null, objectKafkaFuture, null, null);
+                    KafkaFuture<String> stringKafkaFuture = KafkaFutureImpl.completedFuture("CLUSTERID");
+                    dcr = declaredConstructor.newInstance(null, objectKafkaFuture, stringKafkaFuture, null);
                 } catch (ReflectiveOperationException e) {
                     throw new RuntimeException(e);
                 }

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1865,6 +1865,8 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 |integer
 |listeners           1.2+<.<|Addresses of the internal and external listeners.
 |xref:type-ListenerStatus-{context}[`ListenerStatus`] array
+|clusterId           1.2+<.<|Kafka cluster Id.
+|string
 |====
 
 [id='type-Condition-{context}']

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -6927,5 +6927,8 @@ spec:
                       type: string
                     description: A list of TLS certificates which can be used to verify the identity of the server when connecting to the given listener. Set only for `tls` and `external` listeners.
               description: Addresses of the internal and external listeners.
+            clusterId:
+              type: string
+              description: Kafka cluster Id.
           description: The status of the Kafka and ZooKeeper clusters, and Topic Operator.
 {{- end -}}

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -6923,4 +6923,7 @@ spec:
                       type: string
                     description: A list of TLS certificates which can be used to verify the identity of the server when connecting to the given listener. Set only for `tls` and `external` listeners.
               description: Addresses of the internal and external listeners.
+            clusterId:
+              type: string
+              description: Kafka cluster Id.
           description: The status of the Kafka and ZooKeeper clusters, and Topic Operator.

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -8057,4 +8057,7 @@ spec:
                       the identity of the server when connecting to the given listener.
                       Set only for `tls` and `external` listeners.
               description: Addresses of the internal and external listeners.
+            clusterId:
+              type: string
+              description: Kafka cluster Id.
           description: The status of the Kafka and ZooKeeper clusters, and Topic Operator.


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As motivated in #4028, this PR introduces the Kafka cluster Id in the status of a Kafka CRD. 

The advantage of the Kafka cluster Id, as opposed to, say, URLs or bootstrap servers, is that all observers can agree on the same id for a given Kafka cluster, independently of how they access it, for example from within or outside the Kubernetes cluster. 

Having the cluster Id available in the status provides the information to any entity that can list the CR, without requiring higher privileges to access Zookeeper or the Kafka Admin API.

### Checklist

I'm unsure about some of these. The test doesn't do much beyond checking that the cluster Id being set in the status is actually what one gets out of it. Suggestions are welcomed. I have satisfactorily run the patched operator on Minikube. If there is documentation I would need to change I'll be glad to get a pointer.

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

