### PR TITLE
Fix regex to not consume comment-escaping character

### DIFF
--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
@@ -15,12 +15,12 @@ To deploy the Prometheus Operator to your Kafka cluster, apply the YAML bundle r
 On Linux, use:
 +
 [source,shell,subs="+quotes,attributes+"]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml | sed -e 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
+curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml | sed -e '/[[:space:]]\*namespace: [a-zA-Z0-9-]*$/s/namespace:[[:space:]]\*[a-zA-Z0-9-]*$/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
 +
 On MacOS, use:
 +
 [source,shell,subs="+quotes,attributes+"]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml | sed -e '' 's/namespace: .*/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
+curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml | sed -e '' '/[[:space:]]\*namespace: [a-zA-Z0-9-]*$/s/namespace:[[:space:]]\*[a-zA-Z0-9-]*$/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
 +
 ** Replace the example `namespace` with your own.
 +


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Documentation

### Description
Example bundle file contains line with 
`'blah blah namespace: <object namespace>' matcher.''`

The regex from our doc replaces `<object namespace>' matcher.''` (including comment escaping character).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

