### PR TITLE
[DOC] Source and sink connector configuration using KafkaConnectors

### DIFF
--- a/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
@@ -8,14 +8,14 @@
 Strimzi includes an example `KafkaConnector` in `examples/connect/source-connector.yaml`. 
 This creates a basic `FileStreamSourceConnector` instance that sends each line of the Kafka license file (an example file source) to a single Kafka topic. 
 
-You can create a `FileStreamSinkConnector` by changing the configuration of the example `KafkaConnector`.
-
-The following procedure illustrates how to configure Kafka Connect connectors by using the `source-connector.yaml` file as an example. 
+You can create a `FileStreamSinkConnector` by copying the example file and then changing the class and configuration. 
+The `FileStreamSinkConnector` reads messages from a specified topic and then writes them to a file.
 
 [NOTE]
 ====
-The `FileStreamSourceConnector` and `FileStreamSinkConnector` are not intended to be run in containers. 
-In a production environment, you should prepare container images containing the Kafka Connect connectors that you want to use.
+In a production environment, you prepare container images containing the Kafka Connect connectors, as described in xref:using-kafka-connect-with-plug-ins-{context}[].
+
+The `FileStreamSourceConnector` and `FileStreamSinkConnector` are provided as examples. Running these connectors in containers as described here is unlikely to be suitable for production use cases.
 ====
 
 .Prerequisites
@@ -53,6 +53,7 @@ spec:
 +
 The `FileStreamSourceConnector` class accepts the following configuration options:
 +
+.Configuration options for the source connector
 [cols="4*",options="header",stripes="none",separator=¦]
 |===
 
@@ -64,7 +65,7 @@ The `FileStreamSourceConnector` class accepts the following configuration option
 m¦file
 ¦String
 ¦Null
-¦Source file name. If not specified, the standard input is used.
+¦Source file to write messages to. If not specified, the standard input is used.
 
 m¦topic
 ¦List
@@ -75,6 +76,7 @@ m¦topic
 +
 The `FileStreamSinkConnector` class accepts the following configuration options
 +
+.Configuration options for the sync connector
 [cols="4*",options="header",stripes="none",separator=¦]
 |===
 
@@ -86,7 +88,7 @@ The `FileStreamSinkConnector` class accepts the following configuration options
 m¦file
 ¦String
 ¦Null
-¦Destination file name. If not specified, the standard output is used.
+¦Destination file to write messages to. If not specified, the standard output is used.
 
 m¦topics
 ¦List
@@ -114,8 +116,10 @@ kubectl apply -f examples/connect/source-connector.yaml
 +
 [source,shell,subs="+quotes"]
 ----
-kubectl get kctr --selector strimzi.io/cluster=my-connect-cluster -o name
+kubectl get kctr --selector strimzi.io/cluster=_MY-CONNECT-CLUSTER_ -o name
 ----
++
+Replace _MY-CONNECT-CLUSTER_ with the Kafka Connect cluster that the connector was created in.
 
 .Additional resources
 

--- a/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
@@ -3,15 +3,20 @@
 // assembly-kafka-connect.adoc
 
 [id='proc-deploying-kafkaconnector-{context}']
-= Deploying a `KafkaConnector` resource
+= Deploying the example `KafkaConnector` resource
 
-You can configure and deploy a `KafkaConnector` resource to a Kafka Connect cluster. 
-This creates a new connector instance with the specified configuration. 
+Strimzi includes an example `KafkaConnector` in `examples/connect/source-connector.yaml`. 
+This creates a basic `FileStreamSourceConnector` instance that sends each line of the Kafka license file (an example file source) to a single Kafka topic. 
 
-This procedure creates a basic `FileStreamSourceConnector` that sends each line of the Kafka license file to a Kafka topic. 
-You can also create a `FileStreamSinkConnector`.
+You can create a `FileStreamSinkConnector` by changing the configuration of the example `KafkaConnector`.
 
-The file connectors provided with Strimzi are intended to be used as examples only. 
+The following procedure illustrates how to configure Kafka Connect connectors by using the `source-connector.yaml` file as an example. 
+
+[NOTE]
+====
+The `FileStreamSourceConnector` and `FileStreamSinkConnector` are not intended to be run in containers. 
+In a production environment, you should prepare container images containing the Kafka Connect connectors that you want to use.
+====
 
 .Prerequisites
 
@@ -35,7 +40,6 @@ spec:
   class: org.apache.kafka.connect.file.FileStreamSourceConnector <3>
   tasksMax: 2 <4>
   config: <5>
-    tasks.max: 1500
     file: "/opt/kafka/LICENSE"
     topic: my-topic
     # ...
@@ -56,11 +60,6 @@ The `FileStreamSourceConnector` class accepts the following configuration option
 ¦Type
 ¦Default value
 ¦Description
-
-m¦tasks.max
-¦Integer
-¦The default task batch size (2000)
-¦Maximum number of messages read by the `SourceTask` from the source file at a time.
 
 m¦file
 ¦String
@@ -89,9 +88,20 @@ m¦file
 ¦Null
 ¦Destination file name. If not specified, the standard output is used.
 
+m¦topics
+¦List
+¦Null
+¦One or more Kafka topics to read data from.
+
+m¦topics.regex
+¦String
+¦Null
+¦A regular expression matching one or more Kafka topics to read data from.
+
 |===
 +
-Both classes of connectors support the same configuration options as the Kafka Connect REST API.
+The `FileStreamSourceConnector` and `FileStreamSinkConnector` classes support the same configuration options as the Kafka Connect REST API. 
+Other connectors will support different configuration options.
 
 . Create the `KafkaConnector` in your Kubernetes cluster:
 +
@@ -106,3 +116,7 @@ kubectl apply -f examples/connect/source-connector.yaml
 ----
 kubectl get kctr --selector strimzi.io/cluster=my-connect-cluster -o name
 ----
+
+.Additional resources
+
+* xref:con-creating-managing-connectors-{context}[]

--- a/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
@@ -8,8 +8,11 @@
 Strimzi includes an example `KafkaConnector` in `examples/connect/source-connector.yaml`. 
 This creates a basic `FileStreamSourceConnector` instance that sends each line of the Kafka license file (an example file source) to a single Kafka topic. 
 
-You can create a `FileStreamSinkConnector` by copying the example file and then changing the class and configuration. 
-The `FileStreamSinkConnector` reads messages from a specified topic and then writes them to a file.
+This procedure describes how to create: 
+
+* A `FileStreamSourceConnector` that reads messages from a temporary file (the source) and then publishes them to a Kafka topic.
+
+* A `FileStreamSinkConnector` that publishes messages from a Kafka topic to a temporary file (the sink).
 
 [NOTE]
 ====

--- a/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
@@ -10,9 +10,9 @@ This creates a basic `FileStreamSourceConnector` instance that sends each line o
 
 This procedure describes how to create: 
 
-* A `FileStreamSourceConnector` that reads messages from a temporary file (the source) and then publishes them to a Kafka topic.
+* A `FileStreamSourceConnector` that reads data from the Kafka license file (the source) and writes the data as messages to a Kafka topic.
 
-* A `FileStreamSinkConnector` that publishes messages from a Kafka topic to a temporary file (the sink).
+* A `FileStreamSinkConnector` that reads messages from the Kafka topic and writes the messages to a temporary file (the sink).
 
 [NOTE]
 ====
@@ -43,7 +43,7 @@ spec:
   class: org.apache.kafka.connect.file.FileStreamSourceConnector <3>
   tasksMax: 2 <4>
   config: <5>
-    file: "/tmp/my-file" <6>
+    file: "/opt/kafka/LICENSE" <6>
     topic: my-topic <7>
     # ...
 ----
@@ -53,7 +53,7 @@ spec:
 <3> Full name or alias of the connector class. This should be present in the image being used by the Kafka Connect cluster.
 <4> Maximum number of Kafka Connect `Tasks` that the connector can create.
 <5> xref:#kafkaconnector-configs[Connector configuration] as key-value pairs.
-<6> Replace `/opt/kafka/LICENSE` with a temporary file to read the messages from. 
+<6> The source connector reads data from the `/opt/kafka/LICENSE` file. 
 <7> Kafka topic to publish the source data to.
 
 . Create the source `KafkaConnector` in your Kubernetes cluster:
@@ -70,7 +70,7 @@ kubectl apply -f examples/connect/source-connector.yaml
 touch examples/connect/sink-connector.yaml
 ----
 
-. Paste the following example YAML into the `examples/connect/sink-connector.yaml` file:
+. Paste the following YAML into the `sink-connector.yaml` file:
 +
 [source,yaml,subs="attributes+"]
 ----
@@ -84,13 +84,14 @@ spec:
   class: org.apache.kafka.connect.file.FileStreamSinkConnector <1>
   tasksMax: 2 
   config: <2>
-    file: "/tmp/my-file" 
-    topics: my-topic <3>
+    file: "/tmp/my-file" <3>
+    topics: my-topic <4>
 ----
 +
 <1> Full name or alias of the connector class. This should be present in the image being used by the Kafka Connect cluster.
 <2> xref:#kafkaconnector-configs[Connector configuration] as key-value pairs.
-<3> Kafka topic to read the source data from.
+<3> Temporary file to publish the source data to.
+<4> Kafka topic to read the source data from.
 
 . Create the sink `KafkaConnector` in your Kubernetes cluster:
 +
@@ -109,9 +110,9 @@ my-source-connector
 my-sink-connector
 ----
 +
-Replace _MY-CONNECT-CLUSTER_ with the Kafka Connect cluster that the connector was created in.
+Replace _MY-CONNECT-CLUSTER_ with your Kafka Connect cluster.
 
-. In the container, execute the `kafka-console-consumer.sh` to read the messages that were written to the topic by the source connector:
+. In the container, execute `kafka-console-consumer.sh` to read the messages that were written to the topic by the source connector:
 +
 [source,shell,subs="+quotes"]
 ----

--- a/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
@@ -3,7 +3,7 @@
 // assembly-kafka-connect.adoc
 
 [id='proc-deploying-kafkaconnector-{context}']
-= Deploying the example `KafkaConnector` resource
+= Deploying the example `KafkaConnector` resources
 
 Strimzi includes an example `KafkaConnector` in `examples/connect/source-connector.yaml`. 
 This creates a basic `FileStreamSourceConnector` instance that sends each line of the Kafka license file (an example file source) to a single Kafka topic. 
@@ -40,8 +40,8 @@ spec:
   class: org.apache.kafka.connect.file.FileStreamSourceConnector <3>
   tasksMax: 2 <4>
   config: <5>
-    file: "/opt/kafka/LICENSE"
-    topic: my-topic
+    file: "/tmp/my-file" <6>
+    topic: my-topic <7>
     # ...
 ----
 +
@@ -49,11 +49,82 @@ spec:
 <2> Name of the Kafka Connect cluster to create the connector in.
 <3> Full name or alias of the connector class. This should be present in the image being used by the Kafka Connect cluster.
 <4> Maximum number of Kafka Connect `Tasks` that the connector can create.
-<5> Connector configuration as key-value pairs.
+<5> xref:#kafkaconnector-configs[Connector configuration] as key-value pairs.
+<6> Replace `/opt/kafka/LICENSE` with a temporary file to read the messages from. 
+<7> Kafka topic to publish the source data to.
+
+. Create the source `KafkaConnector` in your Kubernetes cluster:
 +
-The `FileStreamSourceConnector` class accepts the following configuration options:
+[source,shell,subs="+quotes"]
+----
+kubectl apply -f examples/connect/source-connector.yaml
+----
+
+. Create an `examples/connect/sink-connector.yaml` file:
 +
-.Configuration options for the source connector
+[source,shell,subs="+quotes"]
+----
+touch examples/connect/sink-connector.yaml
+----
+
+. Paste the following example YAML into the `examples/connect/sink-connector.yaml` file:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaConnector
+metadata:
+  name: my-sink-connector
+  labels:
+    strimzi.io/cluster: my-connect
+spec:
+  class: org.apache.kafka.connect.file.FileStreamSinkConnector <1>
+  tasksMax: 2 
+  config: <2>
+    file: "/tmp/my-file" 
+    topics: my-topic <3>
+----
++
+<1> Full name or alias of the connector class. This should be present in the image being used by the Kafka Connect cluster.
+<2> xref:#kafkaconnector-configs[Connector configuration] as key-value pairs.
+<3> Kafka topic to read the source data from.
+
+. Create the sink `KafkaConnector` in your Kubernetes cluster:
++
+[source,shell,subs="+quotes"]
+----
+kubectl apply -f examples/connect/sink-connector.yaml
+----
+
+. Check that the connector resources were created:
++
+[source,shell,subs="+quotes"]
+----
+kubectl get kctr --selector strimzi.io/cluster=_MY-CONNECT-CLUSTER_ -o name
+
+my-source-connector
+my-sink-connector
+----
++
+Replace _MY-CONNECT-CLUSTER_ with the Kafka Connect cluster that the connector was created in.
+
+. In the container, execute the `kafka-console-consumer.sh` to read the messages that were written to the topic by the source connector:
++
+[source,shell,subs="+quotes"]
+----
+kubectl exec _MY-CLUSTER_-kafka-0 -i -t -- bin/kafka-console-consumer.sh --bootstrap-server _MY-CLUSTER_-kafka-bootstrap._NAMESPACE_.svc:9092 --topic my-topic --from-beginning
+----
+
+[[kafkaconnector-configs]]
+[discrete]
+== Source and sink connector configuration options
+
+The connector configuration is defined in the `spec.config` property of the `KafkaConnector` resource.
+
+The `FileStreamSourceConnector` and `FileStreamSinkConnector` classes support the same configuration options as the Kafka Connect REST API. 
+Other connectors support different configuration options.
+
+.Configuration options for the `FileStreamSource` connector class
 [cols="4*",options="header",stripes="none",separator=¦]
 |===
 
@@ -73,10 +144,8 @@ m¦topic
 ¦The Kafka topic to publish data to.
 
 |===
-+
-The `FileStreamSinkConnector` class accepts the following configuration options
-+
-.Configuration options for the sync connector
+
+.Configuration options for `FileStreamSinkConnector` class
 [cols="4*",options="header",stripes="none",separator=¦]
 |===
 
@@ -101,25 +170,6 @@ m¦topics.regex
 ¦A regular expression matching one or more Kafka topics to read data from.
 
 |===
-+
-The `FileStreamSourceConnector` and `FileStreamSinkConnector` classes support the same configuration options as the Kafka Connect REST API. 
-Other connectors will support different configuration options.
-
-. Create the `KafkaConnector` in your Kubernetes cluster:
-+
-[source,shell,subs="+quotes"]
-----
-kubectl apply -f examples/connect/source-connector.yaml
-----
-
-. Check that the resource was created:
-+
-[source,shell,subs="+quotes"]
-----
-kubectl get kctr --selector strimzi.io/cluster=_MY-CONNECT-CLUSTER_ -o name
-----
-+
-Replace _MY-CONNECT-CLUSTER_ with the Kafka Connect cluster that the connector was created in.
 
 .Additional resources
 

--- a/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
@@ -3,16 +3,21 @@
 // assembly-kafka-connect.adoc
 
 [id='proc-deploying-kafkaconnector-{context}']
-= Deploying a `KafkaConnector` resource to Kafka Connect
+= Deploying a `KafkaConnector` resource
 
-This procedure describes how to deploy the example `KafkaConnector` to a Kafka Connect cluster.
+You can configure and deploy a `KafkaConnector` resource to a Kafka Connect cluster. 
+This creates a new connector instance with the specified configuration. 
 
-The example YAML will create a `FileStreamSourceConnector` to send each line of the license file to Kafka as a message in a topic named `my-topic`.
+This procedure creates a basic `FileStreamSourceConnector` that sends each line of the Kafka license file to a Kafka topic. 
+You can also create a `FileStreamSinkConnector`.
+
+The file connectors provided with Strimzi are intended to be used as examples only. 
 
 .Prerequisites
 
-* A Kafka Connect deployment in which link:{BookURLUsing}#proc-enabling-kafkaconnectors-deployment-configuration-kafka-connect[`KafkaConnectors` are enabled^]
-* A running Cluster Operator
+* A Kafka Connect deployment
+* link:{BookURLUsing}#proc-enabling-kafkaconnectors-deployment-configuration-kafka-connect[`KafkaConnectors` are enabled^]
+* The Cluster Operator is running
 
 .Procedure
 
@@ -30,16 +35,63 @@ spec:
   class: org.apache.kafka.connect.file.FileStreamSourceConnector <3>
   tasksMax: 2 <4>
   config: <5>
+    tasks.max: 1500
     file: "/opt/kafka/LICENSE"
     topic: my-topic
     # ...
 ----
 +
-<1> Enter a name for the `KafkaConnector` resource. This will be used as the name of the connector within Kafka Connect. You can choose any name that is valid for a Kubernetes resource.
-<2> Enter the name of the Kafka Connect cluster in which to create the connector.
-<3> The name or alias of the connector class. This should be present in the image being used by the Kafka Connect cluster.
-<4> The maximum number of tasks that the connector can create.
-<5> Configuration settings for the connector. Available configuration options depend on the connector class.
+<1> Name of the `KafkaConnector` resource, which is used as the name of the connector. Use any name that is valid for a Kubernetes resource.
+<2> Name of the Kafka Connect cluster to create the connector in.
+<3> Full name or alias of the connector class. This should be present in the image being used by the Kafka Connect cluster.
+<4> Maximum number of Kafka Connect `Tasks` that the connector can create.
+<5> Connector configuration as key-value pairs.
++
+The `FileStreamSourceConnector` class accepts the following configuration options:
++
+[cols="4*",options="header",stripes="none",separator=¦]
+|===
+
+¦Name
+¦Type
+¦Default value
+¦Description
+
+m¦tasks.max
+¦Integer
+¦The default task batch size (2000)
+¦Maximum number of messages read by the `SourceTask` from the source file at a time.
+
+m¦file
+¦String
+¦Null
+¦Source file name. If not specified, the standard input is used.
+
+m¦topic
+¦List
+¦Null
+¦The Kafka topic to publish data to.
+
+|===
++
+The `FileStreamSinkConnector` class accepts the following configuration options
++
+[cols="4*",options="header",stripes="none",separator=¦]
+|===
+
+¦Name
+¦Type
+¦Default value
+¦Description
+
+m¦file
+¦String
+¦Null
+¦Destination file name. If not specified, the standard output is used.
+
+|===
++
+Both classes of connectors support the same configuration options as the Kafka Connect REST API.
 
 . Create the `KafkaConnector` in your Kubernetes cluster:
 +

--- a/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
@@ -53,7 +53,7 @@ spec:
 <3> Full name or alias of the connector class. This should be present in the image being used by the Kafka Connect cluster.
 <4> Maximum number of Kafka Connect `Tasks` that the connector can create.
 <5> xref:#kafkaconnector-configs[Connector configuration] as key-value pairs.
-<6> The source connector reads data from the `/opt/kafka/LICENSE` file. 
+<6> This example source connector configuration reads data from the `/opt/kafka/LICENSE` file. 
 <7> Kafka topic to publish the source data to.
 
 . Create the source `KafkaConnector` in your Kubernetes cluster:

--- a/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
@@ -13,7 +13,7 @@ The `FileStreamSinkConnector` reads messages from a specified topic and then wri
 
 [NOTE]
 ====
-In a production environment, you prepare container images containing the Kafka Connect connectors, as described in xref:using-kafka-connect-with-plug-ins-{context}[].
+In a production environment, you prepare container images containing your desired Kafka Connect connectors, as described in xref:using-kafka-connect-with-plug-ins-{context}[].
 
 The `FileStreamSourceConnector` and `FileStreamSinkConnector` are provided as examples. Running these connectors in containers as described here is unlikely to be suitable for production use cases.
 ====

--- a/documentation/modules/metrics/proc-metrics-kafka-deploy-options.adoc
+++ b/documentation/modules/metrics/proc-metrics-kafka-deploy-options.adoc
@@ -26,7 +26,7 @@ Perform the following steps for each `Kafka` resource in your deployment.
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-kubectl edit kafka _KAFKA-CONFIG-FILE_
+kubectl edit kafka
 ----
 
 . Copy the xref:ref-metrics-yaml-files-{context}[example configuration in `kafka-metrics.yaml`] to your own `Kafka` resource definition.

--- a/documentation/modules/metrics/proc-metrics-kafka-deploy-options.adoc
+++ b/documentation/modules/metrics/proc-metrics-kafka-deploy-options.adoc
@@ -26,7 +26,7 @@ Perform the following steps for each `Kafka` resource in your deployment.
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-kubectl edit kafka
+kubectl edit kafka _KAFKA-CONFIG-FILE_
 ----
 
 . Copy the xref:ref-metrics-yaml-files-{context}[example configuration in `kafka-metrics.yaml`] to your own `Kafka` resource definition.


### PR DESCRIPTION
Signed-off-by: Daniel Laing <dlaing@redhat.com>

### Type of change

- Documentation

### Description

Guide(s) affected: _Deploying and upgrading Strimzi_

"Deploying a `KafkaConnector` resource" 

This pull request documents the standard configuration options for the source and sink file connectors for Kafka Connect.

- Add two tables describing the accepted configs
- Explain that the example file connectors are examples only!
- A few other edits for style, terminology, etc.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging - **NO RELATED ISSUES FOUND**
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

