### PR TITLE
Make sure certificate stores don't exist before creating them

### DIFF
--- a/topic-operator/scripts/tls_prepare_certificates.sh
+++ b/topic-operator/scripts/tls_prepare_certificates.sh
@@ -24,13 +24,16 @@ function create_keystore {
 
 echo "Preparing certificates for internal communication"
 STORE=/tmp/topic-operator/replication.truststore.p12
+rm -f "$STORE"
 for CRT in /etc/tls-sidecar/cluster-ca-certs/*.crt; do
   ALIAS=$(basename "$CRT" .crt)
   echo "Adding $CRT to truststore $STORE with alias $ALIAS"
   create_truststore "$STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
 done
 
-create_keystore /tmp/topic-operator/replication.keystore.p12 "$CERTS_STORE_PASSWORD" \
+STORE=/tmp/topic-operator/replication.keystore.p12
+rm -f "$STORE"
+create_keystore "$STORE" "$CERTS_STORE_PASSWORD" \
     /etc/tls-sidecar/eo-certs/entity-operator.crt \
     /etc/tls-sidecar/eo-certs/entity-operator.key \
     /etc/tls-sidecar/cluster-ca-certs/ca.crt \


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The certificate store password is generated every-time our containers starts. When the container restarts, it can happen that the old stores still exist and they use old password. In such case, the newly generated store password does not match the old certificate stores and the container fails to start. So we should make sure the old stores don't exist before we try to create the new ones.

In the PR with support for _read-only toor filesystem_ (#4162) this was added to most of the scripts. But it looks like the TO script was forgotten. This PR fixes it there as well.

