### PR TITLE
[systemtest] Add checks to deprecated MetricsST tests

### DIFF
--- a/examples/metrics/kafka-connect-metrics.yaml
+++ b/examples/metrics/kafka-connect-metrics.yaml
@@ -30,107 +30,107 @@ data:
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     rules:
-      #kafka.connect:type=app-info,client-id="{clientid}"
-      #kafka.consumer:type=app-info,client-id="{clientid}"
-      #kafka.producer:type=app-info,client-id="{clientid}"
-      - pattern: 'kafka.(.+)<type=app-info, client-id=(.+)><>start-time-ms'
-        name: kafka_$1_start_time_seconds
-        labels:
-          clientId: "$2"
-        help: "Kafka $1 JMX metric start time seconds"
-        type: GAUGE
-        valueFactor: 0.001
-      - pattern: 'kafka.(.+)<type=app-info, client-id=(.+)><>(commit-id|version): (.+)'
-        name: kafka_$1_$3_info
-        value: 1
-        labels:
-          clientId: "$2"
-          $3: "$4"
-        help: "Kafka $1 JMX metric info version and commit-id"
-        type: GAUGE
+    #kafka.connect:type=app-info,client-id="{clientid}"
+    #kafka.consumer:type=app-info,client-id="{clientid}"
+    #kafka.producer:type=app-info,client-id="{clientid}"
+    - pattern: 'kafka.(.+)<type=app-info, client-id=(.+)><>start-time-ms'
+      name: kafka_$1_start_time_seconds
+      labels:
+        clientId: "$2"
+      help: "Kafka $1 JMX metric start time seconds"
+      type: GAUGE
+      valueFactor: 0.001
+    - pattern: 'kafka.(.+)<type=app-info, client-id=(.+)><>(commit-id|version): (.+)'
+      name: kafka_$1_$3_info
+      value: 1
+      labels:
+        clientId: "$2"
+        $3: "$4"
+      help: "Kafka $1 JMX metric info version and commit-id"
+      type: GAUGE
 
-      #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
-      #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
-      - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+), partition=(.+)><>(.+-total|compression-rate|.+-avg|.+-replica|.+-lag|.+-lead)
-        name: kafka_$2_$6
-        labels:
-          clientId: "$3"
-          topic: "$4"
-          partition: "$5"
-        help: "Kafka $1 JMX metric type $2"
-        type: GAUGE
+    #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
+    #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
+    - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+), partition=(.+)><>(.+-total|compression-rate|.+-avg|.+-replica|.+-lag|.+-lead)
+      name: kafka_$2_$6
+      labels:
+        clientId: "$3"
+        topic: "$4"
+        partition: "$5"
+      help: "Kafka $1 JMX metric type $2"
+      type: GAUGE
 
-      #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"
-      #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
-      - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+)><>(.+-total|compression-rate|.+-avg)
-        name: kafka_$2_$5
-        labels:
-          clientId: "$3"
-          topic: "$4"
-        help: "Kafka $1 JMX metric type $2"
-        type: GAUGE
+    #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"
+    #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
+    - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+)><>(.+-total|compression-rate|.+-avg)
+      name: kafka_$2_$5
+      labels:
+        clientId: "$3"
+        topic: "$4"
+      help: "Kafka $1 JMX metric type $2"
+      type: GAUGE
 
-      #kafka.connect:type=connect-node-metrics,client-id="{clientid}",node-id="{nodeid}"
-      #kafka.consumer:type=consumer-node-metrics,client-id=consumer-1,node-id="{nodeid}"
-      - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), node-id=(.+)><>(.+-total|.+-avg)
-        name: kafka_$2_$5
-        labels:
-          clientId: "$3"
-          nodeId: "$4"
-        help: "Kafka $1 JMX metric type $2"
-        type: UNTYPED
+    #kafka.connect:type=connect-node-metrics,client-id="{clientid}",node-id="{nodeid}"
+    #kafka.consumer:type=consumer-node-metrics,client-id=consumer-1,node-id="{nodeid}"
+    - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), node-id=(.+)><>(.+-total|.+-avg)
+      name: kafka_$2_$5
+      labels:
+        clientId: "$3"
+        nodeId: "$4"
+      help: "Kafka $1 JMX metric type $2"
+      type: UNTYPED
 
-      #kafka.connect:type=kafka-metrics-count,client-id="{clientid}"
-      #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}"
-      #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
-      #kafka.consumer:type=consumer-metrics,client-id="{clientid}"
-      - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.+-total|.+-avg|.+-bytes|.+-count|.+-ratio|.+-age|.+-flight|.+-threads|.+-connectors|.+-tasks|.+-ago)
-        name: kafka_$2_$4
-        labels:
-          clientId: "$3"
-        help: "Kafka $1 JMX metric type $2"
-        type: GAUGE
+    #kafka.connect:type=kafka-metrics-count,client-id="{clientid}"
+    #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}"
+    #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
+    #kafka.consumer:type=consumer-metrics,client-id="{clientid}"
+    - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.+-total|.+-avg|.+-bytes|.+-count|.+-ratio|.+-age|.+-flight|.+-threads|.+-connectors|.+-tasks|.+-ago)
+      name: kafka_$2_$4
+      labels:
+        clientId: "$3"
+      help: "Kafka $1 JMX metric type $2"
+      type: GAUGE
 
-      #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}<> status"
-      - pattern: 'kafka.connect<type=connector-task-metrics, connector=(.+), task=(.+)><>status: ([a-z-]+)'
-        name: kafka_connect_connector_status
-        value: 1
-        labels:
-          connector: "$1"
-          task: "$2"
-          status: "$3"
-        help: "Kafka Connect JMX Connector status"
-        type: GAUGE
+    #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}<> status"
+    - pattern: 'kafka.connect<type=connector-task-metrics, connector=(.+), task=(.+)><>status: ([a-z-]+)'
+      name: kafka_connect_connector_status
+      value: 1
+      labels:
+        connector: "$1"
+        task: "$2"
+        status: "$3"
+      help: "Kafka Connect JMX Connector status"
+      type: GAUGE
 
-      #kafka.connect:type=task-error-metrics,connector="{connector}",task="{task}"
-      #kafka.connect:type=source-task-metrics,connector="{connector}",task="{task}"
-      #kafka.connect:type=sink-task-metrics,connector="{connector}",task="{task}"
-      #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}"
-      - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-ms|.+-ratio|.+-avg|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)
-        name: kafka_connect_$1_$4
-        labels:
-          connector: "$2"
-          task: "$3"
-        help: "Kafka Connect JMX metric type $1"
-        type: GAUGE
+    #kafka.connect:type=task-error-metrics,connector="{connector}",task="{task}"
+    #kafka.connect:type=source-task-metrics,connector="{connector}",task="{task}"
+    #kafka.connect:type=sink-task-metrics,connector="{connector}",task="{task}"
+    #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}"
+    - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-ms|.+-ratio|.+-avg|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)
+      name: kafka_connect_$1_$4
+      labels:
+        connector: "$2"
+        task: "$3"
+      help: "Kafka Connect JMX metric type $1"
+      type: GAUGE
 
-      #kafka.connect:type=connector-metrics,connector="{connector}"
-      #kafka.connect:type=connect-worker-metrics,connector="{connector}"
-      - pattern: kafka.connect<type=connect-worker-metrics, connector=(.+)><>([a-z-]+)
-        name: kafka_connect_worker_$2
-        labels:
-          connector: "$1"
-        help: "Kafka Connect JMX metric $1"
-        type: GAUGE
+    #kafka.connect:type=connector-metrics,connector="{connector}"
+    #kafka.connect:type=connect-worker-metrics,connector="{connector}"
+    - pattern: kafka.connect<type=connect-worker-metrics, connector=(.+)><>([a-z-]+)
+      name: kafka_connect_worker_$2
+      labels:
+        connector: "$1"
+      help: "Kafka Connect JMX metric $1"
+      type: GAUGE
 
-      #kafka.connect:type=connect-worker-metrics
-      - pattern: kafka.connect<type=connect-worker-metrics><>([a-z-]+)
-        name: kafka_connect_worker_$1
-        help: "Kafka Connect JMX metric worker"
-        type: GAUGE
+    #kafka.connect:type=connect-worker-metrics
+    - pattern: kafka.connect<type=connect-worker-metrics><>([a-z-]+)
+      name: kafka_connect_worker_$1
+      help: "Kafka Connect JMX metric worker"
+      type: GAUGE
 
-      #kafka.connect:type=connect-worker-rebalance-metrics
-      - pattern: kafka.connect<type=connect-worker-rebalance-metrics><>([a-z-]+)
-        name: kafka_connect_worker_rebalance_$1
-        help: "Kafka Connect JMX metric rebalance information"
-        type: GAUGE
+    #kafka.connect:type=connect-worker-rebalance-metrics
+    - pattern: kafka.connect<type=connect-worker-rebalance-metrics><>([a-z-]+)
+      name: kafka_connect_worker_rebalance_$1
+      help: "Kafka Connect JMX metric rebalance information"
+      type: GAUGE

--- a/examples/metrics/kafka-mirror-maker-2-metrics.yaml
+++ b/examples/metrics/kafka-mirror-maker-2-metrics.yaml
@@ -52,107 +52,107 @@ data:
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     rules:
-      #kafka.connect:type=app-info,client-id="{clientid}"
-      #kafka.consumer:type=app-info,client-id="{clientid}"
-      #kafka.producer:type=app-info,client-id="{clientid}"
-      - pattern: 'kafka.(.+)<type=app-info, client-id=(.+)><>start-time-ms'
-        name: kafka_$1_start_time_seconds
-        labels:
-          clientId: "$2"
-        help: "Kafka $1 JMX metric start time seconds"
-        type: GAUGE
-        valueFactor: 0.001
-      - pattern: 'kafka.(.+)<type=app-info, client-id=(.+)><>(commit-id|version): (.+)'
-        name: kafka_$1_$3_info
-        value: 1
-        labels:
-          clientId: "$2"
-          $3: "$4"
-        help: "Kafka $1 JMX metric info version and commit-id"
-        type: GAUGE
+    #kafka.connect:type=app-info,client-id="{clientid}"
+    #kafka.consumer:type=app-info,client-id="{clientid}"
+    #kafka.producer:type=app-info,client-id="{clientid}"
+    - pattern: 'kafka.(.+)<type=app-info, client-id=(.+)><>start-time-ms'
+      name: kafka_$1_start_time_seconds
+      labels:
+        clientId: "$2"
+      help: "Kafka $1 JMX metric start time seconds"
+      type: GAUGE
+      valueFactor: 0.001
+    - pattern: 'kafka.(.+)<type=app-info, client-id=(.+)><>(commit-id|version): (.+)'
+      name: kafka_$1_$3_info
+      value: 1
+      labels:
+        clientId: "$2"
+        $3: "$4"
+      help: "Kafka $1 JMX metric info version and commit-id"
+      type: GAUGE
 
-      #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
-      #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
-      - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+), partition=(.+)><>(.+-total|compression-rate|.+-avg|.+-replica|.+-lag|.+-lead)
-        name: kafka_$2_$6
-        labels:
-          clientId: "$3"
-          topic: "$4"
-          partition: "$5"
-        help: "Kafka $1 JMX metric type $2"
-        type: GAUGE
+    #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
+    #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
+    - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+), partition=(.+)><>(.+-total|compression-rate|.+-avg|.+-replica|.+-lag|.+-lead)
+      name: kafka_$2_$6
+      labels:
+        clientId: "$3"
+        topic: "$4"
+        partition: "$5"
+      help: "Kafka $1 JMX metric type $2"
+      type: GAUGE
 
-      #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"
-      #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
-      - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+)><>(.+-total|compression-rate|.+-avg)
-        name: kafka_$2_$5
-        labels:
-          clientId: "$3"
-          topic: "$4"
-        help: "Kafka $1 JMX metric type $2"
-        type: GAUGE
+    #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"
+    #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
+    - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+)><>(.+-total|compression-rate|.+-avg)
+      name: kafka_$2_$5
+      labels:
+        clientId: "$3"
+        topic: "$4"
+      help: "Kafka $1 JMX metric type $2"
+      type: GAUGE
 
-      #kafka.connect:type=connect-node-metrics,client-id="{clientid}",node-id="{nodeid}"
-      #kafka.consumer:type=consumer-node-metrics,client-id=consumer-1,node-id="{nodeid}"
-      - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), node-id=(.+)><>(.+-total|.+-avg)
-        name: kafka_$2_$5
-        labels:
-          clientId: "$3"
-          nodeId: "$4"
-        help: "Kafka $1 JMX metric type $2"
-        type: UNTYPED
+    #kafka.connect:type=connect-node-metrics,client-id="{clientid}",node-id="{nodeid}"
+    #kafka.consumer:type=consumer-node-metrics,client-id=consumer-1,node-id="{nodeid}"
+    - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), node-id=(.+)><>(.+-total|.+-avg)
+      name: kafka_$2_$5
+      labels:
+        clientId: "$3"
+        nodeId: "$4"
+      help: "Kafka $1 JMX metric type $2"
+      type: UNTYPED
 
-      #kafka.connect:type=kafka-metrics-count,client-id="{clientid}"
-      #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}"
-      #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
-      #kafka.consumer:type=consumer-metrics,client-id="{clientid}"
-      - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.+-total|.+-avg|.+-bytes|.+-count|.+-ratio|.+-age|.+-flight|.+-threads|.+-connectors|.+-tasks|.+-ago)
-        name: kafka_$2_$4
-        labels:
-          clientId: "$3"
-        help: "Kafka $1 JMX metric type $2"
-        type: GAUGE
+    #kafka.connect:type=kafka-metrics-count,client-id="{clientid}"
+    #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}"
+    #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
+    #kafka.consumer:type=consumer-metrics,client-id="{clientid}"
+    - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.+-total|.+-avg|.+-bytes|.+-count|.+-ratio|.+-age|.+-flight|.+-threads|.+-connectors|.+-tasks|.+-ago)
+      name: kafka_$2_$4
+      labels:
+        clientId: "$3"
+      help: "Kafka $1 JMX metric type $2"
+      type: GAUGE
 
-      #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}<> status"
-      - pattern: 'kafka.connect<type=connector-task-metrics, connector=(.+), task=(.+)><>status: ([a-z-]+)'
-        name: kafka_connect_connector_status
-        value: 1
-        labels:
-          connector: "$1"
-          task: "$2"
-          status: "$3"
-        help: "Kafka Connect JMX Connector status"
-        type: GAUGE
+    #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}<> status"
+    - pattern: 'kafka.connect<type=connector-task-metrics, connector=(.+), task=(.+)><>status: ([a-z-]+)'
+      name: kafka_connect_connector_status
+      value: 1
+      labels:
+        connector: "$1"
+        task: "$2"
+        status: "$3"
+      help: "Kafka Connect JMX Connector status"
+      type: GAUGE
 
-      #kafka.connect:type=task-error-metrics,connector="{connector}",task="{task}"
-      #kafka.connect:type=source-task-metrics,connector="{connector}",task="{task}"
-      #kafka.connect:type=sink-task-metrics,connector="{connector}",task="{task}"
-      #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}"
-      - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-ms|.+-ratio|.+-avg|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)
-        name: kafka_connect_$1_$4
-        labels:
-          connector: "$2"
-          task: "$3"
-        help: "Kafka Connect JMX metric type $1"
-        type: GAUGE
+    #kafka.connect:type=task-error-metrics,connector="{connector}",task="{task}"
+    #kafka.connect:type=source-task-metrics,connector="{connector}",task="{task}"
+    #kafka.connect:type=sink-task-metrics,connector="{connector}",task="{task}"
+    #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}"
+    - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-ms|.+-ratio|.+-avg|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)
+      name: kafka_connect_$1_$4
+      labels:
+        connector: "$2"
+        task: "$3"
+      help: "Kafka Connect JMX metric type $1"
+      type: GAUGE
 
-      #kafka.connect:type=connector-metrics,connector="{connector}"
-      #kafka.connect:type=connect-worker-metrics,connector="{connector}"
-      - pattern: kafka.connect<type=connect-worker-metrics, connector=(.+)><>([a-z-]+)
-        name: kafka_connect_worker_$2
-        labels:
-          connector: "$1"
-        help: "Kafka Connect JMX metric $1"
-        type: GAUGE
+    #kafka.connect:type=connector-metrics,connector="{connector}"
+    #kafka.connect:type=connect-worker-metrics,connector="{connector}"
+    - pattern: kafka.connect<type=connect-worker-metrics, connector=(.+)><>([a-z-]+)
+      name: kafka_connect_worker_$2
+      labels:
+        connector: "$1"
+      help: "Kafka Connect JMX metric $1"
+      type: GAUGE
 
-      #kafka.connect:type=connect-worker-metrics
-      - pattern: kafka.connect<type=connect-worker-metrics><>([a-z-]+)
-        name: kafka_connect_worker_$1
-        help: "Kafka Connect JMX metric worker"
-        type: GAUGE
+    #kafka.connect:type=connect-worker-metrics
+    - pattern: kafka.connect<type=connect-worker-metrics><>([a-z-]+)
+      name: kafka_connect_worker_$1
+      help: "Kafka Connect JMX metric worker"
+      type: GAUGE
 
-      #kafka.connect:type=connect-worker-rebalance-metrics
-      - pattern: kafka.connect<type=connect-worker-rebalance-metrics><>([a-z-]+)
-        name: kafka_connect_worker_rebalance_$1
-        help: "Kafka Connect JMX metric rebalance information"
-        type: GAUGE
+    #kafka.connect:type=connect-worker-rebalance-metrics
+    - pattern: kafka.connect<type=connect-worker-rebalance-metrics><>([a-z-]+)
+      name: kafka_connect_worker_rebalance_$1
+      help: "Kafka Connect JMX metric rebalance information"
+      type: GAUGE

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.systemtest;
 
+import io.strimzi.test.TestUtils;
+
 import java.time.Duration;
 
 /**
@@ -112,6 +114,17 @@ public interface Constants {
     int HTTP_JAEGER_DEFAULT_NODE_PORT = 32480;
     int HTTPS_KEYCLOAK_DEFAULT_NODE_PORT = 32481;
     int HTTP_KEYCLOAK_DEFAULT_NODE_PORT = 32482;
+
+    /**
+     * File paths for metrics YAMLs
+     */
+    String PATH_TO_KAFKA_METRICS_CONFIG = TestUtils.USER_PATH + "/../examples/metrics/kafka-metrics.yaml";
+    String PATH_TO_KAFKA_CRUISE_CONTROL_METRICS_CONFIG = TestUtils.USER_PATH + "/../examples/metrics/kafka-cruise-control-metrics.yaml";
+    String PATH_TO_KAFKA_CONNECT_METRICS_CONFIG = TestUtils.USER_PATH + "/../examples/metrics/kafka-connect-metrics.yaml";
+    String PATH_TO_KAFKA_CONNECT_S2I_CONFIG = TestUtils.USER_PATH + "/../examples/connect/kafka-connect-s2i.yaml";
+    String PATH_TO_KAFKA_MIRROR_MAKER_2_METRICS_CONFIG = TestUtils.USER_PATH + "/../examples/metrics/kafka-mirror-maker-2-metrics.yaml";
+
+    String METRICS_CONFIG_YAML_NAME = "metrics-config.yml";
 
     /**
      * Default value which allows execution of tests with any tags

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -32,7 +32,6 @@ import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 
 public class KafkaConnectResource {
     public static final String PATH_TO_KAFKA_CONNECT_CONFIG = TestUtils.USER_PATH + "/../examples/connect/kafka-connect.yaml";
-    public static final String PATH_TO_KAFKA_CONNECT_METRICS_CONFIG = TestUtils.USER_PATH + "/../examples/metrics/kafka-connect-metrics.yaml";
 
     public static MixedOperation<KafkaConnect, KafkaConnectList, DoneableKafkaConnect, Resource<KafkaConnect, DoneableKafkaConnect>> kafkaConnectClient() {
         return Crds.kafkaConnectOperation(ResourceManager.kubeClient().getClient());
@@ -47,14 +46,14 @@ public class KafkaConnectResource {
         return defaultKafkaConnect(kafkaConnect, name, clusterName, kafkaConnectReplicas);
     }
 
-    public static KafkaConnectBuilder kafkaConnectWithMetrics(String name, int kafkaConnectReplicas) {
+    public static DoneableKafkaConnect kafkaConnectWithMetrics(String name, int kafkaConnectReplicas) {
         return kafkaConnectWithMetrics(name, name, kafkaConnectReplicas);
     }
 
     public static KafkaConnectBuilder kafkaConnectWithMetrics(String name, String clusterName, int kafkaConnectReplicas) {
-        KafkaConnect kafkaConnect = getKafkaConnectFromYaml(PATH_TO_KAFKA_CONNECT_METRICS_CONFIG);
+        KafkaConnect kafkaConnect = getKafkaConnectFromYaml(Constants.PATH_TO_KAFKA_CONNECT_METRICS_CONFIG);
 
-        ConfigMap metricsCm = TestUtils.configMapFromYaml(PATH_TO_KAFKA_CONNECT_METRICS_CONFIG, "connect-metrics");
+        ConfigMap metricsCm = TestUtils.configMapFromYaml(Constants.PATH_TO_KAFKA_CONNECT_METRICS_CONFIG, "connect-metrics");
         KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(kubeClient().getNamespace()).createOrReplace(metricsCm);
 
         return defaultKafkaConnect(kafkaConnect, name, clusterName, kafkaConnectReplicas);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -46,7 +46,7 @@ public class KafkaConnectResource {
         return defaultKafkaConnect(kafkaConnect, name, clusterName, kafkaConnectReplicas);
     }
 
-    public static DoneableKafkaConnect kafkaConnectWithMetrics(String name, int kafkaConnectReplicas) {
+    public static KafkaConnectBuilder kafkaConnectWithMetrics(String name, int kafkaConnectReplicas) {
         return kafkaConnectWithMetrics(name, name, kafkaConnectReplicas);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
@@ -28,14 +28,13 @@ import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
 import static io.strimzi.systemtest.resources.ResourceManager.CR_CREATION_TIMEOUT;
 
 public class KafkaConnectS2IResource {
-    public static final String PATH_TO_KAFKA_CONNECT_S2I_CONFIG = TestUtils.USER_PATH + "/../examples/connect/kafka-connect-s2i.yaml";
 
     public static MixedOperation<KafkaConnectS2I, KafkaConnectS2IList, DoneableKafkaConnectS2I, Resource<KafkaConnectS2I, DoneableKafkaConnectS2I>> kafkaConnectS2IClient() {
         return Crds.kafkaConnectS2iOperation(ResourceManager.kubeClient().getClient());
     }
 
     public static KafkaConnectS2IBuilder kafkaConnectS2I(String name, String clusterName, int kafkaConnectS2IReplicas) {
-        KafkaConnectS2I kafkaConnectS2I = getKafkaConnectS2IFromYaml(PATH_TO_KAFKA_CONNECT_S2I_CONFIG);
+        KafkaConnectS2I kafkaConnectS2I = getKafkaConnectS2IFromYaml(Constants.PATH_TO_KAFKA_CONNECT_S2I_CONFIG);
         return defaultKafkaConnectS2I(kafkaConnectS2I, name, clusterName, kafkaConnectS2IReplicas);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
@@ -32,7 +32,6 @@ import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 
 public class KafkaMirrorMaker2Resource {
     public static final String PATH_TO_KAFKA_MIRROR_MAKER_2_CONFIG = TestUtils.USER_PATH + "/../examples/mirror-maker/kafka-mirror-maker-2.yaml";
-    public static final String PATH_TO_KAFKA_MIRROR_MAKER_2_METRICS_CONFIG = TestUtils.USER_PATH + "/../examples/metrics/kafka-mirror-maker-2-metrics.yaml";
 
     public static MixedOperation<KafkaMirrorMaker2, KafkaMirrorMaker2List, DoneableKafkaMirrorMaker2, Resource<KafkaMirrorMaker2, DoneableKafkaMirrorMaker2>> kafkaMirrorMaker2Client() {
         return Crds.kafkaMirrorMaker2Operation(ResourceManager.kubeClient().getClient());
@@ -44,9 +43,9 @@ public class KafkaMirrorMaker2Resource {
     }
 
     public static KafkaMirrorMaker2Builder kafkaMirrorMaker2WithMetrics(String name, String targetClusterName, String sourceClusterName, int kafkaMirrorMaker2Replicas) {
-        KafkaMirrorMaker2 kafkaMirrorMaker2 = getKafkaMirrorMaker2FromYaml(PATH_TO_KAFKA_MIRROR_MAKER_2_METRICS_CONFIG);
+        KafkaMirrorMaker2 kafkaMirrorMaker2 = getKafkaMirrorMaker2FromYaml(Constants.PATH_TO_KAFKA_MIRROR_MAKER_2_METRICS_CONFIG);
 
-        ConfigMap metricsCm = TestUtils.configMapFromYaml(PATH_TO_KAFKA_MIRROR_MAKER_2_METRICS_CONFIG, "mirror-maker-2-metrics");
+        ConfigMap metricsCm = TestUtils.configMapFromYaml(Constants.PATH_TO_KAFKA_MIRROR_MAKER_2_METRICS_CONFIG, "mirror-maker-2-metrics");
         KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(kubeClient().getNamespace()).createOrReplace(metricsCm);
 
         return defaultKafkaMirrorMaker2(kafkaMirrorMaker2, name, targetClusterName, sourceClusterName, kafkaMirrorMaker2Replicas, false);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -42,9 +42,7 @@ import static io.strimzi.systemtest.resources.ResourceManager.CR_CREATION_TIMEOU
 import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 
 public class KafkaResource {
-    private static final String PATH_TO_KAFKA_METRICS_CONFIG = TestUtils.USER_PATH + "/../examples/metrics/kafka-metrics.yaml";
     private static final String PATH_TO_KAFKA_CRUISE_CONTROL_CONFIG = TestUtils.USER_PATH + "/../examples/cruise-control/kafka-cruise-control.yaml";
-    private static final String PATH_TO_KAFKA_CRUISE_CONTROL_METRICS_CONFIG = TestUtils.USER_PATH + "/../examples/metrics/kafka-cruise-control-metrics.yaml";
     private static final String PATH_TO_KAFKA_EPHEMERAL_CONFIG = TestUtils.USER_PATH + "/../examples/kafka/kafka-ephemeral.yaml";
     private static final String PATH_TO_KAFKA_PERSISTENT_CONFIG = TestUtils.USER_PATH + "/../examples/kafka/kafka-persistent.yaml";
 
@@ -96,7 +94,7 @@ public class KafkaResource {
     }
 
     public static KafkaBuilder kafkaWithMetrics(String name, int kafkaReplicas, int zookeeperReplicas) {
-        Kafka kafka = getKafkaFromYaml(PATH_TO_KAFKA_METRICS_CONFIG);
+        Kafka kafka = getKafkaFromYaml(Constants.PATH_TO_KAFKA_METRICS_CONFIG);
 
         deployMetricsConfigMaps();
 
@@ -113,7 +111,7 @@ public class KafkaResource {
     }
 
     public static KafkaBuilder kafkaAndCruiseControlWithMetrics(String name, int kafkaReplicas, int zookeeperReplicas) {
-        Kafka kafka = getKafkaFromYaml(PATH_TO_KAFKA_CRUISE_CONTROL_METRICS_CONFIG);
+        Kafka kafka = getKafkaFromYaml(Constants.PATH_TO_KAFKA_CRUISE_CONTROL_METRICS_CONFIG);
 
         deployMetricsConfigMaps();
 
@@ -160,7 +158,7 @@ public class KafkaResource {
     }
 
     private static void deployMetricsConfigMaps() {
-        ConfigMap metricsCm = TestUtils.configMapFromYaml(PATH_TO_KAFKA_METRICS_CONFIG, "kafka-metrics");
+        ConfigMap metricsCm = TestUtils.configMapFromYaml(Constants.PATH_TO_KAFKA_METRICS_CONFIG, "kafka-metrics");
         KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(kubeClient().getNamespace()).createOrReplace(metricsCm);
     }
 

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -272,6 +273,18 @@ public final class TestUtils {
             throw new IllegalArgumentException(e);
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    public static String fromYamlToJson(String yaml) {
+        try {
+            ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
+            Object obj = yamlReader.readValue(yaml, Object.class);
+
+            ObjectMapper jsonWriter = new ObjectMapper();
+            return jsonWriter.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true).writeValueAsString(obj);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Adding checks to metrics tests

### Description

This PR add some additional checks to "deprecated" metrics tests in MetricsST. We are now parsing the metrics configuration from original metrics yaml and then setting it to `metrics` field.

I had to change indentation in two metrics yamls, so I could parse it without exceptions.

_Thanks for help_ @sknot-rh 

### Checklist

- [x] Make sure all tests pass

