### PR TITLE
[systemtest] Refactor of resource classes and STs - prerequisite for fabric8 upgrade

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaClientsResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaClientsResource.java
@@ -12,7 +12,6 @@ import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
-import io.fabric8.kubernetes.api.model.apps.DoneableDeployment;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserScramSha512ClientAuthentication;
 import io.strimzi.api.kafka.model.KafkaUserTlsClientAuthentication;
@@ -38,28 +37,28 @@ public class KafkaClientsResource {
 
     private static final Logger LOGGER = LogManager.getLogger(KafkaClientsResource.class);
 
-    public static DoneableDeployment deployKafkaClients(String kafkaClusterName) {
+    public static DeploymentBuilder deployKafkaClients(String kafkaClusterName) {
         return deployKafkaClients(false, kafkaClusterName, null);
     }
 
-    public static DoneableDeployment deployKafkaClients(boolean tlsListener, String kafkaClientsName, KafkaUser... kafkaUsers) {
+    public static DeploymentBuilder deployKafkaClients(boolean tlsListener, String kafkaClientsName, KafkaUser... kafkaUsers) {
         return deployKafkaClients(tlsListener, kafkaClientsName, true,  null, null, kafkaUsers);
     }
 
-    public static DoneableDeployment deployKafkaClients(boolean tlsListener, String kafkaClientsName, String listenerName,
+    public static DeploymentBuilder deployKafkaClients(boolean tlsListener, String kafkaClientsName, String listenerName,
                                                         KafkaUser... kafkaUsers) {
         return deployKafkaClients(tlsListener, kafkaClientsName, true, listenerName, null, kafkaUsers);
     }
 
-    public static DoneableDeployment deployKafkaClients(boolean tlsListener, String kafkaClientsName, boolean hostnameVerification,
+    public static DeploymentBuilder deployKafkaClients(boolean tlsListener, String kafkaClientsName, boolean hostnameVerification,
                                                         KafkaUser... kafkaUsers) {
         return deployKafkaClients(tlsListener, kafkaClientsName, hostnameVerification, null, null, kafkaUsers);
     }
 
-    public static DoneableDeployment deployKafkaClients(boolean tlsListener, String kafkaClientsName, boolean hostnameVerification,
+    public static DeploymentBuilder deployKafkaClients(boolean tlsListener, String kafkaClientsName, boolean hostnameVerification,
                                                         String listenerName, String secretPrefix, KafkaUser... kafkaUsers) {
         Map<String, String> label = Collections.singletonMap(Constants.KAFKA_CLIENTS_LABEL_KEY, Constants.KAFKA_CLIENTS_LABEL_VALUE);
-        Deployment kafkaClient = new DeploymentBuilder()
+        return new DeploymentBuilder()
             .withNewMetadata()
                 .withName(kafkaClientsName)
                 .withLabels(label)
@@ -77,10 +76,7 @@ public class KafkaClientsResource {
                     .endMetadata()
                     .withSpec(createClientSpec(tlsListener, kafkaClientsName, hostnameVerification, listenerName, secretPrefix, kafkaUsers))
                 .endTemplate()
-            .endSpec()
-            .build();
-
-        return KubernetesResource.deployNewDeployment(kafkaClient);
+            .endSpec();
     }
 
     private static PodSpec createClientSpec(boolean tlsListener, String kafkaClientsName, boolean hostnameVerification,
@@ -240,5 +236,9 @@ public class KafkaClientsResource {
             "sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \\\n" +
             "username=\"" + kafkaUser.getMetadata().getName() + "\" \\\n" +
             "password=\"" + password + "\";\n";
+    }
+
+    public static Deployment create(Deployment deployment) {
+        return KubernetesResource.deployNewDeployment(deployment);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -38,34 +38,26 @@ public class KafkaConnectResource {
         return Crds.kafkaConnectOperation(ResourceManager.kubeClient().getClient());
     }
 
-    public static DoneableKafkaConnect kafkaConnect(String name, int kafkaConnectReplicas) {
-        return kafkaConnect(name, name, kafkaConnectReplicas, true);
+    public static KafkaConnectBuilder kafkaConnect(String name, int kafkaConnectReplicas) {
+        return kafkaConnect(name, name, kafkaConnectReplicas);
     }
 
-    public static DoneableKafkaConnect kafkaConnect(String name, int kafkaConnectReplicas, boolean allowNP) {
-        return kafkaConnect(name, name, kafkaConnectReplicas, allowNP);
-    }
-
-    public static DoneableKafkaConnect kafkaConnect(String name, String clusterName, int kafkaConnectReplicas, boolean allowNP) {
+    public static KafkaConnectBuilder kafkaConnect(String name, String clusterName, int kafkaConnectReplicas) {
         KafkaConnect kafkaConnect = getKafkaConnectFromYaml(PATH_TO_KAFKA_CONNECT_CONFIG);
-        kafkaConnect = defaultKafkaConnect(kafkaConnect, name, clusterName, kafkaConnectReplicas).build();
-        return allowNP ? deployKafkaConnectWithNetworkPolicy(kafkaConnect) : deployKafkaConnect(kafkaConnect);
+        return defaultKafkaConnect(kafkaConnect, name, clusterName, kafkaConnectReplicas);
     }
 
-    public static DoneableKafkaConnect kafkaConnectWithMetrics(String name, int kafkaConnectReplicas) {
+    public static KafkaConnectBuilder kafkaConnectWithMetrics(String name, int kafkaConnectReplicas) {
         return kafkaConnectWithMetrics(name, name, kafkaConnectReplicas);
     }
 
-    public static DoneableKafkaConnect kafkaConnectWithMetrics(String name, String clusterName, int kafkaConnectReplicas) {
+    public static KafkaConnectBuilder kafkaConnectWithMetrics(String name, String clusterName, int kafkaConnectReplicas) {
         KafkaConnect kafkaConnect = getKafkaConnectFromYaml(PATH_TO_KAFKA_CONNECT_METRICS_CONFIG);
+
         ConfigMap metricsCm = TestUtils.configMapFromYaml(PATH_TO_KAFKA_CONNECT_METRICS_CONFIG, "connect-metrics");
         KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(kubeClient().getNamespace()).createOrReplace(metricsCm);
-        return deployKafkaConnectWithNetworkPolicy(defaultKafkaConnect(kafkaConnect, name, clusterName, kafkaConnectReplicas).build());
-    }
 
-    public static KafkaConnectBuilder defaultKafkaConnect(String name, String kafkaClusterName, int kafkaConnectReplicas) {
-        KafkaConnect kafkaConnect = getKafkaConnectFromYaml(PATH_TO_KAFKA_CONNECT_CONFIG);
-        return defaultKafkaConnect(kafkaConnect, name, kafkaClusterName, kafkaConnectReplicas);
+        return defaultKafkaConnect(kafkaConnect, name, clusterName, kafkaConnectReplicas);
     }
 
     private static KafkaConnectBuilder defaultKafkaConnect(KafkaConnect kafkaConnect, String name, String kafkaClusterName, int kafkaConnectReplicas) {
@@ -92,43 +84,35 @@ public class KafkaConnectResource {
             .endSpec();
     }
 
-    private static DoneableKafkaConnect deployKafkaConnectWithNetworkPolicy(KafkaConnect kafkaConnect) {
-        if (Environment.DEFAULT_TO_DENY_NETWORK_POLICIES) {
-            KubernetesResource.allowNetworkPolicySettingsForResource(kafkaConnect, KafkaConnectResources.deploymentName(kafkaConnect.getMetadata().getName()));
-        }
-        return deployKafkaConnect(kafkaConnect);
+    public static KafkaConnect create(KafkaConnect kafkaConnect) {
+        return create(kafkaConnect, true);
     }
 
-    private static DoneableKafkaConnect deployKafkaConnect(KafkaConnect kafkaConnect) {
-        return new DoneableKafkaConnect(kafkaConnect, kC -> {
-            TestUtils.waitFor("KafkaConnect creation", Constants.POLL_INTERVAL_FOR_RESOURCE_CREATION, CR_CREATION_TIMEOUT,
-                () -> {
-                    try {
-                        kafkaConnectClient().inNamespace(ResourceManager.kubeClient().getNamespace()).createOrReplace(kC);
-                        return true;
-                    } catch (KubernetesClientException e) {
-                        if (e.getMessage().contains("object is being deleted")) {
-                            return false;
-                        } else {
-                            throw e;
-                        }
+    public static KafkaConnect create(KafkaConnect kafkaConnect, boolean allowNP) {
+        if (allowNP) {
+            KubernetesResource.deployNetworkPolicyForResource(kafkaConnect, KafkaConnectResources.deploymentName(kafkaConnect.getMetadata().getName()));
+        }
+
+        TestUtils.waitFor("KafkaConnect creation", Constants.POLL_INTERVAL_FOR_RESOURCE_CREATION, CR_CREATION_TIMEOUT,
+            () -> {
+                try {
+                    kafkaConnectClient().inNamespace(ResourceManager.kubeClient().getNamespace()).createOrReplace(kafkaConnect);
+                    return true;
+                } catch (KubernetesClientException e) {
+                    if (e.getMessage().contains("object is being deleted")) {
+                        return false;
+                    } else {
+                        throw e;
                     }
                 }
-            );
-            return waitFor(deleteLater(kC));
-        });
+            }
+        );
+        return waitFor(deleteLater(kafkaConnect));
     }
 
     public static KafkaConnect kafkaConnectWithoutWait(KafkaConnect kafkaConnect) {
         kafkaConnectClient().inNamespace(ResourceManager.kubeClient().getNamespace()).createOrReplace(kafkaConnect);
         return kafkaConnect;
-    }
-
-
-    public static void allowNetworkPolicyForKafkaConnect(KafkaConnect kafkaConnect) {
-        if (Environment.DEFAULT_TO_DENY_NETWORK_POLICIES) {
-            KubernetesResource.allowNetworkPolicySettingsForResource(kafkaConnect, KafkaConnectResources.deploymentName(kafkaConnect.getMetadata().getName()));
-        }
     }
 
     public static void deleteKafkaConnectWithoutWait(String resourceName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
@@ -34,14 +34,9 @@ public class KafkaConnectS2IResource {
         return Crds.kafkaConnectS2iOperation(ResourceManager.kubeClient().getClient());
     }
 
-    public static DoneableKafkaConnectS2I kafkaConnectS2I(String name, String clusterName, int kafkaConnectS2IReplicas) {
+    public static KafkaConnectS2IBuilder kafkaConnectS2I(String name, String clusterName, int kafkaConnectS2IReplicas) {
         KafkaConnectS2I kafkaConnectS2I = getKafkaConnectS2IFromYaml(PATH_TO_KAFKA_CONNECT_S2I_CONFIG);
-        return deployKafkaConnectS2I(defaultKafkaConnectS2I(kafkaConnectS2I, name, clusterName, kafkaConnectS2IReplicas).build());
-    }
-
-    public static KafkaConnectS2IBuilder defaultKafkaConnectS2I(String name, String kafkaClusterName, int kafkaConnectReplicas) {
-        KafkaConnectS2I kafkaConnectS2I = getKafkaConnectS2IFromYaml(PATH_TO_KAFKA_CONNECT_S2I_CONFIG);
-        return defaultKafkaConnectS2I(kafkaConnectS2I, name, kafkaClusterName, kafkaConnectReplicas);
+        return defaultKafkaConnectS2I(kafkaConnectS2I, name, clusterName, kafkaConnectS2IReplicas);
     }
 
     public static KafkaConnectS2IBuilder defaultKafkaConnectS2I(KafkaConnectS2I kafkaConnectS2I, String name, String kafkaClusterName, int kafkaConnectReplicas) {
@@ -66,27 +61,24 @@ public class KafkaConnectS2IResource {
             .endSpec();
     }
 
-    private static DoneableKafkaConnectS2I deployKafkaConnectS2I(KafkaConnectS2I kafkaConnectS2I) {
-        if (Environment.DEFAULT_TO_DENY_NETWORK_POLICIES) {
-            KubernetesResource.allowNetworkPolicySettingsForResource(kafkaConnectS2I, KafkaConnectS2IResources.deploymentName(kafkaConnectS2I.getMetadata().getName()));
-        }
-        return new DoneableKafkaConnectS2I(kafkaConnectS2I, kC -> {
-            TestUtils.waitFor("KafkaConnect creation", Constants.POLL_INTERVAL_FOR_RESOURCE_CREATION, CR_CREATION_TIMEOUT,
-                () -> {
-                    try {
-                        kafkaConnectS2IClient().inNamespace(ResourceManager.kubeClient().getNamespace()).createOrReplace(kC);
-                        return true;
-                    } catch (KubernetesClientException e) {
-                        if (e.getMessage().contains("object is being deleted")) {
-                            return false;
-                        } else {
-                            throw e;
-                        }
+    public static KafkaConnectS2I create(KafkaConnectS2I kafkaConnectS2I) {
+        KubernetesResource.allowNetworkPolicySettingsForResource(kafkaConnectS2I, KafkaConnectS2IResources.deploymentName(kafkaConnectS2I.getMetadata().getName()));
+
+        TestUtils.waitFor("KafkaConnect creation", Constants.POLL_INTERVAL_FOR_RESOURCE_CREATION, CR_CREATION_TIMEOUT,
+            () -> {
+                try {
+                    kafkaConnectS2IClient().inNamespace(ResourceManager.kubeClient().getNamespace()).createOrReplace(kafkaConnectS2I);
+                    return true;
+                } catch (KubernetesClientException e) {
+                    if (e.getMessage().contains("object is being deleted")) {
+                        return false;
+                    } else {
+                        throw e;
                     }
                 }
-            );
-            return waitFor(deleteLater(kC));
-        });
+            }
+        );
+        return waitFor(deleteLater(kafkaConnectS2I));
     }
 
     public static KafkaConnectS2I kafkaConnectS2IWithoutWait(KafkaConnectS2I kafkaConnectS2I) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
@@ -30,20 +30,20 @@ public class KafkaTopicResource {
         return Crds.topicOperation(ResourceManager.kubeClient().getClient());
     }
 
-    public static DoneableKafkaTopic topic(String clusterName, String topicName) {
-        return topic(defaultTopic(clusterName, topicName, 1, 1, 1).build());
+    public static KafkaTopicBuilder topic(String clusterName, String topicName) {
+        return defaultTopic(clusterName, topicName, 1, 1, 1);
     }
 
-    public static DoneableKafkaTopic topic(String clusterName, String topicName, int partitions) {
-        return topic(defaultTopic(clusterName, topicName, partitions, 1, 1).build());
+    public static KafkaTopicBuilder topic(String clusterName, String topicName, int partitions) {
+        return defaultTopic(clusterName, topicName, partitions, 1, 1);
     }
 
-    public static DoneableKafkaTopic topic(String clusterName, String topicName, int partitions, int replicas) {
-        return topic(defaultTopic(clusterName, topicName, partitions, replicas, replicas).build());
+    public static KafkaTopicBuilder topic(String clusterName, String topicName, int partitions, int replicas) {
+        return defaultTopic(clusterName, topicName, partitions, replicas, replicas);
     }
 
-    public static DoneableKafkaTopic topic(String clusterName, String topicName, int partitions, int replicas, int minIsr) {
-        return topic(defaultTopic(clusterName, topicName, partitions, replicas, minIsr).build());
+    public static KafkaTopicBuilder topic(String clusterName, String topicName, int partitions, int replicas, int minIsr) {
+        return defaultTopic(clusterName, topicName, partitions, replicas, minIsr);
     }
 
     public static KafkaTopicBuilder defaultTopic(String clusterName, String topicName, int partitions, int replicas, int minIsr) {
@@ -61,12 +61,10 @@ public class KafkaTopicResource {
             .endSpec();
     }
 
-    static DoneableKafkaTopic topic(KafkaTopic topic) {
-        return new DoneableKafkaTopic(topic, kt -> {
-            kafkaTopicClient().inNamespace(topic.getMetadata().getNamespace()).createOrReplace(kt);
-            LOGGER.info("Created KafkaTopic {}", kt.getMetadata().getName());
-            return waitFor(deleteLater(kt));
-        });
+    public static KafkaTopic create(KafkaTopic topic) {
+        kafkaTopicClient().inNamespace(topic.getMetadata().getNamespace()).createOrReplace(topic);
+        LOGGER.info("Created KafkaTopic {}", topic.getMetadata().getName());
+        return waitFor(deleteLater(topic));
     }
 
     public static KafkaTopic topicWithoutWait(KafkaTopic kafkaTopic) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaBridgeExampleClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaBridgeExampleClients.java
@@ -4,10 +4,8 @@
  */
 package io.strimzi.systemtest.resources.crd.kafkaclients;
 
-import io.fabric8.kubernetes.api.model.batch.DoneableJob;
 import io.fabric8.kubernetes.api.model.batch.JobBuilder;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 
 import java.util.HashMap;
@@ -109,12 +107,12 @@ public class KafkaBridgeExampleClients extends KafkaBasicExampleClients {
     }
 
 
-    public DoneableJob producerStrimziBridge() {
+    public JobBuilder producerStrimziBridge() {
         Map<String, String> producerLabels = new HashMap<>();
         producerLabels.put("app", producerName);
         producerLabels.put(Constants.KAFKA_CLIENTS_LABEL_KEY, Constants.KAFKA_BRIDGE_CLIENTS_LABEL_VALUE);
 
-        return KubernetesResource.deployNewJob(new JobBuilder()
+        return new JobBuilder()
             .withNewMetadata()
                 .withNamespace(ResourceManager.kubeClient().getNamespace())
                 .withLabels(producerLabels)
@@ -155,16 +153,15 @@ public class KafkaBridgeExampleClients extends KafkaBasicExampleClients {
                             .endContainer()
                     .endSpec()
                 .endTemplate()
-            .endSpec()
-            .build());
+            .endSpec();
     }
 
-    public DoneableJob consumerStrimziBridge() {
+    public JobBuilder consumerStrimziBridge() {
         Map<String, String> consumerLabels = new HashMap<>();
         consumerLabels.put("app", consumerName);
         consumerLabels.put(Constants.KAFKA_CLIENTS_LABEL_KEY, Constants.KAFKA_BRIDGE_CLIENTS_LABEL_VALUE);
 
-        return KubernetesResource.deployNewJob(new JobBuilder()
+        return new JobBuilder()
             .withNewMetadata()
                 .withNamespace(ResourceManager.kubeClient().getNamespace())
                 .withLabels(consumerLabels)
@@ -209,7 +206,6 @@ public class KafkaBridgeExampleClients extends KafkaBasicExampleClients {
                             .endContainer()
                     .endSpec()
                 .endTemplate()
-            .endSpec()
-            .build());
+            .endSpec();
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaOauthExampleClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaOauthExampleClients.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.systemtest.resources.crd.kafkaclients;
 
-import io.fabric8.kubernetes.api.model.batch.DoneableJob;
+import io.fabric8.kubernetes.api.model.batch.JobBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.keycloak.KeycloakInstance;
 
@@ -137,9 +137,13 @@ public class KafkaOauthExampleClients extends KafkaBasicExampleClients {
         return userName;
     }
 
-    public DoneableJob producerStrimziOauthPlain() {
+    public JobBuilder producerStrimziOauthPlain() {
+        return defaultProducerStrimziOauthPlain();
+    }
 
-        return producerStrimzi()
+    private JobBuilder defaultProducerStrimziOauthPlain() {
+
+        return defaultProducerStrimzi()
             .editSpec()
                 .editTemplate()
                     .editSpec()
@@ -176,9 +180,9 @@ public class KafkaOauthExampleClients extends KafkaBasicExampleClients {
             .endSpec();
     }
 
-    public DoneableJob producerStrimziOauthTls(String clusterName) {
+    public JobBuilder producerStrimziOauthTls(String clusterName) {
 
-        return producerStrimziOauthPlain()
+        return defaultProducerStrimziOauthPlain()
             .editSpec()
                 .editTemplate()
                     .editSpec()
@@ -221,9 +225,13 @@ public class KafkaOauthExampleClients extends KafkaBasicExampleClients {
             .endSpec();
     }
 
-    public DoneableJob consumerStrimziOauthPlain() {
+    public JobBuilder consumerStrimziOauthPlain() {
+        return defaultConsumerStrimziOauth();
+    }
 
-        return consumerStrimzi()
+    private JobBuilder defaultConsumerStrimziOauth() {
+
+        return defaultConsumerStrimzi()
             .editSpec()
                 .editTemplate()
                     .editSpec()
@@ -264,9 +272,9 @@ public class KafkaOauthExampleClients extends KafkaBasicExampleClients {
             .endSpec();
     }
 
-    public DoneableJob consumerStrimziOauthTls(String clusterName) {
+    public JobBuilder consumerStrimziOauthTls(String clusterName) {
 
-        return consumerStrimziOauthPlain()
+        return defaultConsumerStrimziOauth()
             .editSpec()
                 .editTemplate()
                     .editSpec()

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaTracingExampleClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaTracingExampleClients.java
@@ -4,8 +4,8 @@
  */
 package io.strimzi.systemtest.resources.crd.kafkaclients;
 
+import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
-import io.fabric8.kubernetes.api.model.apps.DoneableDeployment;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.KubernetesResource;
@@ -125,13 +125,13 @@ public class KafkaTracingExampleClients extends KafkaBasicExampleClients {
         jaegerServiceStreamsName = builder.jaegerServiceStreamsName;
     }
 
-    public DoneableDeployment consumerWithTracing() {
+    public DeploymentBuilder consumerWithTracing() {
         String consumerName = "hello-world-consumer";
 
         Map<String, String> consumerLabels = new HashMap<>();
         consumerLabels.put("app", consumerName);
 
-        return KubernetesResource.deployNewDeployment(new DeploymentBuilder()
+        return new DeploymentBuilder()
                     .withNewMetadata()
                         .withNamespace(ResourceManager.kubeClient().getNamespace())
                         .withLabels(consumerLabels)
@@ -194,17 +194,16 @@ public class KafkaTracingExampleClients extends KafkaBasicExampleClients {
                                 .endContainer()
                             .endSpec()
                         .endTemplate()
-                    .endSpec()
-                    .build());
+                    .endSpec();
     }
 
-    public DoneableDeployment producerWithTracing() {
+    public DeploymentBuilder producerWithTracing() {
         String producerName = "hello-world-producer";
 
         Map<String, String> producerLabels = new HashMap<>();
         producerLabels.put("app", producerName);
 
-        return KubernetesResource.deployNewDeployment(new DeploymentBuilder()
+        return new DeploymentBuilder()
             .withNewMetadata()
                 .withNamespace(ResourceManager.kubeClient().getNamespace())
                 .withLabels(producerLabels)
@@ -263,17 +262,16 @@ public class KafkaTracingExampleClients extends KafkaBasicExampleClients {
                         .endContainer()
                     .endSpec()
                 .endTemplate()
-            .endSpec()
-            .build());
+            .endSpec();
     }
 
-    public DoneableDeployment kafkaStreamsWithTracing() {
+    public DeploymentBuilder kafkaStreamsWithTracing() {
         String kafkaStreamsName = "hello-world-streams";
 
         Map<String, String> kafkaStreamLabels = new HashMap<>();
         kafkaStreamLabels.put("app", kafkaStreamsName);
 
-        return KubernetesResource.deployNewDeployment(new DeploymentBuilder()
+        return new DeploymentBuilder()
             .withNewMetadata()
                 .withNamespace(ResourceManager.kubeClient().getNamespace())
                 .withLabels(kafkaStreamLabels)
@@ -332,7 +330,10 @@ public class KafkaTracingExampleClients extends KafkaBasicExampleClients {
                         .endContainer()
                     .endSpec()
                 .endTemplate()
-            .endSpec()
-            .build());
+            .endSpec();
+    }
+
+    public Deployment create(Deployment deployment) {
+        return KubernetesResource.deployNewDeployment(deployment);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
@@ -7,32 +7,27 @@ package io.strimzi.systemtest.resources.operator;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
-import io.fabric8.kubernetes.api.model.apps.DoneableDeployment;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.TestUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
 public class BundleResource {
-    private static final Logger LOGGER = LogManager.getLogger(BundleResource.class);
-
     public static final String PATH_TO_CO_CONFIG = TestUtils.USER_PATH + "/../install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml";
 
-    public static DoneableDeployment clusterOperator(String namespace, long operationTimeout) {
-        return KubernetesResource.deployNewDeployment(defaultClusterOperator(namespace, operationTimeout, Constants.RECONCILIATION_INTERVAL).build());
+    public static DeploymentBuilder clusterOperator(String namespace, long operationTimeout) {
+        return defaultClusterOperator(namespace, operationTimeout, Constants.RECONCILIATION_INTERVAL);
     }
 
-    public static DoneableDeployment clusterOperator(String namespace, long operationTimeout, long reconciliationInterval) {
-        return KubernetesResource.deployNewDeployment(defaultClusterOperator(namespace, operationTimeout, reconciliationInterval).build());
+    public static DeploymentBuilder clusterOperator(String namespace, long operationTimeout, long reconciliationInterval) {
+        return defaultClusterOperator(namespace, operationTimeout, reconciliationInterval);
     }
 
-    public static DoneableDeployment clusterOperator(String namespace) {
-        return KubernetesResource.deployNewDeployment(defaultClusterOperator(namespace, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Constants.RECONCILIATION_INTERVAL).build());
+    public static DeploymentBuilder clusterOperator(String namespace) {
+        return defaultClusterOperator(namespace, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Constants.RECONCILIATION_INTERVAL);
     }
 
     public static DeploymentBuilder defaultClusterOperator(String namespace) {
@@ -94,4 +89,7 @@ public class BundleResource {
             .endSpec();
     }
 
+    public static Deployment create(Deployment co) {
+        return KubernetesResource.deployNewDeployment(co);
+    }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
@@ -35,7 +35,7 @@ public class JobUtils {
      * @param name name of the job
      */
     public static void deleteJobWithWait(String namespace, String name) {
-        kubeClient().deleteJob(name);
+        kubeClient(namespace).deleteJob(name);
         waitForJobDeletion(name);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -143,7 +143,7 @@ public abstract class AbstractST implements TestSeparator {
                 applyBindings(namespace, bindingsNamespaces);
             }
             // 060-Deployment
-            BundleResource.clusterOperator(namespace, operationTimeout, reconciliationInterval).done();
+            BundleResource.create(BundleResource.clusterOperator(namespace, operationTimeout, reconciliationInterval).build());
         }
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeAbstractST.java
@@ -29,7 +29,7 @@ public class HttpBridgeAbstractST extends AbstractST {
     protected WebClient client;
     protected static KafkaBridgeExampleClients kafkaBridgeClientJob;
 
-    void deployClusterOperator(String namespace) throws Exception {
+    void deployClusterOperator(String namespace) {
         ResourceManager.setClassResources();
         installClusterOperator(namespace);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeCorsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeCorsST.java
@@ -112,15 +112,15 @@ public class HttpBridgeCorsST extends HttpBridgeAbstractST {
     @BeforeAll
     void beforeAll() throws Exception {
         deployClusterOperator(NAMESPACE);
-        KafkaResource.kafkaEphemeral(httpBridgeCorsClusterName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(httpBridgeCorsClusterName, 1, 1).build());
+
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).build());
+        kafkaClientsPodName = kubeClient().listPodsByPrefixInName(kafkaClientsName).get(0).getMetadata().getName();
 
         kafkaBridgeClientJob = kafkaBridgeClientJob.toBuilder().withBootstrapAddress(KafkaBridgeResources.serviceName(httpBridgeCorsClusterName)).build();
 
-        KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).done();
-        kafkaClientsPodName = kubeClient().listPodsByPrefixInName(kafkaClientsName).get(0).getMetadata().getName();
-
-        KafkaBridgeResource.kafkaBridgeWithCors(httpBridgeCorsClusterName, KafkaResources.plainBootstrapAddress(httpBridgeCorsClusterName),
-            1, ALLOWED_ORIGIN, null).done();
+        KafkaBridgeResource.create(KafkaBridgeResource.kafkaBridgeWithCors(httpBridgeCorsClusterName, KafkaResources.plainBootstrapAddress(httpBridgeCorsClusterName),
+            1, ALLOWED_ORIGIN, null).build());
 
         KafkaBridgeHttpCors kafkaBridgeHttpCors = KafkaBridgeResource.kafkaBridgeClient().inNamespace(NAMESPACE).withName(httpBridgeCorsClusterName).get().getSpec().getHttp().getCors();
         LOGGER.info("Bridge with the following CORS settings {}", kafkaBridgeHttpCors.toString());

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeKafkaExternalListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeKafkaExternalListenersST.java
@@ -6,7 +6,6 @@ package io.strimzi.systemtest.bridge;
 
 import io.fabric8.kubernetes.api.model.Service;
 import io.strimzi.api.kafka.model.CertSecretSource;
-import io.strimzi.api.kafka.model.KafkaBridgeResources;
 import io.strimzi.api.kafka.model.KafkaBridgeSpec;
 import io.strimzi.api.kafka.model.KafkaBridgeSpecBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
@@ -59,9 +59,9 @@ class HttpBridgeST extends HttpBridgeAbstractST {
     @Test
     void testSendSimpleMessage() {
         // Create topic
-        KafkaTopicResource.topic(httpBridgeClusterName, TOPIC_NAME).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(httpBridgeClusterName, TOPIC_NAME).build());
 
-        kafkaBridgeClientJob.producerStrimziBridge().done();
+        kafkaBridgeClientJob.create(kafkaBridgeClientJob.producerStrimziBridge().build());
         ClientUtils.waitForClientSuccess(producerName, NAMESPACE, MESSAGE_COUNT);
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
@@ -83,9 +83,9 @@ class HttpBridgeST extends HttpBridgeAbstractST {
 
     @Test
     void testReceiveSimpleMessage() {
-        KafkaTopicResource.topic(httpBridgeClusterName, TOPIC_NAME).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(httpBridgeClusterName, TOPIC_NAME).build());
 
-        kafkaBridgeClientJob.consumerStrimziBridge().done();
+        kafkaBridgeClientJob.create(kafkaBridgeClientJob.consumerStrimziBridge().build());
 
         // Send messages to Kafka
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
@@ -132,7 +132,7 @@ class HttpBridgeST extends HttpBridgeAbstractST {
         int updatedPeriodSeconds = 5;
         int updatedFailureThreshold = 1;
 
-        KafkaBridgeResource.kafkaBridge(bridgeName, KafkaResources.plainBootstrapAddress(httpBridgeClusterName), 1)
+        KafkaBridgeResource.create(KafkaBridgeResource.kafkaBridge(bridgeName, KafkaResources.plainBootstrapAddress(httpBridgeClusterName), 1)
             .editSpec()
                 .withNewTemplate()
                     .withNewBridgeContainer()
@@ -157,7 +157,8 @@ class HttpBridgeST extends HttpBridgeAbstractST {
                     .withSuccessThreshold(successThreshold)
                     .withFailureThreshold(failureThreshold)
                 .endLivenessProbe()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
         Map<String, String> bridgeSnapshot = DeploymentUtils.depSnapshot(KafkaBridgeResources.deploymentName(bridgeName));
 
@@ -211,7 +212,7 @@ class HttpBridgeST extends HttpBridgeAbstractST {
     void testScaleBridgeToZero() {
         String bridgeName = "scaling-bridge";
 
-        KafkaBridgeResource.kafkaBridge(bridgeName, KafkaResources.plainBootstrapAddress(httpBridgeClusterName), 1).done();
+        KafkaBridgeResource.create(KafkaBridgeResource.kafkaBridge(bridgeName, KafkaResources.plainBootstrapAddress(httpBridgeClusterName), 1).build());
 
         List<String> bridgePods = kubeClient().listPodNames(Labels.STRIMZI_CLUSTER_LABEL, bridgeName);
         String deploymentName = KafkaBridgeResources.deploymentName(bridgeName);
@@ -235,7 +236,7 @@ class HttpBridgeST extends HttpBridgeAbstractST {
     void testScaleBridgeSubresource() {
         String bridgeName = "scaling-bridge";
 
-        KafkaBridgeResource.kafkaBridge(bridgeName, KafkaResources.plainBootstrapAddress(httpBridgeClusterName), 1).done();
+        KafkaBridgeResource.create(KafkaBridgeResource.kafkaBridge(bridgeName, KafkaResources.plainBootstrapAddress(httpBridgeClusterName), 1).build());
 
         int scaleTo = 4;
         long bridgeObsGen = KafkaBridgeResource.kafkaBridgeClient().inNamespace(NAMESPACE).withName(bridgeName).get().getStatus().getObservedGeneration();
@@ -270,7 +271,7 @@ class HttpBridgeST extends HttpBridgeAbstractST {
             .withHostnames(aliasHostname)
             .build();
 
-        KafkaBridgeResource.kafkaBridge(bridgeName, KafkaResources.plainBootstrapAddress(httpBridgeClusterName), 1)
+        KafkaBridgeResource.create(KafkaBridgeResource.kafkaBridge(bridgeName, KafkaResources.plainBootstrapAddress(httpBridgeClusterName), 1)
             .editSpec()
                 .withNewTemplate()
                     .withNewPod()
@@ -278,7 +279,7 @@ class HttpBridgeST extends HttpBridgeAbstractST {
                     .endPod()
                 .endTemplate()
             .endSpec()
-            .done();
+            .build());
 
         String bridgePodName = kubeClient().listPods(Labels.STRIMZI_CLUSTER_LABEL, bridgeName).get(0).getMetadata().getName();
 
@@ -291,7 +292,7 @@ class HttpBridgeST extends HttpBridgeAbstractST {
     void testConfigureDeploymentStrategy() {
         String bridgeName = "example-bridge";
 
-        KafkaBridgeResource.kafkaBridge(bridgeName, KafkaResources.plainBootstrapAddress(httpBridgeClusterName), 1)
+        KafkaBridgeResource.create(KafkaBridgeResource.kafkaBridge(bridgeName, KafkaResources.plainBootstrapAddress(httpBridgeClusterName), 1)
             .editSpec()
                 .editOrNewTemplate()
                     .editOrNewDeployment()
@@ -299,7 +300,7 @@ class HttpBridgeST extends HttpBridgeAbstractST {
                     .endDeployment()
                 .endTemplate()
             .endSpec()
-            .done();
+            .build());
 
         String bridgeDepName = KafkaBridgeResources.deploymentName(bridgeName);
 
@@ -336,20 +337,20 @@ class HttpBridgeST extends HttpBridgeAbstractST {
         deployClusterOperator(NAMESPACE);
         LOGGER.info("Deploy Kafka and KafkaBridge before tests");
         // Deploy kafka
-        KafkaResource.kafkaEphemeral(httpBridgeClusterName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(httpBridgeClusterName, 1, 1).build());
 
-        KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).build());
 
         kafkaClientsPodName = kubeClient().listPodsByPrefixInName(kafkaClientsName).get(0).getMetadata().getName();
 
         // Deploy http bridge
-        KafkaBridgeResource.kafkaBridge(httpBridgeClusterName, KafkaResources.plainBootstrapAddress(httpBridgeClusterName), 1)
+        KafkaBridgeResource.create(KafkaBridgeResource.kafkaBridge(httpBridgeClusterName, KafkaResources.plainBootstrapAddress(httpBridgeClusterName), 1)
             .editSpec()
                 .withNewConsumer()
                     .addToConfig(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
                 .endConsumer()
             .endSpec()
-            .done();
+            .build());
 
         kafkaBridgeClientJob = kafkaBridgeClientJob.toBuilder().withBootstrapAddress(KafkaBridgeResources.serviceName(httpBridgeClusterName)).build();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
@@ -46,9 +46,9 @@ class HttpBridgeScramShaST extends HttpBridgeAbstractST {
     @Test
     void testSendSimpleMessageTlsScramSha() {
         // Create topic
-        KafkaTopicResource.topic(httpBridgeScramShaClusterName, TOPIC_NAME).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(httpBridgeScramShaClusterName, TOPIC_NAME).build());
 
-        kafkaBridgeClientJob.producerStrimziBridge().done();
+        kafkaBridgeClientJob.create(kafkaBridgeClientJob.producerStrimziBridge().build());
         ClientUtils.waitForClientSuccess(producerName, NAMESPACE, MESSAGE_COUNT);
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
@@ -67,9 +67,9 @@ class HttpBridgeScramShaST extends HttpBridgeAbstractST {
 
     @Test
     void testReceiveSimpleMessageTlsScramSha() {
-        KafkaTopicResource.topic(httpBridgeScramShaClusterName, TOPIC_NAME).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(httpBridgeScramShaClusterName, TOPIC_NAME).build());
 
-        kafkaBridgeClientJob.consumerStrimziBridge().done();
+        kafkaBridgeClientJob.create(kafkaBridgeClientJob.consumerStrimziBridge().build());
 
         // Send messages to Kafka
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
@@ -94,7 +94,7 @@ class HttpBridgeScramShaST extends HttpBridgeAbstractST {
         LOGGER.info("Deploy Kafka and KafkaBridge before tests");
 
         // Deploy kafka
-        KafkaResource.kafkaEphemeral(httpBridgeScramShaClusterName, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(httpBridgeScramShaClusterName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -108,12 +108,13 @@ class HttpBridgeScramShaST extends HttpBridgeAbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
         // Create Kafka user
-        KafkaUser scramShaUser = KafkaUserResource.scramShaUser(httpBridgeScramShaClusterName, USER_NAME).done();
+        KafkaUser scramShaUser = KafkaUserResource.create(KafkaUserResource.scramShaUser(httpBridgeScramShaClusterName, USER_NAME).build());
 
-        KafkaClientsResource.deployKafkaClients(true, kafkaClientsName, scramShaUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, kafkaClientsName, scramShaUser).build());
 
         kafkaClientsPodName = kubeClient().listPodsByPrefixInName(kafkaClientsName).get(0).getMetadata().getName();
 
@@ -128,7 +129,7 @@ class HttpBridgeScramShaST extends HttpBridgeAbstractST {
         certSecret.setSecretName(KafkaResources.clusterCaCertificateSecretName(httpBridgeScramShaClusterName));
 
         // Deploy http bridge
-        KafkaBridgeResource.kafkaBridge(httpBridgeScramShaClusterName, KafkaResources.tlsBootstrapAddress(httpBridgeScramShaClusterName), 1)
+        KafkaBridgeResource.create(KafkaBridgeResource.kafkaBridge(httpBridgeScramShaClusterName, KafkaResources.tlsBootstrapAddress(httpBridgeScramShaClusterName), 1)
             .editSpec()
                 .withNewConsumer()
                     .addToConfig(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
@@ -141,7 +142,7 @@ class HttpBridgeScramShaST extends HttpBridgeAbstractST {
                     .withTrustedCertificates(certSecret)
                 .endTls()
             .endSpec()
-            .done();
+            .build());
 
         kafkaBridgeClientJob = kafkaBridgeClientJob.toBuilder().withBootstrapAddress(KafkaBridgeResources.serviceName(httpBridgeScramShaClusterName)).build();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
@@ -44,9 +44,9 @@ class HttpBridgeTlsST extends HttpBridgeAbstractST {
     @Test
     void testSendSimpleMessageTls() {
         // Create topic
-        KafkaTopicResource.topic(httpBridgeTlsClusterName, TOPIC_NAME).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(httpBridgeTlsClusterName, TOPIC_NAME).build());
 
-        kafkaBridgeClientJob.producerStrimziBridge().done();
+        kafkaBridgeClientJob.create(kafkaBridgeClientJob.producerStrimziBridge().build());
         ClientUtils.waitForClientSuccess(producerName, NAMESPACE, MESSAGE_COUNT);
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
@@ -65,9 +65,9 @@ class HttpBridgeTlsST extends HttpBridgeAbstractST {
 
     @Test
     void testReceiveSimpleMessageTls() {
-        KafkaTopicResource.topic(httpBridgeTlsClusterName, TOPIC_NAME).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(httpBridgeTlsClusterName, TOPIC_NAME).build());
 
-        kafkaBridgeClientJob.consumerStrimziBridge().done();
+        kafkaBridgeClientJob.create(kafkaBridgeClientJob.consumerStrimziBridge().build());
 
         // Send messages to Kafka
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
@@ -92,7 +92,7 @@ class HttpBridgeTlsST extends HttpBridgeAbstractST {
         LOGGER.info("Deploy Kafka and KafkaBridge before tests");
 
         // Deploy kafka
-        KafkaResource.kafkaEphemeral(httpBridgeTlsClusterName, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(httpBridgeTlsClusterName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -107,12 +107,12 @@ class HttpBridgeTlsST extends HttpBridgeAbstractST {
                     .endListeners()
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
         // Create Kafka user
-        KafkaUser tlsUser = KafkaUserResource.tlsUser(httpBridgeTlsClusterName, USER_NAME).done();
+        KafkaUser tlsUser = KafkaUserResource.create(KafkaUserResource.tlsUser(httpBridgeTlsClusterName, USER_NAME).build());
 
-        KafkaClientsResource.deployKafkaClients(true, kafkaClientsName, tlsUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, kafkaClientsName, tlsUser).build());
 
         kafkaClientsPodName = kubeClient().listPodsByPrefixInName(kafkaClientsName).get(0).getMetadata().getName();
 
@@ -122,7 +122,7 @@ class HttpBridgeTlsST extends HttpBridgeAbstractST {
         certSecret.setSecretName(KafkaResources.clusterCaCertificateSecretName(httpBridgeTlsClusterName));
 
         // Deploy http bridge
-        KafkaBridgeResource.kafkaBridge(httpBridgeTlsClusterName, KafkaResources.tlsBootstrapAddress(httpBridgeTlsClusterName), 1)
+        KafkaBridgeResource.create(KafkaBridgeResource.kafkaBridge(httpBridgeTlsClusterName, KafkaResources.tlsBootstrapAddress(httpBridgeTlsClusterName), 1)
             .editSpec()
                 .withNewConsumer()
                     .addToConfig(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
@@ -138,7 +138,7 @@ class HttpBridgeTlsST extends HttpBridgeAbstractST {
                     .withTrustedCertificates(certSecret)
                 .endTls()
             .endSpec()
-            .done();
+            .build());
 
         kafkaBridgeClientJob = kafkaBridgeClientJob.toBuilder().withBootstrapAddress(KafkaBridgeResources.serviceName(httpBridgeTlsClusterName)).build();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -1271,7 +1271,7 @@ class ConnectST extends AbstractST {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT);
 
-        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).build());
-        kafkaClientsPodName = kubeClient().listPodsByPrefixInName(KAFKA_CLIENTS_NAME).get(0).getMetadata().getName();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).build());
+        kafkaClientsPodName = kubeClient().listPodsByPrefixInName(kafkaClientsName).get(0).getMetadata().getName();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -111,10 +111,10 @@ public class CruiseControlApiST extends AbstractST {
     }
 
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
 
-        KafkaResource.kafkaWithCruiseControl(cruiseControlApiClusterName, 3, 3).done();
+        KafkaResource.create(KafkaResource.kafkaWithCruiseControl(cruiseControlApiClusterName, 3, 3).build());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -289,6 +289,6 @@ public class CruiseControlConfigurationST extends AbstractST {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
 
-        KafkaResource.create(KafkaResource.kafkaWithCruiseControl(CLUSTER_NAME, 3, 3).build());
+        KafkaResource.create(KafkaResource.kafkaWithCruiseControl(clusterName, 3, 3).build());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -285,10 +285,10 @@ public class CruiseControlConfigurationST extends AbstractST {
     }
     
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
 
-        KafkaResource.kafkaWithCruiseControl(CRUISE_CONTROL_CONFIGURATION_CLUSTER_NAME, 3, 3).done();
+        KafkaResource.create(KafkaResource.kafkaWithCruiseControl(CLUSTER_NAME, 3, 3).build());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -289,6 +289,6 @@ public class CruiseControlConfigurationST extends AbstractST {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
 
-        KafkaResource.create(KafkaResource.kafkaWithCruiseControl(clusterName, 3, 3).build());
+        KafkaResource.create(KafkaResource.kafkaWithCruiseControl(CRUISE_CONTROL_CONFIGURATION_CLUSTER_NAME, 3, 3).build());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -57,13 +57,13 @@ public class CruiseControlIsolatedST extends AbstractST {
 
     @Test
     void testAutoCreationOfCruiseControlTopics() {
-        KafkaResource.kafkaWithCruiseControl(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaWithCruiseControl(clusterName, 3, 3)
             .editOrNewSpec()
                 .editKafka()
                     .addToConfig("auto.create.topics.enable", "false")
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
         KafkaTopicSpec metricsTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE)
             .withName(CRUISE_CONTROL_METRICS_TOPIC).get().getSpec();
@@ -88,8 +88,8 @@ public class CruiseControlIsolatedST extends AbstractST {
     @Test
     @Tag(ACCEPTANCE)
     void testCruiseControlWithRebalanceResource() {
-        KafkaResource.kafkaWithCruiseControl(clusterName, 3, 3).done();
-        KafkaRebalanceResource.kafkaRebalance(clusterName).done();
+        KafkaResource.create(KafkaResource.kafkaWithCruiseControl(clusterName, 3, 3).build());
+        KafkaRebalanceResource.create(KafkaRebalanceResource.kafkaRebalance(clusterName).build());
 
         LOGGER.info("Verifying that KafkaRebalance resource is in {} state", KafkaRebalanceState.PendingProposal);
 
@@ -142,16 +142,16 @@ public class CruiseControlIsolatedST extends AbstractST {
         String excludedTopic2 = "excluded-topic-2";
         String includedTopic = "included-topic";
 
-        KafkaResource.kafkaWithCruiseControl(clusterName, 3, 3).done();
-        KafkaTopicResource.topic(clusterName, excludedTopic1).done();
-        KafkaTopicResource.topic(clusterName, excludedTopic2).done();
-        KafkaTopicResource.topic(clusterName, includedTopic).done();
+        KafkaResource.create(KafkaResource.kafkaWithCruiseControl(clusterName, 3, 3).build());
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, excludedTopic1).build());
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, excludedTopic2).build());
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, includedTopic).build());
 
-        KafkaRebalanceResource.kafkaRebalance(clusterName)
+        KafkaRebalanceResource.create(KafkaRebalanceResource.kafkaRebalance(clusterName)
             .editOrNewSpec()
                 .withExcludedTopics("excluded-.*")
             .endSpec()
-            .done();
+            .build());
 
         KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(clusterName, KafkaRebalanceState.ProposalReady);
 
@@ -172,8 +172,8 @@ public class CruiseControlIsolatedST extends AbstractST {
                 "com.linkedin.kafka.cruisecontrol.executor.strategy.PrioritizeLargeReplicaMovementStrategy," +
                 "com.linkedin.kafka.cruisecontrol.executor.strategy.PostponeUrpReplicaMovementStrategy";
 
-        KafkaResource.kafkaWithCruiseControl(clusterName, 3, 3).done();
-        KafkaClientsResource.deployKafkaClients(kafkaClientsName).done();
+        KafkaResource.create(KafkaResource.kafkaWithCruiseControl(clusterName, 3, 3).build());
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(kafkaClientsName).build());
 
         String ccPodName = kubeClient().listPodsByPrefixInName(CruiseControlResources.deploymentName(clusterName)).get(0).getMetadata().getName();
 
@@ -210,7 +210,7 @@ public class CruiseControlIsolatedST extends AbstractST {
             .withHostnames(aliasHostname)
             .build();
 
-        KafkaResource.kafkaWithCruiseControl(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaWithCruiseControl(clusterName, 3, 3)
             .editSpec()
                 .editCruiseControl()
                     .withNewTemplate()
@@ -220,7 +220,7 @@ public class CruiseControlIsolatedST extends AbstractST {
                     .endTemplate()
                 .endCruiseControl()
             .endSpec()
-            .done();
+            .build());
 
         String ccPodName = kubeClient().listPods(Labels.STRIMZI_NAME_LABEL, clusterName + "-cruise-control").get(0).getMetadata().getName();
 
@@ -230,7 +230,7 @@ public class CruiseControlIsolatedST extends AbstractST {
     }
 
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -143,7 +143,7 @@ class KafkaST extends AbstractST {
 
     @Test
     void testEODeletion() {
-        KafkaResource.kafkaEphemeral(clusterName, 3).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3).build());
 
         // Get pod name to check termination process
         Pod pod = kubeClient().listPods().stream()
@@ -210,7 +210,7 @@ class KafkaST extends AbstractST {
         int updatedPeriodSeconds = 5;
         int updatedFailureThreshold = 1;
 
-        KafkaResource.kafkaPersistent(clusterName, 2)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 2)
             .editSpec()
                 .editKafka()
                     .withNewReadinessProbe()
@@ -313,7 +313,7 @@ class KafkaST extends AbstractST {
                     .endTlsSidecar()
                 .endEntityOperator()
                 .endSpec()
-            .done();
+            .build());
 
         Map<String, String> kafkaSnapshot = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(clusterName));
         Map<String, String> zkSnapshot = StatefulSetUtils.ssSnapshot(KafkaResources.zookeeperStatefulSetName(clusterName));
@@ -456,7 +456,7 @@ class KafkaST extends AbstractST {
         Map<String, String> jvmOptionsXX = new HashMap<>();
         jvmOptionsXX.put("UseG1GC", "true");
 
-        KafkaResource.kafkaEphemeral(clusterName, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withResources(new ResourceRequirementsBuilder()
@@ -515,7 +515,8 @@ class KafkaST extends AbstractST {
                         .endJvmOptions()
                     .endUserOperator()
                 .endEntityOperator()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
         // Make snapshots for Kafka cluster to meke sure that there is no rolling update after CO reconciliation
         String zkStsName = KafkaResources.zookeeperStatefulSetName(clusterName);
@@ -579,12 +580,12 @@ class KafkaST extends AbstractST {
 
     @Test
     void testForTopicOperator() throws InterruptedException {
-        KafkaResource.kafkaEphemeral(clusterName, 3).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3).build());
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
         String cliTopicName = "topic-from-cli";
 
         //Creating topics for testing
-        KafkaTopicResource.topic(clusterName, topicName).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
 
         KafkaTopicUtils.waitForKafkaTopicReady(topicName);
 
@@ -638,7 +639,7 @@ class KafkaST extends AbstractST {
     @Test
     void testRemoveTopicOperatorFromEntityOperator() {
         LOGGER.info("Deploying Kafka cluster {}", clusterName);
-        KafkaResource.kafkaEphemeral(clusterName, 3).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3).build());
         String eoPodName = kubeClient().listPodsByPrefixInName(KafkaResources.entityOperatorDeploymentName(clusterName))
             .get(0).getMetadata().getName();
 
@@ -679,7 +680,7 @@ class KafkaST extends AbstractST {
     void testRemoveUserOperatorFromEntityOperator() {
         LOGGER.info("Deploying Kafka cluster {}", clusterName);
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_DEPLOYMENT));
-        KafkaResource.kafkaEphemeral(clusterName, 3).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3).build());
         String eoPodName = kubeClient().listPodsByPrefixInName(KafkaResources.entityOperatorDeploymentName(clusterName))
                 .get(0).getMetadata().getName();
 
@@ -727,7 +728,7 @@ class KafkaST extends AbstractST {
 
         LOGGER.info("Deploying Kafka cluster {}", clusterName);
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_DEPLOYMENT));
-        KafkaResource.kafkaEphemeral(clusterName, 3).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3).build());
 
         String eoDeploymentName = KafkaResources.entityOperatorDeploymentName(clusterName);
 
@@ -763,14 +764,14 @@ class KafkaST extends AbstractST {
     void testEntityOperatorWithoutTopicOperator() {
         LOGGER.info("Deploying Kafka cluster without TO in EO");
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_DEPLOYMENT));
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
             .editSpec()
                 .withNewEntityOperator()
                     .withNewUserOperator()
                     .endUserOperator()
                 .endEntityOperator()
             .endSpec()
-            .done();
+            .build());
 
         timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
         assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSeconds(testClass, testName, timeMeasuringSystem.getOperationID()));
@@ -787,14 +788,14 @@ class KafkaST extends AbstractST {
     void testEntityOperatorWithoutUserOperator() {
         LOGGER.info("Deploying Kafka cluster without UO in EO");
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_DEPLOYMENT));
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
             .editSpec()
                 .withNewEntityOperator()
                     .withNewTopicOperator()
                     .endTopicOperator()
                 .endEntityOperator()
             .endSpec()
-            .done();
+            .build());
 
         timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
         assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSeconds(testClass, testName, timeMeasuringSystem.getOperationID()));
@@ -811,12 +812,12 @@ class KafkaST extends AbstractST {
     void testEntityOperatorWithoutUserAndTopicOperators() {
         LOGGER.info("Deploying Kafka cluster without UO and TO in EO");
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_DEPLOYMENT));
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
             .editSpec()
                 .withNewEntityOperator()
                 .endEntityOperator()
             .endSpec()
-            .done();
+            .build());
 
         timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
         assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSeconds(testClass, testName, timeMeasuringSystem.getOperationID()));
@@ -828,7 +829,7 @@ class KafkaST extends AbstractST {
     @Test
     void testTopicWithoutLabels() {
         // Negative scenario: creating topic without any labels and make sure that TO can't handle this topic
-        KafkaResource.kafkaEphemeral(clusterName, 3).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3).build());
 
         // Creating topic without any label
         KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(clusterName, "topic-without-labels", 1, 1, 1)
@@ -866,7 +867,7 @@ class KafkaST extends AbstractST {
             new PersistentClaimStorageBuilder().withDeleteClaim(true).withId(0).withSize(diskSizeGi + "Gi").build(),
             new PersistentClaimStorageBuilder().withDeleteClaim(false).withId(1).withSize(diskSizeGi + "Gi").build()).build();
 
-        KafkaResource.kafkaJBOD(clusterName, kafkaReplicas, jbodStorage).done();
+        KafkaResource.create(KafkaResource.kafkaJBOD(clusterName, kafkaReplicas, jbodStorage).build());
         // kafka cluster already deployed
         verifyVolumeNamesAndLabels(kafkaReplicas, 2, diskSizeGi);
 
@@ -889,7 +890,7 @@ class KafkaST extends AbstractST {
             new PersistentClaimStorageBuilder().withDeleteClaim(true).withId(0).withSize(diskSizeGi + "Gi").build(),
             new PersistentClaimStorageBuilder().withDeleteClaim(true).withId(1).withSize(diskSizeGi + "Gi").build()).build();
 
-        KafkaResource.kafkaJBOD(clusterName, kafkaReplicas, jbodStorage).done();
+        KafkaResource.create(KafkaResource.kafkaJBOD(clusterName, kafkaReplicas, jbodStorage).build());
         // kafka cluster already deployed
         verifyVolumeNamesAndLabels(kafkaReplicas, 2, diskSizeGi);
 
@@ -912,7 +913,7 @@ class KafkaST extends AbstractST {
             new PersistentClaimStorageBuilder().withDeleteClaim(false).withId(0).withSize(diskSizeGi + "Gi").build(),
             new PersistentClaimStorageBuilder().withDeleteClaim(false).withId(1).withSize(diskSizeGi + "Gi").build()).build();
 
-        KafkaResource.kafkaJBOD(clusterName, kafkaReplicas, jbodStorage).done();
+        KafkaResource.create(KafkaResource.kafkaJBOD(clusterName, kafkaReplicas, jbodStorage).build());
         // kafka cluster already deployed
         verifyVolumeNamesAndLabels(kafkaReplicas, 2, diskSizeGi);
 
@@ -939,7 +940,7 @@ class KafkaST extends AbstractST {
                         new PersistentClaimStorageBuilder().withDeleteClaim(false).withId(1).withSize(diskSizes[1]).build()
                 ).build();
 
-        KafkaResource.kafkaPersistent(clusterName, kafkaRepl)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, kafkaRepl)
             .editSpec()
                 .editKafka()
                     .withStorage(jbodStorage)
@@ -948,11 +949,11 @@ class KafkaST extends AbstractST {
                     withReplicas(1)
                 .endZookeeper()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaTopicResource.topic(clusterName, TEST_TOPIC_NAME).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TEST_TOPIC_NAME).build());
 
-        KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).build());
 
         List<PersistentVolumeClaim> volumes = kubeClient().listPersistentVolumeClaims();
 
@@ -981,7 +982,7 @@ class KafkaST extends AbstractST {
     @Tag(LOADBALANCER_SUPPORTED)
     void testRegenerateCertExternalAddressChange() {
         LOGGER.info("Creating kafka without external listener");
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1).build());
 
         String brokerSecret = "my-cluster-kafka-brokers";
 
@@ -1029,15 +1030,15 @@ class KafkaST extends AbstractST {
         labels.put(labelKeys[0], labelValues[0]);
         labels.put(labelKeys[1], labelValues[1]);
 
-        KafkaResource.kafkaPersistent(clusterName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 1)
                 .editMetadata()
                     .withLabels(labels)
                 .endMetadata()
-                .done();
+                .build());
 
-        KafkaTopicResource.topic(clusterName, TEST_TOPIC_NAME).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TEST_TOPIC_NAME).build());
 
-        KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).build());
 
         String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
 
@@ -1171,11 +1172,11 @@ class KafkaST extends AbstractST {
     @Tag(INTERNAL_CLIENTS_USED)
     void testAppDomainLabels() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1).build());
 
-        KafkaTopicResource.topic(clusterName, topicName).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
 
-        KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).build());
 
         final String kafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -1259,11 +1260,11 @@ class KafkaST extends AbstractST {
         final String secondClusterName = "my-cluster-2";
         final String userName = KafkaUserUtils.generateRandomNameOfKafkaUser();
 
-        KafkaResource.kafkaEphemeral(firstClusterName, 3, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(firstClusterName, 3, 1).build());
 
-        KafkaResource.kafkaEphemeral(secondClusterName, 3, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(secondClusterName, 3, 1).build());
 
-        KafkaUserResource.tlsUser(firstClusterName, userName).done();
+        KafkaUserResource.create(KafkaUserResource.tlsUser(firstClusterName, userName).build());
 
         LOGGER.info("Verifying that user {} in cluster {} is created", userName, firstClusterName);
         String entityOperatorPodName = kubeClient().listPods(Labels.STRIMZI_NAME_LABEL, KafkaResources.entityOperatorDeploymentName(firstClusterName)).get(0).getMetadata().getName();
@@ -1284,13 +1285,13 @@ class KafkaST extends AbstractST {
     @Tag(INTERNAL_CLIENTS_USED)
     void testMessagesAreStoredInDisk() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
-        KafkaResource.kafkaEphemeral(clusterName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 1, 1).build());
 
         Map<String, String> kafkaPodsSnapshot = StatefulSetUtils.ssSnapshot(kafkaStatefulSetName(clusterName));
 
-        KafkaTopicResource.topic(clusterName, topicName, 1, 1).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName, 1, 1).build());
 
-        KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).build());
 
         final String kafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -1355,17 +1356,17 @@ class KafkaST extends AbstractST {
         kafkaConfig.put("offsets.topic.replication.factor", "3");
         kafkaConfig.put("offsets.topic.num.partitions", "100");
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1)
             .editSpec()
                 .editKafka()
                     .withConfig(kafkaConfig)
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaTopicResource.topic(clusterName, TEST_TOPIC_NAME, 3, 1).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TEST_TOPIC_NAME, 3, 1).build());
 
-        KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).build());
 
         final String kafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -1419,7 +1420,7 @@ class KafkaST extends AbstractST {
         statefulSetLabels.put("app.kubernetes.io/part-of", "some-app");
         statefulSetLabels.put("app.kubernetes.io/managed-by", "some-app");
 
-        KafkaResource.kafkaPersistent(clusterName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 1)
             .editSpec()
                 .editKafka()
                     .withNewTemplate()
@@ -1464,7 +1465,7 @@ class KafkaST extends AbstractST {
                     .endPersistentClaimStorage()
                 .endZookeeper()
             .endSpec()
-            .done();
+            .build());
 
         LOGGER.info("Check if Kubernetes labels are applied");
         Map<String, String> actualStatefulSetLabels = kubeClient().getStatefulSet(KafkaResources.kafkaStatefulSetName(clusterName)).getMetadata().getLabels();
@@ -1514,7 +1515,7 @@ class KafkaST extends AbstractST {
     @Test
     void testKafkaOffsetsReplicationFactorHigherThanReplicas() {
         int replicas = 3;
-        Kafka kafka = KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(clusterName, replicas, 1)
+        Kafka kafka = KafkaResource.kafkaWithoutWait(KafkaResource.kafkaEphemeral(clusterName, replicas, 1)
             .editSpec()
                 .editKafka()
                     .addToConfig("offsets.topic.replication.factor", 4)
@@ -1535,7 +1536,7 @@ class KafkaST extends AbstractST {
             .withHostnames(aliasHostname)
             .build();
 
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
             .editSpec()
                 .editKafka()
                     .withNewTemplate()
@@ -1552,7 +1553,7 @@ class KafkaST extends AbstractST {
                     .endTemplate()
                 .endZookeeper()
             .endSpec()
-            .done();
+            .build());
 
         List<String> pods = kubeClient().listPodNames(Labels.STRIMZI_CLUSTER_LABEL, clusterName);
 
@@ -1777,7 +1778,7 @@ class KafkaST extends AbstractST {
     }
 
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -1570,7 +1570,7 @@ class KafkaST extends AbstractST {
     @Test
     @Tag(INTERNAL_CLIENTS_USED)
     void testReadOnlyRootFileSystem() {
-        KafkaResource.kafkaPersistent(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3)
                 .editSpec()
                     .editKafka()
                         .withNewTemplate()
@@ -1617,13 +1617,13 @@ class KafkaST extends AbstractST {
                         .endTemplate()
                     .endCruiseControl()
                 .endSpec()
-                .done();
+                .build());
 
         KafkaUtils.waitForKafkaReady(clusterName);
 
-        KafkaTopicResource.topic(clusterName, TEST_TOPIC_NAME).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TEST_TOPIC_NAME).build());
 
-        KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).build());
 
         String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/dynamicconfiguration/DynamicConfigurationSharedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/dynamicconfiguration/DynamicConfigurationSharedST.java
@@ -179,11 +179,11 @@ public class DynamicConfigurationSharedST extends AbstractST {
     }
 
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
 
         LOGGER.info("Deploying shared Kafka across all test cases!");
-        KafkaResource.kafkaPersistent(dynamicConfigurationSharedClusterName, 3).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(dynamicConfigurationSharedClusterName, 3).build());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/BackwardsCompatibleListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/BackwardsCompatibleListenersST.java
@@ -69,18 +69,18 @@ public class BackwardsCompatibleListenersST extends AbstractST {
                 .endTls()
                 .build();
 
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
                 .editSpec()
                     .editKafka()
                         .withListeners(new ArrayOrObjectKafkaListeners(listeners))
                     .endKafka()
                 .endSpec()
-                .done();
+                .build());
 
-        KafkaTopicResource.topic(clusterName, topicName).done();
-        KafkaUser user = KafkaUserResource.tlsUser(clusterName, kafkaUsername).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, kafkaUsername).build());
 
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
 
         final String kafkaClientsPodName =
             ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -120,18 +120,18 @@ public class BackwardsCompatibleListenersST extends AbstractST {
                 .build();
 
         // Use a Kafka with plain listener disabled
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
                 .editSpec()
                     .editKafka()
                         .withListeners(new ArrayOrObjectKafkaListeners(listeners))
                     .endKafka()
                 .endSpec()
-                .done();
+                .build());
 
-        KafkaTopicResource.topic(clusterName, topicName).done();
-        KafkaUser kafkaUser = KafkaUserResource.scramShaUser(clusterName, kafkaUsername).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
+        KafkaUser kafkaUser = KafkaUserResource.create(KafkaUserResource.scramShaUser(clusterName, kafkaUsername).build());
 
-        KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS, kafkaUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS, kafkaUser).build());
 
         final String kafkaClientsPodName =
             ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -169,16 +169,16 @@ public class BackwardsCompatibleListenersST extends AbstractST {
                 .endKafkaListenerExternalNodePort()
                 .build();
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1)
             .editSpec()
                 .editKafka()
                     .withListeners(new ArrayOrObjectKafkaListeners(listeners))
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaTopicResource.topic(clusterName, topicName).done();
-        KafkaUserResource.tlsUser(clusterName, kafkaUsername).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
+        KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, kafkaUsername).build());
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(topicName)
@@ -209,16 +209,16 @@ public class BackwardsCompatibleListenersST extends AbstractST {
                 .endKafkaListenerExternalLoadBalancer()
                 .build();
 
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
             .editSpec()
                 .editKafka()
                     .withListeners(new ArrayOrObjectKafkaListeners(listeners))
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaTopicResource.topic(clusterName, topicName).done();
-        KafkaUserResource.tlsUser(clusterName, kafkaUsername).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
+        KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, kafkaUsername).build());
 
         ServiceUtils.waitUntilAddressIsReachable(KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(clusterName).get().getStatus().getListeners().get(0).getAddresses().get(0).getHost());
 
@@ -251,16 +251,16 @@ public class BackwardsCompatibleListenersST extends AbstractST {
                 .endKafkaListenerExternalRoute()
                 .build();
 
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
                 .editSpec()
                     .editKafka()
                         .withListeners(new ArrayOrObjectKafkaListeners(listeners))
                     .endKafka()
                 .endSpec()
-                .done();
+                .build());
 
-        KafkaTopicResource.topic(clusterName, topicName).done();
-        KafkaUserResource.tlsUser(clusterName, kafkaUsername).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
+        KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, kafkaUsername).build());
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
                 .withTopicName(topicName)
@@ -302,18 +302,18 @@ public class BackwardsCompatibleListenersST extends AbstractST {
                 .endKafkaListenerExternalNodePort()
                 .build();
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1)
             .editSpec()
                 .editKafka()
                     .withListeners(new ArrayOrObjectKafkaListeners(listeners))
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaTopicResource.topic(clusterName, topicName, 1, 3, 2).done();
-        KafkaUser user = KafkaUserResource.tlsUser(clusterName, kafkaUsername).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName, 1, 3, 2).build());
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, kafkaUsername).build());
 
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
         final String kafkaClientsPodName = ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
@@ -376,7 +376,7 @@ public class BackwardsCompatibleListenersST extends AbstractST {
     }
 
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -153,7 +153,7 @@ public class ListenersST extends AbstractST {
 
         KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
 
-        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(CLUSTER_NAME, kafkaUser).build());
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, kafkaUser).build());
 
         KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -88,10 +88,10 @@ public class ListenersST extends AbstractST {
     void testSendMessagesPlainAnonymous() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        KafkaResource.kafkaEphemeral(clusterName, 3).done();
-        KafkaTopicResource.topic(clusterName, topicName).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3).build());
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
 
-        KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).build());
 
         final String defaultKafkaClientsPodName =
             ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -128,7 +128,7 @@ public class ListenersST extends AbstractST {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
         // Use a Kafka with plain listener disabled
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
                 .editSpec()
                     .editKafka()
                         .withNewListeners()
@@ -148,12 +148,14 @@ public class ListenersST extends AbstractST {
                             .endGenericKafkaListener()
                         .endListeners()
                     .endKafka()
-                .endSpec().done();
-        KafkaTopicResource.topic(clusterName, topicName).done();
+                .endSpec()
+                .build());
 
-        KafkaUser user = KafkaUserResource.tlsUser(clusterName, kafkaUser).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
 
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(CLUSTER_NAME, kafkaUser).build());
+
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
 
         final String kafkaClientsPodName =
             ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -192,7 +194,7 @@ public class ListenersST extends AbstractST {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
         // Use a Kafka with plain listener disabled
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
                 .editSpec()
                     .editKafka()
                         .withNewListeners()
@@ -206,11 +208,12 @@ public class ListenersST extends AbstractST {
                             .endGenericKafkaListener()
                         .endListeners()
                     .endKafka()
-                .endSpec().done();
+                .endSpec()
+                .build());
 
-        KafkaTopicResource.topic(clusterName, topicName).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
 
-        KafkaUser kafkaUser = KafkaUserResource.scramShaUser(clusterName, kafkaUsername).done();
+        KafkaUser kafkaUser = KafkaUserResource.create(KafkaUserResource.scramShaUser(clusterName, kafkaUsername).build());
 
         String brokerPodLog = kubeClient().logs(clusterName + "-kafka-0", "kafka");
         Pattern p = Pattern.compile("^.*" + Pattern.quote(kafkaUsername) + ".*$", Pattern.MULTILINE);
@@ -225,7 +228,7 @@ public class ListenersST extends AbstractST {
             LOGGER.info("Broker pod log:\n----\n{}\n----\n", brokerPodLog);
         }
 
-        KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS, kafkaUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS, kafkaUser).build());
 
         final String kafkaClientsPodName =
             ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -265,7 +268,7 @@ public class ListenersST extends AbstractST {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
         // Use a Kafka with plain listener disabled
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
                 .editSpec()
                     .editKafka()
                         .withNewListeners()
@@ -280,13 +283,13 @@ public class ListenersST extends AbstractST {
                         .endListeners()
                     .endKafka()
                 .endSpec()
-                .done();
+                .build());
 
-        KafkaTopicResource.topic(clusterName, topicName).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
 
-        KafkaUser kafkaUser = KafkaUserResource.scramShaUser(clusterName, kafkaUsername).done();
+        KafkaUser kafkaUser = KafkaUserResource.create(KafkaUserResource.scramShaUser(clusterName, kafkaUsername).build());
 
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, kafkaUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, kafkaUser).build());
 
         final String kafkaClientsPodName =
             ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -319,7 +322,7 @@ public class ListenersST extends AbstractST {
     @Tag(NODEPORT_SUPPORTED)
     @Tag(EXTERNAL_CLIENTS_USED)
     void testNodePort() {
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -339,7 +342,7 @@ public class ListenersST extends AbstractST {
                     .withConfig(singletonMap("default.replication.factor", 3))
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(TOPIC_NAME)
@@ -388,7 +391,7 @@ public class ListenersST extends AbstractST {
                 nodePortListenerBrokerOverride.getBroker());
 
         int clusterBootstrapNodePort = 32100;
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withNewListeners()
@@ -416,7 +419,7 @@ public class ListenersST extends AbstractST {
                         .endListeners()
                     .endKafka()
                 .endSpec()
-                .done();
+                .build());
 
         LOGGER.info("Checking nodePort to {} for bootstrap service {}", clusterBootstrapNodePort,
                 KafkaResources.externalBootstrapServiceName(clusterName));
@@ -446,7 +449,7 @@ public class ListenersST extends AbstractST {
     @Tag(NODEPORT_SUPPORTED)
     @Tag(EXTERNAL_CLIENTS_USED)
     void testNodePortTls() {
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -461,9 +464,9 @@ public class ListenersST extends AbstractST {
                     .withConfig(singletonMap("default.replication.factor", 3))
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaUserResource.tlsUser(clusterName, USER_NAME).done();
+        KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, USER_NAME).build());
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(TOPIC_NAME)
@@ -485,7 +488,7 @@ public class ListenersST extends AbstractST {
     @Tag(LOADBALANCER_SUPPORTED)
     @Tag(EXTERNAL_CLIENTS_USED)
     void testLoadBalancer() {
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -499,7 +502,7 @@ public class ListenersST extends AbstractST {
                     .withConfig(singletonMap("default.replication.factor", 3))
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
         ServiceUtils.waitUntilAddressIsReachable(KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(clusterName).get().getStatus().getListeners().get(0).getAddresses().get(0).getHost());
 
@@ -522,7 +525,7 @@ public class ListenersST extends AbstractST {
     @Tag(LOADBALANCER_SUPPORTED)
     @Tag(EXTERNAL_CLIENTS_USED)
     void testLoadBalancerTls() {
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -537,9 +540,9 @@ public class ListenersST extends AbstractST {
                     .withConfig(singletonMap("default.replication.factor", 3))
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaUserResource.tlsUser(clusterName, USER_NAME).done();
+        KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, USER_NAME).build());
 
         ServiceUtils.waitUntilAddressIsReachable(KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(clusterName).get().getStatus().getListeners().get(0).getAddresses().get(0).getHost());
 
@@ -570,7 +573,7 @@ public class ListenersST extends AbstractST {
     void testCustomSoloCertificatesForNodePort() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 3)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -602,9 +605,10 @@ public class ListenersST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
-        KafkaUser aliceUser = KafkaUserResource.tlsUser(clusterName, userName).done();
+        KafkaUser aliceUser = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, userName).build());
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(topicName)
@@ -623,7 +627,7 @@ public class ListenersST extends AbstractST {
         );
 
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).build());
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
             .withTopicName(topicName)
@@ -652,7 +656,7 @@ public class ListenersST extends AbstractST {
     void testCustomChainCertificatesForNodePort() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 3)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -684,9 +688,10 @@ public class ListenersST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
-        KafkaUser aliceUser = KafkaUserResource.tlsUser(clusterName, userName).done();
+        KafkaUser aliceUser = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, userName).build());
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(topicName)
@@ -705,7 +710,7 @@ public class ListenersST extends AbstractST {
         );
 
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, customListenerName, null, aliceUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, customListenerName, null, aliceUser).build());
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
             .withUsingPodName(kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName())
@@ -734,7 +739,7 @@ public class ListenersST extends AbstractST {
     void testCustomSoloCertificatesForLoadBalancer() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 3)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -766,9 +771,10 @@ public class ListenersST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
-        KafkaUser aliceUser = KafkaUserResource.tlsUser(clusterName, userName).done();
+        KafkaUser aliceUser = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, userName).build());
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(topicName)
@@ -787,7 +793,7 @@ public class ListenersST extends AbstractST {
         );
 
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).build());
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
             .withUsingPodName(kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName())
@@ -816,7 +822,7 @@ public class ListenersST extends AbstractST {
     void testCustomChainCertificatesForLoadBalancer() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 3)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -848,12 +854,13 @@ public class ListenersST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
-        KafkaTopicResource.topic(clusterName, topicName).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
         KafkaTopicUtils.waitForKafkaTopicCreationByNamePrefix(topicName);
 
-        KafkaUser aliceUser = KafkaUserResource.tlsUser(clusterName, userName).done();
+        KafkaUser aliceUser = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, userName).build());
         KafkaUserUtils.waitForKafkaUserCreation(userName);
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
@@ -873,7 +880,7 @@ public class ListenersST extends AbstractST {
         );
 
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).build());
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
             .withUsingPodName(kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName())
@@ -903,7 +910,7 @@ public class ListenersST extends AbstractST {
     void testCustomSoloCertificatesForRoute() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 3)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -935,9 +942,10 @@ public class ListenersST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
-        KafkaUser aliceUser = KafkaUserResource.tlsUser(clusterName, userName).done();
+        KafkaUser aliceUser = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, userName).build());
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(topicName)
@@ -956,7 +964,7 @@ public class ListenersST extends AbstractST {
         );
 
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).build());
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
             .withUsingPodName(kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName())
@@ -985,7 +993,7 @@ public class ListenersST extends AbstractST {
     void testCustomChainCertificatesForRoute() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 3)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -1017,9 +1025,10 @@ public class ListenersST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
-        KafkaUser aliceUser = KafkaUserResource.tlsUser(clusterName, userName).done();
+        KafkaUser aliceUser = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, userName).build());
 
         BasicExternalKafkaClient basicExternalKafkaClient = new BasicExternalKafkaClient.Builder()
             .withTopicName(topicName)
@@ -1038,7 +1047,7 @@ public class ListenersST extends AbstractST {
         );
 
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).build());
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
             .withUsingPodName(kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName())
@@ -1069,7 +1078,7 @@ public class ListenersST extends AbstractST {
     void testCustomCertLoadBalancerAndTlsRollingUpdate() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        KafkaResource.kafkaPersistent(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -1087,9 +1096,10 @@ public class ListenersST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
-        KafkaUser aliceUser = KafkaUserResource.tlsUser(clusterName, userName).done();
+        KafkaUser aliceUser = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, userName).build());
 
         String externalCerts = getKafkaStatusCertificates(Constants.EXTERNAL_LISTENER_DEFAULT_NAME, NAMESPACE, clusterName);
         String externalSecretCerts = getKafkaSecretCertificates(clusterName + "-cluster-ca-cert", "ca.crt");
@@ -1177,7 +1187,7 @@ public class ListenersST extends AbstractST {
         );
 
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).build());
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
             .withUsingPodName(kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName())
@@ -1311,7 +1321,7 @@ public class ListenersST extends AbstractST {
     void testCustomCertNodePortAndTlsRollingUpdate() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        KafkaResource.kafkaPersistent(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -1330,9 +1340,9 @@ public class ListenersST extends AbstractST {
                     .endListeners()
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaUser aliceUser = KafkaUserResource.tlsUser(clusterName, userName).done();
+        KafkaUser aliceUser = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, userName).build());
 
         String externalCerts = getKafkaStatusCertificates(Constants.EXTERNAL_LISTENER_DEFAULT_NAME, NAMESPACE, clusterName);
         String externalSecretCerts = getKafkaSecretCertificates(clusterName + "-cluster-ca-cert", "ca.crt");
@@ -1419,7 +1429,7 @@ public class ListenersST extends AbstractST {
         );
 
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).build());
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
             .withUsingPodName(kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName())
@@ -1542,7 +1552,7 @@ public class ListenersST extends AbstractST {
     void testCustomCertRouteAndTlsRollingUpdate() {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        KafkaResource.kafkaPersistent(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -1560,9 +1570,10 @@ public class ListenersST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
-        KafkaUser aliceUser = KafkaUserResource.tlsUser(clusterName, userName).done();
+        KafkaUser aliceUser = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, userName).build());
 
         String externalCerts = getKafkaStatusCertificates(Constants.EXTERNAL_LISTENER_DEFAULT_NAME, NAMESPACE, clusterName);
         String externalSecretCerts = getKafkaSecretCertificates(clusterName + "-cluster-ca-cert", "ca.crt");
@@ -1651,7 +1662,7 @@ public class ListenersST extends AbstractST {
         );
 
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, false, aliceUser).build());
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
             .withUsingPodName(kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName())
@@ -1773,7 +1784,7 @@ public class ListenersST extends AbstractST {
         String nonExistingCertName = "non-existing-certificate";
         String clusterName = "broken-cluster";
 
-        KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(clusterName, 1, 1)
+        KafkaResource.kafkaWithoutWait(KafkaResource.kafkaEphemeral(clusterName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -1792,7 +1803,8 @@ public class ListenersST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().build());
+            .endSpec()
+            .build());
 
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(clusterName), 1);
 
@@ -1806,7 +1818,7 @@ public class ListenersST extends AbstractST {
         String nonExistingCertName = "non-existing-crt";
         String clusterName = "broken-cluster";
 
-        KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(clusterName, 1, 1)
+        KafkaResource.kafkaWithoutWait(KafkaResource.kafkaEphemeral(clusterName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -1825,7 +1837,8 @@ public class ListenersST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().build());
+            .endSpec()
+            .build());
 
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(clusterName), 1);
 
@@ -1840,7 +1853,7 @@ public class ListenersST extends AbstractST {
         String nonExistingCertKey = "non-existing-key";
         String clusterName = "broken-cluster";
 
-        KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(clusterName, 1, 1)
+        KafkaResource.kafkaWithoutWait(KafkaResource.kafkaEphemeral(clusterName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -1859,7 +1872,8 @@ public class ListenersST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().build());
+            .endSpec()
+            .build());
 
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(clusterName), 1);
 
@@ -1904,7 +1918,7 @@ public class ListenersST extends AbstractST {
     }
 
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
@@ -140,7 +140,7 @@ public class MultipleListenersST extends AbstractST {
         LOGGER.info("This is listeners {}, which will verified.", listeners);
 
         // exercise phase
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -148,15 +148,15 @@ public class MultipleListenersST extends AbstractST {
                     .endListeners()
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
         String kafkaUsername = KafkaUserUtils.generateRandomNameOfKafkaUser();
-        KafkaUser kafkaUserInstance = KafkaUserResource.tlsUser(clusterName, kafkaUsername).done();
+        KafkaUser kafkaUserInstance = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, kafkaUsername).build());
 
         for (GenericKafkaListener listener : listeners) {
 
             String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
-            KafkaTopicResource.topic(clusterName, topicName).done();
+            KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
 
             boolean isTlsEnabled = listener.isTls();
 
@@ -201,8 +201,8 @@ public class MultipleListenersST extends AbstractST {
             } else {
                 // using internal clients
                 if (isTlsEnabled) {
-                    KafkaClientsResource.deployKafkaClients(true, kafkaClientsName + "-tls",
-                        listener.getName(), kafkaUserInstance).done();
+                    KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, kafkaClientsName + "-tls",
+                        listener.getName(), kafkaUserInstance).build());
 
                     final String kafkaClientsTlsPodName =
                         ResourceManager.kubeClient().listPodsByPrefixInName(kafkaClientsName + "-tls").get(0).getMetadata().getName();
@@ -225,7 +225,7 @@ public class MultipleListenersST extends AbstractST {
                         internalTlsKafkaClient.receiveMessagesTls()
                     );
                 } else {
-                    KafkaClientsResource.deployKafkaClients(false, kafkaClientsName + "-plain").done();
+                    KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, kafkaClientsName + "-plain").build());
 
                     final String kafkaClientsPlainPodName =
                         ResourceManager.kubeClient().listPodsByPrefixInName(kafkaClientsName + "-plain").get(0).getMetadata().getName();
@@ -334,7 +334,7 @@ public class MultipleListenersST extends AbstractST {
     }
 
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
@@ -201,8 +201,8 @@ class LogSettingST extends AbstractST {
         String userName = "test-user";
         String topicName = "test-topic";
 
-        KafkaTopicResource.topic(LOG_SETTING_CLUSTER_NAME, topicName).done();
-        KafkaUserResource.tlsUser(LOG_SETTING_CLUSTER_NAME, userName).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(LOG_SETTING_CLUSTER_NAME, topicName).build());
+        KafkaUserResource.create(KafkaUserResource.tlsUser(LOG_SETTING_CLUSTER_NAME, userName).build());
 
         LOGGER.info("Checking if Kafka, Zookeeper, TO and UO of cluster:{} has log level set properly", LOG_SETTING_CLUSTER_NAME);
         assertThat("Kafka's log level is set properly", checkLoggersLevel(KAFKA_LOGGERS, KAFKA_MAP), is(true));
@@ -249,7 +249,7 @@ class LogSettingST extends AbstractST {
 
     @Test
     void testConnectLogSetting() {
-        KafkaConnectResource.kafkaConnect(CONNECT_NAME, LOG_SETTING_CLUSTER_NAME, 1, true)
+        KafkaConnectResource.create(KafkaConnectResource.kafkaConnect(CONNECT_NAME, LOG_SETTING_CLUSTER_NAME, 1)
             .editSpec()
                 .withNewInlineLogging()
                     .withLoggers(CONNECT_LOGGERS)
@@ -258,7 +258,7 @@ class LogSettingST extends AbstractST {
                     .withGcLoggingEnabled(true)
                 .endJvmOptions()
             .endSpec()
-            .done();
+            .build());
 
         String connectDepName = KafkaConnectResources.deploymentName(CONNECT_NAME);
         Map<String, String> connectPods = DeploymentUtils.depSnapshot(connectDepName);
@@ -278,7 +278,7 @@ class LogSettingST extends AbstractST {
     @Test
     @OpenShiftOnly
     void testConnectS2ILogSetting() {
-        KafkaConnectS2IResource.kafkaConnectS2I(CONNECTS2I_NAME, LOG_SETTING_CLUSTER_NAME, 1)
+        KafkaConnectS2IResource.create(KafkaConnectS2IResource.kafkaConnectS2I(CONNECTS2I_NAME, LOG_SETTING_CLUSTER_NAME, 1)
             .editSpec()
                 .withNewInlineLogging()
                     .withLoggers(CONNECT_LOGGERS)
@@ -287,7 +287,7 @@ class LogSettingST extends AbstractST {
                     .withGcLoggingEnabled(true)
                 .endJvmOptions()
             .endSpec()
-            .done();
+            .build());
 
         String connectS2IDepName = KafkaConnectS2IResources.deploymentName(CONNECTS2I_NAME);
         Map<String, String> connectS2IPods = DeploymentConfigUtils.depConfigSnapshot(connectS2IDepName);
@@ -306,7 +306,7 @@ class LogSettingST extends AbstractST {
 
     @Test
     void testMirrorMakerLogSetting() {
-        KafkaMirrorMakerResource.kafkaMirrorMaker(MM_NAME, LOG_SETTING_CLUSTER_NAME, GC_LOGGING_SET_NAME, "my-group", 1, false)
+        KafkaMirrorMakerResource.create(KafkaMirrorMakerResource.kafkaMirrorMaker(MM_NAME, LOG_SETTING_CLUSTER_NAME, GC_LOGGING_SET_NAME, "my-group", 1, false)
             .editSpec()
                 .withNewInlineLogging()
                     .withLoggers(MIRROR_MAKER_LOGGERS)
@@ -315,7 +315,7 @@ class LogSettingST extends AbstractST {
                     .withGcLoggingEnabled(true)
                 .endJvmOptions()
             .endSpec()
-            .done();
+            .build());
 
         String mmDepName = KafkaMirrorMakerResources.deploymentName(MM_NAME);
         Map<String, String> mmPods = DeploymentUtils.depSnapshot(mmDepName);
@@ -334,7 +334,7 @@ class LogSettingST extends AbstractST {
 
     @Test
     void testMirrorMaker2LogSetting() {
-        KafkaMirrorMaker2Resource.kafkaMirrorMaker2(MM2_NAME, LOG_SETTING_CLUSTER_NAME, GC_LOGGING_SET_NAME, 1, false)
+        KafkaMirrorMaker2Resource.create(KafkaMirrorMaker2Resource.kafkaMirrorMaker2(MM2_NAME, LOG_SETTING_CLUSTER_NAME, GC_LOGGING_SET_NAME, 1, false)
             .editSpec()
                 .withNewInlineLogging()
                     .withLoggers(MIRROR_MAKER_LOGGERS)
@@ -343,7 +343,7 @@ class LogSettingST extends AbstractST {
                     .withGcLoggingEnabled(true)
                 .endJvmOptions()
             .endSpec()
-            .done();
+            .build());
 
         String mm2DepName = KafkaMirrorMaker2Resources.deploymentName(MM2_NAME);
         Map<String, String> mm2Pods = DeploymentUtils.depSnapshot(mm2DepName);
@@ -362,7 +362,7 @@ class LogSettingST extends AbstractST {
 
     @Test
     void testBridgeLogSetting() {
-        KafkaBridgeResource.kafkaBridge(BRIDGE_NAME, LOG_SETTING_CLUSTER_NAME, KafkaResources.plainBootstrapAddress(LOG_SETTING_CLUSTER_NAME), 1)
+        KafkaBridgeResource.create(KafkaBridgeResource.kafkaBridge(BRIDGE_NAME, LOG_SETTING_CLUSTER_NAME, KafkaResources.plainBootstrapAddress(LOG_SETTING_CLUSTER_NAME), 1)
             .editSpec()
                 .withNewInlineLogging()
                     .withLoggers(BRIDGE_LOGGERS)
@@ -371,7 +371,7 @@ class LogSettingST extends AbstractST {
                     .withGcLoggingEnabled(true)
                 .endJvmOptions()
             .endSpec()
-            .done();
+            .build());
 
         String bridgeDepName = KafkaBridgeResources.deploymentName(BRIDGE_NAME);
         Map<String, String> bridgePods = DeploymentUtils.depSnapshot(bridgeDepName);
@@ -483,13 +483,13 @@ class LogSettingST extends AbstractST {
     }
 
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
 
         timeMeasuringSystem.setOperationID(startDeploymentMeasuring());
 
-        KafkaResource.kafkaPersistent(LOG_SETTING_CLUSTER_NAME, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaPersistent(LOG_SETTING_CLUSTER_NAME, 3, 1)
             .editSpec()
                 .editKafka()
                     .withNewInlineLogging()
@@ -530,10 +530,10 @@ class LogSettingST extends AbstractST {
                 .withNewKafkaExporter()
                 .endKafkaExporter()
             .endSpec()
-            .done();
+            .build());
 
         // deploying second Kafka here because of MM and MM2 tests
-        KafkaResource.kafkaPersistent(GC_LOGGING_SET_NAME, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaPersistent(GC_LOGGING_SET_NAME, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewJvmOptions()
@@ -554,9 +554,9 @@ class LogSettingST extends AbstractST {
                     .endUserOperator()
                 .endEntityOperator()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).build());
     }
 
     private String startDeploymentMeasuring() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -154,7 +154,7 @@ class LoggingChangeST extends AbstractST {
 
         // We have to install CO in class stack, otherwise it will be deleted at the end of test case and all following tests will fail
         ResourceManager.setClassResources();
-        BundleResource.clusterOperator(NAMESPACE)
+        BundleResource.create(BundleResource.clusterOperator(NAMESPACE)
             .editOrNewSpec()
                 .editOrNewTemplate()
                     .editOrNewSpec()
@@ -171,11 +171,11 @@ class LoggingChangeST extends AbstractST {
                     .endSpec()
                 .endTemplate()
             .endSpec()
-            .done();
+            .build());
         // Now we set pointer stack to method again
         ResourceManager.setMethodResources();
 
-        KafkaResource.kafkaPersistent(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3)
             .editOrNewSpec()
                 .editKafka()
                     .withLogging(new ExternalLoggingBuilder().withName(configMapKafkaName).build())
@@ -192,7 +192,7 @@ class LoggingChangeST extends AbstractST {
                     .endUserOperator()
                 .endEntityOperator()
             .endSpec()
-            .done();
+            .build());
 
         Map<String, String> zkPods = StatefulSetUtils.ssSnapshot(KafkaResources.zookeeperStatefulSetName(clusterName));
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(clusterName));
@@ -213,7 +213,7 @@ class LoggingChangeST extends AbstractST {
         InlineLogging ilOff = new InlineLogging();
         ilOff.setLoggers(Collections.singletonMap("rootLogger.level", "OFF"));
 
-        KafkaResource.kafkaPersistent(clusterName, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 1, 1)
                 .editSpec()
                     .editEntityOperator()
                         .editTopicOperator()
@@ -224,7 +224,7 @@ class LoggingChangeST extends AbstractST {
                         .endUserOperator()
                     .endEntityOperator()
                 .endSpec()
-                .done();
+                .build());
 
         String eoDeploymentName = KafkaResources.entityOperatorDeploymentName(clusterName);
         Map<String, String> eoPods = DeploymentUtils.depSnapshot(eoDeploymentName);
@@ -384,15 +384,15 @@ class LoggingChangeST extends AbstractST {
         loggers.put("logger.ready.level", "OFF");
         ilOff.setLoggers(loggers);
 
-        KafkaResource.kafkaPersistent(clusterName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 1, 1).build());
 
-        KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).build());
 
-        KafkaBridgeResource.kafkaBridge(clusterName, KafkaResources.tlsBootstrapAddress(clusterName), 1)
+        KafkaBridgeResource.create(KafkaBridgeResource.kafkaBridge(clusterName, KafkaResources.tlsBootstrapAddress(clusterName), 1)
                 .editSpec()
                     .withInlineLogging(ilOff)
                 .endSpec()
-                .done();
+                .build());
 
         Map<String, String> bridgeSnapshot = DeploymentUtils.depSnapshot(KafkaBridgeResources.deploymentName(clusterName));
 
@@ -585,17 +585,17 @@ class LoggingChangeST extends AbstractST {
         loggers.put("connect.root.logger.level", "OFF");
         ilOff.setLoggers(loggers);
 
-        KafkaResource.kafkaEphemeral(clusterName, 3).done();
-        KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3).build());
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).build());
         String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(kafkaClientsName).get(0).getMetadata().getName();
-        KafkaConnectResource.kafkaConnect(clusterName, 1)
+        KafkaConnectResource.create(KafkaConnectResource.kafkaConnect(clusterName, 1)
                 .editSpec()
                 .withInlineLogging(ilOff)
                 .endSpec()
                 .editMetadata()
                     .addToAnnotations("strimzi.io/use-connector-resources", "true")
                 .endMetadata()
-                .done();
+                .build());
 
         Map<String, String> connectSnapshot = DeploymentUtils.depSnapshot(KafkaConnectResources.deploymentName(clusterName));
 
@@ -656,7 +656,7 @@ class LoggingChangeST extends AbstractST {
 
     @Test
     void testDynamicallySetKafkaLoggingLevels() {
-        KafkaResource.kafkaPersistent(clusterName, 3, 1).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 1).build());
         String kafkaName = KafkaResources.kafkaStatefulSetName(clusterName);
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaName);
 
@@ -723,7 +723,7 @@ class LoggingChangeST extends AbstractST {
 
     @Test
     void testDynamicallySetUnknownKafkaLogger() {
-        KafkaResource.kafkaPersistent(clusterName, 3, 1).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 1).build());
         String kafkaName = KafkaResources.kafkaStatefulSetName(clusterName);
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaName);
 
@@ -743,7 +743,7 @@ class LoggingChangeST extends AbstractST {
 
     @Test
     void testDynamicallySetUnknownKafkaLoggerValue() {
-        KafkaResource.kafkaPersistent(clusterName, 3, 1).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 1).build());
         String kafkaName = KafkaResources.kafkaStatefulSetName(clusterName);
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaName);
 
@@ -788,13 +788,13 @@ class LoggingChangeST extends AbstractST {
         ExternalLogging el = new ExternalLogging();
         el.setName("external-cm");
 
-        KafkaResource.kafkaPersistent(clusterName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 1)
                 .editOrNewSpec()
                     .editKafka()
                         .withExternalLogging(el)
                     .endKafka()
                 .endSpec()
-                .done();
+                .build());
 
         String kafkaName = KafkaResources.kafkaStatefulSetName(clusterName);
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaName);
@@ -871,10 +871,10 @@ class LoggingChangeST extends AbstractST {
         loggers.put("connect.root.logger.level", "OFF");
         ilOff.setLoggers(loggers);
 
-        KafkaResource.kafkaEphemeral(clusterName + "-source", 3).done();
-        KafkaResource.kafkaEphemeral(clusterName + "-target", 3).done();
-        KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).done();
-        KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, clusterName + "-target", clusterName + "-source", 1, false).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName + "-source", 3).build());
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName + "-target", 3).build());
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).build());
+        KafkaMirrorMaker2Resource.create(KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, clusterName + "-target", clusterName + "-source", 1, false).build());
         String kafkaMM2PodName = kubeClient().listPods(Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND).get(0).getMetadata().getName();
         String mm2LogCheckCmd = "http://localhost:8083/admin/loggers/root";
 
@@ -934,7 +934,7 @@ class LoggingChangeST extends AbstractST {
     }
 
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -188,7 +188,7 @@ public class MetricsST extends AbstractST {
     @Tag(ACCEPTANCE)
     @Tag(INTERNAL_CLIENTS_USED)
     void testKafkaExporterDataAfterExchange() {
-        KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).build());
 
         final String defaultKafkaClientsPodName =
             ResourceManager.kubeClient().listPodsByPrefixInName(kafkaClientsName).get(0).getMetadata().getName();
@@ -245,7 +245,7 @@ public class MetricsST extends AbstractST {
         List<String> resourcesList = Arrays.asList("Kafka", "KafkaBridge", "KafkaConnect", "KafkaConnectS2I", "KafkaConnector", "KafkaMirrorMaker", "KafkaMirrorMaker2", "KafkaRebalance");
 
         // Create some resource which will have state 0. S2I will not be ready, because there is KafkaConnect cluster with same name.
-        KafkaConnectS2IResource.kafkaConnectS2IWithoutWait(KafkaConnectS2IResource.defaultKafkaConnectS2I(metricsClusterName, metricsClusterName, 1).build());
+        KafkaConnectS2IResource.kafkaConnectS2IWithoutWait(KafkaConnectS2IResource.kafkaConnectS2I(metricsClusterName, metricsClusterName, 1).build());
 
         for (String resource : resourcesList) {
             assertCoMetricNotNull("strimzi_reconciliations_periodical_total", resource, clusterOperatorMetricsData);
@@ -357,8 +357,8 @@ public class MetricsST extends AbstractST {
             .build();
 
 
-        kafkaBridgeClientJob.producerStrimziBridge().done();
-        kafkaBridgeClientJob.consumerStrimziBridge().done();
+        kafkaBridgeClientJob.create(kafkaBridgeClientJob.producerStrimziBridge().build());
+        kafkaBridgeClientJob.create(kafkaBridgeClientJob.consumerStrimziBridge().build());
 
         TestUtils.waitFor("KafkaProducer metrics will be available", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT, () -> {
             LOGGER.info("Looking for 'strimzi_bridge_kafka_producer_count' in bridge metrics");
@@ -626,7 +626,7 @@ public class MetricsST extends AbstractST {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
 
-        KafkaResource.kafkaWithMetricsAndCruiseControlWithMetrics(metricsClusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaWithMetricsAndCruiseControlWithMetrics(metricsClusterName, 3, 3)
             .editOrNewSpec()
                 .editEntityOperator()
                     .editUserOperator()
@@ -634,18 +634,18 @@ public class MetricsST extends AbstractST {
                     .endUserOperator()
                 .endEntityOperator()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaResource.kafkaWithMetrics(SECOND_CLUSTER, 1, 1).done();
-        KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).done();
-        KafkaConnectResource.kafkaConnectWithMetrics(metricsClusterName, 1).done();
-        KafkaMirrorMaker2Resource.kafkaMirrorMaker2WithMetrics(MIRROR_MAKER_CLUSTER, metricsClusterName, SECOND_CLUSTER, 1).done();
-        KafkaBridgeResource.kafkaBridgeWithMetrics(BRIDGE_CLUSTER, metricsClusterName, KafkaResources.plainBootstrapAddress(metricsClusterName), 1).done();
-        KafkaTopicResource.topic(metricsClusterName, TOPIC_NAME, 7, 2).done();
-        KafkaTopicResource.topic(metricsClusterName, bridgeTopic).done();
+        KafkaResource.create(KafkaResource.kafkaWithMetrics(SECOND_CLUSTER, 1, 1).build());
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).build());
+        KafkaConnectResource.create(KafkaConnectResource.kafkaConnectWithMetrics(metricsClusterName, 1).build());
+        KafkaMirrorMaker2Resource.create(KafkaMirrorMaker2Resource.kafkaMirrorMaker2WithMetrics(MIRROR_MAKER_CLUSTER, metricsClusterName, SECOND_CLUSTER, 1).build());
+        KafkaBridgeResource.create(KafkaBridgeResource.kafkaBridgeWithMetrics(BRIDGE_CLUSTER, metricsClusterName, KafkaResources.plainBootstrapAddress(metricsClusterName), 1).build());
+        KafkaTopicResource.create(KafkaTopicResource.topic(metricsClusterName, TOPIC_NAME, 7, 2).build());
+        KafkaTopicResource.create(KafkaTopicResource.topic(metricsClusterName, bridgeTopic).build());
 
-        KafkaUserResource.tlsUser(metricsClusterName, KafkaUserUtils.generateRandomNameOfKafkaUser()).done();
-        KafkaUserResource.tlsUser(metricsClusterName, KafkaUserUtils.generateRandomNameOfKafkaUser()).done();
+        KafkaUserResource.create(KafkaUserResource.tlsUser(metricsClusterName, KafkaUserUtils.generateRandomNameOfKafkaUser()).build());
+        KafkaUserResource.create(KafkaUserResource.tlsUser(metricsClusterName, KafkaUserUtils.generateRandomNameOfKafkaUser()).build());
 
         // Wait for Metrics refresh/values change
         Thread.sleep(60_000);

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -109,13 +109,13 @@ class MirrorMaker2ST extends AbstractST {
         String topicSourceNameMirrored = kafkaClusterSourceName + "." + AVAILABILITY_TOPIC_SOURCE_NAME;
 
         // Deploy source kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
         // Deploy target kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
         // Deploy Topic
-        KafkaTopicResource.topic(kafkaClusterSourceName, topicSourceName, 3).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterSourceName, topicSourceName, 3).build());
 
-        KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).build());
 
         final String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
 
@@ -151,7 +151,7 @@ class MirrorMaker2ST extends AbstractST {
             internalKafkaClient.receiveMessagesPlain()
         );
 
-        KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
+        KafkaMirrorMaker2Resource.create(KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
                 .editSpec()
                     .editFirstMirror()
                         .editSourceConnector()
@@ -159,7 +159,7 @@ class MirrorMaker2ST extends AbstractST {
                         .endSourceConnector()
                     .endMirror()
                 .endSpec()
-                .done();
+                .build());
 
         LOGGER.info("Looks like the mirrormaker2 cluster my-cluster deployed OK");
 
@@ -249,7 +249,7 @@ class MirrorMaker2ST extends AbstractST {
         listenerTls.setAuth(auth);
 
         // Deploy source kafka with tls listener and mutual tls auth
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -262,10 +262,11 @@ class MirrorMaker2ST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
         // Deploy target kafka with tls listener and mutual tls auth
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -278,17 +279,18 @@ class MirrorMaker2ST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
         // Deploy topic
-        KafkaTopicResource.topic(kafkaClusterSourceName, topicSourceName, 3).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterSourceName, topicSourceName, 3).build());
 
         // Create Kafka user
-        KafkaUser userSource = KafkaUserResource.tlsUser(kafkaClusterSourceName, kafkaUserSourceName).done();
+        KafkaUser userSource = KafkaUserResource.create(KafkaUserResource.tlsUser(kafkaClusterSourceName, kafkaUserSourceName).build());
 
-        KafkaUser userTarget = KafkaUserResource.tlsUser(kafkaClusterTargetName, kafkaUserTargetName).done();
+        KafkaUser userTarget = KafkaUserResource.create(KafkaUserResource.tlsUser(kafkaClusterTargetName, kafkaUserTargetName).build());
 
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, userSource, userTarget).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, userSource, userTarget).build());
 
         final String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
 
@@ -370,14 +372,14 @@ class MirrorMaker2ST extends AbstractST {
                 .addToConfig("status.storage.replication.factor", 1)
                 .build();
 
-        KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, true)
+        KafkaMirrorMaker2Resource.create(KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, true)
             .editSpec()
                 .withClusters(sourceClusterWithTlsAuth, targetClusterWithTlsAuth)
                 .editFirstMirror()
                     .withNewTopicsPattern(MIRRORMAKER2_TOPIC_NAME + ".*")
                 .endMirror()
             .endSpec()
-            .done();
+            .build());
 
         LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
             topicSourceName, kafkaClusterSourceName, userSource.getMetadata().getName());
@@ -437,7 +439,7 @@ class MirrorMaker2ST extends AbstractST {
         String kafkaUserTarget = "my-user-target";
 
         // Deploy source kafka with tls listener and SCRAM-SHA authentication
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -450,10 +452,11 @@ class MirrorMaker2ST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
         // Deploy target kafka with tls listener and SCRAM-SHA authentication
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -466,16 +469,17 @@ class MirrorMaker2ST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
         // Deploy topic
-        KafkaTopicResource.topic(kafkaClusterSourceName, topicSourceName, 3).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterSourceName, topicSourceName, 3).build());
 
         // Create Kafka user for source cluster
-        KafkaUser userSource = KafkaUserResource.scramShaUser(kafkaClusterSourceName, kafkaUserSource).done();
+        KafkaUser userSource = KafkaUserResource.create(KafkaUserResource.scramShaUser(kafkaClusterSourceName, kafkaUserSource).build());
 
         // Create Kafka user for target cluster
-        KafkaUser userTarget = KafkaUserResource.scramShaUser(kafkaClusterTargetName, kafkaUserTarget).done();
+        KafkaUser userTarget = KafkaUserResource.create(KafkaUserResource.scramShaUser(kafkaClusterTargetName, kafkaUserTarget).build());
 
         // Initialize PasswordSecretSource to set this as PasswordSecret in MirrorMaker2 spec
         PasswordSecretSource passwordSecretSource = new PasswordSecretSource();
@@ -498,7 +502,7 @@ class MirrorMaker2ST extends AbstractST {
         certSecretTarget.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterTargetName));
 
         // Deploy client
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, userSource, userTarget).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, userSource, userTarget).build());
 
         final String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
 
@@ -564,13 +568,14 @@ class MirrorMaker2ST extends AbstractST {
                 .addToConfig("status.storage.replication.factor", 1)
                 .build();
 
-        KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, true)
+        KafkaMirrorMaker2Resource.create(KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, true)
             .editSpec()
                 .withClusters(targetClusterWithScramSha512Auth, sourceClusterWithScramSha512Auth)
                 .editFirstMirror()
                     .withTopicsBlacklistPattern("availability.*")
                 .endMirror()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
         LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
             topicSourceName, kafkaClusterSourceName, userSource.getMetadata().getName());
@@ -633,11 +638,11 @@ class MirrorMaker2ST extends AbstractST {
     @Tag(SCALABILITY)
     void testScaleMirrorMaker2Subresource() {
         // Deploy source kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
         // Deploy target kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
 
-        KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false).done();
+        KafkaMirrorMaker2Resource.create(KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false).build());
 
         int scaleTo = 4;
         long mm2ObsGen = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(NAMESPACE).withName(clusterName).get().getStatus().getObservedGeneration();
@@ -671,13 +676,13 @@ class MirrorMaker2ST extends AbstractST {
         String targetExampleTopic = kafkaClusterSourceName + "." + sourceExampleTopic;
 
         // Deploy source kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
         // Deploy target kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
         // Deploy Topic for example clients
-        KafkaTopicResource.topic(kafkaClusterSourceName, sourceExampleTopic).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterSourceName, sourceExampleTopic).build());
 
-        KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false).done();
+        KafkaMirrorMaker2Resource.create(KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false).build());
 
         //deploying example clients for checking if mm2 will mirror messages with headers
 
@@ -689,7 +694,7 @@ class MirrorMaker2ST extends AbstractST {
             .withDelayMs(1000)
             .build();
 
-        targetKafkaClientsJob.consumerStrimzi().done();
+        targetKafkaClientsJob.create(targetKafkaClientsJob.consumerStrimzi().build());
 
         KafkaBasicExampleClients sourceKafkaClientsJob = new KafkaBasicExampleClients.Builder()
             .withProducerName(sourceProducerName)
@@ -699,7 +704,7 @@ class MirrorMaker2ST extends AbstractST {
             .withDelayMs(1000)
             .build();
 
-        sourceKafkaClientsJob.producerStrimzi()
+        sourceKafkaClientsJob.create(sourceKafkaClientsJob.producerStrimzi()
             .editSpec()
                 .editTemplate()
                     .editSpec()
@@ -712,7 +717,7 @@ class MirrorMaker2ST extends AbstractST {
                     .endSpec()
                 .endTemplate()
             .endSpec()
-            .done();
+            .build());
 
         ClientUtils.waitTillContinuousClientsFinish(sourceProducerName, targetConsumerName, NAMESPACE, MESSAGE_COUNT);
 
@@ -728,11 +733,11 @@ class MirrorMaker2ST extends AbstractST {
     @Tag(SCALABILITY)
     void testScaleMirrorMaker2ToZero() {
         // Deploy source kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
         // Deploy target kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
 
-        KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 3, false).done();
+        KafkaMirrorMaker2Resource.create(KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 3, false).build());
 
         long oldObsGen = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(NAMESPACE).withName(clusterName).get().getStatus().getObservedGeneration();
         String mm2DepName = KafkaMirrorMaker2Resources.deploymentName(clusterName);
@@ -759,17 +764,17 @@ class MirrorMaker2ST extends AbstractST {
         String originalTopicName = "original-topic";
 
         // Deploy source kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
         // Deploy target kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
         // Create topic
-        KafkaTopicResource.topic(kafkaClusterSourceName, originalTopicName, 3).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterSourceName, originalTopicName, 3).build());
 
-        KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).build());
 
         final String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(kafkaClientsName).get(0).getMetadata().getName();
 
-        KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
+        KafkaMirrorMaker2Resource.create(KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
             .editSpec()
                 .editMirror(0)
                     .editSourceConnector()
@@ -777,7 +782,7 @@ class MirrorMaker2ST extends AbstractST {
                     .endSourceConnector()
                 .endMirror()
             .endSpec()
-            .done();
+            .build());
 
         LOGGER.info("Sending and receiving messages via {}", kafkaClusterSourceName);
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
@@ -820,11 +825,11 @@ class MirrorMaker2ST extends AbstractST {
             .build();
 
         // Deploy source kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
         // Deploy target kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
 
-        KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
+        KafkaMirrorMaker2Resource.create(KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
             .editSpec()
                 .withNewTemplate()
                     .withNewPod()
@@ -832,7 +837,7 @@ class MirrorMaker2ST extends AbstractST {
                     .endPod()
                 .endTemplate()
             .endSpec()
-            .done();
+            .build());
 
         String mm2PodName = kubeClient().listPods(Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND).get(0).getMetadata().getName();
 
@@ -844,11 +849,11 @@ class MirrorMaker2ST extends AbstractST {
     @Test
     void testConfigureDeploymentStrategy() {
         // Deploy source kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
         // Deploy target kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
 
-        KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
+        KafkaMirrorMaker2Resource.create(KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
             .editSpec()
                 .editOrNewTemplate()
                     .editOrNewDeployment()
@@ -856,7 +861,7 @@ class MirrorMaker2ST extends AbstractST {
                     .endDeployment()
                 .endTemplate()
             .endSpec()
-            .done();
+            .build());
 
         String mm2DepName = KafkaMirrorMaker2Resources.deploymentName(clusterName);
 
@@ -889,7 +894,7 @@ class MirrorMaker2ST extends AbstractST {
     }
 
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
@@ -83,13 +83,13 @@ public class MirrorMakerST extends AbstractST {
         String topicSourceName = TOPIC_NAME + "-source" + "-" + rng.nextInt(Integer.MAX_VALUE);
 
         // Deploy source kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
         // Deploy target kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
         // Deploy Topic
-        KafkaTopicResource.topic(kafkaClusterSourceName, topicSourceName).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterSourceName, topicSourceName).build());
 
-        KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).build());
 
         final String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
 
@@ -119,7 +119,7 @@ public class MirrorMakerST extends AbstractST {
         );
 
         // Deploy Mirror Maker
-        KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterSourceName, kafkaClusterTargetName, ClientUtils.generateRandomConsumerGroup(), 1, false).
+        KafkaMirrorMakerResource.create(KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterSourceName, kafkaClusterTargetName, ClientUtils.generateRandomConsumerGroup(), 1, false).
                 editSpec()
                 .withResources(new ResourceRequirementsBuilder()
                         .addToLimits("memory", new Quantity("400M"))
@@ -132,7 +132,8 @@ public class MirrorMakerST extends AbstractST {
                     .withXms("200m")
                     .withXx(jvmOptionsXX)
                 .endJvmOptions()
-                .endSpec().done();
+                .endSpec()
+                .build());
 
         verifyLabelsOnPods(clusterName, "mirror-maker", null, "KafkaMirrorMaker");
         verifyLabelsForService(clusterName, "mirror-maker", "KafkaMirrorMaker");
@@ -187,7 +188,7 @@ public class MirrorMakerST extends AbstractST {
         String kafkaTargetUserName = "my-user-target";
 
         // Deploy source kafka with tls listener and mutual tls auth
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -200,10 +201,11 @@ public class MirrorMakerST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
         // Deploy target kafka with tls listener and mutual tls auth
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -216,15 +218,16 @@ public class MirrorMakerST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
         // Deploy topic
-        KafkaTopicResource.topic(kafkaClusterSourceName, topicSourceName).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterSourceName, topicSourceName).build());
 
         // Create Kafka user
-        KafkaUser userSource = KafkaUserResource.tlsUser(kafkaClusterSourceName, kafkaSourceUserName).done();
+        KafkaUser userSource = KafkaUserResource.create(KafkaUserResource.tlsUser(kafkaClusterSourceName, kafkaSourceUserName).build());
 
-        KafkaUser userTarget = KafkaUserResource.tlsUser(kafkaClusterTargetName, kafkaTargetUserName).done();
+        KafkaUser userTarget = KafkaUserResource.create(KafkaUserResource.tlsUser(kafkaClusterTargetName, kafkaTargetUserName).build());
 
         // Initialize CertSecretSource with certificate and secret names for consumer
         CertSecretSource certSecretSource = new CertSecretSource();
@@ -236,7 +239,7 @@ public class MirrorMakerST extends AbstractST {
         certSecretTarget.setCertificate("ca.crt");
         certSecretTarget.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterTargetName));
 
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, userSource, userTarget).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, userSource, userTarget).build());
 
         final String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
 
@@ -269,7 +272,7 @@ public class MirrorMakerST extends AbstractST {
         );
 
         // Deploy Mirror Maker with tls listener and mutual tls auth
-        KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterSourceName, kafkaClusterTargetName, ClientUtils.generateRandomConsumerGroup(), 1, true)
+        KafkaMirrorMakerResource.create(KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterSourceName, kafkaClusterTargetName, ClientUtils.generateRandomConsumerGroup(), 1, true)
             .editSpec()
                 .editConsumer()
                     .withNewTls()
@@ -296,7 +299,7 @@ public class MirrorMakerST extends AbstractST {
                     .endKafkaClientAuthenticationTls()
                 .endProducer()
             .endSpec()
-            .done();
+            .build());
 
         internalKafkaClient = internalKafkaClient.toBuilder()
             .withTopicName(topicSourceName)
@@ -332,7 +335,7 @@ public class MirrorMakerST extends AbstractST {
         String kafkaUserTarget = "my-user-target";
 
         // Deploy source kafka with tls listener and SCRAM-SHA authentication
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -345,10 +348,11 @@ public class MirrorMakerST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
         // Deploy target kafka with tls listener and SCRAM-SHA authentication
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -361,16 +365,17 @@ public class MirrorMakerST extends AbstractST {
                         .endGenericKafkaListener()
                     .endListeners()
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
         // Deploy topic
-        KafkaTopicResource.topic(kafkaClusterSourceName, TOPIC_NAME).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterSourceName, TOPIC_NAME).build());
 
         // Create Kafka user for source cluster
-        KafkaUser userSource = KafkaUserResource.scramShaUser(kafkaClusterSourceName, kafkaUserSource).done();
+        KafkaUser userSource = KafkaUserResource.create(KafkaUserResource.scramShaUser(kafkaClusterSourceName, kafkaUserSource).build());
 
         // Create Kafka user for target cluster
-        KafkaUser userTarget = KafkaUserResource.scramShaUser(kafkaClusterTargetName, kafkaUserTarget).done();
+        KafkaUser userTarget = KafkaUserResource.create(KafkaUserResource.scramShaUser(kafkaClusterTargetName, kafkaUserTarget).build());
 
         // Initialize PasswordSecretSource to set this as PasswordSecret in Mirror Maker spec
         PasswordSecretSource passwordSecretSource = new PasswordSecretSource();
@@ -393,7 +398,7 @@ public class MirrorMakerST extends AbstractST {
         certSecretTarget.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterTargetName));
 
         // Deploy client
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, userSource, userTarget).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, userSource, userTarget).build());
 
         final String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
 
@@ -425,7 +430,7 @@ public class MirrorMakerST extends AbstractST {
         );
 
         // Deploy Mirror Maker with TLS and ScramSha512
-        KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterSourceName, kafkaClusterTargetName, ClientUtils.generateRandomConsumerGroup(), 1, true)
+        KafkaMirrorMakerResource.create(KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterSourceName, kafkaClusterTargetName, ClientUtils.generateRandomConsumerGroup(), 1, true)
             .editSpec()
                 .editConsumer()
                     .withNewKafkaClientAuthenticationScramSha512()
@@ -445,7 +450,8 @@ public class MirrorMakerST extends AbstractST {
                         .withTrustedCertificates(certSecretTarget)
                     .endTls()
                 .endProducer()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
         internalKafkaClient = internalKafkaClient.toBuilder()
             .withTopicName(TOPIC_NAME)
@@ -490,15 +496,15 @@ public class MirrorMakerST extends AbstractST {
         String topicNotInWhitelist = "non-whitelist-topic";
 
         LOGGER.info("Creating kafka source cluster {}", kafkaClusterSourceName);
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
 
         LOGGER.info("Creating kafka target cluster {}", kafkaClusterTargetName);
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
 
-        KafkaTopicResource.topic(kafkaClusterSourceName, topicName).done();
-        KafkaTopicResource.topic(kafkaClusterSourceName, topicNotInWhitelist).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterSourceName, topicName).build());
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterSourceName, topicNotInWhitelist).build());
 
-        KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).build());
 
         String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
 
@@ -528,11 +534,11 @@ public class MirrorMakerST extends AbstractST {
             internalKafkaClient.receiveMessagesPlain()
         );
 
-        KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterSourceName, kafkaClusterTargetName, ClientUtils.generateRandomConsumerGroup(), 1, false)
+        KafkaMirrorMakerResource.create(KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterSourceName, kafkaClusterTargetName, ClientUtils.generateRandomConsumerGroup(), 1, false)
                 .editSpec()
                     .withNewWhitelist(topicName)
                 .endSpec()
-                .done();
+                .build());
 
         internalKafkaClient = internalKafkaClient.toBuilder()
             .withTopicName(topicName)
@@ -577,11 +583,12 @@ public class MirrorMakerST extends AbstractST {
 
     @Test
     void testCustomAndUpdatedValues() {
-        KafkaResource.kafkaEphemeral(clusterName, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 1, 1)
             .editSpec()
                 .withNewEntityOperator()
                 .endEntityOperator()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
         String usedVariable = "KAFKA_MIRRORMAKER_CONFIGURATION_PRODUCER";
 
@@ -616,7 +623,7 @@ public class MirrorMakerST extends AbstractST {
         int updatedPeriodSeconds = 5;
         int updatedFailureThreshold = 1;
 
-        KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, clusterName, clusterName, ClientUtils.generateRandomConsumerGroup(), 1, false)
+        KafkaMirrorMakerResource.create(KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, clusterName, clusterName, ClientUtils.generateRandomConsumerGroup(), 1, false)
             .editSpec()
                 .editProducer()
                     .withConfig(producerConfig)
@@ -644,7 +651,7 @@ public class MirrorMakerST extends AbstractST {
                     .withFailureThreshold(failureThreshold)
                 .endLivenessProbe()
             .endSpec()
-            .done();
+            .build());
 
         Map<String, String> connectSnapshot = DeploymentUtils.depSnapshot(KafkaMirrorMakerResources.deploymentName(clusterName));
 
@@ -692,11 +699,11 @@ public class MirrorMakerST extends AbstractST {
     @Tag(SCALABILITY)
     void testScaleMirrorMakerSubresource() {
         // Deploy source kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
         // Deploy target kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
 
-        KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, ClientUtils.generateRandomConsumerGroup(), 1, false).done();
+        KafkaMirrorMakerResource.create(KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, ClientUtils.generateRandomConsumerGroup(), 1, false).build());
 
         int scaleTo = 4;
         long mmObsGen = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(NAMESPACE).withName(clusterName).get().getStatus().getObservedGeneration();
@@ -726,11 +733,11 @@ public class MirrorMakerST extends AbstractST {
     @Tag(SCALABILITY)
     void testScaleMirrorMakerToZero() {
         // Deploy source kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
         // Deploy target kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
 
-        KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, "my-group" + rng.nextInt(Integer.MAX_VALUE), 3, false).done();
+        KafkaMirrorMakerResource.create(KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, "my-group" + rng.nextInt(Integer.MAX_VALUE), 3, false).build());
 
         long oldObsGen = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(NAMESPACE).withName(clusterName).get().getStatus().getObservedGeneration();
         String mmDepName = KafkaMirrorMakerResources.deploymentName(clusterName);
@@ -759,11 +766,11 @@ public class MirrorMakerST extends AbstractST {
             .build();
 
         // Deploy source kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
         // Deploy target kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
 
-        KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, ClientUtils.generateRandomConsumerGroup(), 3, false)
+        KafkaMirrorMakerResource.create(KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, ClientUtils.generateRandomConsumerGroup(), 3, false)
             .editSpec()
                 .withNewTemplate()
                     .withNewPod()
@@ -771,7 +778,7 @@ public class MirrorMakerST extends AbstractST {
                     .endPod()
                 .endTemplate()
             .endSpec()
-            .done();
+            .build());
 
         String mmPodName = kubeClient().listPods(Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker.RESOURCE_KIND).get(0).getMetadata().getName();
 
@@ -783,11 +790,11 @@ public class MirrorMakerST extends AbstractST {
     @Test
     void testConfigureDeploymentStrategy() {
         // Deploy source kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
         // Deploy target kafka
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
 
-        KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, ClientUtils.generateRandomConsumerGroup(), 1, false)
+        KafkaMirrorMakerResource.create(KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, ClientUtils.generateRandomConsumerGroup(), 1, false)
             .editSpec()
                 .editOrNewTemplate()
                     .editOrNewDeployment()
@@ -795,7 +802,7 @@ public class MirrorMakerST extends AbstractST {
                     .endDeployment()
                 .endTemplate()
             .endSpec()
-            .done();
+            .build());
 
         String mmDepName = KafkaMirrorMakerResources.deploymentName(clusterName);
 
@@ -828,7 +835,7 @@ public class MirrorMakerST extends AbstractST {
     }
     
     @BeforeAll
-    void setupEnvironment() throws Exception {
+    void setupEnvironment() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAbstractST.java
@@ -48,14 +48,14 @@ public class OlmAbstractST extends AbstractST {
     void doTestDeployExampleKafkaUser() {
         String userKafkaName = "user-kafka";
         // KafkaUser example needs Kafka with authorization
-        KafkaResource.kafkaEphemeral(userKafkaName, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(userKafkaName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewKafkaAuthorizationSimple()
                     .endKafkaAuthorizationSimple()
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
         JsonObject kafkaUserResource = OlmResource.getExampleResources().get(KafkaUser.RESOURCE_KIND);
         kafkaUserResource.getJsonObject("metadata").getJsonObject("labels").put(Labels.STRIMZI_CLUSTER_LABEL, userKafkaName);
         cmdKubeClient().applyContent(kafkaUserResource.toString());
@@ -109,7 +109,7 @@ public class OlmAbstractST extends AbstractST {
 
     void doTestDeployExampleKafkaRebalance() {
         String cruiseControlClusterName = "cruise-control";
-        KafkaResource.kafkaWithCruiseControl(cruiseControlClusterName, 3, 3).done();
+        KafkaResource.create(KafkaResource.kafkaWithCruiseControl(cruiseControlClusterName, 3, 3).build());
         JsonObject kafkaRebalanceResource = OlmResource.getExampleResources().get(KafkaRebalance.RESOURCE_KIND);
         kafkaRebalanceResource.getJsonObject("metadata").getJsonObject("labels").put(Labels.STRIMZI_CLUSTER_LABEL, cruiseControlClusterName);
         cmdKubeClient().applyContent(kafkaRebalanceResource.toString());

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
@@ -70,7 +70,7 @@ class NamespaceDeletionRecoveryST extends AbstractST {
             KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).createOrReplace(kafkaTopic);
         }
 
-        KafkaResource.kafkaPersistent(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3)
             .editSpec()
                 .editKafka()
                     .withNewPersistentClaimStorage()
@@ -84,9 +84,10 @@ class NamespaceDeletionRecoveryST extends AbstractST {
                         .withStorageClass(storageClassName)
                     .endPersistentClaimStorage()
                 .endZookeeper()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
-        KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).build());
 
         String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -120,7 +121,7 @@ class NamespaceDeletionRecoveryST extends AbstractST {
         recreateClusterOperator();
 
         // Recreate Kafka Cluster
-        KafkaResource.kafkaPersistent(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3)
             .editSpec()
                 .editKafka()
                     .withNewPersistentClaimStorage()
@@ -136,7 +137,8 @@ class NamespaceDeletionRecoveryST extends AbstractST {
                 .endZookeeper()
                 .withNewEntityOperator()
                 .endEntityOperator()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
         // Wait some time after kafka is ready before delete topics files
         Thread.sleep(60000);
@@ -155,7 +157,7 @@ class NamespaceDeletionRecoveryST extends AbstractST {
 
         DeploymentUtils.waitForDeploymentAndPodsReady(KafkaResources.entityOperatorDeploymentName(clusterName), 1);
 
-        KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).build());
 
         String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -178,8 +180,9 @@ class NamespaceDeletionRecoveryST extends AbstractST {
         prepareEnvForOperator(NAMESPACE);
         applyBindings(NAMESPACE);
         // 060-Deployment
-        BundleResource.clusterOperator(NAMESPACE).done();
-        KafkaResource.kafkaPersistent(clusterName, 3, 3)
+        BundleResource.create(BundleResource.clusterOperator(NAMESPACE).build());
+
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3)
             .editSpec()
                 .editKafka()
                     .withNewPersistentClaimStorage()
@@ -193,10 +196,12 @@ class NamespaceDeletionRecoveryST extends AbstractST {
                         .withStorageClass(storageClassName)
                     .endPersistentClaimStorage()
                 .endZookeeper()
-            .endSpec().done();
-        KafkaTopicResource.topic(clusterName, topicName).done();
+            .endSpec()
+            .build());
 
-        KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
+
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).build());
 
         String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -232,7 +237,7 @@ class NamespaceDeletionRecoveryST extends AbstractST {
         applyClusterOperatorInstallFiles(NAMESPACE);
         applyBindings(NAMESPACE);
         // 060-Deployment
-        BundleResource.clusterOperator(NAMESPACE).done();
+        BundleResource.create(BundleResource.clusterOperator(NAMESPACE).build());
     }
 
     private void deleteAndRecreateNamespace() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceRbacScopeOperatorST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceRbacScopeOperatorST.java
@@ -39,11 +39,11 @@ class NamespaceRbacScopeOperatorST extends AbstractST {
         assumeTrue(Environment.isNamespaceRbacScope());
         prepareEnvironment();
 
-        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 3)
                 .editMetadata()
                     .addToLabels("app", "strimzi")
                 .endMetadata()
-                .done();
+                .build());
 
         // Wait for Kafka to be Ready to ensure all potentially erroneous ClusterRole applications have happened
         KafkaUtils.waitForKafkaReady(CLUSTER_NAME);
@@ -63,6 +63,6 @@ class NamespaceRbacScopeOperatorST extends AbstractST {
         prepareEnvForOperator(NAMESPACE);
         applyBindings(NAMESPACE);
         // 060-Deployment
-        BundleResource.clusterOperator(NAMESPACE).done();
+        BundleResource.create(BundleResource.clusterOperator(NAMESPACE).build());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
@@ -260,7 +260,7 @@ class RecoveryST extends AbstractST {
             .withRequests(requests)
             .build();
 
-        Kafka kafka = KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(clusterName, 3, 3)
+        Kafka kafka = KafkaResource.kafkaWithoutWait(KafkaResource.kafkaEphemeral(clusterName, 3, 3)
             .editSpec()
                 .editKafka()
                     .withResources(resourceReq)
@@ -286,7 +286,7 @@ class RecoveryST extends AbstractST {
     }
 
     @BeforeEach
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setMethodResources();
         installClusterOperator(NAMESPACE);
         deployTestSpecificResources();
@@ -296,8 +296,8 @@ class RecoveryST extends AbstractST {
         clusterName = generateRandomNameOfKafka("recovery-cluster");
         kafkaClientsName = Constants.KAFKA_CLIENTS + "-" + clusterName;
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1).done();
-        KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).done();
-        KafkaBridgeResource.kafkaBridge(clusterName, KafkaResources.plainBootstrapAddress(clusterName), 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1).build());
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).build());
+        KafkaBridgeResource.create(KafkaBridgeResource.kafkaBridge(clusterName, KafkaResources.plainBootstrapAddress(clusterName), 1).build());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -169,7 +169,7 @@ public class TopicST extends AbstractST {
     @Tag(NODEPORT_SUPPORTED)
     @Test
     void testCreateDeleteCreate() throws InterruptedException {
-        KafkaResource.kafkaEphemeral(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 3)
                 .editSpec()
                     .editKafka()
                         .withNewListeners()
@@ -187,7 +187,7 @@ public class TopicST extends AbstractST {
                         .endTopicOperator()
                     .endEntityOperator()
                 .endSpec()
-                .done();
+                .build());
 
         Properties properties = new Properties();
 
@@ -202,11 +202,11 @@ public class TopicST extends AbstractST {
 
             String topicName = "topic-create-delete-create";
 
-            KafkaTopicResource.topic(clusterName, topicName)
+            KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName)
                     .editSpec()
                         .withReplicas(3)
                     .endSpec()
-                    .done();
+                    .build());
             KafkaTopicUtils.waitForKafkaTopicReady(topicName);
 
             adminClient.describeTopics(singletonList(topicName)).values().get(topicName);
@@ -226,11 +226,11 @@ public class TopicST extends AbstractST {
                 Thread.sleep(2_000);
                 long t0 = System.currentTimeMillis();
                 LOGGER.info("Iteration {}: Recreating {}", i, topicName);
-                KafkaTopicResource.topic(clusterName, topicName)
+                KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName)
                         .editSpec()
                             .withReplicas(3)
                         .endSpec()
-                        .done();
+                        .build());
                 ResourceManager.waitForResourceStatus(KafkaTopicResource.kafkaTopicClient(), "KafkaTopic", NAMESPACE, topicName, Ready, 15_000);
                 TestUtils.waitFor("Recreation of topic " + topicName, 1000, 2_000, () -> {
                     try {
@@ -411,6 +411,6 @@ public class TopicST extends AbstractST {
         installClusterOperator(NAMESPACE);
 
         LOGGER.info("Deploying shared kafka across all test cases in {} namespace", NAMESPACE);
-        KafkaResource.create(KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1).build());
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1).build());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -411,6 +411,6 @@ public class TopicST extends AbstractST {
         installClusterOperator(NAMESPACE);
 
         LOGGER.info("Deploying shared kafka across all test cases in {} namespace", NAMESPACE);
-        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1).build());
+        KafkaResource.create(KafkaResource.kafkaEphemeral(TOPIC_CLUSTER_NAME, 3, 1).build());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicScalabilityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicScalabilityST.java
@@ -49,18 +49,13 @@ public class TopicScalabilityST extends AbstractST {
         KafkaTopicUtils.waitForKafkaTopicsCount(NUMBER_OF_TOPICS, clusterName);
     }
 
-    void deployTestSpecificResources() {
-        LOGGER.info("Deploying shared kafka across all test cases in {} namespace", NAMESPACE);
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1).done();
-    }
-
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
 
         LOGGER.info("Deploying shared kafka across all test cases in {} namespace", NAMESPACE);
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1).build());
     }
 
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -352,15 +352,11 @@ class UserST extends AbstractST {
         }
     }
 
-    private void deployTestSpecificResources() {
-        KafkaResource.create(KafkaResource.kafkaEphemeral(CLUSTER_NAME, 1, 1).build());
-    }
-
     @BeforeAll
     void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
 
-        KafkaResource.kafkaEphemeral(userClusterName, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(userClusterName, 1, 1).build());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -74,19 +74,19 @@ class AlternativeReconcileTriggersST extends AbstractST {
         String producerName = "hello-world-producer";
         String consumerName = "hello-world-consumer";
 
-        KafkaResource.kafkaPersistent(clusterName, 3, 3).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3).build());
 
         String kafkaName = KafkaResources.kafkaStatefulSetName(clusterName);
         String zkName = KafkaResources.zookeeperStatefulSetName(clusterName);
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaName);
         Map<String, String> zkPods = StatefulSetUtils.ssSnapshot(zkName);
 
-        KafkaTopicResource.topic(clusterName, topicName).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
         // ##############################
         // Attach clients which will continuously produce/consume messages to/from Kafka brokers during rolling update
         // ##############################
         // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
-        KafkaTopicResource.topic(clusterName, continuousTopicName, 3, 3, 2).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, continuousTopicName, 3, 3, 2).build());
         String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
         // Add transactional id to make producer transactional
         producerAdditionConfiguration = producerAdditionConfiguration.concat("\ntransactional.id=" + continuousTopicName + ".1");
@@ -102,14 +102,14 @@ class AlternativeReconcileTriggersST extends AbstractST {
             .withDelayMs(1000)
             .build();
 
-        kafkaBasicClientJob.producerStrimzi().done();
-        kafkaBasicClientJob.consumerStrimzi().done();
+        kafkaBasicClientJob.create(kafkaBasicClientJob.producerStrimzi().build());
+        kafkaBasicClientJob.create(kafkaBasicClientJob.consumerStrimzi().build());
         // ##############################
 
         String userName = KafkaUserUtils.generateRandomNameOfKafkaUser();
-        KafkaUser user = KafkaUserResource.tlsUser(clusterName, userName).done();
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, userName).build());
 
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
 
         final String defaultKafkaClientsPodName =
             ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -182,7 +182,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
 
         // Create new topic to ensure, that ZK is working properly
         String newTopicName = KafkaTopicUtils.generateRandomNameOfTopic();
-        KafkaTopicResource.topic(clusterName, newTopicName, 1, 1).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, newTopicName, 1, 1).build());
 
         internalKafkaClient = internalKafkaClient.toBuilder()
             .withTopicName(newTopicName)
@@ -214,13 +214,13 @@ class AlternativeReconcileTriggersST extends AbstractST {
      */
     @Test
     void testRollingUpdateOnNextReconciliationAfterClusterCAKeyDel() {
-        KafkaResource.kafkaPersistent(clusterName, 3, 3).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3).build());
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
-        KafkaTopicResource.topic(clusterName, topicName, 2, 2).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName, 2, 2).build());
 
-        KafkaUser user = KafkaUserResource.tlsUser(clusterName, USER_NAME).done();
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, USER_NAME).build());
 
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
         final String defaultKafkaClientsPodName =
             ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
 
@@ -264,7 +264,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
     void testTriggerRollingUpdateAfterOverrideBootstrap() throws CertificateException {
         String bootstrapDns = "kafka-test.XXXX.azure.XXXX.net";
 
-        KafkaResource.kafkaPersistent(clusterName, 3, 3).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3).build());
 
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(clusterName));
 
@@ -312,7 +312,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
 
     @Test
     void testManualRollingUpdateForSinglePod() {
-        KafkaResource.kafkaPersistent(clusterName, 3).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3).build());
 
         String kafkaSsName = KafkaResources.kafkaStatefulSetName(clusterName);
         String zkSsName = KafkaResources.zookeeperStatefulSetName(clusterName);
@@ -386,17 +386,17 @@ class AlternativeReconcileTriggersST extends AbstractST {
         PersistentClaimStorage vol0 = new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").withDeleteClaim(true).build();
         PersistentClaimStorage vol1 = new PersistentClaimStorageBuilder().withId(1).withSize("100Gi").withDeleteClaim(true).build();
 
-        KafkaResource.kafkaJBOD(clusterName, 3, 3, new JbodStorageBuilder().addToVolumes(vol0).build()).done();
+        KafkaResource.create(KafkaResource.kafkaJBOD(clusterName, 3, 3, new JbodStorageBuilder().addToVolumes(vol0).build()).build());
 
         String kafkaName = KafkaResources.kafkaStatefulSetName(clusterName);
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaName);
 
-        KafkaTopicResource.topic(clusterName, topicName).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
         // ##############################
         // Attach clients which will continuously produce/consume messages to/from Kafka brokers during rolling update
         // ##############################
         // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
-        KafkaTopicResource.topic(clusterName, continuousTopicName, 3, 3, 2).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, continuousTopicName, 3, 3, 2).build());
         String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
         // Add transactional id to make producer transactional
         producerAdditionConfiguration = producerAdditionConfiguration.concat("\ntransactional.id=" + continuousTopicName + ".1");
@@ -412,14 +412,14 @@ class AlternativeReconcileTriggersST extends AbstractST {
                 .withDelayMs(1000)
                 .build();
 
-        kafkaBasicClientJob.producerStrimzi().done();
-        kafkaBasicClientJob.consumerStrimzi().done();
+        kafkaBasicClientJob.create(kafkaBasicClientJob.producerStrimzi().build());
+        kafkaBasicClientJob.create(kafkaBasicClientJob.consumerStrimzi().build());
         // ##############################
 
         String userName = KafkaUserUtils.generateRandomNameOfKafkaUser();
-        KafkaUser user = KafkaUserResource.tlsUser(clusterName, userName).done();
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, userName).build());
 
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
 
         final String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -79,13 +79,13 @@ class RollingUpdateST extends AbstractST {
     void testRecoveryDuringZookeeperRollingUpdate() throws Exception {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        KafkaResource.kafkaPersistent(clusterName, 3, 3).done();
-        KafkaTopicResource.topic(clusterName, topicName, 2, 2).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3).build());
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName, 2, 2).build());
 
         String userName = KafkaUserUtils.generateRandomNameOfKafkaUser();
-        KafkaUser user = KafkaUserResource.tlsUser(clusterName, userName).done();
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, userName).build());
 
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
         final String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
 
@@ -141,7 +141,7 @@ class RollingUpdateST extends AbstractST {
 
         // Create new topic to ensure, that ZK is working properly
         String newTopicName = KafkaTopicUtils.generateRandomNameOfTopic();
-        KafkaTopicResource.topic(clusterName, newTopicName, 1, 1).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, newTopicName, 1, 1).build());
 
         internalKafkaClient = internalKafkaClient.toBuilder()
             .withTopicName(newTopicName)
@@ -159,13 +159,13 @@ class RollingUpdateST extends AbstractST {
     void testRecoveryDuringKafkaRollingUpdate() throws Exception {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        KafkaResource.kafkaPersistent(clusterName, 3, 3).done();
-        KafkaTopicResource.topic(clusterName, topicName, 2, 3).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3).build());
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName, 2, 3).build());
 
         String userName = KafkaUserUtils.generateRandomNameOfKafkaUser();
-        KafkaUser user = KafkaUserResource.tlsUser(clusterName, userName).done();
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, userName).build());
 
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
 
         final String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -228,7 +228,7 @@ class RollingUpdateST extends AbstractST {
 
         // Create new topic to ensure, that ZK is working properly
         String newTopicName = KafkaTopicUtils.generateRandomNameOfTopic();
-        KafkaTopicResource.topic(clusterName, newTopicName, 1, 1).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, newTopicName, 1, 1).build());
 
         internalKafkaClient = internalKafkaClient.toBuilder()
             .withTopicName(newTopicName)
@@ -250,15 +250,16 @@ class RollingUpdateST extends AbstractST {
 
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_RECOVERY));
 
-        KafkaResource.kafkaPersistent(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3)
             .editSpec()
                 .editKafka()
                     .addToConfig(singletonMap("default.replication.factor", 1))
                     .addToConfig("auto.create.topics.enable", "false")
                 .endKafka()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
-        KafkaUser user = KafkaUserResource.tlsUser(clusterName, USER_NAME).done();
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, USER_NAME).build());
 
         testDockerImagesForKafkaCluster(clusterName, NAMESPACE, 3, 1, false);
         // kafka cluster already deployed
@@ -269,9 +270,9 @@ class RollingUpdateST extends AbstractST {
 
         assertEquals(3, initialReplicas);
 
-        KafkaTopicResource.topic(clusterName, topicName, 3, initialReplicas, initialReplicas).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName, 3, initialReplicas, initialReplicas).build());
 
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
 
         final String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -352,7 +353,7 @@ class RollingUpdateST extends AbstractST {
 
         // Create new topic to ensure, that ZK is working properly
         String newTopicName = KafkaTopicUtils.generateRandomNameOfTopic();
-        KafkaTopicResource.topic(clusterName, newTopicName, 1, 1).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, newTopicName, 1, 1).build());
 
         internalKafkaClient = internalKafkaClient.toBuilder()
             .withTopicName(newTopicName)
@@ -371,18 +372,18 @@ class RollingUpdateST extends AbstractST {
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_RECOVERY));
-        KafkaResource.kafkaPersistent(clusterName, 3, 3).done();
-        KafkaTopicResource.topic(clusterName, topicName).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3).build());
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
 
         String userName = KafkaUserUtils.generateRandomNameOfKafkaUser();
-        KafkaUser user = KafkaUserResource.tlsUser(clusterName, userName).done();
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, userName).build());
 
         // kafka cluster already deployed
         LOGGER.info("Running zookeeperScaleUpScaleDown with cluster {}", clusterName);
         final int initialZkReplicas = kubeClient().getStatefulSet(KafkaResources.zookeeperStatefulSetName(clusterName)).getStatus().getReplicas();
         assertThat(initialZkReplicas, is(3));
 
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
 
         final String defaultKafkaClientsPodName =
             ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -428,7 +429,7 @@ class RollingUpdateST extends AbstractST {
 
         // Create new topic to ensure, that ZK is working properly
         String scaleUpTopicName = KafkaTopicUtils.generateRandomNameOfTopic();
-        KafkaTopicResource.topic(clusterName, scaleUpTopicName, 1, 1).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, scaleUpTopicName, 1, 1).build());
 
         internalKafkaClient = internalKafkaClient.toBuilder()
             .withTopicName(scaleUpTopicName)
@@ -460,7 +461,7 @@ class RollingUpdateST extends AbstractST {
 
         // Create new topic to ensure, that ZK is working properly
         String scaleDownTopicName = KafkaTopicUtils.generateRandomNameOfTopic();
-        KafkaTopicResource.topic(clusterName, scaleDownTopicName, 1, 1).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, scaleDownTopicName, 1, 1).build());
 
         internalKafkaClient = internalKafkaClient.toBuilder()
             .withTopicName(scaleDownTopicName)
@@ -481,7 +482,7 @@ class RollingUpdateST extends AbstractST {
     @Test
     @Tag(ROLLING_UPDATE)
     void testBrokerConfigurationChangeTriggerRollingUpdate() {
-        KafkaResource.kafkaPersistent(clusterName, 3, 3).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3).build());
 
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(clusterName));
         Map<String, String> zkPods = StatefulSetUtils.ssSnapshot(KafkaResources.zookeeperStatefulSetName(clusterName));
@@ -497,7 +498,7 @@ class RollingUpdateST extends AbstractST {
     @Test
     @Tag(ROLLING_UPDATE)
     void testManualKafkaConfigMapChangeDontTriggerRollingUpdate() {
-        KafkaResource.kafkaPersistent(clusterName, 3, 3).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3).build());
 
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(clusterName));
         Map<String, String> zkPods = StatefulSetUtils.ssSnapshot(KafkaResources.zookeeperStatefulSetName(clusterName));
@@ -516,7 +517,7 @@ class RollingUpdateST extends AbstractST {
     @Tag(ROLLING_UPDATE)
     void testExternalLoggingChangeTriggerRollingUpdate() {
         // EO dynamic logging is tested in io.strimzi.systemtest.log.LoggingChangeST.testDynamicallySetEOloggingLevels
-        KafkaResource.kafkaPersistent(clusterName, 3, 3).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3).build());
 
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(clusterName));
         Map<String, String> zkPods = StatefulSetUtils.ssSnapshot(KafkaResources.zookeeperStatefulSetName(clusterName));
@@ -573,7 +574,7 @@ class RollingUpdateST extends AbstractST {
     @Test
     @Tag(ROLLING_UPDATE)
     void testClusterOperatorFinishAllRollingUpdates() {
-        KafkaResource.kafkaPersistent(clusterName, 3, 3).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3).build());
 
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(clusterName));
         Map<String, String> zkPods = StatefulSetUtils.ssSnapshot(KafkaResources.zookeeperStatefulSetName(clusterName));
@@ -674,7 +675,7 @@ class RollingUpdateST extends AbstractST {
         kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(metricsCMK);
         kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(metricsCMZk);
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 3)
                 .editSpec()
                     .editKafka()
                         .withMetricsConfig(kafkaMetricsConfig)
@@ -685,7 +686,7 @@ class RollingUpdateST extends AbstractST {
                     .withNewKafkaExporter()
                     .endKafkaExporter()
                 .endSpec()
-                .done();
+                .build());
 
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(clusterName));
         Map<String, String> zkPods = StatefulSetUtils.ssSnapshot(KafkaResources.zookeeperStatefulSetName(clusterName));
@@ -775,7 +776,7 @@ class RollingUpdateST extends AbstractST {
     }
 
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
@@ -65,7 +65,7 @@ public class NetworkPoliciesST extends AbstractST {
         Map<String, String> matchLabelForPlain = new HashMap<>();
         matchLabelForPlain.put("app", allowedKafkaClientsName);
 
-        KafkaResource.kafkaEphemeral(clusterName, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -88,18 +88,18 @@ public class NetworkPoliciesST extends AbstractST {
                 .withNewKafkaExporter()
                 .endKafkaExporter()
             .endSpec()
-            .done();
+            .build());
 
         String topic0 = "topic-example-0";
         String topic1 = "topic-example-1";
 
         String userName = "user-example";
-        KafkaUser kafkaUser = KafkaUserResource.scramShaUser(clusterName, userName).done();
+        KafkaUser kafkaUser = KafkaUserResource.create(KafkaUserResource.scramShaUser(clusterName, userName).build());
 
-        KafkaTopicResource.topic(clusterName, topic0).done();
-        KafkaTopicResource.topic(clusterName, topic1).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topic0).build());
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topic1).build());
 
-        KafkaClientsResource.deployKafkaClients(false, allowedKafkaClientsName, kafkaUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, allowedKafkaClientsName, kafkaUser).build());
 
         String allowedKafkaClientsPodName = kubeClient().listPodsByPrefixInName(allowedKafkaClientsName).get(0).getMetadata().getName();
 
@@ -121,7 +121,7 @@ public class NetworkPoliciesST extends AbstractST {
             internalKafkaClient.receiveMessagesPlain()
         );
 
-        KafkaClientsResource.deployKafkaClients(false, deniedKafkaClientsName, kafkaUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, deniedKafkaClientsName, kafkaUser).build());
 
         String deniedKafkaClientsPodName = kubeClient().listPodsByPrefixInName(deniedKafkaClientsName).get(0).getMetadata().getName();
 
@@ -159,7 +159,7 @@ public class NetworkPoliciesST extends AbstractST {
         Map<String, String> matchLabelsForTls = new HashMap<>();
         matchLabelsForTls.put("app", allowedKafkaClientsName);
 
-        KafkaResource.kafkaEphemeral(clusterName, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -180,17 +180,17 @@ public class NetworkPoliciesST extends AbstractST {
                     .endListeners()
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
         String topic0 = "topic-example-0";
         String topic1 = "topic-example-1";
-        KafkaTopicResource.topic(clusterName, topic0).done();
-        KafkaTopicResource.topic(clusterName, topic1).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topic0).build());
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topic1).build());
 
         String userName = "user-example";
-        KafkaUser kafkaUser = KafkaUserResource.scramShaUser(clusterName, userName).done();
+        KafkaUser kafkaUser = KafkaUserResource.create(KafkaUserResource.scramShaUser(clusterName, userName).build());
 
-        KafkaClientsResource.deployKafkaClients(true, allowedKafkaClientsName, kafkaUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, allowedKafkaClientsName, kafkaUser).build());
 
         String allowedKafkaClientsPodName = kubeClient().listPodsByPrefixInName(allowedKafkaClientsName).get(0).getMetadata().getName();
 
@@ -211,7 +211,7 @@ public class NetworkPoliciesST extends AbstractST {
             internalKafkaClient.receiveMessagesTls()
         );
 
-        KafkaClientsResource.deployKafkaClients(true, deniedKafkaClientsName, kafkaUser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, deniedKafkaClientsName, kafkaUser).build());
 
         String deniedKafkaClientsPodName = kubeClient().listPodsByPrefixInName(deniedKafkaClientsName).get(0).getMetadata().getName();
 
@@ -237,7 +237,7 @@ public class NetworkPoliciesST extends AbstractST {
 
         installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
 
-        KafkaResource.kafkaEphemeral(clusterName, 3).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3).build());
 
         checkNetworkPoliciesInNamespace(NAMESPACE);
 
@@ -270,7 +270,7 @@ public class NetworkPoliciesST extends AbstractST {
         clusterRoleBindingList.forEach(clusterRoleBinding ->
             KubernetesResource.clusterRoleBinding(clusterRoleBinding));
         // 060-Deployment
-        BundleResource.clusterOperator("*", Constants.CO_OPERATION_TIMEOUT_DEFAULT)
+        BundleResource.create(BundleResource.clusterOperator("*", Constants.CO_OPERATION_TIMEOUT_DEFAULT)
             .editOrNewSpec()
                 .editOrNewTemplate()
                     .editOrNewSpec()
@@ -280,7 +280,7 @@ public class NetworkPoliciesST extends AbstractST {
                     .endSpec()
                 .endTemplate()
             .endSpec()
-            .done();
+            .build());
 
         kubeClient().getClient().namespaces().withName(NAMESPACE).edit()
             .editMetadata()
@@ -290,11 +290,11 @@ public class NetworkPoliciesST extends AbstractST {
 
         cluster.setNamespace(secondNamespace);
 
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
             .editMetadata()
                 .addToLabels(labels)
             .endMetadata()
-            .done();
+            .build());
 
         checkNetworkPoliciesInNamespace(secondNamespace);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/OpaIntegrationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/OpaIntegrationST.java
@@ -113,7 +113,7 @@ public class OpaIntegrationST extends AbstractST {
         // Install OPA
         cmdKubeClient().apply(FileUtils.updateNamespaceOfYamlFile(TestUtils.USER_PATH + "/../systemtest/src/test/resources/opa/opa.yaml", NAMESPACE));
 
-        KafkaResource.kafkaEphemeral(clusterName,  3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName,  3, 1)
             .editSpec()
                 .editKafka()
                     .withNewKafkaAuthorizationOpa()
@@ -131,16 +131,16 @@ public class OpaIntegrationST extends AbstractST {
                     .endListeners()
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaTopicResource.topic(clusterName, TOPIC_NAME).done();
-        KafkaUser goodUser = KafkaUserResource.tlsUser(clusterName, OPA_GOOD_USER).done();
-        KafkaUser badUser = KafkaUserResource.tlsUser(clusterName, OPA_BAD_USER).done();
-        KafkaUser superuser = KafkaUserResource.tlsUser(clusterName, OPA_SUPERUSER).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TOPIC_NAME).build());
+        KafkaUser goodUser = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, OPA_GOOD_USER).build());
+        KafkaUser badUser = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, OPA_BAD_USER).build());
+        KafkaUser superuser = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, OPA_SUPERUSER).build());
 
         final String kafkaClientsDeploymentName = clusterName + "-" + Constants.KAFKA_CLIENTS;
         // Deploy client pod with custom certificates and collect messages from internal TLS listener
-        KafkaClientsResource.deployKafkaClients(true, kafkaClientsDeploymentName, false, goodUser, badUser, superuser).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, kafkaClientsDeploymentName, false, goodUser, badUser, superuser).build());
         clientsPodName = kubeClient().listPodsByPrefixInName(kafkaClientsDeploymentName).get(0).getMetadata().getName();
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -104,13 +104,13 @@ class SecurityST extends AbstractST {
     @Test
     void testCertificates() {
         LOGGER.info("Running testCertificates {}", clusterName);
-        KafkaResource.kafkaEphemeral(clusterName, 2)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 2)
                 .editSpec()
                     .editZookeeper()
                         .withReplicas(2)
                     .endZookeeper()
                 .endSpec()
-                .done();
+                .build());
 
         LOGGER.info("Check Kafka bootstrap certificate");
         String outputCertificate = SystemTestCertManager.generateOpenSslCommandByComponent(KafkaResources.tlsBootstrapAddress(clusterName), KafkaResources.bootstrapServiceName(clusterName),
@@ -163,9 +163,9 @@ class SecurityST extends AbstractST {
 
         createKafkaCluster();
 
-        KafkaUser user = KafkaUserResource.tlsUser(clusterName, USER_NAME).done();
-        KafkaTopicResource.topic(clusterName, TOPIC_NAME).done();
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, USER_NAME).build());
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TOPIC_NAME).build());
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
 
         String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -243,9 +243,9 @@ class SecurityST extends AbstractST {
 
         // Check a new client (signed by new client key) can consume
         String bobUserName = "bob";
-        user = KafkaUserResource.tlsUser(clusterName, bobUserName).done();
+        user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, bobUserName).build());
 
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
 
         defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -320,12 +320,12 @@ class SecurityST extends AbstractST {
                                             boolean eoShouldRoll) {
         createKafkaCluster();
 
-        KafkaUser user = KafkaUserResource.tlsUser(clusterName, KafkaUserUtils.generateRandomNameOfKafkaUser()).done();
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, KafkaUserUtils.generateRandomNameOfKafkaUser()).build());
 
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
-        KafkaTopicResource.topic(clusterName, topicName).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
 
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
 
         String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -417,8 +417,8 @@ class SecurityST extends AbstractST {
         );
 
         // Finally check a new client (signed by new client key) can consume
-        user = KafkaUserResource.tlsUser(clusterName, KafkaUserUtils.generateRandomNameOfKafkaUser()).done();
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, KafkaUserUtils.generateRandomNameOfKafkaUser()).build());
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
 
         defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -482,7 +482,7 @@ class SecurityST extends AbstractST {
 
     private void createKafkaCluster() {
         LOGGER.info("Creating a cluster");
-        KafkaResource.kafkaPersistent(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3)
                 .editSpec()
                     .editKafka()
                         .withNewListeners()
@@ -514,7 +514,7 @@ class SecurityST extends AbstractST {
                         .endPersistentClaimStorage()
                     .endZookeeper()
                 .endSpec()
-                .done();
+                .build());
     }
 
     @Test
@@ -527,10 +527,10 @@ class SecurityST extends AbstractST {
 
         // 2. Now create a cluster
         createKafkaCluster();
-        KafkaUser user = KafkaUserResource.tlsUser(clusterName, KafkaUserUtils.generateRandomNameOfKafkaUser()).done();
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, KafkaUserUtils.generateRandomNameOfKafkaUser()).build());
 
-        KafkaTopicResource.topic(clusterName, TOPIC_NAME).done();
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TOPIC_NAME).build());
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
 
         String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -577,16 +577,17 @@ class SecurityST extends AbstractST {
 
         String maintenanceWindowCron = "* " + windowStartMin + "-" + windowStopMin + " * * * ? *";
         LOGGER.info("Maintenance window is: {}", maintenanceWindowCron);
-        KafkaResource.kafkaPersistent(clusterName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 1)
                 .editSpec()
                     .addNewMaintenanceTimeWindow(maintenanceWindowCron)
-                .endSpec().done();
+                .endSpec()
+                .build());
 
-        KafkaUser user = KafkaUserResource.tlsUser(clusterName, KafkaUserUtils.generateRandomNameOfKafkaUser()).done();
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, KafkaUserUtils.generateRandomNameOfKafkaUser()).build());
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        KafkaTopicResource.topic(clusterName, topicName).done();
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
 
         String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -637,17 +638,17 @@ class SecurityST extends AbstractST {
     @Tag(INTERNAL_CLIENTS_USED)
     void testCertRegeneratedAfterInternalCAisDeleted() {
 
-        KafkaResource.kafkaPersistent(clusterName, 3, 1).done();
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 1).build());
 
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaStatefulSetName(clusterName));
 
         String userName = KafkaUserUtils.generateRandomNameOfKafkaUser();
-        KafkaUser user = KafkaUserResource.tlsUser(clusterName, userName).done();
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, userName).build());
 
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        KafkaTopicResource.topic(clusterName, topicName).done();
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
 
         String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -701,14 +702,14 @@ class SecurityST extends AbstractST {
 
     @Test
     void testTlsHostnameVerificationWithKafkaConnect() {
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1).build());
         LOGGER.info("Getting IP of the bootstrap service");
 
         String ipOfBootstrapService = kubeClient().getService(KafkaResources.bootstrapServiceName(clusterName)).getSpec().getClusterIP();
 
         LOGGER.info("KafkaConnect without config {} will not connect to {}:9093", "ssl.endpoint.identification.algorithm", ipOfBootstrapService);
 
-        KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.defaultKafkaConnect(clusterName, clusterName, 1)
+        KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.kafkaConnect(clusterName, clusterName, 1)
             .editSpec()
                 .withNewTls()
                     .addNewTrustedCertificate()
@@ -746,8 +747,8 @@ class SecurityST extends AbstractST {
         String sourceKafkaCluster = clusterName + "-source";
         String targetKafkaCluster = clusterName + "-target";
 
-        KafkaResource.kafkaEphemeral(sourceKafkaCluster, 1, 1).done();
-        KafkaResource.kafkaEphemeral(targetKafkaCluster, 1, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(sourceKafkaCluster, 1, 1).build());
+        KafkaResource.create(KafkaResource.kafkaEphemeral(targetKafkaCluster, 1, 1).build());
 
         LOGGER.info("Getting IP of the source bootstrap service for consumer");
         String ipOfSourceBootstrapService = kubeClient().getService(KafkaResources.bootstrapServiceName(sourceKafkaCluster)).getSpec().getClusterIP();
@@ -758,7 +759,7 @@ class SecurityST extends AbstractST {
         LOGGER.info("KafkaMirrorMaker without config {} will not connect to consumer with address {}:9093", "ssl.endpoint.identification.algorithm", ipOfSourceBootstrapService);
         LOGGER.info("KafkaMirrorMaker without config {} will not connect to producer with address {}:9093", "ssl.endpoint.identification.algorithm", ipOfTargetBootstrapService);
 
-        KafkaMirrorMakerResource.kafkaMirrorMakerWithoutWait(KafkaMirrorMakerResource.defaultKafkaMirrorMaker(clusterName, sourceKafkaCluster, targetKafkaCluster,
+        KafkaMirrorMakerResource.kafkaMirrorMakerWithoutWait(KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, sourceKafkaCluster, targetKafkaCluster,
             ClientUtils.generateRandomConsumerGroup(), 1, true)
             .editSpec()
                 .editConsumer()
@@ -816,7 +817,7 @@ class SecurityST extends AbstractST {
         final int numberOfMessages = 500;
         final String consumerGroupName = "consumer-group-name-1";
 
-        KafkaResource.kafkaEphemeral(clusterName,  3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName,  3, 1)
             .editSpec()
                 .editKafka()
                     .withNewKafkaAuthorizationSimple()
@@ -832,11 +833,11 @@ class SecurityST extends AbstractST {
                     .endListeners()
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaTopicResource.topic(clusterName, topicName).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
 
-        KafkaUserResource.tlsUser(clusterName, kafkaUserWrite)
+        KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, kafkaUserWrite)
             .editSpec()
                 .withNewKafkaUserAuthorizationSimple()
                     .addNewAcl()
@@ -853,7 +854,7 @@ class SecurityST extends AbstractST {
                     .endAcl()
                 .endKafkaUserAuthorizationSimple()
             .endSpec()
-            .done();
+            .build());
 
         LOGGER.info("Checking KafkaUser {} that is able to send messages to topic '{}'", kafkaUserWrite, topicName);
 
@@ -871,7 +872,7 @@ class SecurityST extends AbstractST {
 
         assertThrows(WaitException.class, basicExternalKafkaClient::receiveMessagesTls);
 
-        KafkaUserResource.tlsUser(clusterName, kafkaUserRead)
+        KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, kafkaUserRead)
             .editSpec()
                 .withNewKafkaUserAuthorizationSimple()
                     .addNewAcl()
@@ -894,7 +895,7 @@ class SecurityST extends AbstractST {
                     .endAcl()
                 .endKafkaUserAuthorizationSimple()
             .endSpec()
-            .done();
+            .build());
 
         BasicExternalKafkaClient newBasicExternalKafkaClient = basicExternalKafkaClient.toBuilder()
             .withKafkaUsername(kafkaUserRead)
@@ -911,7 +912,7 @@ class SecurityST extends AbstractST {
     @Tag(NODEPORT_SUPPORTED)
     @Tag(EXTERNAL_CLIENTS_USED)
     void testAclWithSuperUser() {
-        KafkaResource.kafkaEphemeral(clusterName,  3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName,  3, 1)
             .editSpec()
                 .editKafka()
                     .withNewKafkaAuthorizationSimple()
@@ -928,11 +929,11 @@ class SecurityST extends AbstractST {
                     .endListeners()
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaTopicResource.topic(clusterName, TOPIC_NAME).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TOPIC_NAME).build());
 
-        KafkaUserResource.tlsUser(clusterName, USER_NAME)
+        KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, USER_NAME)
             .editSpec()
                 .withNewKafkaUserAuthorizationSimple()
                     .addNewAcl()
@@ -949,7 +950,7 @@ class SecurityST extends AbstractST {
                     .endAcl()
                 .endKafkaUserAuthorizationSimple()
             .endSpec()
-            .done();
+            .build());
 
         LOGGER.info("Checking kafka super user:{} that is able to send messages to topic:{}", USER_NAME, TOPIC_NAME);
 
@@ -972,7 +973,7 @@ class SecurityST extends AbstractST {
 
         String nonSuperuserName = USER_NAME + "-non-super-user";
 
-        KafkaUserResource.tlsUser(clusterName, nonSuperuserName)
+        KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, nonSuperuserName)
             .editSpec()
                 .withNewKafkaUserAuthorizationSimple()
                     .addNewAcl()
@@ -989,7 +990,7 @@ class SecurityST extends AbstractST {
                     .endAcl()
                 .endKafkaUserAuthorizationSimple()
             .endSpec()
-            .done();
+            .build());
 
         LOGGER.info("Checking kafka super user:{} that is able to send messages to topic:{}", nonSuperuserName, TOPIC_NAME);
 
@@ -1012,18 +1013,19 @@ class SecurityST extends AbstractST {
     @Test
     @Tag(INTERNAL_CLIENTS_USED)
     void testCaRenewalBreakInMiddle() {
-        KafkaResource.kafkaPersistent(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3)
             .editSpec()
                 .withNewClusterCa()
                     .withRenewalDays(1)
                     .withValidityDays(3)
                 .endClusterCa()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
-        KafkaUser user = KafkaUserResource.tlsUser(clusterName, USER_NAME).done();
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(clusterName, USER_NAME).build());
 
-        KafkaTopicResource.topic(clusterName, TOPIC_NAME).done();
-        KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TOPIC_NAME).build());
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, clusterName + "-" + Constants.KAFKA_CLIENTS, user).build());
 
         String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -1113,7 +1115,7 @@ class SecurityST extends AbstractST {
 
         // Try to send and receive messages with new certificates
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
-        KafkaTopicResource.topic(clusterName, topicName).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());
 
         internalKafkaClient = internalKafkaClient.toBuilder()
             .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
@@ -1138,13 +1140,13 @@ class SecurityST extends AbstractST {
 
         LOGGER.info("Deploying Kafka cluster with the support {} TLS",  tlsVersion12);
 
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
                 .editSpec()
                     .editKafka()
                         .withConfig(configWithNewestVersionOfTls)
                     .endKafka()
                 .endSpec()
-                .done();
+                .build());
 
         Map<String, Object> configsFromKafkaCustomResource = KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(clusterName).get().getSpec().getKafka().getConfig();
 
@@ -1164,9 +1166,9 @@ class SecurityST extends AbstractST {
         configWithLowestVersionOfTls.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, tlsVersion1);
         configWithLowestVersionOfTls.put(SslConfigs.SSL_PROTOCOL_CONFIG, tlsVersion1);
 
-        KafkaClientsResource.deployKafkaClients(kafkaClientsName).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(kafkaClientsName).build());
 
-        KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.defaultKafkaConnect(clusterName, clusterName, 1)
+        KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.kafkaConnect(clusterName, clusterName, 1)
                 .editSpec()
                     .withConfig(configWithLowestVersionOfTls)
                 .endSpec()
@@ -1212,13 +1214,13 @@ class SecurityST extends AbstractST {
 
         LOGGER.info("Deploying Kafka cluster with the support {} cipher algorithms",  cipherSuitesSha384);
 
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
                 .editSpec()
                     .editKafka()
                         .withConfig(configWithCipherSuitesSha384)
                     .endKafka()
                 .endSpec()
-                .done();
+                .build());
 
         Map<String, Object> configsFromKafkaCustomResource = KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(clusterName).get().getSpec().getKafka().getConfig();
 
@@ -1231,9 +1233,9 @@ class SecurityST extends AbstractST {
 
         configWithCipherSuitesSha256.put(SslConfigs.SSL_CIPHER_SUITES_CONFIG, cipherSuitesSha256);
 
-        KafkaClientsResource.deployKafkaClients(kafkaClientsName).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(kafkaClientsName).build());
 
-        KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.defaultKafkaConnect(clusterName, clusterName, 1)
+        KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.kafkaConnect(clusterName, clusterName, 1)
                 .editSpec()
                     .withConfig(configWithCipherSuitesSha256)
                 .endSpec()
@@ -1270,7 +1272,7 @@ class SecurityST extends AbstractST {
          for 5 minutes -> this will prevent the waiting. */
         String secondClusterName = "my-second-cluster";
 
-        KafkaResource.kafkaEphemeral(clusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3)
             .editOrNewSpec()
                 .withNewClusterCa()
                     .withGenerateSecretOwnerReference(false)
@@ -1279,7 +1281,7 @@ class SecurityST extends AbstractST {
                     .withGenerateSecretOwnerReference(false)
                 .endClientsCa()
             .endSpec()
-            .done();
+            .build());
 
         LOGGER.info("Listing all cluster CAs for {}", clusterName);
         List<Secret> caSecrets = kubeClient().listSecrets().stream()
@@ -1300,7 +1302,7 @@ class SecurityST extends AbstractST {
         });
 
         LOGGER.info("Deploying Kafka with generateSecretOwnerReference set to true");
-        KafkaResource.kafkaEphemeral(secondClusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(secondClusterName, 3)
             .editOrNewSpec()
                 .editOrNewClusterCa()
                     .withGenerateSecretOwnerReference(true)
@@ -1309,7 +1311,7 @@ class SecurityST extends AbstractST {
                     .withGenerateSecretOwnerReference(true)
                 .endClientsCa()
             .endSpec()
-            .done();
+            .build());
 
         caSecrets = kubeClient().listSecrets().stream()
             .filter(secret -> secret.getMetadata().getName().contains(secondClusterName + "-cluster-ca") || secret.getMetadata().getName().contains(secondClusterName + "-clients-ca")).collect(Collectors.toList());
@@ -1327,7 +1329,7 @@ class SecurityST extends AbstractST {
     }
 
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -54,7 +54,7 @@ public class OauthAbstractST extends AbstractST {
     protected WebClient client;
 
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
         KubernetesResource.applyDefaultNetworkPolicy(NAMESPACE, DefaultNetworkPolicy.DEFAULT_TO_ALLOW);

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
@@ -80,9 +80,9 @@ public class OauthAuthorizationST extends OauthAbstractST {
     @Test
     @Order(1)
     void smokeTestForClients() {
-        teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        teamAOauthClientJob.create(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(TEAM_A_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
-        teamAOauthClientJob.consumerStrimziOauthTls(oauthClusterName).done();
+        teamAOauthClientJob.create(teamAOauthClientJob.consumerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(TEAM_A_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
     }
 
@@ -99,7 +99,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
             .withTopicName(TOPIC_NAME)
             .build();
 
-        teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        teamAOauthClientJob.create(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).build());
         assertThrows(WaitException.class, () -> JobUtils.waitForJobFailure(TEAM_A_PRODUCER_NAME, NAMESPACE, 30_000));
         JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
 
@@ -111,13 +111,13 @@ public class OauthAuthorizationST extends OauthAbstractST {
             .withTopicName(topicXName)
             .build();
 
-        teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        teamAOauthClientJob.create(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).build());
         assertThrows(WaitException.class, () -> JobUtils.waitForJobFailure(TEAM_A_PRODUCER_NAME, NAMESPACE, 30_000));
         JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
 
         // Team A can not create topic starting with 'x-' only write to existing on
-        KafkaTopicResource.topic(oauthClusterName, topicXName).done();
-        teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(oauthClusterName, topicXName).build());
+        teamAOauthClientJob.create(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(TEAM_A_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
         JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
 
@@ -128,7 +128,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
             .withTopicName(TOPIC_A)
             .build();
 
-        teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        teamAOauthClientJob.create(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(TEAM_A_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
     }
 
@@ -137,7 +137,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
     @Order(3)
     void testTeamAReadFromTopic() {
         LOGGER.info("Sending {} messages to broker with topic name {}", MESSAGE_COUNT, TOPIC_A);
-        teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        teamAOauthClientJob.create(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(TEAM_A_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
         JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
 
@@ -148,7 +148,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
             .withTopicName(TOPIC_A)
             .build();
 
-        teamAOauthClientJob.consumerStrimziOauthTls(oauthClusterName).done();
+        teamAOauthClientJob.create(teamAOauthClientJob.consumerStrimziOauthTls(oauthClusterName).build());
         assertThrows(WaitException.class, () -> JobUtils.waitForJobFailure(TEAM_A_CONSUMER_NAME, NAMESPACE, 30_000));
         JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
 
@@ -159,7 +159,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
             .withTopicName(TOPIC_A)
             .build();
 
-        teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        teamAOauthClientJob.create(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(TEAM_A_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
     }
 
@@ -169,7 +169,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
     void testTeamBWriteToTopic() {
         LOGGER.info("Sending {} messages to broker with topic name {}", MESSAGE_COUNT, TOPIC_NAME);
         // Producer will not produce messages because authorization topic will failed. Team A can write only to topic starting with 'x-'
-        teamBOauthClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        teamBOauthClientJob.create(teamBOauthClientJob.producerStrimziOauthTls(oauthClusterName).build());
         assertThrows(WaitException.class, () -> JobUtils.waitForJobFailure(TEAM_B_PRODUCER_NAME, NAMESPACE, 30_000));
         JobUtils.deleteJobWithWait(NAMESPACE, TEAM_B_PRODUCER_NAME);
 
@@ -180,8 +180,8 @@ public class OauthAuthorizationST extends OauthAbstractST {
             .withTopicName(TOPIC_B)
             .build();
 
-        teamBOauthClientJob.producerStrimziOauthTls(oauthClusterName).done();
-        teamBOauthClientJob.consumerStrimziOauthTls(oauthClusterName).done();
+        teamBOauthClientJob.create(teamBOauthClientJob.producerStrimziOauthTls(oauthClusterName).build());
+        teamBOauthClientJob.create(teamBOauthClientJob.consumerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitTillContinuousClientsFinish(TEAM_B_PRODUCER_NAME, TEAM_B_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
     }
 
@@ -192,14 +192,14 @@ public class OauthAuthorizationST extends OauthAbstractST {
     void testTeamAWriteToTopicStartingWithXAndTeamBReadFromTopicStartingWithX() {
         // only write means that Team A can not create new topic 'x-.*'
         String topicName = TOPIC_X + "-example";
-        KafkaTopicResource.topic(oauthClusterName, topicName).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(oauthClusterName, topicName).build());
 
         teamAOauthClientJob = teamAOauthClientJob.toBuilder()
             .withConsumerGroup("a-consumer_group")
             .withTopicName(topicName)
             .build();
 
-        teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        teamAOauthClientJob.create(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(TEAM_A_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
 
         teamBOauthClientJob = teamBOauthClientJob.toBuilder()
@@ -207,7 +207,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
             .withTopicName(topicName)
             .build();
 
-        teamBOauthClientJob.consumerStrimziOauthTls(oauthClusterName).done();
+        teamBOauthClientJob.create(teamBOauthClientJob.consumerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(TEAM_B_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
     }
 
@@ -219,7 +219,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
         LOGGER.info("Verifying that team B is not able write to topic starting with 'x-' because in kafka cluster" +
                 "does not have super-users to break authorization rules");
 
-        KafkaUserResource.tlsUser(oauthClusterName, USER_NAME).done();
+        KafkaUserResource.create(KafkaUserResource.tlsUser(oauthClusterName, USER_NAME).build());
 
         teamBOauthClientJob = teamBOauthClientJob.toBuilder()
             .withConsumerGroup("x-consumer_group_b")
@@ -227,7 +227,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
             .withUserName(USER_NAME)
             .build();
 
-        teamBOauthClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        teamBOauthClientJob.create(teamBOauthClientJob.producerStrimziOauthTls(oauthClusterName).build());
         assertThrows(WaitException.class, () -> JobUtils.waitForJobFailure(TEAM_B_PRODUCER_NAME, NAMESPACE, 30_000));
         JobUtils.deleteJobWithWait(NAMESPACE, TEAM_B_PRODUCER_NAME);
 
@@ -240,7 +240,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
             .withUserName(USER_NAME)
             .build();
 
-        teamAOauthClientJob.consumerStrimziOauthTls(oauthClusterName).done();
+        teamAOauthClientJob.create(teamAOauthClientJob.consumerStrimziOauthTls(oauthClusterName).build());
         assertThrows(WaitException.class, () -> JobUtils.waitForJobFailure(TEAM_A_CONSUMER_NAME, NAMESPACE, 30_000));
         JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_CONSUMER_NAME);
 
@@ -259,7 +259,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
 
         LOGGER.info("Verifying that team B is able to write to topic starting with 'x-' and break authorization rule");
 
-        teamBOauthClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        teamBOauthClientJob.create(teamBOauthClientJob.producerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(TEAM_B_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
 
         LOGGER.info("Verifying that team A is able to write to topic starting with 'x-' and break authorization rule");
@@ -269,7 +269,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
             .withTopicName(TOPIC_X)
             .build();
 
-        teamAOauthClientJob.consumerStrimziOauthTls(oauthClusterName).done();
+        teamAOauthClientJob.create(teamAOauthClientJob.consumerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(TEAM_A_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
     }
 
@@ -296,8 +296,8 @@ public class OauthAuthorizationST extends OauthAbstractST {
 
         LOGGER.info("Verifying that team A producer is able to send messages to the {} topic -> the topic starting with 'x'", topicXName);
 
-        KafkaTopicResource.topic(oauthClusterName, topicXName).done();
-        KafkaTopicResource.topic(oauthClusterName, topicAName).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(oauthClusterName, topicXName).build());
+        KafkaTopicResource.create(KafkaTopicResource.topic(oauthClusterName, topicAName).build());
 
         teamAOauthClientJob = teamAOauthClientJob.toBuilder()
             .withUserName(TEAM_A_CLIENT)
@@ -305,7 +305,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
             .withMessageCount(MESSAGE_COUNT)
             .build();
 
-        teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        teamAOauthClientJob.create(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(TEAM_A_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
         JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
 
@@ -396,7 +396,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
         teamAOauthClientJob = teamAOauthClientJob.toBuilder()
             .withTopicName(topicAName)
             .build();
-        teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        teamAOauthClientJob.create(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(TEAM_A_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
         JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
 
@@ -411,7 +411,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
             .withDelayMs(1000)
             .build();
 
-        teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        teamAOauthClientJob.create(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(TEAM_A_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
         JobUtils.deleteJobWithWait(NAMESPACE, TEAM_A_PRODUCER_NAME);
 
@@ -461,7 +461,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
     void setUp()  {
         keycloakInstance.setRealm(TEST_REALM, true);
 
-        KafkaResource.kafkaEphemeral(oauthClusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(oauthClusterName, 3)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -500,12 +500,12 @@ public class OauthAuthorizationST extends OauthAbstractST {
                     .endKafkaAuthorizationKeycloak()
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
         LOGGER.info("Setting producer and consumer properties");
 
-        KafkaUserResource.tlsUser(oauthClusterName, TEAM_A_CLIENT).done();
-        KafkaUserResource.tlsUser(oauthClusterName, TEAM_B_CLIENT).done();
+        KafkaUserResource.create(KafkaUserResource.tlsUser(oauthClusterName, TEAM_A_CLIENT).build());
+        KafkaUserResource.create(KafkaUserResource.tlsUser(oauthClusterName, TEAM_B_CLIENT).build());
 
         teamAOauthClientJob = new KafkaOauthExampleClients.Builder()
             .withProducerName(TEAM_A_PRODUCER_NAME)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
@@ -62,10 +62,10 @@ public class OauthPlainST extends OauthAbstractST {
             "As an oauth consumer, I should be able to consumer messages from the kafka broker.")
     @Test
     void testProducerConsumer() {
-        oauthInternalClientJob.producerStrimziOauthPlain().done();
+        oauthInternalClientJob.create(oauthInternalClientJob.producerStrimziOauthPlain().build());
         ClientUtils.waitForClientSuccess(OAUTH_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
 
-        oauthInternalClientJob.consumerStrimziOauthPlain().done();
+        oauthInternalClientJob.create(oauthInternalClientJob.consumerStrimziOauthPlain().build());
         ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
     }
 
@@ -74,15 +74,17 @@ public class OauthPlainST extends OauthAbstractST {
     @Tag(CONNECT)
     @Tag(CONNECT_COMPONENTS)
     void testProducerConsumerConnect() {
-        oauthInternalClientJob.producerStrimziOauthPlain().done();
+        oauthInternalClientJob.create(oauthInternalClientJob.producerStrimziOauthPlain().build());
         ClientUtils.waitForClientSuccess(OAUTH_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_PRODUCER_NAME);
 
-        oauthInternalClientJob.consumerStrimziOauthPlain().done();
+        oauthInternalClientJob.create(oauthInternalClientJob.consumerStrimziOauthPlain().build());
         ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_CONSUMER_NAME);
 
-        KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).build());
 
-        KafkaConnectResource.kafkaConnect(oauthClusterName, 1)
+        KafkaConnectResource.create(KafkaConnectResource.kafkaConnect(oauthClusterName, 1)
                 .withNewSpec()
                     .withReplicas(1)
                     .withBootstrapServers(KafkaResources.plainBootstrapAddress(oauthClusterName))
@@ -100,7 +102,7 @@ public class OauthPlainST extends OauthAbstractST {
                     .endKafkaClientAuthenticationOAuth()
                     .withTls(null)
                 .endSpec()
-                .done();
+                .build());
 
         String kafkaConnectPodName = kubeClient().listPods(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
 
@@ -116,15 +118,17 @@ public class OauthPlainST extends OauthAbstractST {
     @Tag(MIRROR_MAKER)
     @Tag(NODEPORT_SUPPORTED)
     void testProducerConsumerMirrorMaker() {
-        oauthInternalClientJob.producerStrimziOauthPlain().done();
+        oauthInternalClientJob.create(oauthInternalClientJob.producerStrimziOauthPlain().build());
         ClientUtils.waitForClientSuccess(OAUTH_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_PRODUCER_NAME);
 
-        oauthInternalClientJob.consumerStrimziOauthPlain().done();
+        oauthInternalClientJob.create(oauthInternalClientJob.consumerStrimziOauthPlain().build());
         ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_CONSUMER_NAME);
 
         String targetKafkaCluster = oauthClusterName + "-target";
 
-        KafkaResource.kafkaEphemeral(targetKafkaCluster, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(targetKafkaCluster, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -157,9 +161,9 @@ public class OauthPlainST extends OauthAbstractST {
                     .endListeners()
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaMirrorMakerResource.kafkaMirrorMaker(oauthClusterName, oauthClusterName, targetKafkaCluster,
+        KafkaMirrorMakerResource.create(KafkaMirrorMakerResource.kafkaMirrorMaker(oauthClusterName, oauthClusterName, targetKafkaCluster,
                 ClientUtils.generateRandomConsumerGroup(), 1, false)
                 .editSpec()
                     .withNewConsumer()
@@ -190,7 +194,7 @@ public class OauthPlainST extends OauthAbstractST {
                         .withTls(null)
                     .endProducer()
                 .endSpec()
-                .done();
+                .build());
 
         TestUtils.waitFor("Waiting for Mirror Maker will copy messages from " + oauthClusterName + " to " + targetKafkaCluster,
             Constants.GLOBAL_CLIENTS_POLL, Constants.TIMEOUT_FOR_MIRROR_MAKER_COPY_MESSAGES_BETWEEN_BROKERS,
@@ -210,7 +214,7 @@ public class OauthPlainST extends OauthAbstractST {
                     .withOAuthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
                     .build();
 
-                kafkaOauthClientJob.consumerStrimziOauthPlain().done();
+                kafkaOauthClientJob.create(kafkaOauthClientJob.consumerStrimziOauthPlain().build());
 
                 try {
                     ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
@@ -227,18 +231,20 @@ public class OauthPlainST extends OauthAbstractST {
     @Tag(CONNECT_COMPONENTS)
     @Tag(NODEPORT_SUPPORTED)
     void testProducerConsumerMirrorMaker2() {
-        oauthInternalClientJob.producerStrimziOauthPlain().done();
+        oauthInternalClientJob.create(oauthInternalClientJob.producerStrimziOauthPlain().build());
         ClientUtils.waitForClientSuccess(OAUTH_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_PRODUCER_NAME);
 
-        oauthInternalClientJob.consumerStrimziOauthPlain().done();
+        oauthInternalClientJob.create(oauthInternalClientJob.consumerStrimziOauthPlain().build());
         ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_CONSUMER_NAME);
 
         String kafkaSourceClusterName = oauthClusterName;
         String kafkaTargetClusterName = oauthClusterName + "-target";
         // mirror maker 2 adding prefix to mirrored topic for in this case mirrotopic will be : my-cluster.my-topic
         String kafkaTargetClusterTopicName = kafkaSourceClusterName + "." + TOPIC_NAME;
     
-        KafkaResource.kafkaEphemeral(kafkaTargetClusterName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaTargetClusterName, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withNewListeners()
@@ -271,7 +277,7 @@ public class OauthPlainST extends OauthAbstractST {
                         .endListeners()
                     .endKafka()
                 .endSpec()
-                .done();
+                .build());
 
         // Deploy Mirror Maker 2.0 with oauth
         KafkaMirrorMaker2ClusterSpec sourceClusterWithOauth = new KafkaMirrorMaker2ClusterSpecBuilder()
@@ -300,14 +306,14 @@ public class OauthPlainST extends OauthAbstractST {
                 .endKafkaClientAuthenticationOAuth()
                 .build();
         
-        KafkaMirrorMaker2Resource.kafkaMirrorMaker2(oauthClusterName, kafkaTargetClusterName, kafkaSourceClusterName, 1, false)
+        KafkaMirrorMaker2Resource.create(KafkaMirrorMaker2Resource.kafkaMirrorMaker2(oauthClusterName, kafkaTargetClusterName, kafkaSourceClusterName, 1, false)
                 .editSpec()
                     .withClusters(sourceClusterWithOauth, targetClusterWithOauth)
                     .editFirstMirror()
                         .withNewSourceCluster(kafkaSourceClusterName)
                     .endMirror()
                 .endSpec()
-                .done();
+                .build());
 
         TestUtils.waitFor("Waiting for Mirror Maker 2 will copy messages from " + kafkaSourceClusterName + " to " + kafkaTargetClusterName,
             Duration.ofSeconds(30).toMillis(), Constants.TIMEOUT_FOR_MIRROR_MAKER_COPY_MESSAGES_BETWEEN_BROKERS,
@@ -328,7 +334,7 @@ public class OauthPlainST extends OauthAbstractST {
                     .withOAuthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
                     .build();
 
-                kafkaOauthClientJob.consumerStrimziOauthPlain().done();
+                kafkaOauthClientJob.create(kafkaOauthClientJob.consumerStrimziOauthPlain().build());
 
                 try {
                     ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
@@ -344,15 +350,17 @@ public class OauthPlainST extends OauthAbstractST {
     @Test
     @Tag(BRIDGE)
     void testProducerConsumerBridge() {
-        oauthInternalClientJob.producerStrimziOauthPlain().done();
+        oauthInternalClientJob.create(oauthInternalClientJob.producerStrimziOauthPlain().build());
         ClientUtils.waitForClientSuccess(OAUTH_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_PRODUCER_NAME);
 
-        oauthInternalClientJob.consumerStrimziOauthPlain().done();
+        oauthInternalClientJob.create(oauthInternalClientJob.consumerStrimziOauthPlain().build());
         ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_CONSUMER_NAME);
 
-        KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).build());
 
-        KafkaBridgeResource.kafkaBridge(oauthClusterName, KafkaResources.plainBootstrapAddress(oauthClusterName), 1)
+        KafkaBridgeResource.create(KafkaBridgeResource.kafkaBridge(oauthClusterName, KafkaResources.plainBootstrapAddress(oauthClusterName), 1)
                 .editSpec()
                     .withNewKafkaClientAuthenticationOAuth()
                         .withTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
@@ -363,7 +371,7 @@ public class OauthPlainST extends OauthAbstractST {
                         .endClientSecret()
                     .endKafkaClientAuthenticationOAuth()
                 .endSpec()
-                .done();
+                .build());
 
         String producerName = "bridge-producer";
 
@@ -377,8 +385,9 @@ public class OauthPlainST extends OauthAbstractST {
             .withPollInterval(1000)
             .build();
 
-        kafkaBridgeClientJob.producerStrimziBridge().done();
+        kafkaBridgeClientJob.create(kafkaBridgeClientJob.producerStrimziBridge().build());
         ClientUtils.waitForClientSuccess(producerName, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, producerName);
     }
 
     @BeforeAll
@@ -398,7 +407,7 @@ public class OauthPlainST extends OauthAbstractST {
             .withOAuthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
             .build();
 
-        KafkaResource.kafkaEphemeral(oauthClusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(oauthClusterName, 3)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -418,8 +427,8 @@ public class OauthPlainST extends OauthAbstractST {
                     .endListeners()
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaTopicResource.topic(oauthClusterName, TOPIC_NAME).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(oauthClusterName, TOPIC_NAME).build());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsST.java
@@ -67,10 +67,10 @@ public class OauthTlsST extends OauthAbstractST {
             "As an oauth consumer, I am able to consumer messages from the kafka broker using encrypted communication")
     @Test
     void testProducerConsumer() {
-        oauthInternalClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        oauthInternalClientJob.create(oauthInternalClientJob.producerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(OAUTH_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
 
-        oauthInternalClientJob.consumerStrimziOauthTls(oauthClusterName).done();
+        oauthInternalClientJob.create(oauthInternalClientJob.consumerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
     }
 
@@ -79,18 +79,20 @@ public class OauthTlsST extends OauthAbstractST {
     @Tag(CONNECT)
     @Tag(CONNECT_COMPONENTS)
     void testProducerConsumerConnect() {
-        oauthInternalClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        oauthInternalClientJob.create(oauthInternalClientJob.producerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(OAUTH_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_PRODUCER_NAME);
 
-        oauthInternalClientJob.consumerStrimziOauthTls(oauthClusterName).done();
+        oauthInternalClientJob.create(oauthInternalClientJob.consumerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_CONSUMER_NAME);
 
-        KafkaClientsResource.deployKafkaClients(false, oauthClusterName + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, oauthClusterName + "-" + Constants.KAFKA_CLIENTS).build());
 
         String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(oauthClusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
 
-        KafkaConnectResource.kafkaConnect(oauthClusterName, 1)
+        KafkaConnectResource.create(KafkaConnectResource.kafkaConnect(oauthClusterName, 1)
                 .editSpec()
                     .addToConfig("key.converter.schemas.enable", false)
                     .addToConfig("value.converter.schemas.enable", false)
@@ -118,7 +120,7 @@ public class OauthTlsST extends OauthAbstractST {
                     .endTls()
                     .withBootstrapServers(oauthClusterName + "-kafka-bootstrap:9093")
                 .endSpec()
-                .done();
+                .build());
 
         String kafkaConnectPodName = kubeClient().listPods(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
 
@@ -133,15 +135,17 @@ public class OauthTlsST extends OauthAbstractST {
     @Test
     @Tag(BRIDGE)
     void testProducerConsumerBridge() {
-        oauthInternalClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        oauthInternalClientJob.create(oauthInternalClientJob.producerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(OAUTH_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_PRODUCER_NAME);
 
-        oauthInternalClientJob.consumerStrimziOauthTls(oauthClusterName).done();
+        oauthInternalClientJob.create(oauthInternalClientJob.consumerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_CONSUMER_NAME);
 
-        KafkaClientsResource.deployKafkaClients(true, kafkaClientsName).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, kafkaClientsName).build());
 
-        KafkaBridgeResource.kafkaBridge(oauthClusterName, KafkaResources.tlsBootstrapAddress(oauthClusterName), 1)
+        KafkaBridgeResource.create(KafkaBridgeResource.kafkaBridge(oauthClusterName, KafkaResources.tlsBootstrapAddress(oauthClusterName), 1)
                 .editSpec()
                     .withNewTls()
                         .withTrustedCertificates(
@@ -163,7 +167,7 @@ public class OauthTlsST extends OauthAbstractST {
                         .withDisableTlsHostnameVerification(true)
                     .endKafkaClientAuthenticationOAuth()
                 .endSpec()
-                .done();
+                .build());
 
         String producerName = "bridge-producer";
 
@@ -177,8 +181,9 @@ public class OauthTlsST extends OauthAbstractST {
             .withPollInterval(1000)
             .build();
 
-        kafkaBridgeClientJob.producerStrimziBridge().done();
+        kafkaBridgeClientJob.create(kafkaBridgeClientJob.producerStrimziBridge().build());
         ClientUtils.waitForClientSuccess(producerName, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, producerName);
     }
 
     @Description("As a oauth mirror maker, I am able to replicate topic data using using encrypted communication")
@@ -186,15 +191,17 @@ public class OauthTlsST extends OauthAbstractST {
     @Tag(MIRROR_MAKER)
     @Tag(NODEPORT_SUPPORTED)
     void testMirrorMaker() {
-        oauthInternalClientJob.producerStrimziOauthTls(oauthClusterName).done();
+        oauthInternalClientJob.create(oauthInternalClientJob.producerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(OAUTH_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_PRODUCER_NAME);
 
-        oauthInternalClientJob.consumerStrimziOauthTls(oauthClusterName).done();
+        oauthInternalClientJob.create(oauthInternalClientJob.consumerStrimziOauthTls(oauthClusterName).build());
         ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_CONSUMER_NAME);
 
         String targetKafkaCluster = oauthClusterName + "-target";
 
-        KafkaResource.kafkaEphemeral(targetKafkaCluster, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(targetKafkaCluster, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -239,9 +246,9 @@ public class OauthTlsST extends OauthAbstractST {
                     .endListeners()
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaMirrorMakerResource.kafkaMirrorMaker(oauthClusterName, oauthClusterName, targetKafkaCluster,
+        KafkaMirrorMakerResource.create(KafkaMirrorMakerResource.kafkaMirrorMaker(oauthClusterName, oauthClusterName, targetKafkaCluster,
             ClientUtils.generateRandomConsumerGroup(), 1, true)
                 .editSpec()
                     .withNewConsumer()
@@ -296,7 +303,7 @@ public class OauthTlsST extends OauthAbstractST {
                         .addToConfig(ProducerConfig.ACKS_CONFIG, "all")
                     .endProducer()
                 .endSpec()
-                .done();
+                .build());
 
         String mirrorMakerPodName = kubeClient().listPodsByPrefixInName(KafkaMirrorMakerResources.deploymentName(oauthClusterName)).get(0).getMetadata().getName();
         String kafkaMirrorMakerLogs = kubeClient().logs(mirrorMakerPodName);
@@ -304,16 +311,15 @@ public class OauthTlsST extends OauthAbstractST {
         assertThat(kafkaMirrorMakerLogs,
             not(containsString("keytool error: java.io.FileNotFoundException: /opt/kafka/consumer-oauth-certs/**/* (No such file or directory)")));
 
-        KafkaUserResource.tlsUser(oauthClusterName, USER_NAME).done();
+        KafkaUserResource.create(KafkaUserResource.tlsUser(oauthClusterName, USER_NAME).build());
         KafkaUserUtils.waitForKafkaUserCreation(USER_NAME);
-
-        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_PRODUCER_NAME);
 
         LOGGER.info("Creating new client with new consumer-group and also to point on {} cluster", targetKafkaCluster);
 
         KafkaOauthExampleClients kafkaOauthClientJob = new KafkaOauthExampleClients.Builder()
             .withProducerName(OAUTH_PRODUCER_NAME)
             .withConsumerName(OAUTH_CONSUMER_NAME)
+            .withUserName(USER_NAME)
             .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(targetKafkaCluster))
             .withTopicName(TOPIC_NAME)
             .withMessageCount(MESSAGE_COUNT)
@@ -322,9 +328,10 @@ public class OauthTlsST extends OauthAbstractST {
             .withOAuthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
             .build();
 
-        kafkaOauthClientJob.consumerStrimziOauthTls(oauthClusterName);
+        kafkaOauthClientJob.create(kafkaOauthClientJob.consumerStrimziOauthTls(targetKafkaCluster).build());
 
         ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_CONSUMER_NAME);
     }
 
     @Test
@@ -339,7 +346,7 @@ public class OauthTlsST extends OauthAbstractST {
                 .withNewCertificate(KeycloakInstance.KEYCLOAK_SECRET_CERT)
                 .build();
 
-        KafkaResource.kafkaEphemeral(introspectionKafka, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(introspectionKafka, 1)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -364,7 +371,7 @@ public class OauthTlsST extends OauthAbstractST {
                     .endListeners()
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
 
         KafkaOauthExampleClients oauthInternalClientIntrospectionJob = new KafkaOauthExampleClients.Builder()
@@ -378,10 +385,10 @@ public class OauthTlsST extends OauthAbstractST {
                 .withOAuthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
                 .build();
 
-        oauthInternalClientIntrospectionJob.producerStrimziOauthTls(introspectionKafka).done();
+        oauthInternalClientIntrospectionJob.create(oauthInternalClientIntrospectionJob.producerStrimziOauthTls(introspectionKafka).build());
         ClientUtils.waitForClientSuccess(OAUTH_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
 
-        oauthInternalClientIntrospectionJob.consumerStrimziOauthTls(introspectionKafka).done();
+        oauthInternalClientIntrospectionJob.create(oauthInternalClientIntrospectionJob.consumerStrimziOauthTls(introspectionKafka).build());
         ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
     }
 
@@ -402,7 +409,7 @@ public class OauthTlsST extends OauthAbstractST {
             .withOAuthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
             .build();
 
-        KafkaResource.kafkaEphemeral(oauthClusterName, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(oauthClusterName, 3)
             .editSpec()
                 .editKafka()
                     .withNewListeners()
@@ -428,11 +435,11 @@ public class OauthTlsST extends OauthAbstractST {
                     .endListeners()
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
-        KafkaTopicResource.topic(oauthClusterName, TOPIC_NAME).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(oauthClusterName, TOPIC_NAME).build());
 
-        KafkaUserResource.tlsUser(oauthClusterName, OAUTH_CLIENT_NAME).done();
+        KafkaUserResource.create(KafkaUserResource.tlsUser(oauthClusterName, OAUTH_CLIENT_NAME).build());
     }
 }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/ClusterOperationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/ClusterOperationST.java
@@ -46,7 +46,7 @@ public class ClusterOperationST extends AbstractST {
         List<String> continuousConsumerGroups = IntStream.range(0, size).boxed().map(i -> "continuous-consumer-group-" + i).collect(Collectors.toList());
         int continuousClientsMessageCount = 300;
 
-        KafkaResource.kafkaPersistent(clusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, 3, 3)
                 .editOrNewSpec()
                     .editEntityOperator()
                         .editUserOperator()
@@ -54,9 +54,9 @@ public class ClusterOperationST extends AbstractST {
                         .endUserOperator()
                     .endEntityOperator()
                 .endSpec()
-                .done();
+                .build());
 
-        topicNames.forEach(topicName -> KafkaTopicResource.topic(clusterName, topicName, 3, 3, 2).done());
+        topicNames.forEach(topicName -> KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName, 3, 3, 2).build()));
 
         String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
         KafkaBasicExampleClients kafkaBasicClientResource;
@@ -73,8 +73,8 @@ public class ClusterOperationST extends AbstractST {
                 .withDelayMs(1000)
                 .build();
 
-            kafkaBasicClientResource.producerStrimzi();
-            kafkaBasicClientResource.consumerStrimzi();
+            kafkaBasicClientResource.create(kafkaBasicClientResource.producerStrimzi().build());
+            kafkaBasicClientResource.create(kafkaBasicClientResource.consumerStrimzi().build());
         }
 
         // ##############################
@@ -91,7 +91,7 @@ public class ClusterOperationST extends AbstractST {
     }
 
     @BeforeAll
-    void setup() throws Exception {
+    void setup() {
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/HelmChartST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/HelmChartST.java
@@ -27,8 +27,8 @@ class HelmChartST extends AbstractST {
 
     @Test
     void testDeployKafkaClusterViaHelmChart() {
-        KafkaResource.kafkaEphemeral(clusterName, 3).done();
-        KafkaTopicResource.topic(clusterName, TOPIC_NAME).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3).build());
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TOPIC_NAME).build());
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(clusterName), 3);
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(clusterName), 3);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -174,7 +174,7 @@ public class SpecificST extends AbstractST {
                     .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
                 .endSpec().build());
 
-        KubernetesResource.deployNetworkPolicyForResource(kc, KafkaConnectResources.deploymentName(CLUSTER_NAME));
+        KubernetesResource.deployNetworkPolicyForResource(kc, KafkaConnectResources.deploymentName(clusterName));
 
         PodUtils.waitForPendingPod(clusterName + "-connect");
         List<String> connectWrongPods = kubeClient().listPodNames(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND);
@@ -248,7 +248,7 @@ public class SpecificST extends AbstractST {
                 .endSpec()
                 .build());
 
-        KubernetesResource.deployNetworkPolicyForResource(kc, KafkaConnectResources.deploymentName(CLUSTER_NAME));
+        KubernetesResource.deployNetworkPolicyForResource(kc, KafkaConnectResources.deploymentName(clusterName));
 
         String topicName = "topic-test-rack-aware";
         KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, topicName).build());

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -121,7 +121,7 @@ public class TracingST extends AbstractST {
         configOfSourceKafka.put("transaction.state.log.replication.factor", "1");
         configOfSourceKafka.put("transaction.state.log.min.isr", "1");
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withNewPersistentClaimStorage()
@@ -136,16 +136,16 @@ public class TracingST extends AbstractST {
                         .endPersistentClaimStorage()
                     .endZookeeper()
                 .endSpec()
-                .done();
+                .build());
 
-        KafkaTopicResource.topic(clusterName, TOPIC_NAME)
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TOPIC_NAME)
                 .editSpec()
                     .withReplicas(1)
                     .withPartitions(12)
                 .endSpec()
-                .done();
+                .build());
 
-        kafkaTracingClient.producerWithTracing().done();
+        kafkaTracingClient.create(kafkaTracingClient.producerWithTracing().build());
 
         TracingUtils.verify(JAEGER_PRODUCER_SERVICE, kafkaClientsPodName);
 
@@ -161,7 +161,7 @@ public class TracingST extends AbstractST {
         // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withNewPersistentClaimStorage()
@@ -176,7 +176,7 @@ public class TracingST extends AbstractST {
                         .endPersistentClaimStorage()
                     .endZookeeper()
                 .endSpec()
-                .done();
+                .build());
 
         Map<String, Object> configOfKafkaConnect = new HashMap<>();
         configOfKafkaConnect.put("config.storage.replication.factor", "1");
@@ -187,7 +187,7 @@ public class TracingST extends AbstractST {
         configOfKafkaConnect.put("key.converter.schemas.enable", "false");
         configOfKafkaConnect.put("value.converter.schemas.enable", "false");
 
-        KafkaConnectResource.kafkaConnect(clusterName, 1)
+        KafkaConnectResource.create(KafkaConnectResource.kafkaConnect(clusterName, 1)
                 .withNewSpec()
                     .withConfig(configOfKafkaConnect)
                     .withNewJaegerTracing()
@@ -215,7 +215,7 @@ public class TracingST extends AbstractST {
                         .endConnectContainer()
                     .endTemplate()
                 .endSpec()
-                .done();
+                .build());
 
         String kafkaConnectPodName = kubeClient().listPods(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
         String pathToConnectorSinkConfig = TestUtils.USER_PATH + "/../systemtest/src/test/resources/file/sink/connector.json";
@@ -256,7 +256,7 @@ public class TracingST extends AbstractST {
         configOfSourceKafka.put("transaction.state.log.replication.factor", "1");
         configOfSourceKafka.put("transaction.state.log.min.isr", "1");
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withConfig(configOfSourceKafka)
@@ -272,27 +272,27 @@ public class TracingST extends AbstractST {
                         .endPersistentClaimStorage()
                     .endZookeeper()
                 .endSpec()
-                .done();
+                .build());
 
-        KafkaTopicResource.topic(clusterName, TOPIC_NAME)
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TOPIC_NAME)
                 .editSpec()
                     .withReplicas(3)
                     .withPartitions(12)
                 .endSpec()
-                .done();
+                .build());
 
-        KafkaTopicResource.topic(clusterName, TOPIC_TARGET_NAME)
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TOPIC_TARGET_NAME)
                 .editSpec()
                     .withReplicas(3)
                     .withPartitions(12)
                 .endSpec()
-                .done();
+                .build());
 
-        kafkaTracingClient.producerWithTracing().done();
+        kafkaTracingClient.create(kafkaTracingClient.producerWithTracing().build());
 
         TracingUtils.verify(JAEGER_PRODUCER_SERVICE, kafkaClientsPodName);
 
-        kafkaTracingClient.kafkaStreamsWithTracing().done();
+        kafkaTracingClient.create(kafkaTracingClient.kafkaStreamsWithTracing().build());
 
         TracingUtils.verify(JAEGER_KAFKA_STREAMS_SERVICE, kafkaClientsPodName);
 
@@ -315,7 +315,7 @@ public class TracingST extends AbstractST {
         configOfSourceKafka.put("transaction.state.log.replication.factor", "1");
         configOfSourceKafka.put("transaction.state.log.min.isr", "1");
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withConfig(configOfSourceKafka)
@@ -331,20 +331,20 @@ public class TracingST extends AbstractST {
                         .endPersistentClaimStorage()
                     .endZookeeper()
                 .endSpec()
-                .done();
+                .build());
 
-        KafkaTopicResource.topic(clusterName, TOPIC_NAME)
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TOPIC_NAME)
                 .editSpec()
                     .withReplicas(3)
                     .withPartitions(12)
                 .endSpec()
-                .done();
+                .build());
 
-        kafkaTracingClient.producerWithTracing().done();
+        kafkaTracingClient.create(kafkaTracingClient.producerWithTracing().build());
 
         TracingUtils.verify(JAEGER_PRODUCER_SERVICE, kafkaClientsPodName);
 
-        kafkaTracingClient.consumerWithTracing().done();
+        kafkaTracingClient.create(kafkaTracingClient.consumerWithTracing().build());
 
         TracingUtils.verify(JAEGER_CONSUMER_SERVICE, kafkaClientsPodName);
 
@@ -364,7 +364,7 @@ public class TracingST extends AbstractST {
         configOfSourceKafka.put("transaction.state.log.replication.factor", "1");
         configOfSourceKafka.put("transaction.state.log.min.isr", "1");
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withConfig(configOfSourceKafka)
@@ -380,32 +380,32 @@ public class TracingST extends AbstractST {
                         .endPersistentClaimStorage()
                     .endZookeeper()
                 .endSpec()
-                .done();
+                .build());
 
-        KafkaTopicResource.topic(clusterName, TOPIC_NAME)
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TOPIC_NAME)
                 .editSpec()
                     .withReplicas(3)
                     .withPartitions(12)
                 .endSpec()
-                .done();
+                .build());
 
 
-        KafkaTopicResource.topic(clusterName, TOPIC_TARGET_NAME)
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TOPIC_TARGET_NAME)
                 .editSpec()
                     .withReplicas(3)
                     .withPartitions(12)
                 .endSpec()
-                .done();
+                .build());
 
-        kafkaTracingClient.producerWithTracing().done();
+        kafkaTracingClient.create(kafkaTracingClient.producerWithTracing().build());
 
         TracingUtils.verify(JAEGER_PRODUCER_SERVICE, kafkaClientsPodName);
 
-        kafkaTracingClient.consumerWithTracing().done();
+        kafkaTracingClient.create(kafkaTracingClient.consumerWithTracing().build());
 
         TracingUtils.verify(JAEGER_CONSUMER_SERVICE, kafkaClientsPodName);
 
-        kafkaTracingClient.kafkaStreamsWithTracing().done();
+        kafkaTracingClient.create(kafkaTracingClient.kafkaStreamsWithTracing().build());
 
         TracingUtils.verify(JAEGER_KAFKA_STREAMS_SERVICE, kafkaClientsPodName);
 
@@ -427,7 +427,7 @@ public class TracingST extends AbstractST {
         final String kafkaClusterSourceName = clusterName + "-source";
         final String kafkaClusterTargetName = clusterName + "-target";
 
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withNewPersistentClaimStorage()
@@ -442,9 +442,9 @@ public class TracingST extends AbstractST {
                         .endPersistentClaimStorage()
                     .endZookeeper()
                 .endSpec()
-                .done();
+                .build());
 
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withNewPersistentClaimStorage()
@@ -459,22 +459,22 @@ public class TracingST extends AbstractST {
                         .endPersistentClaimStorage()
                     .endZookeeper()
                 .endSpec()
-                .done();
+                .build());
 
         // Create topic and deploy clients before Mirror Maker to not wait for MM to find the new topics
-        KafkaTopicResource.topic(kafkaClusterSourceName, TOPIC_NAME)
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterSourceName, TOPIC_NAME)
                 .editSpec()
                     .withReplicas(3)
                     .withPartitions(12)
                 .endSpec()
-                .done();
+                .build());
 
-        KafkaTopicResource.topic(kafkaClusterTargetName, kafkaClusterSourceName + "." + TOPIC_NAME)
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterTargetName, kafkaClusterSourceName + "." + TOPIC_NAME)
                 .editSpec()
                     .withReplicas(3)
                     .withPartitions(12)
                 .endSpec()
-                .done();
+                .build());
 
         LOGGER.info("Setting for kafka source plain bootstrap:{}", KafkaResources.plainBootstrapAddress(kafkaClusterSourceName));
 
@@ -482,7 +482,7 @@ public class TracingST extends AbstractST {
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterSourceName))
             .build();
 
-        sourceKafkaTracingClient.producerWithTracing().done();
+        sourceKafkaTracingClient.create(sourceKafkaTracingClient.producerWithTracing().build());
 
         LOGGER.info("Setting for kafka target plain bootstrap:{}", KafkaResources.plainBootstrapAddress(kafkaClusterTargetName));
 
@@ -491,9 +491,9 @@ public class TracingST extends AbstractST {
             .withTopicName(kafkaClusterSourceName + "." + TOPIC_NAME)
             .build();
 
-        targetKafkaTracingClient.consumerWithTracing().done();
+        targetKafkaTracingClient.create(targetKafkaTracingClient.consumerWithTracing().build());
 
-        KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
+        KafkaMirrorMaker2Resource.create(KafkaMirrorMaker2Resource.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
                 .editMetadata()
                     .withName("my-mirror-maker2")
                 .endMetadata()
@@ -521,7 +521,7 @@ public class TracingST extends AbstractST {
                         .endConnectContainer()
                     .endTemplate()
                 .endSpec()
-                .done();
+                .build());
 
         TracingUtils.verify(JAEGER_PRODUCER_SERVICE, kafkaClientsPodName, "To_" + TOPIC_NAME);
         TracingUtils.verify(JAEGER_CONSUMER_SERVICE, kafkaClientsPodName, "From_" + kafkaClusterSourceName + "." + TOPIC_NAME);
@@ -538,7 +538,7 @@ public class TracingST extends AbstractST {
         final String kafkaClusterSourceName = clusterName + "-source";
         final String kafkaClusterTargetName = clusterName + "-target";
 
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withNewPersistentClaimStorage()
@@ -553,9 +553,9 @@ public class TracingST extends AbstractST {
                         .endPersistentClaimStorage()
                     .endZookeeper()
                 .endSpec()
-                .done();
+                .build());
 
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 3, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withNewPersistentClaimStorage()
@@ -570,23 +570,23 @@ public class TracingST extends AbstractST {
                         .endPersistentClaimStorage()
                     .endZookeeper()
                 .endSpec()
-                .done();
+                .build());
 
         // Create topic and deploy clients before Mirror Maker to not wait for MM to find the new topics
-        KafkaTopicResource.topic(kafkaClusterSourceName, TOPIC_NAME)
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterSourceName, TOPIC_NAME)
                 .editSpec()
                     .withReplicas(3)
                     .withPartitions(12)
                 .endSpec()
-                .done();
+                .build());
 
-        KafkaTopicResource.topic(kafkaClusterTargetName, TOPIC_NAME + "-target")
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterTargetName, TOPIC_NAME + "-target")
                 .editSpec()
                     .withReplicas(3)
                     .withPartitions(12)
                     .withTopicName(TOPIC_NAME)
                 .endSpec()
-                .done();
+                .build());
 
         LOGGER.info("Setting for kafka source plain bootstrap:{}", KafkaResources.plainBootstrapAddress(kafkaClusterSourceName));
 
@@ -594,7 +594,7 @@ public class TracingST extends AbstractST {
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterSourceName))
             .build();
 
-        sourceKafkaTracingClient.producerWithTracing().done();
+        sourceKafkaTracingClient.create(sourceKafkaTracingClient.producerWithTracing().build());
 
         LOGGER.info("Setting for kafka target plain bootstrap:{}", KafkaResources.plainBootstrapAddress(kafkaClusterTargetName));
 
@@ -602,9 +602,9 @@ public class TracingST extends AbstractST {
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterTargetName))
             .build();
 
-        targetKafkaTracingClient.consumerWithTracing().done();
+        targetKafkaTracingClient.create(targetKafkaTracingClient.consumerWithTracing().build());
 
-        KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterSourceName, kafkaClusterTargetName,
+        KafkaMirrorMakerResource.create(KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterSourceName, kafkaClusterTargetName,
             ClientUtils.generateRandomConsumerGroup(), 1, false)
                 .editMetadata()
                     .withName("my-mirror-maker")
@@ -633,7 +633,7 @@ public class TracingST extends AbstractST {
                         .endMirrorMakerContainer()
                     .endTemplate()
                 .endSpec()
-                .done();
+                .build());
 
         TracingUtils.verify(JAEGER_PRODUCER_SERVICE, kafkaClientsPodName, "To_" + TOPIC_NAME);
         TracingUtils.verify(JAEGER_CONSUMER_SERVICE, kafkaClientsPodName, "From_" + TOPIC_NAME);
@@ -653,53 +653,53 @@ public class TracingST extends AbstractST {
         final String kafkaClusterSourceName = clusterName + "-source";
         final String kafkaClusterTargetName = clusterName + "-target";
 
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 3, 1).done();
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 3, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 3, 1).build());
+        KafkaResource.create(KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 3, 1).build());
 
         // Create topic and deploy clients before Mirror Maker to not wait for MM to find the new topics
-        KafkaTopicResource.topic(kafkaClusterSourceName, TOPIC_NAME)
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterSourceName, TOPIC_NAME)
                 .editSpec()
                     .withReplicas(3)
                     .withPartitions(12)
                 .endSpec()
-                .done();
+                .build());
 
-        KafkaTopicResource.topic(kafkaClusterSourceName, TOPIC_TARGET_NAME)
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterSourceName, TOPIC_TARGET_NAME)
                 .editSpec()
                     .withReplicas(3)
                     .withPartitions(12)
                 .endSpec()
-                .done();
+                .build());
 
-        KafkaTopicResource.topic(kafkaClusterTargetName, TOPIC_NAME + "-target")
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterTargetName, TOPIC_NAME + "-target")
                 .editSpec()
                     .withReplicas(3)
                     .withPartitions(12)
                     .withTopicName(TOPIC_NAME)
                 .endSpec()
-                .done();
+                .build());
 
-        KafkaTopicResource.topic(kafkaClusterTargetName, TOPIC_TARGET_NAME + "-target")
+        KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterTargetName, TOPIC_TARGET_NAME + "-target")
                 .editSpec()
                     .withReplicas(3)
                     .withPartitions(12)
                     .withTopicName(TOPIC_TARGET_NAME)
                 .endSpec()
-                .done();
+                .build());
 
         KafkaTracingExampleClients sourceKafkaTracingClient = kafkaTracingClient.toBuilder()
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterSourceName))
             .build();
 
-        sourceKafkaTracingClient.producerWithTracing().done();
+        sourceKafkaTracingClient.create(sourceKafkaTracingClient.producerWithTracing().build());
 
         KafkaTracingExampleClients targetKafkaTracingClient = kafkaTracingClient.toBuilder()
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterTargetName))
             .build();
 
-        targetKafkaTracingClient.consumerWithTracing().done();
+        targetKafkaTracingClient.create(targetKafkaTracingClient.consumerWithTracing().build());
 
-        sourceKafkaTracingClient.kafkaStreamsWithTracing().done();
+        sourceKafkaTracingClient.create(sourceKafkaTracingClient.kafkaStreamsWithTracing().build());
 
         Map<String, Object> configOfKafkaConnect = new HashMap<>();
         configOfKafkaConnect.put("config.storage.replication.factor", "1");
@@ -710,7 +710,7 @@ public class TracingST extends AbstractST {
         configOfKafkaConnect.put("key.converter.schemas.enable", "false");
         configOfKafkaConnect.put("value.converter.schemas.enable", "false");
 
-        KafkaConnectResource.kafkaConnect(clusterName, 1)
+        KafkaConnectResource.create(KafkaConnectResource.kafkaConnect(clusterName, 1)
                 .withNewSpec()
                     .withConfig(configOfKafkaConnect)
                     .withNewJaegerTracing()
@@ -738,7 +738,7 @@ public class TracingST extends AbstractST {
                         .endConnectContainer()
                     .endTemplate()
                 .endSpec()
-                .done();
+                .build());
 
 
         String kafkaConnectPodName = kubeClient().listPods(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
@@ -749,7 +749,7 @@ public class TracingST extends AbstractST {
         cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "curl -X POST -H \"Content-Type: application/json\" --data "
                 + "'" + connectorConfig + "'" + " http://localhost:8083/connectors");
 
-        KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterSourceName, kafkaClusterTargetName,
+        KafkaMirrorMakerResource.create(KafkaMirrorMakerResource.kafkaMirrorMaker(clusterName, kafkaClusterSourceName, kafkaClusterTargetName,
             ClientUtils.generateRandomConsumerGroup(), 1, false)
                 .editMetadata()
                     .withName("my-mirror-maker")
@@ -778,7 +778,7 @@ public class TracingST extends AbstractST {
                         .endMirrorMakerContainer()
                     .endTemplate()
                 .endSpec()
-                .done();
+                .build());
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
             .withUsingPodName(kafkaClientsPodName)
@@ -813,14 +813,14 @@ public class TracingST extends AbstractST {
         // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
         assumeFalse(Environment.isNamespaceRbacScope());
 
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1).build());
 
-        kafkaTracingClient.producerWithTracing().done();
-        kafkaTracingClient.consumerWithTracing().done();
+        kafkaTracingClient.create(kafkaTracingClient.producerWithTracing().build());
+        kafkaTracingClient.create(kafkaTracingClient.consumerWithTracing().build());
 
         final String kafkaConnectS2IName = "kafka-connect-s2i-name-1";
 
-        KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).build());
 
         Map<String, Object> configOfKafkaConnectS2I = new HashMap<>();
         configOfKafkaConnectS2I.put("key.converter.schemas.enable", "false");
@@ -828,8 +828,7 @@ public class TracingST extends AbstractST {
         configOfKafkaConnectS2I.put("key.converter", "org.apache.kafka.connect.storage.StringConverter");
         configOfKafkaConnectS2I.put("value.converter", "org.apache.kafka.connect.storage.StringConverter");
 
-
-        KafkaConnectS2IResource.kafkaConnectS2I(kafkaConnectS2IName, clusterName, 1)
+        KafkaConnectS2IResource.create(KafkaConnectS2IResource.kafkaConnectS2I(kafkaConnectS2IName, clusterName, 1)
                 .editSpec()
                     .withConfig(configOfKafkaConnectS2I)
                     .withNewJaegerTracing()
@@ -855,7 +854,7 @@ public class TracingST extends AbstractST {
                         .endConnectContainer()
                     .endTemplate()
                 .endSpec()
-                .done();
+                .build());
 
         String kafkaConnectS2IPodName = kubeClient().listPods(Labels.STRIMZI_KIND_LABEL, KafkaConnectS2I.RESOURCE_KIND).get(0).getMetadata().getName();
         String execPodName = kubeClient().listPodsByPrefixInName(kafkaClientsName).get(0).getMetadata().getName();
@@ -893,10 +892,10 @@ public class TracingST extends AbstractST {
     @Tag(BRIDGE)
     @Test
     void testKafkaBridgeService() {
-        KafkaResource.kafkaEphemeral(clusterName, 3, 1).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(clusterName, 3, 1).build());
 
         // Deploy http bridge
-        KafkaBridgeResource.kafkaBridge(clusterName, KafkaResources.plainBootstrapAddress(clusterName), 1)
+        KafkaBridgeResource.create(KafkaBridgeResource.kafkaBridge(clusterName, KafkaResources.plainBootstrapAddress(clusterName), 1)
             .editSpec()
                 .withNewJaegerTracing()
                 .endJaegerTracing()
@@ -921,10 +920,10 @@ public class TracingST extends AbstractST {
                         .endBridgeContainer()
                     .endTemplate()
             .endSpec()
-            .done();
+            .build());
 
         String bridgeProducer = "bridge-producer";
-        KafkaTopicResource.topic(clusterName, TOPIC_NAME).done();
+        KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, TOPIC_NAME).build());
 
         KafkaBridgeExampleClients kafkaBridgeClientJob = new KafkaBridgeExampleClients.Builder()
             .withProducerName(bridgeProducer)
@@ -936,7 +935,7 @@ public class TracingST extends AbstractST {
             .withPollInterval(1000)
             .build();
 
-        kafkaBridgeClientJob.producerStrimziBridge().done();
+        kafkaBridgeClientJob.create(kafkaBridgeClientJob.producerStrimziBridge().build());
         ClientUtils.waitForClientSuccess(bridgeProducer, NAMESPACE, MESSAGE_COUNT);
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
@@ -1035,7 +1034,7 @@ public class TracingST extends AbstractST {
         // deployment of the jaeger
         deployJaeger();
 
-        KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, kafkaClientsName).build());
 
         kafkaClientsPodName = kubeClient().listPodsByPrefixInName(kafkaClientsName).get(0).getMetadata().getName();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
@@ -128,7 +128,7 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
 
         if (KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(clusterName).get() == null) {
             LOGGER.info("Deploying initial Kafka version {} with logMessageFormat={} and interBrokerProtocol={}", initialVersion.version(), initLogMsgFormat, initInterBrokerProtocol);
-            KafkaResource.kafkaPersistent(clusterName, kafkaReplicas, zkReplicas)
+            KafkaResource.create(KafkaResource.kafkaPersistent(clusterName, kafkaReplicas, zkReplicas)
                 .editSpec()
                     .editKafka()
                         .withVersion(initialVersion.version())
@@ -136,13 +136,13 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
                         .addToConfig("inter.broker.protocol.version", initInterBrokerProtocol)
                     .endKafka()
                 .endSpec()
-                .done();
+                .build());
 
             // ##############################
             // Attach clients which will continuously produce/consume messages to/from Kafka brokers during rolling update
             // ##############################
             // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
-            KafkaTopicResource.topic(clusterName, continuousTopicName, 3, 3, 2).done();
+            KafkaTopicResource.create(KafkaTopicResource.topic(clusterName, continuousTopicName, 3, 3, 2).build());
             String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
 
             KafkaBasicExampleClients kafkaBasicClientJob = new KafkaBasicExampleClients.Builder()
@@ -155,8 +155,8 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
                 .withDelayMs(1000)
                 .build();
 
-            kafkaBasicClientJob.producerStrimzi().done();
-            kafkaBasicClientJob.consumerStrimzi().done();
+            kafkaBasicClientJob.create(kafkaBasicClientJob.producerStrimzi().build());
+            kafkaBasicClientJob.create(kafkaBasicClientJob.consumerStrimzi().build());
             // ##############################
 
         } else {
@@ -276,6 +276,6 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
 
         applyBindings(NAMESPACE);
         // 060-Deployment
-        BundleResource.clusterOperator(NAMESPACE).done();
+        BundleResource.create(BundleResource.clusterOperator(NAMESPACE).build());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeST.java
@@ -106,8 +106,8 @@ public class OlmUpgradeST extends AbstractUpgradeST {
             ResourceManager.setMethodResources();
         }
 
-        kafkaBasicClientJob.producerStrimzi().done();
-        kafkaBasicClientJob.consumerStrimzi().done();
+        kafkaBasicClientJob.create(kafkaBasicClientJob.producerStrimzi().build());
+        kafkaBasicClientJob.create(kafkaBasicClientJob.consumerStrimzi().build());
 
         String clusterOperatorDeploymentName = ResourceManager.kubeClient().getDeploymentNameByPrefix(Environment.OLM_OPERATOR_DEPLOYMENT_NAME);
         LOGGER.info("Old deployment name of cluster operator is {}", clusterOperatorDeploymentName);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -179,7 +179,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         // Modify + apply installation files
         copyModifyApply(coDir);
         // Apply Kafka Persistent without version
-        KafkaResource.kafkaFromYaml(previousKafkaPersistent, kafkaClusterName, 3, 3)
+        KafkaResource.create(KafkaResource.kafkaFromYaml(previousKafkaPersistent, kafkaClusterName, 3, 3)
             .editSpec()
                 .editKafka()
                     .withVersion(null)
@@ -187,7 +187,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
                     .addToConfig("inter.broker.protocol.version", getValueForLastKafkaVersionInFile(previousKafkaVersionsYaml, "protocol"))
                 .endKafka()
             .endSpec()
-            .done();
+            .build());
 
         assertNull(KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(kafkaClusterName).get().getSpec().getKafka().getVersion());
 
@@ -280,7 +280,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
             // ##############################
             // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
             if (KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(continuousTopicName).get() == null) {
-                KafkaTopicResource.topic(kafkaClusterName, continuousTopicName, 3, 3, 2).done();
+                KafkaTopicResource.create(KafkaTopicResource.topic(kafkaClusterName, continuousTopicName, 3, 3, 2).build());
             }
 
             String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
@@ -296,8 +296,8 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
                 .withDelayMs(1000)
                 .build();
 
-            kafkaBasicClientJob.producerStrimzi().done();
-            kafkaBasicClientJob.consumerStrimzi().done();
+            kafkaBasicClientJob.create(kafkaBasicClientJob.producerStrimzi().build());
+            kafkaBasicClientJob.create(kafkaBasicClientJob.consumerStrimzi().build());
             // ##############################
         }
 
@@ -493,7 +493,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         LOGGER.info("Deploying Kafka clients with image {}", image);
 
         // Deploy new clients
-        KafkaClientsResource.deployKafkaClients(true, kafkaClusterName + "-" + Constants.KAFKA_CLIENTS, kafkaUser)
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, kafkaClusterName + "-" + Constants.KAFKA_CLIENTS, kafkaUser)
             .editSpec()
                 .editTemplate()
                     .editSpec()
@@ -502,7 +502,8 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
                         .endContainer()
                     .endSpec()
                 .endTemplate()
-            .endSpec().done();
+            .endSpec()
+            .build());
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/utils/KafkaVersionUtilsTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/utils/KafkaVersionUtilsTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class KafkaVersionUtilsTest {
 
     @Test
-    public void parsingTest() throws Exception {
+    public void parsingTest() {
         List<TestKafkaVersion> versions = TestKafkaVersion.getKafkaVersions();
         assertTrue(versions.size() > 0);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
@@ -109,12 +109,13 @@ class AllNamespaceST extends AbstractNamespaceST {
         assumeFalse(Environment.isNamespaceRbacScope());
 
         String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
-        KafkaClientsResource.deployKafkaClients(false, SECOND_CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, SECOND_CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).build());
         // Deploy Kafka Connect in other namespace than CO
-        KafkaConnectResource.kafkaConnect(SECOND_CLUSTER_NAME, 1)
+        KafkaConnectResource.create(KafkaConnectResource.kafkaConnect(SECOND_CLUSTER_NAME, 1)
             .editMetadata()
                 .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
-            .endMetadata().done();
+            .endMetadata()
+            .build());
         // Deploy Kafka Connector
         deployKafkaConnectorWithSink(SECOND_CLUSTER_NAME, SECOND_NAMESPACE, TOPIC_NAME, KafkaConnect.RESOURCE_KIND);
 
@@ -131,12 +132,13 @@ class AllNamespaceST extends AbstractNamespaceST {
         assumeFalse(Environment.isNamespaceRbacScope());
 
         String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
-        KafkaClientsResource.deployKafkaClients(false, SECOND_CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(false, SECOND_CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).build());
         // Deploy Kafka Connect in other namespace than CO
-        KafkaConnectS2IResource.kafkaConnectS2I(SECOND_CLUSTER_NAME, SECOND_CLUSTER_NAME, 1)
+        KafkaConnectS2IResource.create(KafkaConnectS2IResource.kafkaConnectS2I(SECOND_CLUSTER_NAME, SECOND_CLUSTER_NAME, 1)
             .editMetadata()
                 .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
-            .endMetadata().done();
+            .endMetadata()
+            .build());
         // Deploy Kafka Connector
         deployKafkaConnectorWithSink(SECOND_CLUSTER_NAME, SECOND_NAMESPACE, TOPIC_NAME, KafkaConnectS2I.RESOURCE_KIND);
 
@@ -150,7 +152,7 @@ class AllNamespaceST extends AbstractNamespaceST {
 
         String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
         LOGGER.info("Creating user in other namespace than CO and Kafka cluster with UO");
-        KafkaUserResource.tlsUser(MAIN_NAMESPACE_CLUSTER_NAME, USER_NAME).done();
+        KafkaUserResource.create(KafkaUserResource.tlsUser(MAIN_NAMESPACE_CLUSTER_NAME, USER_NAME).build());
 
         cluster.setNamespace(previousNamespace);
     }
@@ -161,7 +163,7 @@ class AllNamespaceST extends AbstractNamespaceST {
         assumeFalse(Environment.isNamespaceRbacScope());
 
         String startingNamespace = cluster.setNamespace(SECOND_NAMESPACE);
-        KafkaUser user = KafkaUserResource.tlsUser(MAIN_NAMESPACE_CLUSTER_NAME, USER_NAME).done();
+        KafkaUser user = KafkaUserResource.create(KafkaUserResource.tlsUser(MAIN_NAMESPACE_CLUSTER_NAME, USER_NAME).build());
 
         Condition kafkaCondition = KafkaUserResource.kafkaUserClient().inNamespace(SECOND_NAMESPACE).withName(USER_NAME)
                 .get().getStatus().getConditions().get(0);
@@ -181,7 +183,7 @@ class AllNamespaceST extends AbstractNamespaceST {
             }
         }
 
-        KafkaClientsResource.deployKafkaClients(true, MAIN_NAMESPACE_CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaClientsResource.create(KafkaClientsResource.deployKafkaClients(true, MAIN_NAMESPACE_CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, user).build());
 
         final String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(MAIN_NAMESPACE_CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
@@ -229,11 +231,11 @@ class AllNamespaceST extends AbstractNamespaceST {
         clusterRoleBindingList.forEach(clusterRoleBinding ->
                 KubernetesResource.clusterRoleBinding(clusterRoleBinding));
         // 060-Deployment
-        BundleResource.clusterOperator("*").done();
+        BundleResource.create(BundleResource.clusterOperator("*").build());
 
         String previousNamespace = cluster.setNamespace(THIRD_NAMESPACE);
 
-        KafkaResource.kafkaEphemeral(MAIN_NAMESPACE_CLUSTER_NAME, 1, 1)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(MAIN_NAMESPACE_CLUSTER_NAME, 1, 1)
             .editSpec()
                 .editEntityOperator()
                     .editTopicOperator()
@@ -244,11 +246,11 @@ class AllNamespaceST extends AbstractNamespaceST {
                     .endUserOperator()
                 .endEntityOperator()
             .endSpec()
-            .done();
+            .build());
 
         cluster.setNamespace(SECOND_NAMESPACE);
         // Deploy Kafka in other namespace than CO
-        KafkaResource.kafkaEphemeral(SECOND_CLUSTER_NAME, 3).done();
+        KafkaResource.create(KafkaResource.kafkaEphemeral(SECOND_CLUSTER_NAME, 3).build());
 
         cluster.setNamespace(previousNamespace);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
@@ -88,18 +88,19 @@ class MultipleNamespaceST extends AbstractNamespaceST {
         applyBindings(CO_NAMESPACE);
         applyBindings(CO_NAMESPACE, SECOND_NAMESPACE);
         // 060-Deployment
-        BundleResource.clusterOperator(String.join(",", CO_NAMESPACE, SECOND_NAMESPACE)).done();
+        BundleResource.create(BundleResource.clusterOperator(String.join(",", CO_NAMESPACE, SECOND_NAMESPACE)).build());
 
         cluster.setNamespace(SECOND_NAMESPACE);
 
-        KafkaResource.kafkaEphemeral(MAIN_NAMESPACE_CLUSTER_NAME, 3)
+        KafkaResource.create(KafkaResource.kafkaEphemeral(MAIN_NAMESPACE_CLUSTER_NAME, 3)
             .editSpec()
                 .editEntityOperator()
                     .editTopicOperator()
                         .withWatchedNamespace(CO_NAMESPACE)
                     .endTopicOperator()
                 .endEntityOperator()
-            .endSpec().done();
+            .endSpec()
+            .build());
 
         cluster.setNamespace(CO_NAMESPACE);
     }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Refactoring

### Description

This PR is small prerequisite before the fabric8 upgrade and (maybe) for the paralelism PRs from @see-quick.
Because in new version of fabric8 they are removing the Doneable classes, we had to rework our resource classes and STs (as we used it everywhere). So (after discussion with @Frawless and little look to @see-quick 's code) I decided to have the `create(..)` method which will create resource from the builders.

### Checklist

- [x] Make sure all tests pass


