### PR TITLE
Add support for Pod Topology Spread Constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # CHANGELOG
 
 ## 0.21.0
@@ -14,6 +15,7 @@
 * Support passing metrics configuration as an external ConfigMap
 * Enable CORS configuration for Cruise Control
 * Add support for rolling individual Kafka or ZooKeeper pods through the Cluster Operator using an annotation
+* Add support for Topology Spread Constraints in Pod templates
 
 ### Deprecations and removals
 * The `metrics` field in the Strimzi custom resources has been deprecated and will be removed in the future. For configuring metrics, use the new `metricsConfig` field and pass the configuration via ConfigMap.

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.HostAlias;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.PodSecurityContext;
 import io.fabric8.kubernetes.api.model.Toleration;
+import io.fabric8.kubernetes.api.model.TopologySpreadConstraint;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -35,7 +36,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"metadata", "imagePullSecrets", "securityContext", "terminationGracePeriodSeconds", "affinity",
-        "tolerations", "priorityClassName", "schedulerName", "hostAliases"})
+        "tolerations", "topologySpreadConstraint", "priorityClassName", "schedulerName", "hostAliases"})
 @EqualsAndHashCode
 @DescriptionFile
 public class PodTemplate implements Serializable, UnknownPropertyPreserving {
@@ -47,6 +48,7 @@ public class PodTemplate implements Serializable, UnknownPropertyPreserving {
     private int terminationGracePeriodSeconds = 30;
     private Affinity affinity;
     private List<Toleration> tolerations;
+    private List<TopologySpreadConstraint> topologySpreadConstraints;
     private String priorityClassName;
     private String schedulerName;
     private List<HostAlias> hostAliases;
@@ -122,6 +124,17 @@ public class PodTemplate implements Serializable, UnknownPropertyPreserving {
 
     public void setTolerations(List<Toleration> tolerations) {
         this.tolerations = tolerations;
+    }
+
+    @Description("The pod's topology spread constraints.")
+    @KubeLink(group = "core", version = "v1", kind = "topologyspreadconstraint")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<TopologySpreadConstraint> getTopologySpreadConstraints() {
+        return topologySpreadConstraints;
+    }
+
+    public void setTopologySpreadConstraints(List<TopologySpreadConstraint> topologySpreadConstraints) {
+        this.topologySpreadConstraints = topologySpreadConstraints;
     }
 
     @Description("The name of the priority class used to assign priority to the pods. " +

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
@@ -1319,6 +1319,37 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for Kafka `Pods`.
                       bootstrapService:
                         type: object
@@ -2380,6 +2411,37 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for ZooKeeper `Pods`.
                       clientService:
                         type: object
@@ -3554,6 +3616,37 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for Entity Operator `Pods`.
                       tlsSidecarContainer:
                         type: object
@@ -4459,6 +4552,37 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for Cruise Control `Pods`.
                       apiService:
                         type: object
@@ -5201,6 +5325,37 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for JmxTrans `Pods`.
                       container:
                         type: object
@@ -5693,6 +5848,37 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for Kafka Exporter `Pods`.
                       service:
                         type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
@@ -1300,6 +1300,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for Kafka `Pods`.
                       bootstrapService:
                         type: object
@@ -2325,6 +2355,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for ZooKeeper `Pods`.
                       clientService:
                         type: object
@@ -3469,6 +3529,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for Entity Operator `Pods`.
                       tlsSidecarContainer:
                         type: object
@@ -4360,6 +4450,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for Cruise Control `Pods`.
                       apiService:
                         type: object
@@ -5087,6 +5207,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for JmxTrans `Pods`.
                       container:
                         type: object
@@ -5569,6 +5719,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for Kafka Exporter `Pods`.
                       service:
                         type: object
@@ -8254,6 +8434,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for Kafka `Pods`.
                       bootstrapService:
                         type: object
@@ -9581,6 +9791,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for ZooKeeper `Pods`.
                       clientService:
                         type: object
@@ -11337,6 +11577,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for Entity Operator `Pods`.
                       tlsSidecarContainer:
                         type: object
@@ -12228,6 +12498,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for Cruise Control `Pods`.
                       apiService:
                         type: object
@@ -12959,6 +13259,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for JmxTrans `Pods`.
                       container:
                         type: object
@@ -13441,6 +13771,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for Kafka Exporter `Pods`.
                       service:
                         type: object
@@ -16126,6 +16486,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for Kafka `Pods`.
                       bootstrapService:
                         type: object
@@ -17453,6 +17843,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for ZooKeeper `Pods`.
                       clientService:
                         type: object
@@ -19209,6 +19629,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for Entity Operator `Pods`.
                       tlsSidecarContainer:
                         type: object
@@ -20100,6 +20550,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for Cruise Control `Pods`.
                       apiService:
                         type: object
@@ -20831,6 +21311,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for JmxTrans `Pods`.
                       container:
                         type: object
@@ -21313,6 +21823,36 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          topologySpreadConstraints:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                maxSkew:
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                            description: The pod's topology spread constraints.
                         description: Template for Kafka Exporter `Pods`.
                       service:
                         type: object

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -39,6 +39,7 @@ import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 import io.fabric8.kubernetes.api.model.Toleration;
+import io.fabric8.kubernetes.api.model.TopologySpreadConstraint;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
@@ -260,6 +261,7 @@ public abstract class AbstractModel {
     protected String templatePodPriorityClassName;
     protected String templatePodSchedulerName;
     protected List<HostAlias> templatePodHostAliases;
+    protected List<TopologySpreadConstraint> templatePodTopologySpreadConstraints;
     protected PodManagementPolicy templatePodManagementPolicy = PodManagementPolicy.PARALLEL;
 
     protected List<Condition> warningConditions = new ArrayList<>(0);
@@ -1012,6 +1014,7 @@ public abstract class AbstractModel {
                             .withPriorityClassName(templatePodPriorityClassName)
                             .withSchedulerName(templatePodSchedulerName != null ? templatePodSchedulerName : "default-scheduler")
                             .withHostAliases(templatePodHostAliases)
+                            .withTopologySpreadConstraints(templatePodTopologySpreadConstraints)
                         .endSpec()
                     .endTemplate()
                     .withVolumeClaimTemplates(volumeClaims)
@@ -1061,6 +1064,7 @@ public abstract class AbstractModel {
                             .withPriorityClassName(templatePodPriorityClassName)
                             .withSchedulerName(templatePodSchedulerName)
                             .withHostAliases(templatePodHostAliases)
+                            .withTopologySpreadConstraints(templatePodTopologySpreadConstraints)
                         .endSpec()
                     .endTemplate()
                 .endSpec()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -149,6 +149,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                             .withPriorityClassName(templatePodPriorityClassName)
                             .withSchedulerName(templatePodSchedulerName)
                             .withHostAliases(templatePodHostAliases)
+                            .withTopologySpreadConstraints(templatePodTopologySpreadConstraints)
                         .endSpec()
                     .endTemplate()
                     .withTriggers(configChangeTrigger, imageChangeTrigger)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -258,6 +258,7 @@ public class ModelUtils {
             model.templatePodPriorityClassName = pod.getPriorityClassName();
             model.templatePodSchedulerName = pod.getSchedulerName();
             model.templatePodHostAliases = pod.getHostAliases();
+            model.templatePodTopologySpreadConstraints = pod.getTopologySpreadConstraints();
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -14,6 +14,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.HostAlias;
 import io.fabric8.kubernetes.api.model.HostAliasBuilder;
 import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -23,6 +24,8 @@ import io.fabric8.kubernetes.api.model.SecretKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.TopologySpreadConstraint;
+import io.fabric8.kubernetes.api.model.TopologySpreadConstraintBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -528,6 +531,20 @@ public class KafkaConnectS2IClusterTest {
                 .withIp("192.168.1.87")
                 .build();
 
+        TopologySpreadConstraint tsc1 = new TopologySpreadConstraintBuilder()
+                .withTopologyKey("kubernetes.io/zone")
+                .withMaxSkew(1)
+                .withWhenUnsatisfiable("DoNotSchedule")
+                .withLabelSelector(new LabelSelectorBuilder().withMatchLabels(singletonMap("label", "value")).build())
+                .build();
+
+        TopologySpreadConstraint tsc2 = new TopologySpreadConstraintBuilder()
+                .withTopologyKey("kubernetes.io/hostname")
+                .withMaxSkew(2)
+                .withWhenUnsatisfiable("ScheduleAnyway")
+                .withLabelSelector(new LabelSelectorBuilder().withMatchLabels(singletonMap("label", "value")).build())
+                .build();
+
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
                 .editSpec()
                     .withNewTemplate()
@@ -546,6 +563,7 @@ public class KafkaConnectS2IClusterTest {
                             .withNewPriorityClassName("top-priority")
                             .withNewSchedulerName("my-scheduler")
                             .withHostAliases(hostAlias1, hostAlias2)
+                            .withTopologySpreadConstraints(tsc1, tsc2)
                         .endPod()
                         .withNewApiService()
                             .withNewMetadata()
@@ -577,6 +595,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(dep.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnots.entrySet()), is(true));
         assertThat(dep.getSpec().getTemplate().getSpec().getSchedulerName(), is("my-scheduler"));
         assertThat(dep.getSpec().getTemplate().getSpec().getHostAliases(), containsInAnyOrder(hostAlias1, hostAlias2));
+        assertThat(dep.getSpec().getTemplate().getSpec().getTopologySpreadConstraints(), containsInAnyOrder(tsc1, tsc2));
 
         // Check Service
         Service svc = kc.generateService();

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1274,6 +1274,10 @@ include::../api/io.strimzi.api.kafka.model.template.PodTemplate.adoc[leveloffset
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#HostAlias-v1-core[HostAlias] array
+|topologySpreadConstraints      1.2+<.<|The pod's topology spread constraints. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#topologyspreadconstraint-v1-core[external documentation for core/v1 topologyspreadconstraint].
+
+
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#topologyspreadconstraint-v1-core[TopologySpreadConstraint] array
 |====
 
 [id='type-ResourceTemplate-{context}']

--- a/documentation/modules/configuring/ref-affinity.adoc
+++ b/documentation/modules/configuring/ref-affinity.adoc
@@ -23,7 +23,7 @@ The affinity configuration can include different types of affinity:
 * Pod affinity and anti-affinity
 * Node affinity
 
-NOTE: On Kubernetes 1.16 and 1.17, teh support for `topologySpreadConstraint` is disabled by default.
+NOTE: On Kubernetes 1.16 and 1.17, the support for `topologySpreadConstraint` is disabled by default.
 In order to use `topologySpreadConstraint`, you have to enable the `EvenPodsSpread` feature gate in Kubernetes API server and scheduler.
 
 .Additional resources

--- a/documentation/modules/configuring/ref-affinity.adoc
+++ b/documentation/modules/configuring/ref-affinity.adoc
@@ -3,10 +3,10 @@
 // assembly-scheduling.adoc
 
 [id='affinity-{context}']
-= Specifying affinity and tolerations
+= Specifying affinity, tolerations, and topology spread constraints
 
-Use affinity and tolerations to schedule the pods of kafka resources onto nodes.
-Affinity and tolerations are configured using the `affinity` and `tolerations` properties in following resources:
+Use affinity, tolerations and topology spread constraints to schedule the pods of kafka resources onto nodes.
+Affinity, tolerations and topology spread constraints are configured using the `affinity`, `tolerations`, and `topologySpreadConstraint` properties in following resources:
 
 * `Kafka.spec.kafka.template.pod`
 * `Kafka.spec.zookeeper.template.pod`
@@ -14,17 +14,23 @@ Affinity and tolerations are configured using the `affinity` and `tolerations` p
 * `KafkaConnect.spec.template.pod`
 * `KafkaConnectS2I.spec.template.pod`
 * `KafkaBridge.spec.template.pod`
+* `KafkaMirrorMaker.spec.template.pod`
+* `KafkaMirrorMaker2.spec.template.pod`
 
-The format of the `affinity` and `tolerations` properties follows the Kubernetes specification.
+The format of the `affinity`, `tolerations`, and `topologySpreadConstraint` properties follows the Kubernetes specification.
 The affinity configuration can include different types of affinity:
 
 * Pod affinity and anti-affinity
 * Node affinity
 
+NOTE: On Kubernetes 1.16 and 1.17, teh support for `topologySpreadConstraint` is disabled by default.
+In order to use `topologySpreadConstraint`, you have to enable the `EvenPodsSpread` feature gate in Kubernetes API server and scheduler.
+
 .Additional resources
 
 * {K8sAffinity}
 * {K8sTolerations}
+* {K8sTopologySpreadConstraints}
 
 [id='con-scheduling-based-on-other-pods-{context}']
 == Use pod anti-affinity to avoid critical applications sharing nodes

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -53,6 +53,7 @@
 :KafkaRacks: link:https://kafka.apache.org/documentation/#basic_ops_racks[Kafka racks documentation^]
 :K8sAffinity: link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Kubernetes node and pod affinity documentation^]
 :K8sTolerations: link:https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[Kubernetes taints and tolerations^]
+:K8sTopologySpreadConstraints: link:https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/[Kubernetes Topology Spread Constraints^]
 :K8sEmptyDir: link:https://kubernetes.io/docs/concepts/storage/volumes/#emptydir[emptyDir^]
 :K8sPersistentVolumeClaims: link:https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/[Persistent Volume Claims^]
 :K8sLocalPersistentVolumes: link:https://kubernetes.io/docs/concepts/storage/volumes/#local[Local persistent volumes^]

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -1917,6 +1917,36 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for Kafka `Pods`.
                     bootstrapService:
                       type: object
@@ -3083,6 +3113,36 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for ZooKeeper `Pods`.
                     clientService:
                       type: object
@@ -4671,6 +4731,36 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for Entity Operator `Pods`.
                     tlsSidecarContainer:
                       type: object
@@ -5462,6 +5552,36 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for Cruise Control `Pods`.
                     apiService:
                       type: object
@@ -6102,6 +6222,36 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for JmxTrans `Pods`.
                     container:
                       type: object
@@ -6545,6 +6695,36 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for Kafka Exporter `Pods`.
                     service:
                       type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -894,6 +894,36 @@ spec:
                           ip:
                             type: string
                       description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                    topologySpreadConstraints:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          maxSkew:
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                      description: The pod's topology spread constraints.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -720,6 +720,36 @@ spec:
                           ip:
                             type: string
                       description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                    topologySpreadConstraints:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          maxSkew:
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                      description: The pod's topology spread constraints.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -1053,6 +1053,36 @@ spec:
                           ip:
                             type: string
                       description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                    topologySpreadConstraints:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          maxSkew:
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                      description: The pod's topology spread constraints.
                   description: Template for Kafka MirrorMaker `Pods`.
                 mirrorMakerContainer:
                   type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -694,6 +694,36 @@ spec:
                           ip:
                             type: string
                       description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                    topologySpreadConstraints:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          maxSkew:
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                      description: The pod's topology spread constraints.
                   description: Template for Kafka Bridge `Pods`.
                 apiService:
                   type: object

--- a/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm2/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -976,6 +976,36 @@ spec:
                           ip:
                             type: string
                       description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                    topologySpreadConstraints:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          maxSkew:
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                      description: The pod's topology spread constraints.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1913,6 +1913,36 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for Kafka `Pods`.
                     bootstrapService:
                       type: object
@@ -3079,6 +3109,36 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for ZooKeeper `Pods`.
                     clientService:
                       type: object
@@ -4667,6 +4727,36 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for Entity Operator `Pods`.
                     tlsSidecarContainer:
                       type: object
@@ -5458,6 +5548,36 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for Cruise Control `Pods`.
                     apiService:
                       type: object
@@ -6098,6 +6218,36 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for JmxTrans `Pods`.
                     container:
                       type: object
@@ -6541,6 +6691,36 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for Kafka Exporter `Pods`.
                     service:
                       type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -890,6 +890,36 @@ spec:
                           ip:
                             type: string
                       description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                    topologySpreadConstraints:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          maxSkew:
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                      description: The pod's topology spread constraints.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -716,6 +716,36 @@ spec:
                           ip:
                             type: string
                       description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                    topologySpreadConstraints:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          maxSkew:
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                      description: The pod's topology spread constraints.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -1049,6 +1049,36 @@ spec:
                           ip:
                             type: string
                       description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                    topologySpreadConstraints:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          maxSkew:
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                      description: The pod's topology spread constraints.
                   description: Template for Kafka MirrorMaker `Pods`.
                 mirrorMakerContainer:
                   type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -690,6 +690,36 @@ spec:
                           ip:
                             type: string
                       description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                    topologySpreadConstraints:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          maxSkew:
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                      description: The pod's topology spread constraints.
                   description: Template for Kafka Bridge `Pods`.
                 apiService:
                   type: object

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -972,6 +972,36 @@ spec:
                           ip:
                             type: string
                       description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                    topologySpreadConstraints:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          maxSkew:
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                      description: The pod's topology spread constraints.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -2465,6 +2465,36 @@ spec:
                           description: The pod's HostAliases. HostAliases is an optional
                             list of hosts and IPs that will be injected into the pod's
                             hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for Kafka `Pods`.
                     bootstrapService:
                       type: object
@@ -3789,6 +3819,36 @@ spec:
                           description: The pod's HostAliases. HostAliases is an optional
                             list of hosts and IPs that will be injected into the pod's
                             hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for ZooKeeper `Pods`.
                     clientService:
                       type: object
@@ -5543,6 +5603,36 @@ spec:
                           description: The pod's HostAliases. HostAliases is an optional
                             list of hosts and IPs that will be injected into the pod's
                             hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for Entity Operator `Pods`.
                     tlsSidecarContainer:
                       type: object
@@ -6431,6 +6521,36 @@ spec:
                           description: The pod's HostAliases. HostAliases is an optional
                             list of hosts and IPs that will be injected into the pod's
                             hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for Cruise Control `Pods`.
                     apiService:
                       type: object
@@ -7159,6 +7279,36 @@ spec:
                           description: The pod's HostAliases. HostAliases is an optional
                             list of hosts and IPs that will be injected into the pod's
                             hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for JmxTrans `Pods`.
                     container:
                       type: object
@@ -7641,6 +7791,36 @@ spec:
                           description: The pod's HostAliases. HostAliases is an optional
                             list of hosts and IPs that will be injected into the pod's
                             hosts file if specified.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              maxSkew:
+                                type: integer
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
                       description: Template for Kafka Exporter `Pods`.
                     service:
                       type: object

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -975,6 +975,36 @@ spec:
                       description: The pod's HostAliases. HostAliases is an optional
                         list of hosts and IPs that will be injected into the pod's
                         hosts file if specified.
+                    topologySpreadConstraints:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          maxSkew:
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                      description: The pod's topology spread constraints.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -763,6 +763,36 @@ spec:
                       description: The pod's HostAliases. HostAliases is an optional
                         list of hosts and IPs that will be injected into the pod's
                         hosts file if specified.
+                    topologySpreadConstraints:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          maxSkew:
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                      description: The pod's topology spread constraints.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -1169,6 +1169,36 @@ spec:
                       description: The pod's HostAliases. HostAliases is an optional
                         list of hosts and IPs that will be injected into the pod's
                         hosts file if specified.
+                    topologySpreadConstraints:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          maxSkew:
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                      description: The pod's topology spread constraints.
                   description: Template for Kafka MirrorMaker `Pods`.
                 mirrorMakerContainer:
                   type: object

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -775,6 +775,36 @@ spec:
                       description: The pod's HostAliases. HostAliases is an optional
                         list of hosts and IPs that will be injected into the pod's
                         hosts file if specified.
+                    topologySpreadConstraints:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          maxSkew:
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                      description: The pod's topology spread constraints.
                   description: Template for Kafka Bridge `Pods`.
                 apiService:
                   type: object

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1081,6 +1081,36 @@ spec:
                       description: The pod's HostAliases. HostAliases is an optional
                         list of hosts and IPs that will be injected into the pod's
                         hosts file if specified.
+                    topologySpreadConstraints:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          maxSkew:
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                      description: The pod's topology spread constraints.
                   description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Node Affinity can be used for a basic scheduling of pods to nodes or zones. But once you have more then one pod per zone, it does not necessarily guarantee equal spread of pods across the nodes or zones. That is something where `TopologySpreadConstraints` can help (https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/). This PR adds support for `TopologySpreadConstraints` to the pod templates and allows users to specify them in our custom resources.

This PR closes #4136 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md