### PR TITLE
Remove the remains of the -server JVM option

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
@@ -31,7 +31,6 @@ public class JvmOptions implements UnknownPropertyPreserving, Serializable {
 
     private String xmx;
     private String xms;
-    private Boolean server;
     private boolean gcLoggingEnabled = false;
     private List<SystemProperty> javaSystemProperties;
     private Map<String, String> xx;
@@ -57,16 +56,6 @@ public class JvmOptions implements UnknownPropertyPreserving, Serializable {
 
     public void setXms(String xms) {
         this.xms = xms;
-    }
-
-    @JsonProperty("-server")
-    @Description("-server option to to the JVM")
-    public Boolean isServer() {
-        return server;
-    }
-
-    public void setServer(Boolean server) {
-        this.server = server;
     }
 
     @Description("Specifies whether the Garbage Collection logging is enabled. The default is false.")

--- a/api/src/test/java/io/strimzi/api/kafka/model/JvmOptionsTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/JvmOptionsTest.java
@@ -30,37 +30,6 @@ public class JvmOptionsTest {
     }
 
     @Test
-    public void testServer() {
-        JvmOptions opts = TestUtils.fromJson("{" +
-                "  \"-server\": \"true\"" +
-                "}", JvmOptions.class);
-
-        assertThat(opts.isServer(), is(true));
-
-        opts = TestUtils.fromJson("{" +
-                "  \"-server\": true" +
-                "}", JvmOptions.class);
-
-        assertThat(opts.isServer(), is(true));
-
-        opts = TestUtils.fromJson("{" +
-                "  \"-server\": \"false\"" +
-                "}", JvmOptions.class);
-
-        assertThat(opts.isServer(), is(false));
-
-        opts = TestUtils.fromJson("{" +
-                "  \"-server\": false" +
-                "}", JvmOptions.class);
-
-        assertThat(opts.isServer(), is(false));
-
-        opts = TestUtils.fromJson("{}", JvmOptions.class);
-
-        assertThat(opts.isServer(), is(nullValue()));
-    }
-
-    @Test
     public void testXx() {
         JvmOptions opts = TestUtils.fromJson("{" +
                 "    \"-XX\":" +

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1233,11 +1233,6 @@ public abstract class AbstractModel {
     protected void jvmPerformanceOptions(List<EnvVar> envVars) {
         StringBuilder jvmPerformanceOpts = new StringBuilder();
 
-        Boolean isServer = jvmOptions != null ? jvmOptions.isServer() : null;
-        if (isServer != null && isServer) {
-            jvmPerformanceOpts.append("-server");
-        }
-
         Map<String, String> xx = jvmOptions != null ? jvmOptions.getXx() : null;
         if (xx != null) {
             xx.forEach((k, v) -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -360,12 +360,6 @@ public class EntityOperator extends AbstractModel {
             strimziJavaOpts.append(" -Xmx").append(xmx);
         }
 
-        Boolean server = jvmOptions != null ? jvmOptions.isServer() : null;
-
-        if (server != null && server) {
-            strimziJavaOpts.append(' ').append(" -server");
-        }
-
         Map<String, String> xx = jvmOptions != null ? jvmOptions.getXx() : null;
         if (xx != null) {
             xx.forEach((k, v) -> {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -136,12 +136,6 @@ public class AbstractModelTest {
         assertThat(getPerformanceOptions(opts), is(nullValue()));
 
         opts = TestUtils.fromJson("{" +
-                "  \"-server\": \"true\"" +
-                "}", JvmOptions.class);
-
-        assertThat(getPerformanceOptions(opts), is("-server"));
-
-        opts = TestUtils.fromJson("{" +
                 "    \"-XX\":" +
                 "            {\"key1\": \"value1\"," +
                 "            \"key2\": \"true\"," +

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -1095,7 +1095,6 @@ public class KafkaConnectClusterTest {
                     .withNewJvmOptions()
                         .withNewXms("512m")
                         .withNewXmx("1024m")
-                        .withNewServer(true)
                         .withXx(xx)
                     .endJvmOptions()
                 .endSpec()
@@ -1104,7 +1103,6 @@ public class KafkaConnectClusterTest {
 
         Deployment dep = kc.generateDeployment(Collections.EMPTY_MAP, true, null, null);
         Container cont = dep.getSpec().getTemplate().getSpec().getContainers().get(0);
-        assertThat(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-server"), is(true));
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-XX:+UseG1GC"), is(true));
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-XX:MaxGCPauseMillis=20"), is(true));
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_HEAP_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Xmx1024m"), is(true));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -1067,7 +1067,6 @@ public class KafkaConnectS2IClusterTest {
                     .withNewJvmOptions()
                         .withNewXms("512m")
                         .withNewXmx("1024m")
-                        .withNewServer(true)
                         .withXx(xx)
                     .endJvmOptions()
                 .endSpec()
@@ -1076,7 +1075,6 @@ public class KafkaConnectS2IClusterTest {
 
         DeploymentConfig dep = kc.generateDeploymentConfig(Collections.EMPTY_MAP, true, null, null);
         Container cont = dep.getSpec().getTemplate().getSpec().getContainers().get(0);
-        assertThat(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-server"), is(true));
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-XX:+UseG1GC"), is(true));
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-XX:MaxGCPauseMillis=20"), is(true));
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_HEAP_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Xmx1024m"), is(true));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -1156,7 +1156,6 @@ public class KafkaMirrorMaker2ClusterTest {
                     .withNewJvmOptions()
                         .withNewXms("512m")
                         .withNewXmx("1024m")
-                        .withNewServer(true)
                         .withXx(xx)
                     .endJvmOptions()
                 .endSpec()
@@ -1165,7 +1164,6 @@ public class KafkaMirrorMaker2ClusterTest {
 
         Deployment dep = kmm2.generateDeployment(Collections.EMPTY_MAP, true, null, null);
         Container cont = getContainer(dep);
-        assertThat(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-server"), is(true));
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-XX:+UseG1GC"), is(true));
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-XX:MaxGCPauseMillis=20"), is(true));
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_HEAP_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Xmx1024m"), is(true));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -751,7 +751,6 @@ public class KafkaMirrorMakerClusterTest {
                     .withNewJvmOptions()
                         .withNewXms("512m")
                         .withNewXmx("1024m")
-                        .withNewServer(true)
                         .withXx(xx)
                     .endJvmOptions()
                 .endSpec()
@@ -760,7 +759,6 @@ public class KafkaMirrorMakerClusterTest {
 
         Deployment dep = mmc.generateDeployment(Collections.EMPTY_MAP, true, null, null);
         Container cont = dep.getSpec().getTemplate().getSpec().getContainers().get(0);
-        assertThat(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-server"), is(true));
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-XX:+UseG1GC"), is(true));
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-XX:MaxGCPauseMillis=20"), is(true));
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_HEAP_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Xmx1024m"), is(true));

--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -451,25 +451,10 @@ Setting the same value for initial (`-Xms`) and maximum (`-Xmx`) heap sizes avoi
 For Kafka and ZooKeeper pods such allocation could cause unwanted latency.
 For Kafka Connect avoiding over allocation may be the most important concern, especially in distributed mode where the effects of over-allocation is multiplied by the number of consumers.
 
-*-server*
-
-`-server` enables the server JVM. This option can be set to true or false.
-
-.Example fragment configuring `-server`
-[source,yaml,subs=attributes+]
-----
-# ...
-jvmOptions:
-  "-server": true
-# ...
-----
-
-NOTE: When neither of the two options (`-server` and `-XX`) are specified, the default Apache Kafka configuration of `KAFKA_JVM_PERFORMANCE_OPTS` is used.
-
 *-XX*
 
 `-XX` object can be used for configuring advanced runtime options of a JVM.
-The `-server` and `-XX` options are used to configure the `KAFKA_JVM_PERFORMANCE_OPTS` option of Apache Kafka.
+The `-XX` options are used to configure the `KAFKA_JVM_PERFORMANCE_OPTS` option of Apache Kafka.
 
 .Example showing the use of the `-XX` object
 [source,yaml,subs=attributes+]
@@ -489,7 +474,7 @@ The example configuration above will result in the following JVM options:
 -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -XX:-UseParNewGC
 ----
 
-NOTE: When neither of the two options (`-server` and `-XX`) are specified, the default Apache Kafka configuration of `KAFKA_JVM_PERFORMANCE_OPTS` is used.
+NOTE: When no `-XX` options are specified, the default Apache Kafka configuration of `KAFKA_JVM_PERFORMANCE_OPTS` is used.
 
 [id='con-common-configuration-garbage-collection-{context}']
 === Garbage collector logging

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -272,7 +272,7 @@ public abstract class AbstractST implements TestSeparator {
         return result;
     }
 
-    protected void assertExpectedJavaOpts(String podName, String containerName, String expectedXmx, String expectedXms, String expectedServer, String expectedXx) {
+    protected void assertExpectedJavaOpts(String podName, String containerName, String expectedXmx, String expectedXms, String expectedXx) {
         List<List<String>> cmdLines = commandLines(podName, containerName, "java");
         assertThat("Expected exactly 1 java process to be running", cmdLines.size(), is(1));
         List<String> cmd = cmdLines.get(0);
@@ -287,8 +287,6 @@ public abstract class AbstractST implements TestSeparator {
             assertCmdOption(cmd, expectedXmx);
         if (expectedXms != null)
             assertCmdOption(cmd, expectedXms);
-        if (expectedServer != null)
-            assertCmdOption(cmd, expectedServer);
         if (expectedXx != null)
             assertCmdOption(cmd, expectedXx);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
@@ -348,7 +348,6 @@ class ConnectS2IST extends AbstractST {
                 .withNewJvmOptions()
                     .withXmx("200m")
                     .withXms("200m")
-                    .withServer(true)
                     .withXx(jvmOptionsXX)
                 .endJvmOptions()
             .endSpec().build());
@@ -381,7 +380,7 @@ class ConnectS2IST extends AbstractST {
         assertResources(NAMESPACE, podName, kafkaConnectS2IName + "-connect",
             "400M", "2", "300M", "1");
         assertExpectedJavaOpts(podName, kafkaConnectS2IName + "-connect",
-            "-Xmx200m", "-Xms200m", "-server", "-XX:+UseG1GC");
+            "-Xmx200m", "-Xms200m", "-XX:+UseG1GC");
 
         KafkaConnectS2IResource.deleteKafkaConnectS2IWithoutWait(kafkaConnectS2IName);
         DeploymentConfigUtils.waitForDeploymentConfigDeletion(KafkaConnectS2IResources.deploymentName(kafkaConnectS2IName));

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -325,7 +325,6 @@ class ConnectST extends AbstractST {
                     .withNewJvmOptions()
                         .withXmx("200m")
                         .withXms("200m")
-                        .withServer(true)
                         .withXx(jvmOptionsXX)
                     .endJvmOptions()
                 .endSpec()
@@ -335,7 +334,7 @@ class ConnectST extends AbstractST {
         assertResources(NAMESPACE, podName, KafkaConnectResources.deploymentName(CLUSTER_NAME),
                 "400M", "2", "300M", "1");
         assertExpectedJavaOpts(podName, KafkaConnectResources.deploymentName(CLUSTER_NAME),
-                "-Xmx200m", "-Xms200m", "-server", "-XX:+UseG1GC");
+                "-Xmx200m", "-Xms200m", "-XX:+UseG1GC");
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -465,7 +465,6 @@ class KafkaST extends AbstractST {
                     .withNewJvmOptions()
                         .withXmx("1g")
                         .withXms("512m")
-                        .withServer(true)
                         .withXx(jvmOptionsXX)
                     .endJvmOptions()
                 .endKafka()
@@ -480,7 +479,6 @@ class KafkaST extends AbstractST {
                     .withNewJvmOptions()
                         .withXmx("1G")
                         .withXms("512M")
-                        .withServer(true)
                         .withXx(jvmOptionsXX)
                     .endJvmOptions()
                 .endZookeeper()
@@ -527,12 +525,12 @@ class KafkaST extends AbstractST {
         assertResources(cmdKubeClient().namespace(), KafkaResources.kafkaPodName(CLUSTER_NAME, 0), "kafka",
                 "1536Mi", "1", "1Gi", "50m");
         assertExpectedJavaOpts(KafkaResources.kafkaPodName(CLUSTER_NAME, 0), "kafka",
-                "-Xmx1g", "-Xms512m", "-server", "-XX:+UseG1GC");
+                "-Xmx1g", "-Xms512m", "-XX:+UseG1GC");
 
         assertResources(cmdKubeClient().namespace(), KafkaResources.zookeeperPodName(CLUSTER_NAME, 0), "zookeeper",
                 "1G", "500m", "500M", "25m");
         assertExpectedJavaOpts(KafkaResources.zookeeperPodName(CLUSTER_NAME, 0), "zookeeper",
-                "-Xmx1G", "-Xms512M", "-server", "-XX:+UseG1GC");
+                "-Xmx1G", "-Xms512M", "-XX:+UseG1GC");
 
         Optional<Pod> pod = kubeClient().listPods()
                 .stream().filter(p -> p.getMetadata().getName().startsWith(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME)))
@@ -544,9 +542,9 @@ class KafkaST extends AbstractST {
         assertResources(cmdKubeClient().namespace(), pod.get().getMetadata().getName(), "user-operator",
                 "512M", "300m", "256M", "30m");
         assertExpectedJavaOpts(pod.get().getMetadata().getName(), "topic-operator",
-                "-Xmx2G", "-Xms1024M", null, null);
+                "-Xmx2G", "-Xms1024M", null);
         assertExpectedJavaOpts(pod.get().getMetadata().getName(), "user-operator",
-                "-Xmx1G", "-Xms512M", null, null);
+                "-Xmx1G", "-Xms512M", null);
 
         String eoPod = eoPods.keySet().toArray()[0].toString();
         kubeClient().getPod(eoPod).getSpec().getContainers().forEach(container -> {

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
@@ -130,7 +130,6 @@ public class MirrorMakerST extends AbstractST {
                 .withNewJvmOptions()
                     .withXmx("200m")
                     .withXms("200m")
-                    .withServer(true)
                     .withXx(jvmOptionsXX)
                 .endJvmOptions()
                 .endSpec().done();
@@ -151,7 +150,7 @@ public class MirrorMakerST extends AbstractST {
         assertResources(NAMESPACE, podName, CLUSTER_NAME.concat("-mirror-maker"),
                 "400M", "2", "300M", "1");
         assertExpectedJavaOpts(podName, KafkaMirrorMakerResources.deploymentName(CLUSTER_NAME),
-                "-Xmx200m", "-Xms200m", "-server", "-XX:+UseG1GC");
+                "-Xmx200m", "-Xms200m", "-XX:+UseG1GC");
 
         timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Originally, the `jvmOptions` section has an option `-server` to turn the server mode of the JVM. This option was removed by mistake about 2 years ago. I originally tried to add it back in #4088. But as pointed by @tombentley, it does not seem to be needed anymore (Tom suggested it, I confirmed it) as the JVM is in the _server_ mode by default. Since nobody complained the whole time it was missing, we decided to just remove it instead of adding it back. That is what this Pr does.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally