### PR TITLE
[DOC] Add Kafka Connect Build documentation

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Build.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Build.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -29,6 +30,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({ "output", "connectorPlugins", "resources" })
+@DescriptionFile
 @EqualsAndHashCode
 public class Build implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;

--- a/documentation/api/io.strimzi.api.kafka.model.connect.build.Build.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.build.Build.adoc
@@ -1,0 +1,191 @@
+Configures additional connectors for Kafka Connect deployments.
+
+=== `output`
+
+In order to build new container images with additional connector plugins, Strimzi requires a container registry where the images can be pushed to, stored and pulled from.
+Strimzi does not run its own container registry, so users need to provide their own registry.
+Strimzi is able to use private container registries as well as public registries such as link:https://quay.io/[Quay^] or link:https://hub.docker.com//[Docker Hub^].
+The container registry is configured in the `.spec.build.output` section of the `KafkaConnect` custom resource.
+The `output` configuration supports two types: `docker` and `imagestream`.
+The `output` section is required.
+
+.Using Docker registry
+
+To use a Docker registry, you have to specify the `type` as `docker`, and the `image` field with the full name of the new container image.
+The full name has to include:
+
+* The address of the registry.
+* Port number if it is listening on non-standard port
+* The tag of the new container image
+
+Examples of valid image names are:
+
+* `docker.io/my-org/my-image/my-tag`
+* `quay.io/my-org/my-image/my-tag`
+* `image-registry.image-registry.svc:5000/myproject/kafka-connect-build:latest`
+
+Different Kafka Connect deployments should use a different image (for example at least with different tags).
+
+If the registry requires authentication, the field `pushSecret` can be used to set a name of the Secret with the registry credentials.
+The Secret should use the `kubernetes.io/dockerconfigjson` type and contain the `.dockerconfigjson` file with the Docker credentials.
+For more details see link:https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials[Create a Secret based on existing Docker credentials^]
+
+[source,yaml,subs=attributes+,options="nowrap"]
+.Example `output` configuration
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+spec:
+  #...
+  build:
+    output:
+      type: docker # <1>
+      image: my-registry.io/my-org/my-connect-cluster:latest # <2>
+      pushSecret: my-registry-credentials # <3>
+  #...
+----
+<1> The type of the output which should be used by Strimzi. (Required)
+<2> The full name of the image which will be used including the repository and tag. (Required)
+<3> Name of the secret with the container registry credentials. (Optional)
+
+.Using OpenShift ImageStream
+
+Alternatively, you can also use OpenShift ImageStream to store the new container image.
+The ImageStream has to be created manually before deploying the Kafka Connect.
+To use OpenShift ImageStream, you have to set the `type` to `imagestream`, and the `image` field should contain the name of the ImageStream and the tag which should be used.
+For example `my-connect-image-stream:latest`.
+
+[source,yaml,subs=attributes+,options="nowrap"]
+.Example `output` configuration
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+spec:
+  #...
+  build:
+    output:
+      type: imagestream # <1>
+      imageStream: image-stream-name # <2>
+  #...
+----
+<1> The type of the output which should be used by Strimzi. (Required)
+<2> The name of the ImageStream and tag. (Required)
+
+=== `plugins`
+
+The connector plugins which will be added to the container image are configured in the `.spec.build.plugins` section of the `KafkaConnect` custom resource.
+Each connector plugin needs to have a name which is unique within the Kafka Connect deployment.
+Additionally, it contains a list of artifacts which it consists of.
+These artifacts will be downloaded by Strimzi, added to the new container image, and used in the Kafka Connect deployment.
+The connector plugin artifacts can also include additional components such as (de)serializers and so on.
+Each connector plugin will be downloaded into a separate directory so that the different connectors and their dependencies are properly sand-boxed.
+The `plugins` section is required.
+Each plugin has to be configured with at least one `artifact`.
+
+[source,yaml,subs=attributes+,options="nowrap"]
+.Example `plugins` configuration with two connector plugins
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+spec:
+  #...
+  build:
+    output:
+      #...
+    plugins: # <1>
+      - name: debezium-postgres-connector
+        artifacts:
+          - type: tgz
+            url: https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/1.3.1.Final/debezium-connector-postgres-1.3.1.Final-plugin.tar.gz
+            sha512sum: 962a12151bdf9a5a30627eebac739955a4fd95a08d373b86bdcea2b4d0c27dd6e1edd5cb548045e115e33a9e69b1b2a352bee24df035a0447cb820077af00c03
+      - name: camel-telegram
+        artifacts:
+          - type: tgz
+            url: https://repo.maven.apache.org/maven2/org/apache/camel/kafkaconnector/camel-telegram-kafka-connector/0.7.0/camel-telegram-kafka-connector-0.7.0-package.tar.gz
+            sha512sum: a9b1ac63e3284bea7836d7d24d84208c49cdf5600070e6bd1535de654f6920b74ad950d51733e8020bf4187870699819f54ef5859c7846ee4081507f48873479
+  #...
+----
+<1> List of connector plugins and their artifacts which should be downloaded. (Required)
+
+Currently, Strimzi supports two types of artifacts:
+* Downloading JAR files and using them directly
+* Downloading TGZ archives and unpacking them
+
+IMPORTANT: Strimzi does not do any security scanning of the downloaded artifacts.
+For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build and in the Kafka Connect deployment.
+
+.Using JAR artifacts
+
+The JAR artifacts represent a resource which will be downloaded and added to the container image.
+It is intended to be mainly used for downloading JAR files.
+It can be also used to download other file types.
+To use a JAR artifacts, you have to set the `type` field to `jar` and use the `url` to specify the URL from which it should be downloaded.
+
+Additionally, you can specify SHA-512 checksum of the file which will be downloaded.
+If specified, Strimzi will verify the checksum of the artifact while building the new container image.
+
+[source,yaml,subs=attributes+,options="nowrap"]
+.Example of a JAR artifact
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+spec:
+  #...
+  build:
+    output:
+      #...
+    plugins:
+      - name: my-plugin
+        artifacts:
+          - type: jar # <1>
+            url: https://my-domain.tld/my-jar.jar # <2>
+            sha512sum: 589...ab4 # <3>
+          - type: jar
+            url: https://my-domain.tld/my-jar2.jar
+  #...
+----
+<1> Type of the artifact. (Required)
+<2> The URL from which the artifact will be downloaded. (Required)
+<3> The SHA-512 checksum to verify the artifact. (Optional)
+
+.Using TGZ artifacts
+
+The TGZ artifacts can be used to download TAR archives compressed using the Gzip compression.
+The TGZ archive can contain the whole Kafka Connect connector even if it consists of multiple different files.
+It will be automatically downloaded and unpacked by Strimzi while building the new container image.
+To use a TGZ artifacts, you have to set the `type` field to `tgz` and use the `url` to specify the URL from which the TGZ archive should be downloaded.
+
+Additionally, you can specify SHA-512 checksum of the archive which will be downloaded.
+If specified, Strimzi will verify the checksum before unpacking it and building the new container image.
+
+[source,yaml,subs=attributes+,options="nowrap"]
+.Example of a JAR artifact
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+spec:
+  #...
+  build:
+    output:
+      #...
+    plugins:
+      - name: my-plugin
+        artifacts:
+          - type: tgz # <1>
+            url: https://my-domain.tld/my-connector-archive.jar # <2>
+            sha512sum: 158...jg10 # <3>
+  #...
+----
+<1> Type of the artifact. (Required)
+<2> The URL from which the archive will be downloaded. (Required)
+<3> The SHA-512 checksum to verify the archive. (Optional)

--- a/documentation/api/io.strimzi.api.kafka.model.connect.build.Build.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.build.Build.adoc
@@ -27,7 +27,7 @@ Each Kafka Connect deployment must use a separate image, which can mean differen
 
 If the registry requires authentication, use the `pushSecret` to set a name of the Secret with the registry credentials.
 For the Secret, use the `kubernetes.io/dockerconfigjson` type and a `.dockerconfigjson` file to contain the Docker credentials.
-For more information on pulling an image from a private registry, see link:https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials[Create a Secret based on existing Docker credentials^].
+For more information on pulling an image from a private registry, see {K8sDockerSecret}.
 
 [source,yaml,subs=attributes+,options="nowrap"]
 .Example `output` configuration
@@ -68,7 +68,7 @@ spec:
   build:
     output:
       type: imagestream # <1>
-      imageStream: image-stream-name # <2>
+      image: my-connect-build:latest # <2>
   #...
 ----
 <1> (Required) Type of output used by Strimzi. 
@@ -76,6 +76,7 @@ spec:
 
 === `plugins`
 
+Connector plugins are a set of files that define the implementation required to connect to certain types of external system.
 The connector plugins required for a container image must be configured using the `.spec.build.plugins` property of the `KafkaConnect` custom resource.
 Each connector plugin must have a name which is unique within the Kafka Connect deployment.
 Additionally, the plugin artifacts must be listed.

--- a/documentation/api/io.strimzi.api.kafka.model.connect.build.Build.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.build.Build.adoc
@@ -2,33 +2,32 @@ Configures additional connectors for Kafka Connect deployments.
 
 === `output`
 
-In order to build new container images with additional connector plugins, Strimzi requires a container registry where the images can be pushed to, stored and pulled from.
-Strimzi does not run its own container registry, so users need to provide their own registry.
-Strimzi is able to use private container registries as well as public registries such as link:https://quay.io/[Quay^] or link:https://hub.docker.com//[Docker Hub^].
+To build new container images with additional connector plugins, Strimzi requires a container registry where the images can be pushed to, stored, and pulled from.
+Strimzi does not run its own container registry, so a registry must be provided.
+Strimzi supports private container registries as well as public registries such as link:https://quay.io/[Quay^] or link:https://hub.docker.com//[Docker Hub^].
 The container registry is configured in the `.spec.build.output` section of the `KafkaConnect` custom resource.
-The `output` configuration supports two types: `docker` and `imagestream`.
-The `output` section is required.
+The `output` configuration, which is required, supports two types: `docker` and `imagestream`.
 
 .Using Docker registry
 
 To use a Docker registry, you have to specify the `type` as `docker`, and the `image` field with the full name of the new container image.
-The full name has to include:
+The full name must include:
 
-* The address of the registry.
-* Port number if it is listening on non-standard port
+* The address of the registry
+* Port number (if listening on a non-standard port)
 * The tag of the new container image
 
-Examples of valid image names are:
+Example valid container image names:
 
 * `docker.io/my-org/my-image/my-tag`
 * `quay.io/my-org/my-image/my-tag`
 * `image-registry.image-registry.svc:5000/myproject/kafka-connect-build:latest`
 
-Different Kafka Connect deployments should use a different image (for example at least with different tags).
+Each Kafka Connect deployment must use a separate image, which can mean different tags at the most basic level.
 
-If the registry requires authentication, the field `pushSecret` can be used to set a name of the Secret with the registry credentials.
-The Secret should use the `kubernetes.io/dockerconfigjson` type and contain the `.dockerconfigjson` file with the Docker credentials.
-For more details see link:https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials[Create a Secret based on existing Docker credentials^]
+If the registry requires authentication, use the `pushSecret` to set a name of the Secret with the registry credentials.
+For the Secret, use the `kubernetes.io/dockerconfigjson` type and a `.dockerconfigjson` file to contain the Docker credentials.
+For more information on pulling an image from a private registry, see link:https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials[Create a Secret based on existing Docker credentials^].
 
 [source,yaml,subs=attributes+,options="nowrap"]
 .Example `output` configuration
@@ -46,16 +45,16 @@ spec:
       pushSecret: my-registry-credentials # <3>
   #...
 ----
-<1> The type of the output which should be used by Strimzi. (Required)
-<2> The full name of the image which will be used including the repository and tag. (Required)
-<3> Name of the secret with the container registry credentials. (Optional)
+<1> (Required) Type of output used by Strimzi. 
+<2> (Required) Full name of the image used, including the repository and tag. 
+<3> (Optional) Name of the secret with the container registry credentials. 
 
 .Using OpenShift ImageStream
 
-Alternatively, you can also use OpenShift ImageStream to store the new container image.
-The ImageStream has to be created manually before deploying the Kafka Connect.
-To use OpenShift ImageStream, you have to set the `type` to `imagestream`, and the `image` field should contain the name of the ImageStream and the tag which should be used.
-For example `my-connect-image-stream:latest`.
+Instead of Docker, you can use OpenShift ImageStream to store a new container image.
+The ImageStream has to be created manually before deploying Kafka Connect.
+To use ImageStream, set the `type` to `imagestream`, and use the `image` property to specify the name of the ImageStream and the tag used.
+For example, `my-connect-image-stream:latest`.
 
 [source,yaml,subs=attributes+,options="nowrap"]
 .Example `output` configuration
@@ -72,19 +71,18 @@ spec:
       imageStream: image-stream-name # <2>
   #...
 ----
-<1> The type of the output which should be used by Strimzi. (Required)
-<2> The name of the ImageStream and tag. (Required)
+<1> (Required) Type of output used by Strimzi. 
+<2> (Required) Name of the ImageStream and tag. 
 
 === `plugins`
 
-The connector plugins which will be added to the container image are configured in the `.spec.build.plugins` section of the `KafkaConnect` custom resource.
-Each connector plugin needs to have a name which is unique within the Kafka Connect deployment.
-Additionally, it contains a list of artifacts which it consists of.
-These artifacts will be downloaded by Strimzi, added to the new container image, and used in the Kafka Connect deployment.
-The connector plugin artifacts can also include additional components such as (de)serializers and so on.
-Each connector plugin will be downloaded into a separate directory so that the different connectors and their dependencies are properly sand-boxed.
-The `plugins` section is required.
-Each plugin has to be configured with at least one `artifact`.
+The connector plugins required for a container image must be configured using the `.spec.build.plugins` property of the `KafkaConnect` custom resource.
+Each connector plugin must have a name which is unique within the Kafka Connect deployment.
+Additionally, the plugin artifacts must be listed.
+These artifacts are downloaded by Strimzi, added to the new container image, and used in the Kafka Connect deployment.
+The connector plugin artifacts can also include additional components, such as (de)serializers.
+Each connector plugin is downloaded into a separate directory so that the different connectors and their dependencies are properly _sandboxed_.
+Each plugin must be configured with at least one `artifact`.
 
 [source,yaml,subs=attributes+,options="nowrap"]
 .Example `plugins` configuration with two connector plugins
@@ -111,27 +109,26 @@ spec:
             sha512sum: a9b1ac63e3284bea7836d7d24d84208c49cdf5600070e6bd1535de654f6920b74ad950d51733e8020bf4187870699819f54ef5859c7846ee4081507f48873479
   #...
 ----
-<1> List of connector plugins and their artifacts which should be downloaded. (Required)
+<1> (Required) List of connector plugins and their artifacts. 
 
-Currently, Strimzi supports two types of artifacts:
-* Downloading JAR files and using them directly
-* Downloading TGZ archives and unpacking them
+Strimzi supports two types of artifacts:
+* JAR files, which are downloaded and used directly
+* TGZ archives, which are downloaded and unpacked
 
-IMPORTANT: Strimzi does not do any security scanning of the downloaded artifacts.
-For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build and in the Kafka Connect deployment.
+IMPORTANT: Strimzi does not perform any security scanning of the downloaded artifacts.
+For security reasons, you should first verify the artifacts manually, and configure the checksum verification to make sure the same artifact is used in the automated build and in the Kafka Connect deployment.
 
 .Using JAR artifacts
 
-The JAR artifacts represent a resource which will be downloaded and added to the container image.
-It is intended to be mainly used for downloading JAR files.
-It can be also used to download other file types.
-To use a JAR artifacts, you have to set the `type` field to `jar` and use the `url` to specify the URL from which it should be downloaded.
+JAR artifacts represent a resource which is downloaded and added to a container image.
+JAR artifacts are mainly used for downloading JAR files, but they can also used to download other file types.
+To use a JAR artifacts, set the `type` property to `jar`, and specify the download location using the `url` property.
 
-Additionally, you can specify SHA-512 checksum of the file which will be downloaded.
+Additionally, you can specify a SHA-512 checksum of the artifact.
 If specified, Strimzi will verify the checksum of the artifact while building the new container image.
 
 [source,yaml,subs=attributes+,options="nowrap"]
-.Example of a JAR artifact
+.Example JAR artifact
 ----
 apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnect
@@ -152,22 +149,22 @@ spec:
             url: https://my-domain.tld/my-jar2.jar
   #...
 ----
-<1> Type of the artifact. (Required)
-<2> The URL from which the artifact will be downloaded. (Required)
-<3> The SHA-512 checksum to verify the artifact. (Optional)
+<1> (Required) Type of artifact. 
+<2> (Required) URL from which the artifact is downloaded. 
+<3> (Optional) SHA-512 checksum to verify the artifact. 
 
 .Using TGZ artifacts
 
-The TGZ artifacts can be used to download TAR archives compressed using the Gzip compression.
-The TGZ archive can contain the whole Kafka Connect connector even if it consists of multiple different files.
-It will be automatically downloaded and unpacked by Strimzi while building the new container image.
-To use a TGZ artifacts, you have to set the `type` field to `tgz` and use the `url` to specify the URL from which the TGZ archive should be downloaded.
+TGZ artifacts are used to download TAR archives that have been compressed using Gzip compression.
+The TGZ artifact can contain the whole Kafka Connect connector, even when comprising multiple different files.
+The TGZ artifact is automatically downloaded and unpacked by Strimzi while building the new container image.
+To use TGZ artifacts, set the `type` property to `tgz`, and specify the download location using the `url` property.
 
-Additionally, you can specify SHA-512 checksum of the archive which will be downloaded.
+Additionally, you can specify a SHA-512 checksum of the artifact.
 If specified, Strimzi will verify the checksum before unpacking it and building the new container image.
 
 [source,yaml,subs=attributes+,options="nowrap"]
-.Example of a JAR artifact
+.Example TGZ artifact
 ----
 apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnect
@@ -186,6 +183,6 @@ spec:
             sha512sum: 158...jg10 # <3>
   #...
 ----
-<1> Type of the artifact. (Required)
-<2> The URL from which the archive will be downloaded. (Required)
-<3> The SHA-512 checksum to verify the archive. (Optional)
+<1> (Required) Type of artifact. 
+<2> (Required) URL from which the archive is downloaded. 
+<3> (Optional) SHA-512 checksum to verify the artifact.  

--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect-with-plugins.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect-with-plugins.adoc
@@ -22,9 +22,9 @@ m¦FileStreamSinkConnector
 
 |===
 
-The Cluster Operator can also use images that you have created to deploy a Kafka Connect cluster to your Kubernetes cluster.
-
 The procedures in this section show how to add your own connector classes to connector images by:
+
+* xref:creating-new-image-using-kafka-connect-build-{context}[Creating new container image automatically using Strimzi]
 
 * xref:creating-new-image-from-base-{context}[Creating a container image from the Kafka Connect base image (manually or using continuous integration)]
 
@@ -32,6 +32,8 @@ The procedures in this section show how to add your own connector classes to con
 
 IMPORTANT: You create the configuration for connectors directly xref:con-creating-managing-connectors-{context}[using the Kafka Connect REST API or KafkaConnector custom resources].
 
+//Procedure to create a container images using Strimzi and Kafka Connect build
+include::modules/proc-deploy-kafka-connect-using-kafka-connect-build.adoc[leveloffset=+1]
 //Procedure to create a container images from base image
 include::modules/proc-deploy-kafka-connect-new-image-from-base.adoc[leveloffset=+1]
 //Procedure to create a base images from OpenShift builds and S2I

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2285,6 +2285,11 @@ Used in: xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
 
 Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`]
 
+include::../api/io.strimzi.api.kafka.model.connect.build.Build.adoc[leveloffset=+1]
+
+[id='type-Build-schema-{context}']
+==== Schema reference
+
 
 [options="header"]
 |====

--- a/documentation/modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// assembly-using-kafka-connect-with-plugins.adoc
+
+[id='creating-new-image-using-kafka-connect-build-{context}']
+= Creating new container image automatically using Strimzi
+
+This procedure shows how to have Strimzi automatically build a new container image with additional connectors.
+You can define the connector plugins as part of the `KafkaConnect` custom resource in the `.spec.build.plugins`.
+Strimzi will automatically download them, add them into a new container image.
+The container will be pushed into the container repository specified in `.spec.build.output` and autoamtically used in the Kafka Connect deployment.
+
+.Prerequisites
+
+* xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
+* Container registry where the newly built container can be pushed
+
+.Procedure
+
+. Prepare the `KafkaConnect` custom resource with the container registry configured in `.spec.build.output` and additional connectors configured in `.spec.build.plugins`:
++
+[source,yaml,subs=attributes+,options="nowrap"]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+spec: # <1>
+  #...
+  build:
+    output: # <2>
+      type: docker
+      image: my-registry.io/my-org/my-connect-cluster:latest
+      pushSecret: my-registry-credentials
+    plugins: # <3>
+      - name: debezium-postgres-connector
+        artifacts:
+          - type: tgz
+            url: https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/1.3.1.Final/debezium-connector-postgres-1.3.1.Final-plugin.tar.gz
+            sha512sum: 962a12151bdf9a5a30627eebac739955a4fd95a08d373b86bdcea2b4d0c27dd6e1edd5cb548045e115e33a9e69b1b2a352bee24df035a0447cb820077af00c03
+      - name: camel-telegram
+        artifacts:
+          - type: tgz
+            url: https://repo.maven.apache.org/maven2/org/apache/camel/kafkaconnector/camel-telegram-kafka-connector/0.7.0/camel-telegram-kafka-connector-0.7.0-package.tar.gz
+            sha512sum: a9b1ac63e3284bea7836d7d24d84208c49cdf5600070e6bd1535de654f6920b74ad950d51733e8020bf4187870699819f54ef5859c7846ee4081507f48873479
+  #...
+----
+<1> link:{BookURLUsing}#type-KafkaConnectSpec-reference[The specification for the Kafka Connect cluster^].
+<2> Configuration of the container registry where the new image should be pushed.
+<3> List of connector plugins which should be added to the container image and their artifacts.
+
+. Create the `KafkaConnect` custom resource from the YAML file:
++
+[source,subs="+quotes"]
+----
+$ kubectl apply -f <YAMLfile>
+----
+
+. Wait for the new container image to be built and for the Kafka Connect cluster to be deployed.
+
+. Use the Kafka Connect REST API or the KafkaConnector custom resources to use the connector plugins you added.
+
+.Additional resources
+
+See the _Using Strimzi_ guide for more information on:
+
+* link:{BookURLUsing}#type-Build-reference[Kafka Connect Build reference^]

--- a/documentation/modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc
@@ -5,19 +5,22 @@
 [id='creating-new-image-using-kafka-connect-build-{context}']
 = Creating new container image automatically using Strimzi
 
-This procedure shows how to have Strimzi automatically build a new container image with additional connectors.
-You can define the connector plugins as part of the `KafkaConnect` custom resource in the `.spec.build.plugins`.
-Strimzi will automatically download them, add them into a new container image.
-The container will be pushed into the container repository specified in `.spec.build.output` and autoamtically used in the Kafka Connect deployment.
+This procedure shows how to configure Kafka Connect so that Strimzi automatically builds a new container image with additional connectors.
+You define the connector plugins using the `.spec.build.plugins` property of the `KafkaConnect` custom resource.
+Strimzi will automatically download and add the connector plugins into a new container image.
+The container is pushed into the container repository specified in `.spec.build.output` and automatically used in the Kafka Connect deployment.
 
 .Prerequisites
 
 * xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
-* Container registry where the newly built container can be pushed
+* A container registry
+
+You need to provide your own container registry where images can be pushed to, stored, and pulled from.
+Strimzi supports private container registries as well as public registries such as link:https://quay.io/[Quay^] or link:https://hub.docker.com//[Docker Hub^].
 
 .Procedure
 
-. Prepare the `KafkaConnect` custom resource with the container registry configured in `.spec.build.output` and additional connectors configured in `.spec.build.plugins`:
+. Configure the `KafkaConnect` custom resource by specifying the container registry in `.spec.build.output`, and additional connectors in `.spec.build.plugins`:
 +
 [source,yaml,subs=attributes+,options="nowrap"]
 ----
@@ -46,22 +49,22 @@ spec: # <1>
   #...
 ----
 <1> link:{BookURLUsing}#type-KafkaConnectSpec-reference[The specification for the Kafka Connect cluster^].
-<2> Configuration of the container registry where the new image should be pushed.
-<3> List of connector plugins which should be added to the container image and their artifacts.
+<2> (Required) Configuration of the container registry where the new image are pushed.
+<3> (Required) List of connector plugins and their artifacts to add to the new container image. Each plugin must be configured with at least one `artifact`.
 
-. Create the `KafkaConnect` custom resource from the YAML file:
+. Create or update the resource:
 +
 [source,subs="+quotes"]
 ----
-$ kubectl apply -f <YAMLfile>
+$ kubectl apply -f _KAFKA-CONNECT-CONFIG-FILE_
 ----
 
-. Wait for the new container image to be built and for the Kafka Connect cluster to be deployed.
+. Wait for the new container image to build, and for the Kafka Connect cluster to be deployed.
 
-. Use the Kafka Connect REST API or the KafkaConnector custom resources to use the connector plugins you added.
+. Use the Kafka Connect REST API or the `KafkaConnector` custom resources to use the connector plugins you added.
 
 .Additional resources
 
 See the _Using Strimzi_ guide for more information on:
 
-* link:{BookURLUsing}#type-Build-reference[Kafka Connect Build reference^]
+* link:{BookURLUsing}#type-Build-reference[Kafka Connect `Build` schema reference^]

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -74,6 +74,7 @@
 :K8sPriorityClass: link:https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption[Pod Priority and Preemption^]
 :K8sServiceDiscovery: https://kubernetes.io/docs/concepts/services-networking/service/#discovering-services[Discovering services^]
 :K8sWellKnownLabelsAnnotationsAndTaints: link:https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/[Well-Known Labels, Annotations and Taints^]
+:K8sDockerSecret: link:https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials[Create a Secret based on existing Docker credentials^]
 :Minikube: link:https://kubernetes.io/docs/tasks/tools/install-minikube/[Install and start Minikube]
 :NginxIngressController: link:https://github.com/kubernetes/ingress-nginx[NGINX Ingress Controller for Kubernetes^]
 :NginxIngressControllerTLSPassthrough: link:https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough[TLS passthrough documentation]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR adds the documentation to #4168 - Kafka Connect Build. It adds procedure on how to use it to this section: https://strimzi.io/docs/operators/master/full/deploying.html#using-kafka-connect-with-plug-ins-str ... and it adds a more detailed description of all the options into the reference documentation into the Build section.

_(The build will fail until #4168 is merged, but the content should be ready for review.)_

### Checklist

- [x] Update documentation