### PR TITLE
Updated Kafka Connect and Mirror Maker 2 dashboards using cadvisor CPU usage metric

### DIFF
--- a/examples/metrics/grafana-dashboards/strimzi-kafka-connect.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kafka-connect.json
@@ -430,11 +430,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(process_cpu_seconds_total{strimzi_io_kind=~\"KafkaConnect.*\",strimzi_io_cluster=\"$strimzi_connect_cluster_name\"}[1m])",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$kubernetes_namespace\",pod=~\"$strimzi_connect_cluster_name-connect-.+\",container=\"$strimzi_connect_cluster_name-connect\"}[5m])) by (pod)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
-          "legendFormat": "{{kubernetes_pod_name}}",
+          "legendFormat": "{{pod}}",
           "metric": "",
           "refId": "A",
           "step": 4

--- a/examples/metrics/grafana-dashboards/strimzi-kafka-mirror-maker-2.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kafka-mirror-maker-2.json
@@ -436,11 +436,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(process_cpu_seconds_total{strimzi_io_kind=~\"KafkaMirrorMaker2\",strimzi_io_cluster=\"$strimzi_mirror_maker_cluster_name\"}[1m])",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$kubernetes_namespace\",pod=~\"$strimzi_mirror_maker_cluster_name-mirrormaker2-.+\",container=\"$strimzi_mirror_maker_cluster_name-mirrormaker2\"}[5m])) by (pod)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
-          "legendFormat": "{{kubernetes_pod_name}}",
+          "legendFormat": "{{pod}}",
           "metric": "",
           "refId": "A",
           "step": 4


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR fixed #4135 using the `container_cpu_usage_seconds_total` metric (coming from cadvisor) instead of `process_cpu_seconds_total` (coming from Promethes exporter library) on the Kafka Connect and Kafka Mirror Maker 2 as already used for the other dashboards for consistency.

### Checklist

- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
