### PR TITLE
Add PDF build for our documentation

### DIFF
--- a/.azure/scripts/check_docs.sh
+++ b/.azure/scripts/check_docs.sh
@@ -12,7 +12,7 @@ function grep_check {
   local description=$2
   local opts=${3:--i -E -r -n}
   local fatalness=${4:-1}
-  local excludes="--exclude-dir=logo --exclude-dir=images --exclude-dir=contributing --exclude-dir=html --exclude-dir=htmlnoheader"
+  local excludes="--exclude-dir=logo --exclude-dir=images --exclude-dir=contributing --exclude-dir=html --exclude-dir=htmlnoheader --exclude-dir=pdf"
   x=$($GREP $opts $excludes "$pattern" documentation/)
   if [ -n "$x" ]; then
     echo "$description:"

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ velocity.log
 
 # Generated docs
 documentation/html/**
+documentation/pdf/**
 documentation/htmlnoheader/**
 documentation/**/build/**
 master.html

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ release_docu: docu_html docu_htmlnoheader docu_pdf
 	$(CP) -rv documentation/html/using.html strimzi-$(RELEASE_VERSION)/docs/html/
 	$(CP) -rv documentation/html/images/ strimzi-$(RELEASE_VERSION)/docs/html/images/
 
-docu_clean: docu_htmlclean docu_htmlnoheaderclean
+docu_clean: docu_htmlclean docu_htmlnoheaderclean docu_pdfclean
 
 docu_htmlclean:
 	rm -rf documentation/html

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,6 @@ docu_html: docu_htmlclean docu_versions docu_check
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a BridgeVersion=$(BRIDGE_VERSION) -a GithubVersion=$(GITHUB_VERSION) documentation/quickstart/master.adoc -o documentation/html/quickstart.html
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a BridgeVersion=$(BRIDGE_VERSION) -a GithubVersion=$(GITHUB_VERSION) documentation/contributing/master.adoc -o documentation/html/contributing.html
 
-
 docu_htmlnoheader: docu_htmlnoheaderclean docu_versions docu_check
 	mkdir -p documentation/htmlnoheader
 	$(CP) -vrL documentation/shared/images documentation/htmlnoheader/images
@@ -126,6 +125,14 @@ docu_htmlnoheader: docu_htmlnoheaderclean docu_versions docu_check
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a BridgeVersion=$(BRIDGE_VERSION) -a GithubVersion=$(GITHUB_VERSION) -s documentation/overview/master.adoc -o documentation/htmlnoheader/overview-book.html
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a BridgeVersion=$(BRIDGE_VERSION) -a GithubVersion=$(GITHUB_VERSION) -s documentation/quickstart/master.adoc -o documentation/htmlnoheader/quickstart-book.html
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a BridgeVersion=$(BRIDGE_VERSION) -a GithubVersion=$(GITHUB_VERSION) -s documentation/contributing/master.adoc -o documentation/htmlnoheader/contributing-book.html
+
+docu_pdf: docu_pdfclean docu_versions docu_check
+	mkdir -p documentation/pdf
+	asciidoctor-pdf -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a BridgeVersion=$(BRIDGE_VERSION) -a GithubVersion=$(GITHUB_VERSION) documentation/deploying/master.adoc -o documentation/pdf/deploying.pdf
+	asciidoctor-pdf -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a BridgeVersion=$(BRIDGE_VERSION) -a GithubVersion=$(GITHUB_VERSION) documentation/using/master.adoc -o documentation/pdf/using.pdf
+	asciidoctor-pdf -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a BridgeVersion=$(BRIDGE_VERSION) -a GithubVersion=$(GITHUB_VERSION) documentation/overview/master.adoc -o documentation/pdf/overview.pdf
+	asciidoctor-pdf -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a BridgeVersion=$(BRIDGE_VERSION) -a GithubVersion=$(GITHUB_VERSION) documentation/quickstart/master.adoc -o documentation/pdf/quickstart.pdf
+	asciidoctor-pdf -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a BridgeVersion=$(BRIDGE_VERSION) -a GithubVersion=$(GITHUB_VERSION) documentation/contributing/master.adoc -o documentation/pdf/contributing.pdf
 
 docu_check:
 	./.azure/scripts/check_docs.sh
@@ -141,13 +148,18 @@ docu_pushtowebsite: docu_htmlnoheader docu_html
 pushtonexus:
 	./.azure/scripts/push-to-nexus.sh
 
-release_docu: docu_html docu_htmlnoheader
-	mkdir -p strimzi-$(RELEASE_VERSION)/docs
-	$(CP) -rv documentation/html/overview.html strimzi-$(RELEASE_VERSION)/docs/
-	$(CP) -rv documentation/html/quickstart.html strimzi-$(RELEASE_VERSION)/docs/
-	$(CP) -rv documentation/html/deploying.html strimzi-$(RELEASE_VERSION)/docs/
-	$(CP) -rv documentation/html/using.html strimzi-$(RELEASE_VERSION)/docs/
-	$(CP) -rv documentation/html/images/ strimzi-$(RELEASE_VERSION)/docs/images/
+release_docu: docu_html docu_htmlnoheader docu_pdf
+	mkdir -p strimzi-$(RELEASE_VERSION)/docs/html
+	mkdir -p strimzi-$(RELEASE_VERSION)/docs/pdf
+	$(CP) -rv documentation/pdf/overview.pdf strimzi-$(RELEASE_VERSION)/docs/pdf/
+	$(CP) -rv documentation/pdf/quickstart.pdf strimzi-$(RELEASE_VERSION)/docs/pdf/
+	$(CP) -rv documentation/pdf/deploying.pdf strimzi-$(RELEASE_VERSION)/docs/pdf/
+	$(CP) -rv documentation/pdf/using.pdf strimzi-$(RELEASE_VERSION)/docs/pdf/
+	$(CP) -rv documentation/html/overview.html strimzi-$(RELEASE_VERSION)/docs/html/
+	$(CP) -rv documentation/html/quickstart.html strimzi-$(RELEASE_VERSION)/docs/html/
+	$(CP) -rv documentation/html/deploying.html strimzi-$(RELEASE_VERSION)/docs/html/
+	$(CP) -rv documentation/html/using.html strimzi-$(RELEASE_VERSION)/docs/html/
+	$(CP) -rv documentation/html/images/ strimzi-$(RELEASE_VERSION)/docs/html/images/
 
 docu_clean: docu_htmlclean docu_htmlnoheaderclean
 
@@ -156,6 +168,9 @@ docu_htmlclean:
 
 docu_htmlnoheaderclean:
 	rm -rf documentation/htmlnoheader
+
+docu_pdfclean:
+	rm -rf documentation/pdf
 
 systemtests:
 	./systemtest/scripts/run_tests.sh $(SYSTEMTEST_ARGS)

--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -92,7 +92,7 @@ To build this project you must first install several command line utilities and 
     - Both Helm 2 and Helm 3 are supported. In order to use either two, you need to download both versions. A convenient way to do so is to download the [get_helm.sh](https://helm.sh/docs/intro/install/#from-script) script and specify the version you want to download either for Helm 2 or Helm 3.
     - After you download one binary, you can, for convenience, rename it to `helm2` and `helm3` accordingly.
     - Note that if you are using the Helm version 2 charts, after installing the Helm CLI, ensure you run `helm2 init` to configure to your cluster.
-- [`asciidoctor`](https://asciidoctor.org/) - Documentation generation. 
+- [`asciidoctor` and `asciidoctor-pdf`](https://asciidoctor.org/) - Documentation generation. 
     - Use `gem` to install latest version for your platform.
 - [`yq`](https://github.com/mikefarah/yq) - (version 3.3.1 and above) YAML manipulation tool. 
     - **Warning:** There are several different `yq` YAML projects in the wild. Use [this one](https://github.com/mikefarah/yq). You need **v3** version.


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Documentation

### Description

In the past, it was quite hard to build PDFs form Asciidoc since it required LaTeX or Docbook as a middle step. But with the _new_ `adciidoctor-pdf` tool, it is now much easier - like the HTML docs. And there was some demand for PDF docs on Slack. This PR adds it to the build and release system to make it easy to build the PDF versions.