### PR TITLE
Use Secret YAMLs with stringData instead of the create secret commands for monitoring

### DIFF
--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus-alertmanager.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus-alertmanager.adoc
@@ -22,10 +22,10 @@ The following resources are defined on deployment:
 
 .Procedure
 
-. Create a `Secret` resource from the Alertmanager configuration file (`alert-manager-config.yaml`):
+. Create a `Secret` resource from the Alertmanager configuration file (`alert-manager-config.yaml` in the `examples/metrics/prometheus-alertmanager-config` directory):
 +
 [source,shell,subs="+quotes,attributes"]
-kubectl create secret generic alertmanager-alertmanager --from-file=alertmanager.yaml=alert-manager-config.yaml
+kubectl apply -f alert-manager-config.yaml
 
 . Update the `alert-manager-config.yaml` file to replace the:
 +

--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus.adoc
@@ -43,10 +43,10 @@ The Grafana dashboards provided show metrics for CPU, memory and disk volume usa
 +
 The Prometheus Operator does not have a monitoring resource like `PodMonitor` for scraping the nodes, so the `prometheus-additional.yaml` file contains the additional configuration needed.
 
-.. Create a `Secret` resource:
+.. Create a `Secret` resource from the configuration file (`prometheus-additional.yaml` in the `examples/metrics/prometheus-additional-properties` directory):
 +
 [source,shell,subs="+quotes,attributes"]
-kubectl create secret generic additional-scrape-configs --from-file=prometheus-additional.yaml
+kubectl apply -f prometheus-additional.yaml
 
 .. Edit the `additionalScrapeConfigs` property in the `prometheus.yaml` file to include the name of the `Secret` and the `prometheus-additional.yaml` file.
 

--- a/examples/metrics/prometheus-additional-properties/prometheus-additional.yaml
+++ b/examples/metrics/prometheus-additional-properties/prometheus-additional.yaml
@@ -1,88 +1,93 @@
-# To update additional settings create a Secret custom resource by using a command below
-# kubectl create secret generic additional-scrape-configs --from-file=prometheus-additional.yaml
-- job_name: kubernetes-cadvisor
-  honor_labels: true
-  scrape_interval: 10s
-  scrape_timeout: 10s
-  metrics_path: /metrics/cadvisor
-  scheme: https
-  kubernetes_sd_configs:
-  - role: node
-    namespaces:
-      names: []
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-  relabel_configs:
-  - separator: ;
-    regex: __meta_kubernetes_node_label_(.+)
-    replacement: $1
-    action: labelmap
-  - separator: ;
-    regex: (.*)
-    target_label: __address__
-    replacement: kubernetes.default.svc:443
-    action: replace
-  - source_labels: [__meta_kubernetes_node_name]
-    separator: ;
-    regex: (.+)
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
-    action: replace
-  - source_labels: [__meta_kubernetes_node_name]
-    separator: ;
-    regex: (.*)
-    target_label: node_name
-    replacement: $1
-    action: replace
-  - source_labels: [__meta_kubernetes_node_address_InternalIP]
-    separator: ;
-    regex: (.*)
-    target_label: node_ip
-    replacement: $1
-    action: replace
-  metric_relabel_configs:
-  - source_labels: [container, __name__]
-    separator: ;
-    regex: POD;container_(network).*
-    target_label: container
-    replacement: $1
-    action: replace
-  - source_labels: [container]
-    separator: ;
-    regex: POD
-    replacement: $1
-    action: drop
-  - source_labels: [container]
-    separator: ;
-    regex: ^$
-    replacement: $1
-    action: drop
-  - source_labels: [__name__]
-    separator: ;
-    regex: container_(network_tcp_usage_total|tasks_state|memory_failures_total|network_udp_usage_total)
-    replacement: $1
-    action: drop
+apiVersion: v1
+kind: Secret
+metadata:
+  name: additional-scrape-configs
+type: Opaque
+stringData:
+  prometheus-additional.yaml: |
+    - job_name: kubernetes-cadvisor
+      honor_labels: true
+      scrape_interval: 10s
+      scrape_timeout: 10s
+      metrics_path: /metrics/cadvisor
+      scheme: https
+      kubernetes_sd_configs:
+      - role: node
+        namespaces:
+          names: []
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+      relabel_configs:
+      - separator: ;
+        regex: __meta_kubernetes_node_label_(.+)
+        replacement: $1
+        action: labelmap
+      - separator: ;
+        regex: (.*)
+        target_label: __address__
+        replacement: kubernetes.default.svc:443
+        action: replace
+      - source_labels: [__meta_kubernetes_node_name]
+        separator: ;
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+        action: replace
+      - source_labels: [__meta_kubernetes_node_name]
+        separator: ;
+        regex: (.*)
+        target_label: node_name
+        replacement: $1
+        action: replace
+      - source_labels: [__meta_kubernetes_node_address_InternalIP]
+        separator: ;
+        regex: (.*)
+        target_label: node_ip
+        replacement: $1
+        action: replace
+      metric_relabel_configs:
+      - source_labels: [container, __name__]
+        separator: ;
+        regex: POD;container_(network).*
+        target_label: container
+        replacement: $1
+        action: replace
+      - source_labels: [container]
+        separator: ;
+        regex: POD
+        replacement: $1
+        action: drop
+      - source_labels: [container]
+        separator: ;
+        regex: ^$
+        replacement: $1
+        action: drop
+      - source_labels: [__name__]
+        separator: ;
+        regex: container_(network_tcp_usage_total|tasks_state|memory_failures_total|network_udp_usage_total)
+        replacement: $1
+        action: drop
 
-- job_name: kubernetes-nodes-kubelet
-  scrape_interval: 10s
-  scrape_timeout: 10s
-  scheme: https
-  kubernetes_sd_configs:
-  - role: node
-    namespaces:
-      names: []
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-  relabel_configs:
-  - action: labelmap
-    regex: __meta_kubernetes_node_label_(.+)
-  - target_label: __address__
-    replacement: kubernetes.default.svc:443
-  - source_labels: [__meta_kubernetes_node_name]
-    regex: (.+)
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}/proxy/metrics
+    - job_name: kubernetes-nodes-kubelet
+      scrape_interval: 10s
+      scrape_timeout: 10s
+      scheme: https
+      kubernetes_sd_configs:
+      - role: node
+        namespaces:
+          names: []
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics

--- a/examples/metrics/prometheus-alertmanager-config/alert-manager-config.yaml
+++ b/examples/metrics/prometheus-alertmanager-config/alert-manager-config.yaml
@@ -1,12 +1,18 @@
-# kubectl create secret generic alertmanager-alertmanager --from-file=alertmanager.yaml=alert-manager-config.yaml
-global:
-  slack_api_url: https://hooks.slack.com/services/change/me/please
-route:
-  receiver: slack
-receivers:
-- name: slack
-  slack_configs:
-  - channel: "#strimzi-alerts"
-    title: "{{ range .Alerts }}{{ .Annotations.summary }}\n{{ end }}"
-    text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
-    send_resolved: true
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-alertmanager
+type: Opaque
+stringData:
+  alertmanager.yaml: |
+    global:
+      slack_api_url: https://hooks.slack.com/services/change/me/please
+    route:
+      receiver: slack
+    receivers:
+    - name: slack
+      slack_configs:
+      - channel: "#strimzi-alerts"
+        title: "{{ range .Alerts }}{{ .Annotations.summary }}\n{{ end }}"
+        text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
+        send_resolved: true


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In the metrics examples, the additional Prometheus configuration and the Alert Manager configuration exist only as the configuration files and `kubect create secret` needs to be used to create a secret containing them. That seems to be very unintuitive since all other files in examples can be directly applied. This PR changes the 2 files to Secret YAMLs with `stringData`. That way, they are still easy to read and edit, but can be also just applied with `kubectl apply` which should make it easier to use them.