### PR TITLE
Include some more useful targets into make all command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endif
 SUBDIRS=kafka-agent mirror-maker-agent tracing-agent crd-annotations test crd-generator api mockkube certificate-manager operator-common config-model config-model-generator cluster-operator topic-operator user-operator kafka-init docker-images helm-charts/helm2 helm-charts/helm3 install examples
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
-all: prerequisites_check $(SUBDIRS) crd_install helm_install
+all: prerequisites_check $(SUBDIRS) crd_install helm_install shellcheck docu_versions docu_check
 clean: prerequisites_check $(SUBDIRS) docu_clean
 $(DOCKER_TARGETS): prerequisites_check $(SUBDIRS)
 release: release_prepare release_version release_helm_version release_maven $(SUBDIRS) release_docu release_single_file release_pkg release_helm_repo docu_clean


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `make all` command is mostly used for local development. It seems to be missing some important targets. Some of them (such as `shellcheck`) are done later in CI and not having it in `make all` means that issues might be discovered only too late. Other such as `docu_versions` seem to be triggered only when specifically rendering the docs and not having them causes PRs such as #4142.

This PR adds these steps to the `make all` command to make sure they are run already locally by developers using this workflow and the issues are discovered earlier.