### PR TITLE
[DOC] Update to Overview to describe kafka connect build config

### DIFF
--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect-with-plugins.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect-with-plugins.adoc
@@ -24,7 +24,7 @@ m¦FileStreamSinkConnector
 
 The procedures in this section show how to add your own connector classes to connector images by:
 
-* xref:creating-new-image-using-kafka-connect-build-{context}[Creating new container image automatically using Strimzi]
+* xref:creating-new-image-using-kafka-connect-build-{context}[Creating a new container image automatically using Strimzi]
 
 * xref:creating-new-image-from-base-{context}[Creating a container image from the Kafka Connect base image (manually or using continuous integration)]
 

--- a/documentation/modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc
@@ -3,7 +3,7 @@
 // assembly-using-kafka-connect-with-plugins.adoc
 
 [id='creating-new-image-using-kafka-connect-build-{context}']
-= Creating new container image automatically using Strimzi
+= Creating a new container image automatically using Strimzi
 
 This procedure shows how to configure Kafka Connect so that Strimzi automatically builds a new container image with additional connectors.
 You define the connector plugins using the `.spec.build.plugins` property of the `KafkaConnect` custom resource.
@@ -13,7 +13,7 @@ The container is pushed into the container repository specified in `.spec.build.
 .Prerequisites
 
 * xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
-* A container registry
+* A container registry.
 
 You need to provide your own container registry where images can be pushed to, stored, and pulled from.
 Strimzi supports private container registries as well as public registries such as link:https://quay.io/[Quay^] or link:https://hub.docker.com//[Docker Hub^].
@@ -49,7 +49,7 @@ spec: # <1>
   #...
 ----
 <1> link:{BookURLUsing}#type-KafkaConnectSpec-reference[The specification for the Kafka Connect cluster^].
-<2> (Required) Configuration of the container registry where the new image are pushed.
+<2> (Required) Configuration of the container registry where new images are pushed.
 <3> (Required) List of connector plugins and their artifacts to add to the new container image. Each plugin must be configured with at least one `artifact`.
 
 . Create or update the resource:

--- a/documentation/modules/overview/con-configuration-points-connect.adoc
+++ b/documentation/modules/overview/con-configuration-points-connect.adoc
@@ -48,14 +48,45 @@ Kafka provides two built-in connectors:
 * `FileStreamSinkConnector` streams data from Kafka to an external system, reading messages from a Kafka topic and creating a line for each in an output file.
 --
 
-You can add other connectors using connector plugins, which are a set of JAR files that define the implementation required to connect to certain types of external system.
+You can add other connectors using connector plugins, which are a set of JAR files or TGZ archives that define the implementation required to connect to certain types of external system.
 
-You create a custom Kafka Connect image that uses new Kafka Connect plugins.
+You create a custom Kafka Connect image that uses new connector plugins.
 
 To create the image, you can use:
 
-* A Kafka container image on {DockerRepository} as a base image
-* OpenShift {docs-okd} and the {docs-okd-s2i} framework to create new container images
+* Kafka Connect configuration so that Strimzi creates the new image automatically.
+* A Kafka container image on {DockerRepository} as a base image.
+* OpenShift {docs-okd} and the {docs-okd-s2i} framework to create new container images.
+
+For Strimzi to create the new image automatically, a `build` configuration requires `output` properties to reference a container registry that stores the container image,
+and `plugins` properties to list the connector plugins and their artifacts to add to the image.
+
+The `output` properties describe the type and name of the image, and optionally the name of the Secret containing the credentials needed to access the container registry.
+The `plugins` properties describe the type of artifact and the URL from which the artifact is downloaded. Additionally, you can specify a SHA-512 checksum to verify the artifact before unpacking it.
+
+.Example Kafka Connect configuration to create a new image automatically
+[source,yaml,subs=quotes,attributes]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+spec:
+  # ...
+  build:
+    output:
+      type: docker
+      image: my-registry.io/my-org/my-connect-cluster:latest
+      pushSecret: my-registry-credentials
+    plugins:
+      - name: debezium-postgres-connector
+        artifacts:
+          - type: tgz
+            url: https://_ARTIFACT-ADDRESS_.tgz
+            sha512sum: _HASH-NUMBER-TO-VERIFY-ARTIFACT_
+      # ...
+  #...
+----
 
 [discrete]
 == Managing connectors


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Update to the _Overview_ guide to add some information on configuring Kafka Connect so that Strimzi creates a new image that uses connector plugins automatically

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

