### PR TITLE
Fix TO trying to create internal topic

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -940,6 +940,9 @@ class TopicOperator {
                 });
             }
         };
+        if (topicName.toString().startsWith("__")) {
+            return Future.succeededFuture();
+        }
         return executeWithTopicLockHeld(logContext, topicName, action);
     }
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicsWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicsWatcher.java
@@ -146,13 +146,17 @@ class ZkTopicsWatcher {
                     tcw.addChild(topicName);
                     tw.addChild(topicName);
                     LogContext logContext = LogContext.zkWatch(TOPICS_ZNODE, watchCount + ":+" + topicName);
-                    topicOperator.onTopicCreated(logContext, new TopicName(topicName)).onComplete(ar -> {
-                        if (ar.succeeded()) {
-                            LOGGER.debug("{}: Success responding to creation of topic {}", logContext, topicName);
-                        } else {
-                            LOGGER.warn("{}: Error responding to creation of topic {}", logContext, topicName, ar.cause());
-                        }
-                    });
+                    if ("__consumer_offsets".equals(topicName) || "__transaction_state".equals(topicName)) {
+                        LOGGER.debug("{}: Cannot create internal topic {}", logContext, topicName);
+                    } else {
+                        topicOperator.onTopicCreated(logContext, new TopicName(topicName)).onComplete(ar -> {
+                            if (ar.succeeded()) {
+                                LOGGER.debug("{}: Success responding to creation of topic {}", logContext, topicName);
+                            } else {
+                                LOGGER.warn("{}: Error responding to creation of topic {}", logContext, topicName, ar.cause());
+                            }
+                        });
+                    }
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
TO is trying to create internal topics. That produces errors like this 
```
2021-01-08 08:21:27,45461 WARN  [vert.x-eventloop-thread-0] ZkTopicsWatcher:153 - 6|/brokers/topics 3:+__consumer_offsets: Error responding to creation of topic __consumer_offsets
org.apache.kafka.common.errors.UnknownTopicOrPartitionException:
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

