### PR TITLE
Remove admin context for oc client in IT/STs

### DIFF
--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -249,9 +249,6 @@ Otherwise, it will use the context from kubeconfig with a name specified by the 
 For example, command `TEST_CLUSTER_CONTEXT=remote-cluster ./systemtest/scripts/run_tests.sh` will execute tests with cluster context `remote-cluster`.
 However, since system tests use command line `Executor` for some actions, make sure that you are using context from `TEST_CLUSTER_CONTEXT`.
 
-System tests uses admin user for some actions.
-You can specify the admin user using variable `TEST_CLUSTER_ADMIN` (by default it uses `developer` because `system:admin` cannot be used over remote connections).
-
 ## Helper script
 
 The `./systemtest/scripts/run_tests.sh` script can be used to run the `systemtests` using the same configuration as used in the Azure build.

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -180,7 +180,7 @@ public abstract class AbstractST implements TestSeparator {
 
             }
             clusterOperatorConfigs.push(entry.getKey().getPath());
-            cmdKubeClient().clientWithAdmin().namespace(namespace).applyContent(fileContents);
+            cmdKubeClient().namespace(namespace).applyContent(fileContents);
         }
     }
 
@@ -203,7 +203,7 @@ public abstract class AbstractST implements TestSeparator {
         while (!clusterOperatorConfigs.empty()) {
             String clusterOperatorConfig = clusterOperatorConfigs.pop();
             LOGGER.info("Deleting configuration file: {}", clusterOperatorConfig);
-            cmdKubeClient().clientWithAdmin().delete(clusterOperatorConfig);
+            cmdKubeClient().delete(clusterOperatorConfig);
         }
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -958,7 +958,7 @@ public class TracingST extends AbstractST {
      */
     void deleteJaeger() {
         while (!jaegerConfigs.empty()) {
-            cmdKubeClient().clientWithAdmin().namespace(cluster.getNamespace()).deleteContent(jaegerConfigs.pop());
+            cmdKubeClient().namespace(cluster.getNamespace()).deleteContent(jaegerConfigs.pop());
         }
     }
 
@@ -979,7 +979,7 @@ public class TracingST extends AbstractST {
                 fileContents = switchClusterRolesToRoles(fileContents);
             }
             jaegerConfigs.push(fileContents);
-            cmdKubeClient().clientWithAdmin().namespace(cluster.getNamespace()).applyContent(fileContents);
+            cmdKubeClient().namespace(cluster.getNamespace()).applyContent(fileContents);
         }
 
         installJaegerInstance();
@@ -1021,7 +1021,7 @@ public class TracingST extends AbstractST {
                 fileContents = switchClusterRolesToRoles(fileContents);
             }
             jaegerConfigs.push(fileContents);
-            cmdKubeClient().clientWithAdmin().namespace(cluster.getNamespace()).applyContent(fileContents);
+            cmdKubeClient().namespace(cluster.getNamespace()).applyContent(fileContents);
         }
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -196,7 +196,7 @@ public class KubeClusterResource {
         for (String resource : resources) {
             LOGGER.info("Creating resources {} in Namespace {}", resource, getNamespace());
             deploymentResources.add(resource);
-            cmdKubeClient().clientWithAdmin().namespace(getNamespace()).create(resource);
+            cmdKubeClient().namespace(getNamespace()).create(resource);
         }
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -63,13 +63,12 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
 
     private static final Context NOOP = new Context();
 
-    @Override
-    public abstract K clientWithAdmin();
-
     protected Context defaultContext() {
         return NOOP;
     }
 
+    // Admin contex tis not implemented now, because it's not needed
+    // In case it will be neded in future, we should change the kubeconfig and apply it for both oc and kubectl
     protected Context adminContext() {
         return defaultContext();
     }

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
@@ -57,10 +57,6 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
     /** Replaces the resources in the given files. */
     K replace(File... files);
 
-
-    /** Returns an equivalent client, but logged in as cluster admin. */
-    K clientWithAdmin();
-
     K applyContent(String yamlContent);
 
     K deleteContent(String yamlContent);

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/Kubectl.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/Kubectl.java
@@ -41,11 +41,4 @@ public class Kubectl extends BaseCmdKubeClient<Kubectl> {
     public String cmd() {
         return KUBECTL;
     }
-
-    @Override
-    public Kubectl clientWithAdmin() {
-        return this;
-    }
-
-
 }

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/Oc.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/Oc.java
@@ -27,32 +27,6 @@ public class Oc extends BaseCmdKubeClient<Oc> {
     }
 
     @Override
-    protected Context adminContext() {
-        String previous = Exec.exec(Oc.OC, "whoami").out().trim();
-        String admin = System.getenv().getOrDefault("TEST_CLUSTER_ADMIN", "developer");
-
-        boolean isCurrentUserAdmin = !Exec.exec(OC, "get", "clusterrolebinding.rbac", "cluster-admin", "-o=jsonpath='{.subjects[?(@.name==\"" + previous + "\")]}'").out().isEmpty();
-
-        if (!isCurrentUserAdmin && !previous.equals(admin)) {
-            LOGGER.info("Switching from login {} to {}", previous, admin);
-            Exec.exec(Oc.OC, "login", "-u", admin);
-        }
-
-        return new Context() {
-            @Override
-            public void close() {
-                LOGGER.trace("Switching back to login {} from {}", previous, admin);
-                Exec.exec(Oc.OC, "login", "-u", previous);
-            }
-        };
-    }
-
-    @Override
-    public Oc clientWithAdmin() {
-        return new AdminOc();
-    }
-
-    @Override
     public String defaultNamespace() {
         return "myproject";
     }
@@ -94,26 +68,5 @@ public class Oc extends BaseCmdKubeClient<Oc> {
     @Override
     public String cmd() {
         return OC;
-    }
-
-    /**
-     * An {@code Oc} which uses the admin context.
-     */
-    private class AdminOc extends Oc {
-
-        @Override
-        public String namespace() {
-            return Oc.this.namespace();
-        }
-
-        @Override
-        protected Context defaultContext() {
-            return adminContext();
-        }
-
-        @Override
-        public Oc clientWithAdmin() {
-            return this;
-        }
     }
 }


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change


- Bugfix

### Description

We face the issue, when you execute tests manually against OCP cluster under different login than `developer`, the test machine will change it to developer even if you are already logged as admin and developer don't exist. We decided to remove adminContext completely because it's not used in tests anyway. We always use the user, which is associated with currently active kubecontext and we don't switch the kube context.

In case we will want to switch users, we should implement switching kubecontext for fabric8 and kubeconfig for kubectl/oc, but definitely in separate PR when it will be needed.

### Checklist

- [x] Make sure all tests pass


