### PR TITLE
[systemtest] Test of manual rolling update of single ZK or Kafka pod

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -315,9 +315,11 @@ class AlternativeReconcileTriggersST extends AbstractST {
         String zkSsName = KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME);
 
         Pod kafkaPod = kubeClient().getPod(KafkaResources.kafkaPodName(CLUSTER_NAME, 0));
+        // snapshot of one single Kafka pod
         Map<String, String> kafkaSnapshot = Collections.singletonMap(kafkaPod.getMetadata().getName(), kafkaPod.getMetadata().getUid());
 
         Pod zkPod = kubeClient().getPod(KafkaResources.zookeeperPodName(CLUSTER_NAME, 0));
+        // snapshot of one single ZK pod
         Map<String, String> zkSnapshot = Collections.singletonMap(zkPod.getMetadata().getName(), zkPod.getMetadata().getUid());
 
         LOGGER.info("Trying to roll just single Kafka and single ZK pod");
@@ -327,6 +329,8 @@ class AlternativeReconcileTriggersST extends AbstractST {
             .endMetadata()
             .done();
 
+        // here we are waiting just to one pod's snapshot will be changed and all 3 pods ready -> if we set expectedPods to 1,
+        // the check will pass immediately without waiting for all pods to be ready -> the method picks first ready pod and return true
         kafkaSnapshot = StatefulSetUtils.waitTillSsHasRolled(kafkaSsName, 3, kafkaSnapshot);
 
         kubeClient().editPod(KafkaResources.zookeeperPodName(CLUSTER_NAME, 0))
@@ -335,6 +339,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
             .endMetadata()
             .done();
 
+        // same as above
         zkSnapshot = StatefulSetUtils.waitTillSsHasRolled(zkSsName, 3, zkSnapshot);
 
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.rollingupdate;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.api.model.Pod;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.listener.arraylistener.ArrayOrObjectKafkaListeners;
@@ -39,6 +40,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
@@ -305,8 +307,63 @@ class AlternativeReconcileTriggersST extends AbstractST {
         }
     }
 
+    @Test
+    void testManualRollingUpdateForSinglePod() {
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3).done();
+
+        String kafkaSsName = KafkaResources.kafkaStatefulSetName(CLUSTER_NAME);
+        String zkSsName = KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME);
+
+        Pod kafkaPod = kubeClient().getPod(KafkaResources.kafkaPodName(CLUSTER_NAME, 0));
+        Map<String, String> kafkaSnapshot = Collections.singletonMap(kafkaPod.getMetadata().getName(), kafkaPod.getMetadata().getUid());
+
+        Pod zkPod = kubeClient().getPod(KafkaResources.zookeeperPodName(CLUSTER_NAME, 0));
+        Map<String, String> zkSnapshot = Collections.singletonMap(zkPod.getMetadata().getName(), zkPod.getMetadata().getUid());
+
+        LOGGER.info("Trying to roll just single Kafka and single ZK pod");
+        kubeClient().editPod(KafkaResources.kafkaPodName(CLUSTER_NAME, 0))
+            .editMetadata()
+                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
+            .endMetadata()
+            .done();
+
+        kafkaSnapshot = StatefulSetUtils.waitTillSsHasRolled(kafkaSsName, 3, kafkaSnapshot);
+
+        kubeClient().editPod(KafkaResources.zookeeperPodName(CLUSTER_NAME, 0))
+            .editMetadata()
+                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
+            .endMetadata()
+            .done();
+
+        zkSnapshot = StatefulSetUtils.waitTillSsHasRolled(zkSsName, 3, zkSnapshot);
+
+
+        LOGGER.info("Adding anno to all ZK and Kafka pods");
+        kafkaSnapshot.keySet().forEach(podName -> {
+            kubeClient().editPod(podName)
+                .editMetadata()
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
+                .endMetadata()
+                .done();
+        });
+
+        LOGGER.info("Checking if the rolling update will be successful for Kafka");
+        StatefulSetUtils.waitTillSsHasRolled(kafkaSsName, 3, kafkaSnapshot);
+
+        zkSnapshot.keySet().forEach(podName -> {
+            kubeClient().editPod(podName)
+                .editMetadata()
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
+                .endMetadata()
+                .done();
+        });
+
+        LOGGER.info("Checking if the rolling update will be successful for ZK");
+        StatefulSetUtils.waitTillSsHasRolled(zkSsName, 3, zkSnapshot);
+    }
+
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
     }

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -150,6 +150,10 @@ public class KubeClient {
     // ---------> POD <---------
     // =========================
 
+    public DoneablePod editPod(String podName) {
+        return client.pods().inNamespace(getNamespace()).withName(podName).withPropagationPolicy(DeletionPropagation.ORPHAN).edit();
+    }
+
     public String execInPod(String podName, String container, String... command) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         LOGGER.info("Running command on pod {}: {}", podName, command);


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test

### Description

After #4070 we are able to roll single ZK or Kafka pod, by triggering it with annotation - which can sometimes come really handy.
This PR adds new test for this feature - firstly it testing rolling just the single ZK/Kafka pod and then all three pods (the pods should be rolled one by another like in normal RU).

### Checklist

- [X] Write tests
- [x] Make sure all tests pass
