### PR TITLE
Update Helm2 to handle change chart repository addresses

### DIFF
--- a/.azure/templates/default_variables.yaml
+++ b/.azure/templates/default_variables.yaml
@@ -21,7 +21,7 @@ variables:
   test_cluster: minikube
   test_kubectl_version: v1.16.0
   test_nsenter_version: 2.32
-  test_helm_version: v2.16.3
+  test_helm_version: v2.17.0
   test_minikube_version: v1.2.0
   strimzi_default_log_level: DEBUG
   docker_registry: quay.io

--- a/.azure/templates/general_steps.yaml
+++ b/.azure/templates/general_steps.yaml
@@ -35,5 +35,5 @@ steps:
 - bash: ".azure/scripts/setup-helm.sh"
   displayName: "Setup Helm"
   env:
-    TEST_HELM2_VERSION: 'v2.16.3'
-    TEST_HELM3_VERSION: 'v3.2.0'
+    TEST_HELM2_VERSION: 'v2.17.0'
+    TEST_HELM3_VERSION: 'v3.4.2'

--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -28,8 +28,8 @@ pipeline {
         OPERATOR_IMAGE_PULL_POLICY = "IfNotPresent"
         COMPONENTS_IMAGE_PULL_POLICY = "IfNotPresent"
         JAVA_VERSION = "11"
-        TEST_HELM2_VERSION = "v2.16.3"
-        TEST_HELM3_VERSION = "v3.2.0"
+        TEST_HELM2_VERSION = "v2.17.0"
+        TEST_HELM3_VERSION = "v3.4.2"
         TEST_CLUSTER = "minikube"
     }
     stages {

--- a/helm-charts/helm2/Makefile
+++ b/helm-charts/helm2/Makefile
@@ -22,7 +22,7 @@ helm_template:
 	../kafka-version-tpl.sh strimzi-kafka-operator/templates/_kafka_image_map.tpl
 
 helm_pkg: helm_lint helm_template
-	$(HELM_CLI) init --client-only
+	$(HELM_CLI) init --client-only --skip-refresh
 	# Copying unarchived Helm Chart to release directory
 	mkdir -p strimzi-$(RELEASE_VERSION)/charts/
 	$(CP) -r $(CHART_PATH) strimzi-$(RELEASE_VERSION)/charts/$(CHART_NAME)


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Helm Chart repositories were moved to new URLs (see https://helm.sh/blog/new-location-stable-incubator-charts/). That is now causing our builds to fail:

```
helm2 init --client-only
Creating /home/vsts/.helm 
Creating /home/vsts/.helm/repository 
Creating /home/vsts/.helm/repository/cache 
Creating /home/vsts/.helm/repository/local 
Creating /home/vsts/.helm/plugins 
Creating /home/vsts/.helm/starters 
Creating /home/vsts/.helm/cache/archive 
Creating /home/vsts/.helm/repository/repositories.yaml 
Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com 
Error: error initializing: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden
Makefile:25: recipe for target 'helm_pkg' failed
make[1]: *** [helm_pkg] Error 1
make[1]: Leaving directory '/home/vsts/work/1/s/helm-charts/helm2'
Makefile:168: recipe for target 'helm-charts/helm2' failed
make: *** [helm-charts/helm2] Error 2
```

This PR updates the Helm 2 and 3 to newer versions which should support the new repository locations to make it work again. It also adds additional option to the `helm init` command which might make it work with older versions in the local environments. But not sure it helps since I have locally already 2.17.