### PR TITLE
Use the Fabric8 support for status sub-resource instead of our own support

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -580,7 +580,7 @@ public class ConnectorMockTest {
         verify(api, times(2)).list(
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         // triggered three times (Connect creation, Connector Status update, Connect Status update)
-        verify(api, times(3)).createOrUpdatePutRequest(
+        verify(api, times(4)).createOrUpdatePutRequest(
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));

--- a/mockkube/pom.xml
+++ b/mockkube/pom.xml
@@ -54,19 +54,6 @@
             <artifactId>openshift-model</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.squareup.okio</groupId>
-            <artifactId>okio</artifactId>
-            <version>${okio.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
         </dependency>

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
@@ -284,6 +284,7 @@ class MockBuilder<T extends HasMetadata,
         mockGet(resourceName, resource);
         mockWatch(resourceName, resource);
         mockCreate(resourceName, resource);
+        mockSetStatus(resourceName, resource);
         when(resource.createNew()).thenReturn(doneable(resource::create));
         when(resource.createOrReplace(any())).thenAnswer(i -> {
             T resource2 = i.getArgument(0);
@@ -466,6 +467,16 @@ class MockBuilder<T extends HasMetadata,
         return when(resource.isReady()).thenAnswer(i -> {
             LOGGER.debug("{} {} is ready", resourceType, resourceName);
             return Boolean.TRUE;
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    protected OngoingStubbing<T> mockSetStatus(String resourceName, R resource) {
+        return when(resource.updateStatus((T) any())).thenAnswer(i -> {
+            T r = i.getArgument(0);
+            updateStatus(r.getMetadata().getNamespace(), r.getMetadata().getName(), r);
+            LOGGER.debug("{} {} setStatus {}", resourceType, resourceName, r);
+            return copyResource(db.get(resourceName));
         });
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -31,7 +31,6 @@ public class CrdOperator<C extends KubernetesClient,
     private final Class<T> cls;
     private final Class<L> listCls;
     private final Class<D> doneableCls;
-    protected final String plural;
     protected final CustomResourceDefinition crd;
 
     /**
@@ -48,7 +47,6 @@ public class CrdOperator<C extends KubernetesClient,
         this.cls = cls;
         this.listCls = listCls;
         this.doneableCls = doneableCls;
-        this.plural = crd.getSpec().getNames().getPlural();
         this.crd = crd;
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -4,11 +4,9 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Doneable;
-import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.CustomResourceList;
@@ -16,21 +14,11 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
-import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
-import io.fabric8.kubernetes.client.utils.Serialization;
 import io.strimzi.operator.common.Util;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Collections;
 
 @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
         justification = "Erroneous on Java 11: https://github.com/spotbugs/spotbugs/issues/756")
@@ -45,7 +33,6 @@ public class CrdOperator<C extends KubernetesClient,
     private final Class<D> doneableCls;
     protected final String plural;
     protected final CustomResourceDefinition crd;
-
 
     /**
      * Constructor
@@ -124,56 +111,15 @@ public class CrdOperator<C extends KubernetesClient,
         Promise<T> blockingPromise = Promise.promise();
 
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(future -> {
+            String namespace = resource.getMetadata().getNamespace();
+            String name = resource.getMetadata().getName();
+
             try {
-
-                OkHttpClient client = this.client.adapt(OkHttpClient.class);
-                RequestBody postBody = RequestBody.create(OperationSupport.JSON, new ObjectMapper().writeValueAsString(resource));
-
-                Request request = new Request.Builder().put(postBody).url(
-                        this.client.getMasterUrl().toString() + "apis/" + resource.getApiVersion() + "/namespaces/" + resource.getMetadata().getNamespace()
-                                + "/" + this.plural + "/" + resource.getMetadata().getName() + "/status").build();
-
-                String method = request.method();
-                Response response = client.newCall(request).execute();
-                T returnedResource = null;
-                try {
-                    final int code = response.code();
-
-                    if (code == 422)    {
-                        Status status = OperationSupport.createStatus(response);
-
-                        if (status != null
-                                && status.getDetails() != null
-                                && status.getDetails().getCauses() != null
-                                && status.getDetails().getCauses().size() > 0
-                                && status.getDetails().getCauses().stream().filter(cause -> "FieldValueInvalid".equals(cause.getReason()) && "apiVersion".equals(cause.getField())).findAny().orElse(null) != null)  {
-                            log.debug("Got semi-expected {} status code {}: {}", method, code, status);
-                            log.warn("Cannot update status of resource {} named {}. The resource needs to be updated to newer apiVersion first.", resource.getKind(), resource.getMetadata().getName());
-                        } else {
-                            log.debug("Got unexpected {} status code {}: {}", method, code, status);
-                            throw OperationSupport.requestFailure(request, status);
-                        }
-                    } else if (code != 200) {
-                        Status status = OperationSupport.createStatus(response);
-                        log.debug("Got unexpected {} status code {}: {}", method, code, status);
-                        throw OperationSupport.requestFailure(request, status);
-                    } else {
-                        // Success!
-                        if (response.body() != null) {
-                            try (InputStream bodyInputStream = response.body().byteStream()) {
-                                returnedResource = Serialization.unmarshal(bodyInputStream, cls, Collections.emptyMap());
-                            }
-                        }
-                    }
-                } finally {
-                    // Only messages with body should be closed
-                    if (response.body() != null) {
-                        response.close();
-                    }
-                }
-                future.complete(returnedResource);
-            } catch (IOException | RuntimeException e) {
-                log.debug("Updating status failed", e);
+                T result = operation().inNamespace(namespace).withName(name).updateStatus(resource);
+                log.debug("Status of {} {} in namespace {} has been updated", resourceKind, name, namespace);
+                future.complete(result);
+            } catch (Exception e) {
+                log.debug("Caught exception while updating status of {} {} in namespace {}", resourceKind, name, namespace, e);
                 future.fail(e);
             }
         }, true, blockingPromise);

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
@@ -5,37 +5,27 @@
 package io.strimzi.operator.common.operator.resource;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
-import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaList;
-import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.DoneableKafka;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.listener.KafkaListenersBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.ArrayOrObjectKafkaListeners;
+import io.strimzi.api.kafka.model.status.ConditionBuilder;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxTestContext;
-import okhttp3.Call;
-import okhttp3.OkHttpClient;
-import okhttp3.Protocol;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.net.URL;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -76,6 +66,7 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
                     .endZookeeper()
                 .endSpec()
                 .withNewStatus()
+                    .addToConditions(new ConditionBuilder().withNewStatus("Ready").withNewMessage("Kafka is ready").build())
                 .endStatus()
                 .build();
     }
@@ -92,113 +83,23 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
 
     @Test
     public void testUpdateStatusAsync(VertxTestContext context) throws IOException {
-        KubernetesClient mockClient = mock(KubernetesClient.class);
+        Kafka resource = resource();
+        Resource mockResource = mock(resourceType());
+        when(mockResource.updateStatus(any())).thenReturn(resource);
 
-        OkHttpClient mockOkHttp = mock(OkHttpClient.class);
-        when(mockClient.adapt(eq(OkHttpClient.class))).thenReturn(mockOkHttp);
-        URL fakeUrl = new URL("http", "my-host", 9443, "/");
-        when(mockClient.getMasterUrl()).thenReturn(fakeUrl);
-        Call mockCall = mock(Call.class);
-        when(mockOkHttp.newCall(any(Request.class))).thenReturn(mockCall);
-        ResponseBody body = ResponseBody.create(OperationSupport.JSON, "{ }");
-        Response response = new Response.Builder().code(200).request(new Request.Builder().url(fakeUrl).build()).body(body).message("Created").protocol(Protocol.HTTP_1_1).build();
-        when(mockCall.execute()).thenReturn(response);
+        NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(resource.getMetadata().getName()))).thenReturn(mockResource);
+
+        MixedOperation mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(resource.getMetadata().getNamespace()))).thenReturn(mockNameable);
+
+        KubernetesClient mockClient = mock(KubernetesClient.class);
+        mocker(mockClient, mockCms);
 
         Checkpoint async = context.checkpoint();
 
         createResourceOperations(vertx, mockClient)
             .updateStatusAsync(resource())
             .onComplete(context.succeeding(kafka -> async.flag()));
-    }
-
-    @Test
-    public void testUpdateStatusWorksAfterUpgradeWithHttp422ResponseAboutApiVersionField(VertxTestContext context) throws IOException {
-        KubernetesClient mockClient = mock(KubernetesClient.class);
-
-        OkHttpClient mockOkHttp = mock(OkHttpClient.class);
-        when(mockClient.adapt(eq(OkHttpClient.class))).thenReturn(mockOkHttp);
-        URL fakeUrl = new URL("http", "my-host", 9443, "/");
-        when(mockClient.getMasterUrl()).thenReturn(fakeUrl);
-        Call mockCall = mock(Call.class);
-        when(mockOkHttp.newCall(any(Request.class))).thenReturn(mockCall);
-        ResponseBody body = ResponseBody.create(OperationSupport.JSON, "{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"Kafka." + Constants.RESOURCE_GROUP_NAME + " \\\"my-cluster\\\" is invalid: apiVersion: Invalid value: \\\"" + Constants.RESOURCE_GROUP_NAME + "/" + Constants.V1ALPHA1 + "\\\": must be " + Constants.RESOURCE_GROUP_NAME + "/" + Constants.V1BETA1 + "\",\"reason\":\"Invalid\",\"details\":{\"name\":\"my-cluster\",\"group\":\"" + Constants.RESOURCE_GROUP_NAME + "\",\"kind\":\"Kafka\",\"causes\":[{\"reason\":\"FieldValueInvalid\",\"message\":\"Invalid value: \\\"" + Constants.RESOURCE_GROUP_NAME + "/" + Constants.V1ALPHA1 + "\\\": must be " + Constants.RESOURCE_GROUP_NAME + "/" + Constants.V1BETA1 + "\",\"field\":\"apiVersion\"}]},\"code\":422}");
-        Response response = new Response.Builder().code(422).request(new Request.Builder().url(fakeUrl).build()).body(body).message("Unprocessable Entity").protocol(Protocol.HTTP_1_1).build();
-        when(mockCall.execute()).thenReturn(response);
-
-        Checkpoint async = context.checkpoint();
-        createResourceOperations(vertx, mockClient)
-            .updateStatusAsync(resource())
-            .onComplete(context.succeeding(kafka -> async.flag()));
-
-    }
-
-    @Test
-    public void testUpdateStatusThrowsWhenHttp422ResponseWithOtherField(VertxTestContext context) throws IOException {
-        KubernetesClient mockClient = mock(KubernetesClient.class);
-
-        OkHttpClient mockOkHttp = mock(OkHttpClient.class);
-        when(mockClient.adapt(eq(OkHttpClient.class))).thenReturn(mockOkHttp);
-        URL fakeUrl = new URL("http", "my-host", 9443, "/");
-        when(mockClient.getMasterUrl()).thenReturn(fakeUrl);
-        Call mockCall = mock(Call.class);
-        when(mockOkHttp.newCall(any(Request.class))).thenReturn(mockCall);
-        ResponseBody body = ResponseBody.create(OperationSupport.JSON, "{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"Kafka." + Constants.RESOURCE_GROUP_NAME + " \\\"my-cluster\\\" is invalid: apiVersion: Invalid value: \\\"" + Constants.RESOURCE_GROUP_NAME + "/" + Constants.V1ALPHA1 + "\\\": must be " + Constants.RESOURCE_GROUP_NAME + "/" + Constants.V1BETA1 + "\",\"reason\":\"Invalid\",\"details\":{\"name\":\"my-cluster\",\"group\":\"" + Constants.RESOURCE_GROUP_NAME + "\",\"kind\":\"Kafka\",\"causes\":[{\"reason\":\"FieldValueInvalid\",\"message\":\"Invalid value: \\\"" + Constants.RESOURCE_GROUP_NAME + "/" + Constants.V1ALPHA1 + "\\\": must be " + Constants.RESOURCE_GROUP_NAME + "/" + Constants.V1BETA1 + "\",\"field\":\"someOtherField\"}]},\"code\":422}");
-        Response response = new Response.Builder().code(422).request(new Request.Builder().url(fakeUrl).build()).body(body).message("Unprocessable Entity").protocol(Protocol.HTTP_1_1).build();
-        when(mockCall.execute()).thenReturn(response);
-
-        Checkpoint async = context.checkpoint();
-        createResourceOperations(vertx, mockClient)
-            .updateStatusAsync(resource())
-            .onComplete(context.failing(e -> context.verify(() -> {
-                assertThat(e, instanceOf(KubernetesClientException.class));
-                async.flag();
-            })));
-
-    }
-
-    @Test
-    public void testUpdateStatusThrowsWhenHttp422ResponseWithNoBody(VertxTestContext context) throws IOException {
-        KubernetesClient mockClient = mock(KubernetesClient.class);
-
-        OkHttpClient mockOkHttp = mock(OkHttpClient.class);
-        when(mockClient.adapt(eq(OkHttpClient.class))).thenReturn(mockOkHttp);
-        URL fakeUrl = new URL("http", "my-host", 9443, "/");
-        when(mockClient.getMasterUrl()).thenReturn(fakeUrl);
-        Call mockCall = mock(Call.class);
-        when(mockOkHttp.newCall(any(Request.class))).thenReturn(mockCall);
-        ResponseBody body = ResponseBody.create(OperationSupport.JSON, "{ }");
-        Response response = new Response.Builder().code(422).request(new Request.Builder().url(fakeUrl).build()).message("Unprocessable Entity").protocol(Protocol.HTTP_1_1).build();
-        when(mockCall.execute()).thenReturn(response);
-
-        Checkpoint async = context.checkpoint();
-        createResourceOperations(vertx, mockClient)
-            .updateStatusAsync(resource())
-            .onComplete(context.failing(e -> context.verify(() -> {
-                assertThat(e, instanceOf(KubernetesClientException.class));
-                async.flag();
-            })));
-    }
-
-    @Test
-    public void testUpdateStatusThrowsWhenHttp409Response(VertxTestContext context) throws IOException {
-        KubernetesClient mockClient = mock(KubernetesClient.class);
-
-        OkHttpClient mockOkHttp = mock(OkHttpClient.class);
-        when(mockClient.adapt(eq(OkHttpClient.class))).thenReturn(mockOkHttp);
-        URL fakeUrl = new URL("http", "my-host", 9443, "/");
-        when(mockClient.getMasterUrl()).thenReturn(fakeUrl);
-        Call mockCall = mock(Call.class);
-        when(mockOkHttp.newCall(any(Request.class))).thenReturn(mockCall);
-        ResponseBody body = ResponseBody.create(OperationSupport.JSON, "{ }");
-        Response response = new Response.Builder().code(409).request(new Request.Builder().url(fakeUrl).build()).body(body).message("Conflict").protocol(Protocol.HTTP_1_1).build();
-        when(mockCall.execute()).thenReturn(response);
-
-        Checkpoint async = context.checkpoint();
-        createResourceOperations(vertx, mockClient)
-            .updateStatusAsync(resource())
-            .onComplete(context.failing(e -> context.verify(() -> {
-                assertThat(e, instanceOf(KubernetesClientException.class));
-                async.flag();
-            })));
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/NodeOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/NodeOperatorIT.java
@@ -39,6 +39,7 @@ public class NodeOperatorIT extends AbstractNonNamespacedResourceOperatorIT<Kube
                 .endMetadata()
                 .withNewSpec()
                     .withNewUnschedulable(true)
+                    .withNewPodCIDR("172.16.3.0/24")
                 .endSpec()
                 .build();
     }
@@ -52,6 +53,7 @@ public class NodeOperatorIT extends AbstractNonNamespacedResourceOperatorIT<Kube
                 .endMetadata()
                 .withNewSpec()
                     .withNewUnschedulable(true)
+                    .withNewPodCIDR("172.16.3.0/24")
                 .endSpec()
                 .build();
     }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -91,7 +91,7 @@ public class TopicOperatorMockTest {
     public void createMockKube(VertxTestContext context) throws Exception {
         MockKube mockKube = new MockKube();
         mockKube.withCustomResourceDefinition(Crds.kafkaTopic(),
-                        KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
+                        KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class, KafkaTopic::getStatus, KafkaTopic::setStatus);
         kubeClient = mockKube.build();
 
         kafkaCluster = new KafkaCluster();
@@ -205,14 +205,15 @@ public class TopicOperatorMockTest {
         int retention = 100_000_000;
         KafkaTopic kt = new KafkaTopicBuilder()
                 .withNewMetadata()
-                .withName("my-topic")
-                .addToLabels(Labels.STRIMZI_KIND_LABEL, "topic")
-                .addToLabels(Labels.KUBERNETES_NAME_LABEL, "topic-operator")
+                    .withName("my-topic")
+                    .withNamespace("myproject")
+                    .addToLabels(Labels.STRIMZI_KIND_LABEL, "topic")
+                    .addToLabels(Labels.KUBERNETES_NAME_LABEL, "topic-operator")
                 .endMetadata()
                 .withNewSpec()
-                .withPartitions(1)
-                .withReplicas(1)
-                .addToConfig("retention.bytes", retention)
+                    .withPartitions(1)
+                    .withReplicas(1)
+                    .addToConfig("retention.bytes", retention)
                 .endSpec().build();
 
         testCreatedInKube(context, kt);
@@ -320,14 +321,15 @@ public class TopicOperatorMockTest {
         int retention = 100_000_000;
         KafkaTopic kt = new KafkaTopicBuilder()
                 .withNewMetadata()
-                .withName("my-topic")
-                .addToLabels(Labels.STRIMZI_KIND_LABEL, "topic")
+                    .withName("my-topic")
+                    .withNamespace("myproject")
+                    .addToLabels(Labels.STRIMZI_KIND_LABEL, "topic")
                 .endMetadata()
                 .withNewSpec()
-                .withTopicName("my-topic") // the same as metadata.name
-                .withPartitions(1)
-                .withReplicas(1)
-                .addToConfig("retention.bytes", retention)
+                    .withTopicName("my-topic") // the same as metadata.name
+                    .withPartitions(1)
+                    .withReplicas(1)
+                    .addToConfig("retention.bytes", retention)
                 .endSpec().build();
 
         testCreatedInKube(context, kt);
@@ -338,8 +340,9 @@ public class TopicOperatorMockTest {
         int retention = 100_000_000;
         KafkaTopic kt = new KafkaTopicBuilder()
                 .withNewMetadata()
-                .withName("my-topic")
-                .addToLabels(Labels.STRIMZI_KIND_LABEL, "topic")
+                    .withName("my-topic")
+                    .withNamespace("myproject")
+                    .addToLabels(Labels.STRIMZI_KIND_LABEL, "topic")
                 .endMetadata()
                 .withNewSpec()
                     .withTopicName("DIFFERENT") // different to metadata.name


### PR DESCRIPTION
### Type of change

- Task

### Description

When we originally started the using the status sub-resource in our CRDs, Fabric8 did not supported it. So we had to implement our own handling using the OkHttp client. But Fabric8 now supports it, so it might be best to move and use it => while our own support seemed to work fine, the Fabric8 support might be more tested against different versions etc.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally