### PR TITLE
Bump up jupiter version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <okhttp.version>3.12.6</okhttp.version>
         <okio.version>1.15.0</okio.version>
         <vertx.version>3.9.1</vertx.version>
-        <vertx-junit5.version>3.9.1</vertx-junit5.version>
+        <vertx-junit5.version>3.9.5</vertx-junit5.version>
         <log4j.version>2.13.3</log4j.version>
         <hamcrest.version>2.2</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>
@@ -119,7 +119,7 @@
         <rest-assured.version>4.1.1</rest-assured.version>
         <json-path.version>4.1.1</json-path.version>
         <jupiter.version>5.7.0</jupiter.version>
-        <junit.platform.version>1.6.2</junit.platform.version>
+        <junit.platform.version>1.7.0</junit.platform.version>
         <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
         <opentest4j.version>1.2.0</opentest4j.version>
         <gson.version>2.8.2</gson.version>
@@ -704,6 +704,11 @@
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
                 <version>${test-containers.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-commons</artifactId>
+                <version>${junit.platform.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <okhttp.version>3.12.6</okhttp.version>
         <okio.version>1.15.0</okio.version>
         <vertx.version>3.9.1</vertx.version>
-        <vertx-junit5.version>3.9.5</vertx-junit5.version>
+        <vertx-junit5.version>3.9.1</vertx-junit5.version>
         <log4j.version>2.13.3</log4j.version>
         <hamcrest.version>2.2</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <javax.json.version>1.1.4</javax.json.version>
         <rest-assured.version>4.1.1</rest-assured.version>
         <json-path.version>4.1.1</json-path.version>
-        <jupiter.version>5.6.2</jupiter.version>
+        <jupiter.version>5.7.0</jupiter.version>
         <junit.platform.version>1.6.2</junit.platform.version>
         <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
         <opentest4j.version>1.2.0</opentest4j.version>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -224,6 +224,10 @@
             <groupId>io.strimzi</groupId>
             <artifactId>config-model</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-commons</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Chores

### Description

Bump up Jupiter version to 5.7.0. It is mainly needed because of @Isolated annotation from Jupiter. 4.7.0. We need this annotation for a test case or test suite to run in isolation, no other test class or method can run concurrently. For instance, when we change the state of shared Kafka we need to run only that test case.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

