### PR TITLE
[DOC] Make it more clear where brokerCertChainAndKey can be used

### DIFF
--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -196,7 +196,7 @@ xref:scaling-clusters-{context}[scale clusters].
 <13> Defines whether the fully-qualified DNS names including the cluster service suffix (usually `.cluster.local`) are assigned.
 <14> Listener authentication mechanism xref:assembly-securing-kafka-brokers-str[specified as mutual TLS, SCRAM-SHA-512 or token-based OAuth 2.0].
 <15> External listener configuration specifies xref:assembly-configuring-external-listeners-str[how the Kafka cluster is exposed outside Kubernetes, such as through a `route`, `loadbalancer` or `nodeport`].
-<16> Optional configuration for a xref:kafka-listener-certificates-str[Kafka listener certificate] managed by an external Certificate Authority. The `brokerCertChainAndKey` specifies a `Secret` that contains a server certificate and a private key. You can configure Kafka listener certificates for both `tls` and `external` listeners.
+<16> Optional configuration for a xref:kafka-listener-certificates-str[Kafka listener certificate] managed by an external Certificate Authority. The `brokerCertChainAndKey` specifies a `Secret` that contains a server certificate and a private key. You can configure Kafka listener certificates on any listener with enabled TLS encryption.
 <17> Authorization xref:con-securing-kafka-authorization-str[enables simple, OAUTH 2.0, or OPA authorization on the Kafka broker.] Simple authorization uses the `AclAuthorizer` Kafka plugin.
 <18> The `config` specifies the broker configuration. xref:property-kafka-config-reference[Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi].
 <19> xref:con-common-configuration-ssl-reference[SSL properties for external listeners to run with a specific _cipher suite_ for a TLS version].

--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -199,7 +199,7 @@ xref:scaling-clusters-{context}[scale clusters].
 <16> Optional configuration for a xref:kafka-listener-certificates-str[Kafka listener certificate] managed by an external Certificate Authority. The `brokerCertChainAndKey` specifies a `Secret` that contains a server certificate and a private key. You can configure Kafka listener certificates on any listener with enabled TLS encryption.
 <17> Authorization xref:con-securing-kafka-authorization-str[enables simple, OAUTH 2.0, or OPA authorization on the Kafka broker.] Simple authorization uses the `AclAuthorizer` Kafka plugin.
 <18> The `config` specifies the broker configuration. xref:property-kafka-config-reference[Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi].
-<19> xref:con-common-configuration-ssl-reference[SSL properties for external listeners to run with a specific _cipher suite_ for a TLS version].
+<19> xref:con-common-configuration-ssl-reference[SSL properties for listeners with TLS encryption enabled to enable a specific _cipher suite_ or TLS version].
 <20> xref:assembly-storage-{context}[Storage] is configured as `ephemeral`, `persistent-claim` or `jbod`.
 <21> Storage size for xref:proc-resizing-persistent-volumes-{context}[persistent volumes may be increased] and additional xref:proc-adding-volumes-to-jbod-storage-{context}[volumes may be added to JBOD storage].
 <22> Persistent storage has xref:ref-persistent-storage-{context}[additional configuration options], such as a storage `id` and `class` for dynamic volume provisioning.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR fixes a part of our documentation which looks like it was not updated to the new listeners configuration and is still referring to `tls` and `external` listeners. It also fixes another invalid reference to external listeners.

This should close #4160 

### Checklist

- [x] Update documentation