### PR TITLE
Fix TopicST build in master branch

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -169,8 +169,6 @@ public class TopicST extends AbstractST {
     @Tag(NODEPORT_SUPPORTED)
     @Test
     void testCreateDeleteCreate() throws InterruptedException {
-        String clusterName = CLUSTER_NAME + "-sdkvnsdkjn";
-
         KafkaResource.kafkaEphemeral(clusterName, 3, 3)
                 .editSpec()
                     .editKafka()


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

After merging the ST refactor and TO bugfix, the master does not build properly:

```
[ERROR] COMPILATION ERROR : 
[ERROR] /home/vsts/work/1/s/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java:[172,30] cannot find symbol
  symbol:   variable CLUSTER_NAME
  location: class io.strimzi.systemtest.operators.topic.TopicST
```

This PR fixes it.