### PR TITLE
Try to fix flaky ConnectorMockTest.testConnectorConnectConnectorConnect

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -49,8 +49,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -102,7 +101,7 @@ public class ConnectorMockTest {
         }
     }
 
-    private static Vertx vertx;
+    private Vertx vertx;
     private KubernetesClient client;
     private KafkaConnectApi api;
     private HashMap<String, ConnectorState> runningConnectors;
@@ -131,18 +130,10 @@ public class ConnectorMockTest {
         return connectorState != null ? Future.succeededFuture(statusNode) : Future.failedFuture("No such connector " + connectorName);
     }
 
-    @BeforeAll
-    public static void before() {
-        vertx = Vertx.vertx();
-    }
-
-    @AfterAll
-    public static void after() {
-        vertx.close();
-    }
-
     @BeforeEach
     public void setup(VertxTestContext testContext) {
+        vertx = Vertx.vertx();
+
         client = new MockKube()
                 .withCustomResourceDefinition(Crds.kafkaConnect(), KafkaConnect.class, KafkaConnectList.class, DoneableKafkaConnect.class,
                         KafkaConnect::getStatus, KafkaConnect::setStatus).end()
@@ -290,6 +281,11 @@ public class ConnectorMockTest {
             .onComplete(testContext.succeeding())
             .compose(watch -> AbstractConnectOperator.createConnectorWatch(kafkaConnectOperator, kafkaConnectS2iOperator, NAMESPACE))
             .onComplete(testContext.succeeding(v -> async.flag()));
+    }
+
+    @AfterEach
+    public void teardown() {
+        vertx.close();
     }
 
     private static <T extends HasMetadata & HasStatus<?>> Predicate<T> statusIsForCurrentGeneration() {
@@ -580,7 +576,7 @@ public class ConnectorMockTest {
         verify(api, times(2)).list(
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         // triggered three times (Connect creation, Connector Status update, Connect Status update)
-        verify(api, times(4)).createOrUpdatePutRequest(
+        verify(api, times(3)).createOrUpdatePutRequest(
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -130,6 +130,7 @@ public class ConnectorMockTest {
         return connectorState != null ? Future.succeededFuture(statusNode) : Future.failedFuture("No such connector " + connectorName);
     }
 
+    @SuppressWarnings({"checkstyle:MethodLength"})
     @BeforeEach
     public void setup(VertxTestContext testContext) {
         vertx = Vertx.vertx();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The test `ConnectorMockTest.testConnectorConnectConnectorConnect` seems to be very flaky since #4156. It looks like not using the OkHttp changed timing and that changed the flow of the tests in this class. When digging a bit more into it, it seems the tests are badly isolated because Vert.x is created in `@BeforeAll` and not `@BeforeEach`. Because of that the `testConnectorConnectConnectorConnect` test seems to:
* Always pass with 4 invocations of `createOrUpdatePutRequest` when running locally with all other tests from its class.
* Always fail with only 3 invocations of `createOrUpdatePutRequest` when running locally alone (without the other tests)
* On Azure, it seems to be flaky when run with all other tests and always fail in the re-runs

This PR moves the creation and teardown of Vert.x from `@BeforeAll` and `@AfterAll` to be done before and after each test. That seems to stabilize the tests when running locally to give the same results both when running in the suite and alone. Hopefully this solves also the flakiness on Azure.

### Checklist

- [x] Make sure all tests pass