### PR TITLE
Patch topic recreation

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -574,6 +574,7 @@ class TopicOperator {
             }
         } else {
             if (k8sTopic == null) {
+                statusUpdateGeneration.remove(privateTopic.getTopicName().toString());
                 if (kafkaTopic == null) {
                     // delete privateState
                     LOGGER.debug("{}: KafkaTopic deleted in k8s and topic deleted in kafka => delete from topicStore", logContext);
@@ -780,6 +781,7 @@ class TopicOperator {
                     new Reconciliation("onTopicDeleted", true) {
                         @Override
                         public Future<Void> execute() {
+                            statusUpdateGeneration.remove(topicName.toString());
                             return reconcileOnTopicChange(logContext, topicName, null, this);
                         }
                     }),
@@ -1049,6 +1051,10 @@ class TopicOperator {
                             .compose(mt ->  {
                                 final Topic k8sTopic;
                                 if (mt != null) {
+
+                                    if (action.equals(Watcher.Action.DELETED)) {
+                                        statusUpdateGeneration.remove(mt.getMetadata().getName());
+                                    }
 
                                     Long generation = statusUpdateGeneration.get(mt.getMetadata().getName());
                                     LOGGER.debug("{}: last updated generation={}", logContext, generation);


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/4086
TO is stateful and that causes some issues. When the topic (k8s CR) is removed and recreated immediately, TO's property `statusUpdateGeneration` contains stale data, which causes the wrong evaluation of the condition and the Kafka topic is not recreated to align k8s resource.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

