### PR TITLE
rename ZookepeerUpgradeST -> KafkaUpgradeDowngradeST

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
@@ -34,9 +34,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @Tag(UPGRADE)
-public class ZookeeperUpgradeST extends AbstractST {
+public class KafkaUpgradeDowngradeST extends AbstractST {
 
-    private static final Logger LOGGER = LogManager.getLogger(ZookeeperUpgradeST.class);
+    private static final Logger LOGGER = LogManager.getLogger(KafkaUpgradeDowngradeST.class);
 
     public static final String NAMESPACE = "zookeeper-upgrade-test";
 


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Refactoring

### Description

Rename `ZookeeperUpgradeST` to  `KafkaUpgradeDowngradeST` because it's more related to Kafka than to zk.

### Checklist

- [x] Make sure all tests pass

