### PR TITLE
Disable PrometheusST to see if it fixes regression bundle VII

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/PrometheusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/PrometheusST.java
@@ -13,6 +13,7 @@ import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -28,6 +29,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Tag(REGRESSION)
 @Tag(PROMETHEUS)
 @Tag(METRICS)
+@Disabled
 public class PrometheusST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(PrometheusST.class);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The bundle VII seems to be failing in the regression tests. This PR tries to see if the PrometheusST changes are the cause.