### PR TITLE
Fix adding and removing JBOD volumes

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -100,7 +100,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.addAll;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static io.strimzi.operator.cluster.model.CruiseControl.CRUISE_CONTROL_METRIC_REPORTER;
@@ -1163,9 +1162,12 @@ public class KafkaCluster extends AbstractModel {
         stsAnnotations.put(ANNO_STRIMZI_IO_KAFKA_VERSION, kafkaVersion.version());
         stsAnnotations.put(ANNO_STRIMZI_IO_STORAGE, ModelUtils.encodeStorageToJson(storage));
 
+        Map<String, String> podAnnotations = new HashMap<>(1);
+        podAnnotations.put(ANNO_STRIMZI_IO_STORAGE, ModelUtils.encodeStorageToJson(storage));
+
         return createStatefulSet(
                 stsAnnotations,
-                emptyMap(),
+                podAnnotations,
                 getVolumes(isOpenShift),
                 getVolumeClaims(),
                 getMergedAffinity(),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -46,6 +46,7 @@ import io.strimzi.api.kafka.model.status.ListenerAddress;
 import io.strimzi.api.kafka.model.status.ListenerAddressBuilder;
 import io.strimzi.api.kafka.model.status.ListenerStatus;
 import io.strimzi.api.kafka.model.status.ListenerStatusBuilder;
+import io.strimzi.api.kafka.model.storage.JbodStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.PlatformFeaturesAvailability;
@@ -72,6 +73,7 @@ import io.strimzi.operator.cluster.model.ListenersUtils;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.NodeUtils;
 import io.strimzi.operator.cluster.model.StatusDiff;
+import io.strimzi.operator.cluster.model.StorageDiff;
 import io.strimzi.operator.cluster.model.StorageUtils;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.cluster.operator.resource.ConcurrentDeletionException;
@@ -312,6 +314,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(state -> state.kafkaPodDisruptionBudget())
                 .compose(state -> state.kafkaStatefulSet())
                 .compose(state -> state.kafkaVersionChange(true))
+                .compose(state -> state.kafkaRollToAddOrRemoveVolumes())
                 .compose(state -> state.kafkaRollingUpdate())
                 .compose(state -> state.kafkaScaleUp())
                 .compose(state -> state.kafkaPodsReady())
@@ -728,7 +731,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         .compose(i -> kafkaSetOperations.getAsync(namespace, KafkaCluster.kafkaClusterName(name)))
                         .compose(sts -> new KafkaRoller(vertx, reconciliation, podOperations, 1_000, operationTimeoutMs,
                             () -> new BackOff(250, 2, 10), sts, clusterCa.caCertSecret(), oldCoSecret, adminClientProvider,
-                            kafkaCluster.getBrokersConfiguration(), kafkaLogging, kafkaCluster.getKafkaVersion())
+                            kafkaCluster.getBrokersConfiguration(), kafkaLogging, kafkaCluster.getKafkaVersion(), true)
                             .rollingRestart(rollPodAndLogReason))
                         .compose(i -> rollDeploymentIfExists(EntityOperator.entityOperatorName(name), reason.toString()))
                         .compose(i -> rollDeploymentIfExists(KafkaExporter.kafkaExporterName(name), reason.toString()))
@@ -1388,16 +1391,31 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         /**
+         * Rolls Kafka pods if needed
          *
          * @param sts Kafka statefullset
          * @param podNeedsRestart this function serves as a predicate whether to roll pod or not
+         *
          * @return succeeded future if kafka pod was rolled and is ready
          */
         Future<Void> maybeRollKafka(StatefulSet sts, Function<Pod, List<String>> podNeedsRestart) {
+            return maybeRollKafka(sts, podNeedsRestart, true);
+        }
+
+        /**
+         * Rolls Kafka pods if needed
+         *
+         * @param sts Kafka statefullset
+         * @param podNeedsRestart this function serves as a predicate whether to roll pod or not
+         * @param allowReconfiguration defines whether the rolling update should also attempt to do dynamic reconfiguration or not
+         *
+         * @return succeeded future if kafka pod was rolled and is ready
+         */
+        Future<Void> maybeRollKafka(StatefulSet sts, Function<Pod, List<String>> podNeedsRestart, boolean allowReconfiguration) {
             return adminClientSecrets()
                 .compose(compositeFuture -> new KafkaRoller(vertx, reconciliation, podOperations, 1_000, operationTimeoutMs,
                     () -> new BackOff(250, 2, 10), sts, compositeFuture.resultAt(0), compositeFuture.resultAt(1), adminClientProvider,
-                        kafkaCluster.getBrokersConfiguration(), kafkaLogging, kafkaCluster.getKafkaVersion())
+                        kafkaCluster.getBrokersConfiguration(), kafkaLogging, kafkaCluster.getKafkaVersion(), allowReconfiguration)
                     .rollingRestart(podNeedsRestart));
         }
 
@@ -2739,6 +2757,63 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             List<PersistentVolumeClaim> pvcs = kafkaCluster.generatePersistentVolumeClaims(kafkaCluster.getStorage());
 
             return maybeResizeReconcilePvcs(pvcs, kafkaCluster);
+        }
+
+        Future<ReconciliationState> maybeRollKafkaInSequence(StatefulSet sts, Function<Pod, List<String>> podNeedsRestart, int nextPod, int lastPod) {
+            if (nextPod <= lastPod)  {
+                final int podToRoll = nextPod;
+
+                return maybeRollKafka(sts, pod -> {
+                    if (pod != null && pod.getMetadata().getName().endsWith("-" + podToRoll))    {
+                        return podNeedsRestart.apply(pod);
+                    } else {
+                        return null;
+                    }
+                }, false)
+                        .compose(ignore -> maybeRollKafkaInSequence(sts, podNeedsRestart, nextPod + 1, lastPod));
+            } else {
+                // All pods checked for sequential RU => nothing more to do
+                return withVoid(Future.succeededFuture());
+            }
+        }
+
+        Future<ReconciliationState> kafkaRollToAddOrRemoveVolumes() {
+            Storage storage = kafkaCluster.getStorage();
+
+            // If storage is not Jbod storage, we never add or remove volumes
+            if (storage instanceof JbodStorage) {
+                JbodStorage jbodStorage = (JbodStorage) storage;
+
+                return kafkaSetOperations.getAsync(namespace, KafkaCluster.kafkaClusterName(name))
+                        .compose(sts -> {
+                            if (sts != null) {
+                                int lastPodIndex = Math.min(kafkaCurrentReplicas, kafkaCluster.getReplicas()) - 1;
+                                return maybeRollKafkaInSequence(sts, pod -> needsRestartBecauseAddedOrRemovedJbodVolumes(pod, jbodStorage, kafkaCurrentReplicas, kafkaCluster.getReplicas()), 0, lastPodIndex);
+                            } else {
+                                // STS does not exist => nothing to roll
+                                return withVoid(Future.succeededFuture());
+                            }
+                        });
+            } else {
+                return withVoid(Future.succeededFuture());
+            }
+        }
+
+        private List<String> needsRestartBecauseAddedOrRemovedJbodVolumes(Pod pod, JbodStorage desiredStorage, int currentReplicas, int desiredReplicas)  {
+            if (pod != null
+                    && pod.getMetadata() != null) {
+                String jsonStorage = Annotations.stringAnnotation(pod, ANNO_STRIMZI_IO_STORAGE, null);
+
+                if (jsonStorage != null) {
+                    Storage currentStorage = ModelUtils.decodeStorageFromJson(jsonStorage);
+
+                    if (new StorageDiff(currentStorage, desiredStorage, currentReplicas, desiredReplicas).isVolumesAddedOrRemoved())    {
+                        return singletonList("JBOD volumes were added or removed");
+                    }
+                }
+            }
+
+            return null;
         }
 
         StatefulSet getKafkaStatefulSet()   {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
@@ -31,11 +31,13 @@ public class StorageDiffTest {
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
+        assertThat(diff.isVolumesAddedOrRemoved(), is(false));
 
         diff = new StorageDiff(jbod, jbod2, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(false));
         assertThat(diff.shrinkSize(), is(false));
+        assertThat(diff.isVolumesAddedOrRemoved(), is(false));
     }
 
     @Test
@@ -127,15 +129,19 @@ public class StorageDiffTest {
 
         StorageDiff diffJbodEphemeral = new StorageDiff(jbod, ephemeral, 3, 3);
         StorageDiff diffPersistentEphemeral = new StorageDiff(persistent, ephemeral, 3, 3);
-        StorageDiff fiddJbodPersistent = new StorageDiff(jbod, persistent, 3, 3);
+        StorageDiff diffJbodPersistent = new StorageDiff(jbod, persistent, 3, 3);
 
         assertThat(diffJbodEphemeral.changesType(), is(true));
         assertThat(diffPersistentEphemeral.changesType(), is(true));
-        assertThat(fiddJbodPersistent.changesType(), is(true));
+        assertThat(diffJbodPersistent.changesType(), is(true));
 
         assertThat(diffJbodEphemeral.isEmpty(), is(false));
         assertThat(diffPersistentEphemeral.isEmpty(), is(false));
-        assertThat(fiddJbodPersistent.isEmpty(), is(false));
+        assertThat(diffJbodPersistent.isEmpty(), is(false));
+
+        assertThat(diffJbodEphemeral.isVolumesAddedOrRemoved(), is(false));
+        assertThat(diffPersistentEphemeral.isVolumesAddedOrRemoved(), is(false));
+        assertThat(diffJbodPersistent.isVolumesAddedOrRemoved(), is(false));
     }
 
     @Test
@@ -172,48 +178,63 @@ public class StorageDiffTest {
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
+        assertThat(diff.isVolumesAddedOrRemoved(), is(true));
 
         // Volume removed
         diff = new StorageDiff(jbod2, jbod, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
+        assertThat(diff.isVolumesAddedOrRemoved(), is(true));
 
         // Volume added with changes
         diff = new StorageDiff(jbod, jbod3, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(false));
         assertThat(diff.shrinkSize(), is(true));
+        assertThat(diff.isVolumesAddedOrRemoved(), is(true));
+
+        // No volume added, but with changes
+        diff = new StorageDiff(jbod2, jbod3, 3, 3);
+        assertThat(diff.changesType(), is(false));
+        assertThat(diff.isEmpty(), is(false));
+        assertThat(diff.shrinkSize(), is(true));
+        assertThat(diff.isVolumesAddedOrRemoved(), is(false));
 
         // Volume removed from the beginning
         diff = new StorageDiff(jbod3, jbod5, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
+        assertThat(diff.isVolumesAddedOrRemoved(), is(true));
 
         // Volume added to the beginning
         diff = new StorageDiff(jbod5, jbod3, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
+        assertThat(diff.isVolumesAddedOrRemoved(), is(true));
 
         // Volume replaced with another ID and another volume which is kept changed
         diff = new StorageDiff(jbod3, jbod6, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(false));
         assertThat(diff.shrinkSize(), is(false));
+        assertThat(diff.isVolumesAddedOrRemoved(), is(true));
 
         // Volume replaced with another ID in single volume broker
         diff = new StorageDiff(jbod, jbod4, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
+        assertThat(diff.isVolumesAddedOrRemoved(), is(true));
 
         // Volume replaced with another ID without chenging the volumes which are kept
         diff = new StorageDiff(jbod2, jbod6, 3, 3);
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
+        assertThat(diff.isVolumesAddedOrRemoved(), is(true));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -585,7 +585,7 @@ public class KafkaRollerTest {
                                   int... controllers) {
             super(KafkaRollerTest.vertx, new Reconciliation("test", "Kafka", stsNamespace(), clusterName()), podOps, 500, 1000,
                 () -> new BackOff(10L, 2, 4),
-                sts, clusterCaCertSecret, coKeySecret, "", "", KafkaVersionTestUtils.getLatestVersion());
+                sts, clusterCaCertSecret, coKeySecret, "", "", KafkaVersionTestUtils.getLatestVersion(), true);
             this.controllers = controllers;
             this.controllerCall = 0;
             Objects.requireNonNull(acOpenException);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -97,6 +97,10 @@ public class KafkaResource {
                 .endKafka()
                 .editZookeeper().
                     withReplicas(zookeeperReplicas)
+                    .withNewPersistentClaimStorage()
+                        .withNewSize("100")
+                        .withDeleteClaim(true)
+                    .endPersistentClaimStorage()
                 .endZookeeper()
             .endSpec()
             .build());

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -11,6 +11,10 @@ import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.listener.arraylistener.ArrayOrObjectKafkaListeners;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.api.kafka.model.storage.JbodStorage;
+import io.strimzi.api.kafka.model.storage.JbodStorageBuilder;
+import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
+import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
@@ -324,20 +328,20 @@ class AlternativeReconcileTriggersST extends AbstractST {
 
         LOGGER.info("Trying to roll just single Kafka and single ZK pod");
         kubeClient().editPod(KafkaResources.kafkaPodName(CLUSTER_NAME, 0))
-            .editMetadata()
+                .editMetadata()
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
-            .endMetadata()
-            .done();
+                .endMetadata()
+                .done();
 
         // here we are waiting just to one pod's snapshot will be changed and all 3 pods ready -> if we set expectedPods to 1,
         // the check will pass immediately without waiting for all pods to be ready -> the method picks first ready pod and return true
         kafkaSnapshot = StatefulSetUtils.waitTillSsHasRolled(kafkaSsName, 3, kafkaSnapshot);
 
         kubeClient().editPod(KafkaResources.zookeeperPodName(CLUSTER_NAME, 0))
-            .editMetadata()
+                .editMetadata()
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
-            .endMetadata()
-            .done();
+                .endMetadata()
+                .done();
 
         // same as above
         zkSnapshot = StatefulSetUtils.waitTillSsHasRolled(zkSsName, 3, zkSnapshot);
@@ -346,10 +350,10 @@ class AlternativeReconcileTriggersST extends AbstractST {
         LOGGER.info("Adding anno to all ZK and Kafka pods");
         kafkaSnapshot.keySet().forEach(podName -> {
             kubeClient().editPod(podName)
-                .editMetadata()
+                    .editMetadata()
                     .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
-                .endMetadata()
-                .done();
+                    .endMetadata()
+                    .done();
         });
 
         LOGGER.info("Checking if the rolling update will be successful for Kafka");
@@ -357,14 +361,112 @@ class AlternativeReconcileTriggersST extends AbstractST {
 
         zkSnapshot.keySet().forEach(podName -> {
             kubeClient().editPod(podName)
-                .editMetadata()
+                    .editMetadata()
                     .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
-                .endMetadata()
-                .done();
+                    .endMetadata()
+                    .done();
         });
 
         LOGGER.info("Checking if the rolling update will be successful for ZK");
         StatefulSetUtils.waitTillSsHasRolled(zkSsName, 3, zkSnapshot);
+    }
+
+    /**
+     * Adding and removing JBOD volumes requires rolling updates in the sequential order. Otherwise the StatefulSet does
+     * not like it. This tests tries to add and remove volume from JBOD to test both of these situations.
+     */
+    @Test
+    void testAddingAndRemovingJbodVolumes() {
+        String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
+        String clusterName = CLUSTER_NAME + "-jbod-changes";
+        String continuousTopicName = "continuous-topic";
+        // 500 messages will take 500 seconds in that case
+        int continuousClientsMessageCount = 500;
+        String producerName = "hello-world-producer";
+        String consumerName = "hello-world-consumer";
+
+        PersistentClaimStorage vol0 = new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").withDeleteClaim(true).build();
+        PersistentClaimStorage vol1 = new PersistentClaimStorageBuilder().withId(1).withSize("100Gi").withDeleteClaim(true).build();
+
+        KafkaResource.kafkaJBOD(clusterName, 3, 3, new JbodStorageBuilder().addToVolumes(vol0).build()).done();
+
+        String kafkaName = KafkaResources.kafkaStatefulSetName(clusterName);
+        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaName);
+
+        KafkaTopicResource.topic(clusterName, topicName).done();
+        // ##############################
+        // Attach clients which will continuously produce/consume messages to/from Kafka brokers during rolling update
+        // ##############################
+        // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
+        KafkaTopicResource.topic(clusterName, continuousTopicName, 3, 3, 2).done();
+        String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
+        // Add transactional id to make producer transactional
+        producerAdditionConfiguration = producerAdditionConfiguration.concat("\ntransactional.id=" + continuousTopicName + ".1");
+        producerAdditionConfiguration = producerAdditionConfiguration.concat("\nenable.idempotence=true");
+
+        KafkaBasicExampleClients kafkaBasicClientJob = new KafkaBasicExampleClients.Builder()
+                .withProducerName(producerName)
+                .withConsumerName(consumerName)
+                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))
+                .withTopicName(continuousTopicName)
+                .withMessageCount(continuousClientsMessageCount)
+                .withAdditionalConfig(producerAdditionConfiguration)
+                .withDelayMs(1000)
+                .build();
+
+        kafkaBasicClientJob.producerStrimzi().done();
+        kafkaBasicClientJob.consumerStrimzi().done();
+        // ##############################
+
+        String userName = KafkaUserUtils.generateRandomNameOfKafkaUser();
+        KafkaUser user = KafkaUserResource.tlsUser(clusterName, userName).done();
+
+        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+
+        final String defaultKafkaClientsPodName =
+                ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
+
+        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
+                .withUsingPodName(defaultKafkaClientsPodName)
+                .withTopicName(topicName)
+                .withNamespaceName(NAMESPACE)
+                .withClusterName(clusterName)
+                .withMessageCount(MESSAGE_COUNT)
+                .withKafkaUsername(userName)
+                .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+                .build();
+
+        int sent = internalKafkaClient.sendMessagesTls();
+        assertThat(sent, is(MESSAGE_COUNT));
+
+        // Add Jbod volume to Kafka => triggers RU
+        LOGGER.info("Add JBOD volume to the Kafka cluster {}", kafkaName);
+        timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.ROLLING_UPDATE));
+        KafkaResource.replaceKafkaResource(clusterName, kafka -> {
+            JbodStorage storage = (JbodStorage) kafka.getSpec().getKafka().getStorage();
+            storage.getVolumes().add(vol1);
+        });
+
+        // Wait util it rolls
+        StatefulSetUtils.waitTillSsHasRolled(kafkaName, 3, kafkaPods);
+        kafkaPods = StatefulSetUtils.ssSnapshot(kafkaName);
+
+        // Remove Jbod volume to Kafka => triggers RU
+        LOGGER.info("Remove JBOD volume to the Kafka cluster {}", kafkaName);
+        timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.ROLLING_UPDATE));
+        KafkaResource.replaceKafkaResource(clusterName, kafka -> {
+            JbodStorage storage = (JbodStorage) kafka.getSpec().getKafka().getStorage();
+            storage.getVolumes().remove(vol1);
+        });
+
+        // Wait util it rolls
+        StatefulSetUtils.waitTillSsHasRolled(kafkaName, 3, kafkaPods);
+
+        // ##############################
+        // Validate that continuous clients finished successfully
+        // ##############################
+        ClientUtils.waitTillContinuousClientsFinish(producerName, consumerName, NAMESPACE, continuousClientsMessageCount);
+        // ##############################
     }
 
     @BeforeAll


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When adding or removing JBOD volumes, the pods need to be rolled in a specific order - from first to last. This does not happen in regular RU because of how we roll the controller last and how we possible change the order because of partitions not being in-sync etc. The whole issue is described in more detail in #3136.

This PR adds a special step to `KafkaAssemblyOperator` which detects new volumes being added or removed from JBOD and rolls them in the right order regardless the controller, replicas etc. It also adds ST for this.

This issue should close #3136.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging