### PR TITLE
Fix #4213: Bug renaming KafkaTopics to remove the hash

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -636,7 +636,10 @@ class TopicOperator {
             // they're the same => do nothing, but still create the private copy
             LOGGER.debug("{}: KafkaTopic created in k8s and topic created in kafka, but they're identical => just creating in topicStore", logContext);
             LOGGER.debug("{}: k8s and kafka versions of topic '{}' are the same", logContext, kafkaTopic.getTopicName());
-            reconciliationResultHandler = createInTopicStore(logContext, kafkaTopic, involvedObject);
+            Topic privateTopic = new Topic.Builder(kafkaTopic)
+                    .withMapName(k8sTopic.getResourceName().toString())
+                    .build();
+            reconciliationResultHandler = createInTopicStore(logContext, privateTopic, involvedObject);
         } else if (!diff.changesReplicationFactor()
                 && !diff.changesNumPartitions()
                 && diff.changesConfig()
@@ -644,7 +647,10 @@ class TopicOperator {
             LOGGER.debug("{}: KafkaTopic created in k8s and topic created in kafka, they differ only in topic config, and those configs are disjoint: Updating k8s and kafka, and creating in topic store", logContext);
             Map<String, String> mergedConfigs = new HashMap<>(kafkaTopic.getConfig());
             mergedConfigs.putAll(k8sTopic.getConfig());
-            Topic mergedTopic = new Topic.Builder(kafkaTopic).withConfig(mergedConfigs).build();
+            Topic mergedTopic = new Topic.Builder(kafkaTopic)
+                    .withConfig(mergedConfigs)
+                    .withMapName(k8sTopic.getResourceName().toString())
+                    .build();
             reconciliationResultHandler = updateResource(logContext, mergedTopic)
                     .compose(updatedResource -> {
                         reconciliation.observedTopicFuture(updatedResource);
@@ -663,7 +669,10 @@ class TopicOperator {
                     updateResource(logContext, kafkaTopic))
                 .compose(updatedResource -> {
                     reconciliation.observedTopicFuture(updatedResource);
-                    return createInTopicStore(logContext, kafkaTopic, involvedObject);
+                    Topic privateTopic = new Topic.Builder(kafkaTopic)
+                            .withMapName(k8sTopic.getResourceName().toString())
+                            .build();
+                    return createInTopicStore(logContext, privateTopic, involvedObject);
                 });
         }
         return reconciliationResultHandler;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes #4213.

