### PR TITLE
Removed ZooKeeper dependency and used Admin Client for user quotas

### DIFF
--- a/.spotbugs/spotbugs-exclude.xml
+++ b/.spotbugs/spotbugs-exclude.xml
@@ -12,6 +12,11 @@
     <Package name="io.strimzi.certs"/>
   </Match>
   <Match>
+    <Bug pattern="REC_CATCH_EXCEPTION"/>
+    <Class name="io.strimzi.operator.user.operator.KafkaUserQuotasOperator"/>
+    <Method name="describeUserQuotas"/>
+  </Match>
+  <Match>
     <Class name="~io\.strimzi\.api\.kafka\.model\..+(Builder|FluentImpl)(\$.*)?" />
   </Match>
   <Match>

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -126,14 +126,6 @@
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>zjsonpatch</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -84,7 +84,7 @@ public class Main {
                     SimpleAclOperator aclOperations = new SimpleAclOperator(vertx, adminClient);
                     ScramShaCredentials scramShaCredentials = new ScramShaCredentials(config.getZookeperConnect(), (int) config.getZookeeperSessionTimeoutMs());
                     ScramShaCredentialsOperator scramShaCredentialsOperator = new ScramShaCredentialsOperator(vertx, scramShaCredentials);
-                    KafkaUserQuotasOperator quotasOperator = new KafkaUserQuotasOperator(vertx, config.getZookeperConnect(), (int) config.getZookeeperSessionTimeoutMs());
+                    KafkaUserQuotasOperator quotasOperator = new KafkaUserQuotasOperator(vertx, adminClient);
 
                     KafkaUserOperator kafkaUserOperations = new KafkaUserOperator(vertx,
                             certManager, crdOperations,

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserQuotasOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserQuotasOperator.java
@@ -4,36 +4,34 @@
  */
 package io.strimzi.operator.user.operator;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.fabric8.zjsonpatch.JsonDiff;
 import io.strimzi.api.kafka.model.KafkaUserQuotas;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
-import org.I0Itec.zkclient.ZkClient;
-import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.common.quota.ClientQuotaAlteration;
+import org.apache.kafka.common.quota.ClientQuotaFilter;
+import org.apache.kafka.common.quota.ClientQuotaFilterComponent;
+import org.apache.kafka.common.quota.ClientQuotaEntity;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 public class KafkaUserQuotasOperator {
     private static final Logger log = LogManager.getLogger(KafkaUserQuotasOperator.class.getName());
 
-    private final static int CONNECTION_TIMEOUT = 30_000;
+    private final Vertx vertx;
+    private final Admin adminClient;
 
-    private ZkClient zkClient;
-    private Vertx vertx;
-
-    public KafkaUserQuotasOperator(Vertx vertx, String zookeeperUrl, int zookeeperSessionTimeout) {
-        this.zkClient = new ZkClient(zookeeperUrl, zookeeperSessionTimeout, CONNECTION_TIMEOUT, new BytesPushThroughSerializer());
+    public KafkaUserQuotasOperator(Vertx vertx, Admin adminClient) {
         this.vertx = vertx;
+        this.adminClient = adminClient;
     }
 
     Future<ReconcileResult<KafkaUserQuotas>> reconcile(String username, KafkaUserQuotas quotas) {
@@ -69,130 +67,22 @@ public class KafkaUserQuotasOperator {
      *
      * @param username The name of the user which should be created or updated
      * @param quotas The desired user quotas
+     * @throws Exception when altering quotas fails
      */
-    public void createOrUpdate(String username, KafkaUserQuotas quotas) {
-        String encodedUsername = encodeUsername(username);
-
-        byte[] data = zkClient.readData("/config/users/" + encodedUsername, true);
-
-        if (data != null)   {
+    public void createOrUpdate(String username, KafkaUserQuotas quotas) throws Exception {
+        KafkaUserQuotas current = describeUserQuotas(username);
+        if (current != null) {
             log.debug("Checking quota updates for user {}", username);
-            JsonNode diff = null;
-
-            try {
-                ObjectMapper objectMapper = new ObjectMapper();
-                diff = JsonDiff.asJson(objectMapper.readTree(data), objectMapper.readTree(createOrUpdateUserJson(data, quotas)));
-            } catch (IOException e) {
-                log.error("Failed to diff user configuration for user {}", username, e);
-            }
-
-            if (diff != null && diff.size() > 0) {
+            if (!quotasEquals(current, quotas)) {
                 log.debug("Updating quotas for user {}", username);
-                zkClient.writeData("/config/users/" + encodedUsername, createOrUpdateUserJson(data, quotas));
-                notifyChanges(username);
+                alterUserQuotas(username, toClientQuotaAlterationOps(quotas));
             } else {
                 log.debug("Nothing to update in quotas for user {}", username);
             }
         } else {
             log.debug("Creating quotas for user {}", username);
-            ensurePath("/config/users");
-            zkClient.createPersistent("/config/users/" + encodedUsername, createUserJson(quotas));
-            notifyChanges(username);
+            alterUserQuotas(username, toClientQuotaAlterationOps(quotas));
         }
-    }
-
-    /**
-     * Generates the JSON with the credentials
-     *
-     * @param quotas  quotas
-     * @return  Returns the generated JSON as byte array
-     */
-    protected byte[] createUserJson(KafkaUserQuotas quotas)   {
-        return createOrUpdateUserJson(null, quotas);
-    }
-
-    /**
-     * Updates the quotas in existing JSON. If the existing JSON is null, new JSON will be created.
-     *
-     * @param user user configuration
-     * @param quotas  quotas
-     *
-     * @return  Returns the updated JSON as byte array
-     */
-    protected byte[] createOrUpdateUserJson(byte[] user, KafkaUserQuotas quotas)   {
-        JsonObject json;
-
-        if (user != null) {
-            json = new JsonObject(new String(user, StandardCharsets.UTF_8));
-            validateJsonVersion(json);
-        } else {
-            json = new JsonObject()
-                    .put("version", 1)
-                    .put("config", new JsonObject());
-        }
-
-        JsonObject config = json.getJsonObject("config", new JsonObject());
-
-        if (quotas != null && quotas.getProducerByteRate() != null) {
-            config.put("producer_byte_rate", quotas.getProducerByteRate().toString());
-        } else {
-            if (config.getString("producer_byte_rate") != null) {
-                config.remove("producer_byte_rate");
-            }
-        }
-
-        if (quotas != null && quotas.getConsumerByteRate() != null) {
-            config.put("consumer_byte_rate", quotas.getConsumerByteRate().toString());
-        } else {
-            if (config.getString("consumer_byte_rate") != null) {
-                config.remove("consumer_byte_rate");
-            }
-        }
-
-        if (quotas != null && quotas.getRequestPercentage() != null) {
-            config.put("request_percentage", quotas.getRequestPercentage().toString());
-        } else {
-            if (config.getString("request_percentage") != null) {
-                config.remove("request_percentage");
-            }
-        }
-
-        json.put("config", config);
-
-        return json.encode().getBytes(StandardCharsets.UTF_8);
-    }
-
-    /**
-     * This notifies Kafka about the changes we have made
-     *
-     * @param username  Name of the user whose configuration changed
-     */
-    private void notifyChanges(String username) {
-        String encodedUsername = encodeUsername(username);
-
-        log.debug("Notifying changes for user {}", username);
-
-        ensurePath("/config/changes");
-
-        JsonObject json = new JsonObject().put("version", 2).put("entity_path", "users/" + encodedUsername);
-        zkClient.createPersistentSequential("/config/changes/config_change_", json.encode().getBytes(StandardCharsets.UTF_8));
-    }
-
-    /**
-     * Ensures that the path in Zookeeper exists.
-     * It checks whether it already exists and in case it doesn't, it will create the path.
-     *
-     * @param path The Zookeeper path which should exist
-     */
-    private void ensurePath(String path)    {
-        if (!zkClient.exists(path))   {
-            zkClient.createPersistent(path, true);
-        }
-    }
-
-    /* test */
-    boolean isPathExist(String path)    {
-        return zkClient.exists(path);
     }
 
     /**
@@ -202,34 +92,8 @@ public class KafkaUserQuotasOperator {
      *
      * @return True if the user exists
      */
-    boolean exists(String username) {
-        String encodedUsername = encodeUsername(username);
-
-        byte[] data = zkClient.readData("/config/users/" + encodedUsername, true);
-
-        if (data != null)   {
-            String jsonString = new String(data, StandardCharsets.UTF_8);
-            JsonObject json = new JsonObject(jsonString);
-            validateJsonVersion(json);
-            JsonObject config = json.getJsonObject("config");
-
-            if (config != null) {
-                String prod = config.getString("producer_byte_rate");
-                String cons = config.getString("consumer_byte_rate");
-                String perc = config.getString("request_percentage");
-
-                if (prod != null || cons != null || perc != null) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private boolean configJsonIsEmpty(JsonObject json) {
-        validateJsonVersion(json);
-        JsonObject config = json.getJsonObject("config");
-        return config.isEmpty();
+    boolean exists(String username) throws Exception {
+        return describeUserQuotas(username) != null;
     }
 
     /**
@@ -237,84 +101,96 @@ public class KafkaUserQuotasOperator {
      * It is not an error if the user doesn't exist, or doesn't currently have any quotas.
      *
      * @param username Name of the user
+     * @throws Exception when altering quotas fails
      */
-    public void delete(String username) {
-        String encodedUsername = encodeUsername(username);
-
-        byte[] data = zkClient.readData("/config/users/" + encodedUsername, true);
-
-        if (data != null)   {
+    public void delete(String username) throws Exception {
+        KafkaUserQuotas current = describeUserQuotas(username);
+        if (current != null) {
             log.debug("Deleting quotas for user {}", username);
-            JsonObject deleteJson = removeQuotasFromJsonUser(data);
-            if (configJsonIsEmpty(deleteJson)) {
-                zkClient.deleteRecursive("/config/users/" + encodedUsername);
-                log.debug("User {} deleted from ZK store", username);
-            } else {
-                zkClient.writeData("/config/users/" + encodedUsername, deleteJson.toBuffer().getBytes());
-            }
-            notifyChanges(username);
+            current.setProducerByteRate(null);
+            current.setConsumerByteRate(null);
+            current.setRequestPercentage(null);
+            alterUserQuotas(username, toClientQuotaAlterationOps(current));
         } else {
             log.warn("Quotas for user {} already don't exist", username);
         }
     }
 
-    /**
-     * Deletes the quotas from existing JSON
-     *
-     * @param userConfig JSON string with existing userConfig configuration as byte[]
-     *
-     * @return  Returns the updated JSON without the quotas
-     */
-    protected JsonObject removeQuotasFromJsonUser(byte[] userConfig)   {
-        JsonObject json = new JsonObject(new String(userConfig, StandardCharsets.UTF_8));
-
-        validateJsonVersion(json);
-        JsonObject config = json.getJsonObject("config");
-        if (config == null) {
-            json.put("config", new JsonObject());
-        } else {
-            if (config.getString("producer_byte_rate") != null) {
-                config.remove("producer_byte_rate");
-            }
-            if (config.getString("consumer_byte_rate") != null) {
-                config.remove("consumer_byte_rate");
-            }
-            if (config.getString("request_percentage") != null) {
-                config.remove("request_percentage");
-            }
-        }
-        return json;
-    }
-
-    protected void validateJsonVersion(JsonObject json) {
-        if (json.getInteger("version") != 1) {
-            throw new RuntimeException("Failed to validate the user JSON. The version is missing or has an invalid value.");
-        }
-    }
-
-    protected JsonObject getQuotas(String username) {
-        String encodedUsername = encodeUsername(username);
-
-        byte[] data = zkClient.readData("/config/users/" + encodedUsername, true);
-
-        if (data != null) {
-            String jsonString = new String(data, StandardCharsets.UTF_8);
-            JsonObject json = new JsonObject(jsonString);
-            return json;
-        } else return null;
-    }
-
-    /**
-     * Encodes the username with URL Encoder
-     *
-     * @param username  Username which should be encoded
-     * @return          Encoded username
-     */
-    protected static String encodeUsername(String username) {
+    protected void alterUserQuotas(String username, Set<ClientQuotaAlteration.Op> ops) throws Exception {
+        ClientQuotaEntity cqe = new ClientQuotaEntity(Collections.singletonMap(ClientQuotaEntity.USER, username));
+        ClientQuotaAlteration cqa = new ClientQuotaAlteration(cqe, ops);
         try {
-            return URLEncoder.encode(username, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException("Failed to encode username", e);
+            adminClient.alterClientQuotas(Collections.singleton(cqa)).all().get();
+        } catch (Exception e) {
+            log.error("Creating/Altering quotas for user {} failed", username, e);
+            throw e;
         }
+    }
+
+    protected KafkaUserQuotas describeUserQuotas(String username) throws Exception {
+        ClientQuotaFilterComponent c = ClientQuotaFilterComponent.ofEntity(ClientQuotaEntity.USER, username);
+        ClientQuotaFilter f =  ClientQuotaFilter.contains(Collections.singleton(c));
+        KafkaUserQuotas current = null;
+        try {
+            ClientQuotaEntity cqe = new ClientQuotaEntity(Collections.singletonMap(ClientQuotaEntity.USER, username));
+            Map<ClientQuotaEntity, Map<String, Double>> map = adminClient.describeClientQuotas(f).entities().get();
+            if (map.containsKey(cqe)) {
+                current = fromClientQuota(map.get(cqe));
+            }
+        } catch (Exception e) {
+            log.error("Getting quotas for user {} failed", username, e);
+            throw e;
+        }
+        return current;
+    }
+
+    /**
+     * Returns a KafkaUserQuotas instance from a map of quotas key-value pairs
+     *
+     * @param map map of quotas key-value pairs
+     * @return KafkaUserQuotas instance
+     */
+    protected KafkaUserQuotas fromClientQuota(Map<String, Double> map) {
+        KafkaUserQuotas kuq = new KafkaUserQuotas();
+        if (map.containsKey("producer_byte_rate")) {
+            kuq.setProducerByteRate(map.get("producer_byte_rate").intValue());
+        }
+        if (map.containsKey("consumer_byte_rate")) {
+            kuq.setConsumerByteRate(map.get("consumer_byte_rate").intValue());
+        }
+        if (map.containsKey("request_percentage")) {
+            kuq.setRequestPercentage(map.get("request_percentage").intValue());
+        }
+        return kuq;
+    }
+
+    /**
+     * Map a KafkaUserQuotas instance to a corresponding set of ClientQuotaAlteration operations for the Admin Client
+     *
+     * @param quotas KafkaUserQuotas instance to map
+     * @return ClientQuotaAlteration operations for the Admin Client
+     */
+    protected Set<ClientQuotaAlteration.Op> toClientQuotaAlterationOps(KafkaUserQuotas quotas) {
+        Set<ClientQuotaAlteration.Op> ops = new HashSet<>(3);
+        ops.add(new ClientQuotaAlteration.Op("producer_byte_rate",
+                quotas.getProducerByteRate() != null ? Double.valueOf(quotas.getProducerByteRate()) : null));
+        ops.add(new ClientQuotaAlteration.Op("consumer_byte_rate",
+                quotas.getConsumerByteRate() != null ? Double.valueOf(quotas.getConsumerByteRate()) : null));
+        ops.add(new ClientQuotaAlteration.Op("request_percentage",
+                quotas.getRequestPercentage() != null ? Double.valueOf(quotas.getRequestPercentage()) : null));
+        return ops;
+    }
+
+    /**
+     * Check if two KafkaUserQuotas instances are equal
+     *
+     * @param kuq1 first instance to compare
+     * @param kuq2 second instance to compare
+     * @return true if they are equals, false otherwise
+     */
+    private boolean quotasEquals(KafkaUserQuotas kuq1, KafkaUserQuotas kuq2) {
+        return Objects.equals(kuq1.getProducerByteRate(), kuq2.getProducerByteRate()) &&
+                Objects.equals(kuq1.getConsumerByteRate(), kuq2.getConsumerByteRate()) &&
+                Objects.equals(kuq1.getRequestPercentage(), kuq2.getRequestPercentage());
     }
 }

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserQuotasIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserQuotasIT.java
@@ -4,13 +4,17 @@
  */
 package io.strimzi.operator.user.operator;
 
+import io.debezium.kafka.KafkaCluster;
+import io.debezium.util.Testing;
 import io.strimzi.api.kafka.model.KafkaUserQuotas;
-import io.strimzi.test.EmbeddedZooKeeper;
+import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.I0Itec.zkclient.ZkClient;
+import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer;
+import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,18 +22,22 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.hamcrest.Matchers.hasSize;
 
 @ExtendWith(VertxExtension.class)
 public class KafkaUserQuotasIT {
 
-    private static EmbeddedZooKeeper zkServer;
+    private static ZkClient zkClient;
 
     private static KafkaUserQuotasOperator kuq;
 
@@ -37,20 +45,38 @@ public class KafkaUserQuotasIT {
 
     private static Vertx vertx;
 
+    private static KafkaCluster kafkaCluster;
 
     @BeforeAll
-    public static void before() throws IOException, InterruptedException {
+    public static void beforeAll() {
         vertx = Vertx.vertx();
-        // Start ZookKeeper Server
-        zkServer = new EmbeddedZooKeeper();
-        kuq = new KafkaUserQuotasOperator(vertx, zkServer.getZkConnectString(), 6_000);
+
+        try {
+            kafkaCluster =
+                    new KafkaCluster()
+                            .usingDirectory(Testing.Files.createTestingDirectory("user-quotas-operator-integration-test"))
+                            .deleteDataPriorToStartup(true)
+                            .deleteDataUponShutdown(true)
+                            .addBrokers(1)
+                            .startup();
+        } catch (IOException e) {
+            assertThat(false, is(true));
+        }
+
+        zkClient = new ZkClient("localhost:" + kafkaCluster.zkPort(), 6000_0, 30_000, new BytesPushThroughSerializer());
+
+        kuq = new KafkaUserQuotasOperator(vertx,
+                new DefaultAdminClientProvider().createAdminClient(kafkaCluster.brokerList(), null, null, null));
     }
 
     @AfterAll
-    public static void after() {
-        vertx.close();
-        // Teardown ZooKeeper Server
-        zkServer.close();
+    public static void afterAll() {
+        if (kafkaCluster != null) {
+            kafkaCluster.shutdown();
+        }
+        if (vertx != null) {
+            vertx.close();
+        }
     }
 
     @BeforeEach
@@ -61,275 +87,189 @@ public class KafkaUserQuotasIT {
     }
 
     @Test
-    public void testTlsUserExistsAfterCreate() {
+    public void testTlsUserExistsAfterCreate() throws Exception {
         testUserExistsAfterCreate("CN=userExists");
     }
 
     @Test
-    public void testRegularUserExistsAfterCreate() {
+    public void testRegularUserExistsAfterCreate() throws Exception {
         testUserExistsAfterCreate("userExists");
     }
 
-    public void testUserExistsAfterCreate(String username) {
+    public void testUserExistsAfterCreate(String username) throws Exception {
         assertThat(kuq.exists(username), is(false));
         kuq.createOrUpdate(username, defaultQuotas);
         assertThat(kuq.exists(username), is(true));
     }
 
     @Test
-    public void testTlsUserDoesNotExistPriorToCreate() {
+    public void testTlsUserDoesNotExistPriorToCreate() throws Exception {
         testUserDoesNotExistPriorToCreate("CN=userNotExists");
     }
 
     @Test
-    public void testRegularUserDoesNotExistPriorToCreate() {
+    public void testRegularUserDoesNotExistPriorToCreate() throws Exception {
         testUserDoesNotExistPriorToCreate("userNotExists");
     }
 
-    public void testUserDoesNotExistPriorToCreate(String username) {
+    public void testUserDoesNotExistPriorToCreate(String username) throws Exception {
         assertThat(kuq.exists(username), is(false));
     }
 
     @Test
-    public void testCreateOrUpdateTlsUser() {
+    public void testCreateOrUpdateTlsUser() throws Exception {
         testCreateOrUpdate("CN=tlsUser");
     }
 
     @Test
-    public void testCreateOrUpdateRegularUser() {
+    public void testCreateOrUpdateRegularUser() throws Exception {
         testCreateOrUpdate("user");
     }
 
-    public void testCreateOrUpdate(String username) {
-        assertThat(kuq.exists(username), is(false));
-        assertThat(kuq.getQuotas(username), is(nullValue()));
-        assertThat(kuq.isPathExist("/config/users/" + kuq.encodeUsername(username)), is(false));
+    public void testCreateOrUpdate(String username) throws Exception {
+        assertThat(kuq.describeUserQuotas(username), is(nullValue()));
+        assertThat(isPathExist("/config/users/" + encodeUsername(username)), is(false));
 
         KafkaUserQuotas newQuotas = new KafkaUserQuotas();
         newQuotas.setConsumerByteRate(1000);
         newQuotas.setProducerByteRate(2000);
         kuq.createOrUpdate(username, newQuotas);
-        assertThat(kuq.exists(username), is(true));
-        assertThat(kuq.getQuotas(username).getJsonObject("config").getString("consumer_byte_rate"), is("1000"));
-        assertThat(kuq.getQuotas(username).getJsonObject("config").getString("producer_byte_rate"), is("2000"));
-        assertThat(kuq.isPathExist("/config/users/" + kuq.encodeUsername(username)), is(true));
+        assertThat(kuq.describeUserQuotas(username), is(notNullValue()));
+        assertThat(kuq.describeUserQuotas(username).getConsumerByteRate(), is(1000));
+        assertThat(kuq.describeUserQuotas(username).getProducerByteRate(), is(2000));
+        assertThat(isPathExist("/config/users/" + encodeUsername(username)), is(true));
     }
 
     @Test
-    public void testCreateOrUpdateTwiceTlsUser() {
+    public void testCreateOrUpdateTwiceTlsUser() throws Exception {
         testCreateOrUpdateTwice("CN=doubleCreate");
     }
 
     @Test
-    public void testCreateOrUpdateTwiceRegularUSer() {
+    public void testCreateOrUpdateTwiceRegularUSer() throws Exception {
         testCreateOrUpdateTwice("doubleCreate");
     }
 
-    public void testCreateOrUpdateTwice(String username) {
-        assertThat(kuq.isPathExist("/config/users/" + kuq.encodeUsername(username)), is(false));
-        assertThat(kuq.exists(username), is(false));
-        assertThat(kuq.getQuotas(username), is(nullValue()));
+    public void testCreateOrUpdateTwice(String username) throws Exception {
+        assertThat(isPathExist("/config/users/" + encodeUsername(username)), is(false));
+        assertThat(kuq.describeUserQuotas(username), is(nullValue()));
 
         kuq.createOrUpdate(username, defaultQuotas);
         kuq.createOrUpdate(username, defaultQuotas);
-        assertThat(kuq.exists(username), is(true));
-        assertThat(kuq.getQuotas(username).getJsonObject("config").getString("consumer_byte_rate"), is("1000"));
-        assertThat(kuq.getQuotas(username).getJsonObject("config").getString("producer_byte_rate"), is("2000"));
-        assertThat(kuq.isPathExist("/config/users/" + kuq.encodeUsername(username)), is(true));
+        assertThat(kuq.describeUserQuotas(username), is(notNullValue()));
+        assertThat(kuq.describeUserQuotas(username).getConsumerByteRate(), is(1000));
+        assertThat(kuq.describeUserQuotas(username).getProducerByteRate(), is(2000));
+        assertThat(isPathExist("/config/users/" + encodeUsername(username)), is(true));
     }
 
     @Test
-    public void testDeleteTlsUser() {
+    public void testDeleteTlsUser() throws Exception {
         testDelete("CN=normalDelete");
     }
 
     @Test
-    public void testDeleteRegularUser() {
+    public void testDeleteRegularUser() throws Exception {
         testDelete("normalDelete");
     }
 
-    public void testDelete(String username) {
+    public void testDelete(String username) throws Exception {
         kuq.createOrUpdate(username, defaultQuotas);
-        assertThat(kuq.isPathExist("/config/users/" + kuq.encodeUsername(username)), is(true));
+        assertThat(isPathExist("/config/users/" + encodeUsername(username)), is(true));
         assertThat(kuq.exists(username), is(true));
 
         kuq.delete(username);
         assertThat(kuq.exists(username), is(false));
-        assertThat(kuq.isPathExist("/config/users/" + kuq.encodeUsername(username)), is(false));
     }
 
     @Test
-    public void testDeleteTwiceTlsUser() {
+    public void testDeleteTwiceTlsUser() throws Exception {
         testDeleteTwice("CN=doubleDelete");
     }
 
     @Test
-    public void testDeleteTwiceRegularUser() {
+    public void testDeleteTwiceRegularUser() throws Exception {
         testDeleteTwice("doubleDelete");
     }
 
-    public void testDeleteTwice(String username) {
+    public void testDeleteTwice(String username) throws Exception {
         kuq.createOrUpdate(username, defaultQuotas);
-        assertThat(kuq.isPathExist("/config/users/" + kuq.encodeUsername(username)), is(true));
+        assertThat(isPathExist("/config/users/" + encodeUsername(username)), is(true));
         assertThat(kuq.exists(username), is(true));
 
         kuq.delete(username);
         kuq.delete(username);
         assertThat(kuq.exists(username), is(false));
-        assertThat(kuq.isPathExist("/config/users/" + kuq.encodeUsername(username)), is(false));
     }
 
     @Test
-    public void testUpdateConsumerByteRate() {
+    public void testUpdateConsumerByteRate() throws Exception {
         kuq.createOrUpdate("changeProducerByteRate", defaultQuotas);
         defaultQuotas.setConsumerByteRate(4000);
         kuq.createOrUpdate("changeProducerByteRate", defaultQuotas);
-        assertThat(kuq.getQuotas("changeProducerByteRate").getJsonObject("config").getString("consumer_byte_rate"),
-                is("4000"));
+        assertThat(kuq.describeUserQuotas("changeProducerByteRate").getConsumerByteRate(), is(4000));
     }
 
     @Test
-    public void testUpdateProducerByteRate() {
+    public void testUpdateProducerByteRate() throws Exception {
         kuq.createOrUpdate("changeProducerByteRate", defaultQuotas);
         defaultQuotas.setProducerByteRate(8000);
         kuq.createOrUpdate("changeProducerByteRate", defaultQuotas);
-        assertThat(kuq.getQuotas("changeProducerByteRate").getJsonObject("config").getString("producer_byte_rate"),
-                is("8000"));
-    }
-
-
-    @Test
-    public void testValidation()    {
-        JsonObject valid = new JsonObject().put("version", 1);
-        JsonObject invalidEmptyJsonObject = new JsonObject();
-        JsonObject invalidVersion = new JsonObject().put("version", 2);
-
-        kuq.validateJsonVersion(valid);
-
-        assertThrows(RuntimeException.class, () -> kuq.validateJsonVersion(invalidEmptyJsonObject),
-                "Empty JsonObject should cause validate to throw Exception");
-
-        assertThrows(RuntimeException.class, () -> kuq.validateJsonVersion(invalidVersion),
-                "Invalid version (!=1) should cause validate to throw Exception");
+        assertThat(kuq.describeUserQuotas("changeProducerByteRate").getProducerByteRate(), is(8000));
     }
 
     @Test
-    public void testRemoveQuotasFromJsonUserWorksForVariousJonObjectInitialisations()  {
-        JsonObject original = new JsonObject(new String(kuq.createUserJson(defaultQuotas), StandardCharsets.UTF_8));
-        JsonObject updated = kuq.removeQuotasFromJsonUser(original.encode().getBytes(StandardCharsets.UTF_8));
-        assertThat(updated.getJsonObject("config").getString("producer_byte_rate"), is(nullValue()));
-        assertThat(updated.getJsonObject("config").getString("consumer_byte_rate"), is(nullValue()));
-
-        original = new JsonObject().put("version", 1).put("config", new JsonObject().put("producer_byte_rate", "1000").put("consumer_byte_rate", "2000"));
-        updated = kuq.removeQuotasFromJsonUser(original.encode().getBytes(StandardCharsets.UTF_8));
-        assertThat(updated.getJsonObject("config").getString("producer_byte_rate"), is(nullValue()));
-        assertThat(updated.getJsonObject("config").getString("consumer_byte_rate"), is(nullValue()));
-
-        original = new JsonObject().put("version", 1).put("config", new JsonObject());
-        updated = kuq.removeQuotasFromJsonUser(original.encode().getBytes(StandardCharsets.UTF_8));
-        assertThat(updated.getJsonObject("config").getString("producer_byte_rate"), is(nullValue()));
-        assertThat(updated.getJsonObject("config").getString("consumer_byte_rate"), is(nullValue()));
-
-        original = new JsonObject().put("version", 1).put("config", new JsonObject().put("consumer_byte_rate", "1000"));
-        updated = kuq.removeQuotasFromJsonUser(original.encode().getBytes(StandardCharsets.UTF_8));
-        assertThat(updated.getJsonObject("config").getString("producer_byte_rate"), is(nullValue()));
-        assertThat(updated.getJsonObject("config").getString("consumer_byte_rate"), is(nullValue()));
-    }
-
-    @Test
-    public void testRemoveQuotasFromJsonUserPersistsNonQuotaKeys()  {
-        JsonObject original = new JsonObject(new String(kuq.createUserJson(defaultQuotas), StandardCharsets.UTF_8));
-        String keyThatShouldPersist = "persist";
-        int valueThatShouldPersist = 42;
-        original.getJsonObject("config").put(keyThatShouldPersist, valueThatShouldPersist);
-
-        JsonObject updated = kuq.removeQuotasFromJsonUser(original.encode().getBytes(StandardCharsets.UTF_8));
-        assertThat(updated.getJsonObject("config").getString("producer_byte_rate"), is(nullValue()));
-        assertThat(updated.getJsonObject("config").getString("consumer_byte_rate"), is(nullValue()));
-        assertThat(updated.getJsonObject("config").getInteger(keyThatShouldPersist), is(valueThatShouldPersist));
-    }
-
-    @Test
-    public void testCreateOrUpdateUserJsonByUpdatingAndRemovingFields()  {
-        // test creation
+    public void testUserQuotasToClientQuotaAlterationOps() {
         KafkaUserQuotas quotas = new KafkaUserQuotas();
         quotas.setConsumerByteRate(2000);
         quotas.setProducerByteRate(4000);
         quotas.setRequestPercentage(40);
+        Set<ClientQuotaAlteration.Op> ops = kuq.toClientQuotaAlterationOps(quotas);
+        assertThat(ops, hasSize(3));
+        assertThat(ops.contains(new ClientQuotaAlteration.Op("consumer_byte_rate", 2000d)), is(true));
+        assertThat(ops.contains(new ClientQuotaAlteration.Op("producer_byte_rate", 4000d)), is(true));
+        assertThat(ops.contains(new ClientQuotaAlteration.Op("request_percentage", 40d)), is(true));
 
-        JsonObject createdUserJson = new JsonObject(new String(kuq.createUserJson(quotas), StandardCharsets.UTF_8));
-        assertThat(createdUserJson.getJsonObject("config").getString("consumer_byte_rate"), is(notNullValue()));
-        assertThat(createdUserJson.getJsonObject("config").getString("producer_byte_rate"), is(notNullValue()));
-        assertThat(createdUserJson.getJsonObject("config").getString("request_percentage"), is(notNullValue()));
-        assertThat(createdUserJson.getJsonObject("config").getString("consumer_byte_rate"), is("2000"));
-        assertThat(createdUserJson.getJsonObject("config").getString("producer_byte_rate"), is("4000"));
-        assertThat(createdUserJson.getJsonObject("config").getString("request_percentage"), is("40"));
-
-
-        byte[] createdUserJsonInBytes = createdUserJson.encode().getBytes(StandardCharsets.UTF_8);
-
-        // test update by removing request_percentage field
-        KafkaUserQuotas quotas2 = new KafkaUserQuotas();
-        quotas2.setConsumerByteRate(2000);
-        quotas2.setProducerByteRate(4000);
-
-        JsonObject updated = new JsonObject(new String(kuq.createOrUpdateUserJson(createdUserJsonInBytes, quotas2), StandardCharsets.UTF_8));
-        assertThat(updated.getJsonObject("config").getString("consumer_byte_rate"), is(notNullValue()));
-        assertThat(updated.getJsonObject("config").getString("producer_byte_rate"), is(notNullValue()));
-        assertThat(updated.getJsonObject("config").getString("request_percentage"), is(nullValue()));
-        assertThat(updated.getJsonObject("config").getString("consumer_byte_rate"), is("2000"));
-        assertThat(updated.getJsonObject("config").getString("producer_byte_rate"), is("4000"));
-
-        // test update by removing producer_byte_rate field
-        KafkaUserQuotas quotas3 = new KafkaUserQuotas();
-        quotas3.setConsumerByteRate(2000);
-        quotas3.setRequestPercentage(40);
-
-        updated = new JsonObject(new String(kuq.createOrUpdateUserJson(createdUserJsonInBytes, quotas3), StandardCharsets.UTF_8));
-        assertThat(updated.getJsonObject("config").getString("consumer_byte_rate"), is(notNullValue()));
-        assertThat(updated.getJsonObject("config").getString("producer_byte_rate"), is(nullValue()));
-        assertThat(updated.getJsonObject("config").getString("request_percentage"), is(notNullValue()));
-        assertThat(updated.getJsonObject("config").getString("consumer_byte_rate"), is("2000"));
-        assertThat(updated.getJsonObject("config").getString("request_percentage"), is("40"));
-
-        // test update by removing consumer_byte_rate field
-        KafkaUserQuotas quotas4 = new KafkaUserQuotas();
-        quotas4.setProducerByteRate(4000);
-        quotas4.setRequestPercentage(40);
-
-        updated = new JsonObject(new String(kuq.createOrUpdateUserJson(createdUserJsonInBytes, quotas4), StandardCharsets.UTF_8));
-        assertThat(updated.getJsonObject("config").getString("consumer_byte_rate"), is(nullValue()));
-        assertThat(updated.getJsonObject("config").getString("producer_byte_rate"), is(notNullValue()));
-        assertThat(updated.getJsonObject("config").getString("request_percentage"), is(notNullValue()));
-        assertThat(updated.getJsonObject("config").getString("producer_byte_rate"), is("4000"));
-        assertThat(updated.getJsonObject("config").getString("request_percentage"), is("40"));
-
-        // test update by modifying all fields
-        KafkaUserQuotas quotas5 = new KafkaUserQuotas();
-        quotas5.setConsumerByteRate(20000);
-        quotas5.setProducerByteRate(40000);
-        quotas5.setRequestPercentage(50);
-
-        updated = new JsonObject(new String(kuq.createOrUpdateUserJson(createdUserJsonInBytes, quotas5), StandardCharsets.UTF_8));
-        assertThat(updated.getJsonObject("config").getString("consumer_byte_rate"), is(notNullValue()));
-        assertThat(updated.getJsonObject("config").getString("producer_byte_rate"), is(notNullValue()));
-        assertThat(updated.getJsonObject("config").getString("request_percentage"), is(notNullValue()));
-        assertThat(updated.getJsonObject("config").getString("consumer_byte_rate"), is("20000"));
-        assertThat(updated.getJsonObject("config").getString("producer_byte_rate"), is("40000"));
-        assertThat(updated.getJsonObject("config").getString("request_percentage"), is("50"));
+        quotas.setConsumerByteRate(null);
+        quotas.setProducerByteRate(null);
+        quotas.setRequestPercentage(null);
+        ops = kuq.toClientQuotaAlterationOps(quotas);
+        assertThat(ops, hasSize(3));
+        assertThat(ops.contains(new ClientQuotaAlteration.Op("consumer_byte_rate", null)), is(true));
+        assertThat(ops.contains(new ClientQuotaAlteration.Op("producer_byte_rate", null)), is(true));
+        assertThat(ops.contains(new ClientQuotaAlteration.Op("request_percentage", null)), is(true));
     }
 
     @Test
-    public void testReconcileCreatesTlsUserWithQuotas(VertxTestContext testContext)  {
+    public void testClientQuotaAlterationOpsToUserQuotas() {
+        Map<String, Double> map = new HashMap<>(3);
+        map.put("consumer_byte_rate", 2000d);
+        map.put("producer_byte_rate", 4000d);
+        map.put("request_percentage", 40d);
+        KafkaUserQuotas quotas = kuq.fromClientQuota(map);
+        assertThat(quotas.getConsumerByteRate(), is(2000));
+        assertThat(quotas.getProducerByteRate(), is(4000));
+        assertThat(quotas.getRequestPercentage(), is(40));
+
+        map.remove("consumer_byte_rate");
+        map.remove("producer_byte_rate");
+        map.remove("request_percentage");
+        quotas = kuq.fromClientQuota(map);
+        assertThat(quotas.getConsumerByteRate(), is(nullValue()));
+        assertThat(quotas.getProducerByteRate(), is(nullValue()));
+        assertThat(quotas.getRequestPercentage(), is(nullValue()));
+    }
+
+    @Test
+    public void testReconcileCreatesTlsUserWithQuotas(VertxTestContext testContext) throws Exception  {
         testReconcileCreatesUserWithQuotas("CN=createTestUser", testContext);
     }
 
     @Test
-    public void testReconcileCreatesRegularUserWithQuotas(VertxTestContext testContext)  {
+    public void testReconcileCreatesRegularUserWithQuotas(VertxTestContext testContext) throws Exception  {
         testReconcileCreatesUserWithQuotas("createTestUser", testContext);
     }
 
-    public void testReconcileCreatesUserWithQuotas(String username, VertxTestContext testContext)  {
+    public void testReconcileCreatesUserWithQuotas(String username, VertxTestContext testContext) throws Exception  {
         KafkaUserQuotas quotas = new KafkaUserQuotas();
         quotas.setConsumerByteRate(2_000_000);
         quotas.setProducerByteRate(1_000_000);
@@ -341,25 +281,25 @@ public class KafkaUserQuotasIT {
         kuq.reconcile(username, quotas)
             .onComplete(testContext.succeeding(rr -> testContext.verify(() -> {
                 assertThat(kuq.exists(username), is(true));
-                assertThat(kuq.getQuotas(username).getJsonObject("config").getString("consumer_byte_rate"), is("2000000"));
-                assertThat(kuq.getQuotas(username).getJsonObject("config").getString("producer_byte_rate"), is("1000000"));
-                assertThat(kuq.getQuotas(username).getJsonObject("config").getString("request_percentage"), is("50"));
-                assertThat(kuq.isPathExist("/config/users/" + kuq.encodeUsername(username)), is(true));
+                assertThat(kuq.describeUserQuotas(username).getConsumerByteRate(), is(2000000));
+                assertThat(kuq.describeUserQuotas(username).getProducerByteRate(), is(1000000));
+                assertThat(kuq.describeUserQuotas(username).getRequestPercentage(), is(50));
+                assertThat(isPathExist("/config/users/" + encodeUsername(username)), is(true));
                 async.flag();
             })));
     }
 
     @Test
-    public void testReconcileUpdatesTlsUserQuotaValues(VertxTestContext testContext)  {
+    public void testReconcileUpdatesTlsUserQuotaValues(VertxTestContext testContext) throws Exception {
         testReconcileUpdatesUserQuotaValues("CN=updateTestUser", testContext);
     }
 
     @Test
-    public void testReconcileUpdatesRegularUserQuotaValues(VertxTestContext testContext)  {
+    public void testReconcileUpdatesRegularUserQuotaValues(VertxTestContext testContext) throws Exception {
         testReconcileUpdatesUserQuotaValues("updateTestUser", testContext);
     }
 
-    public void testReconcileUpdatesUserQuotaValues(String username, VertxTestContext testContext)  {
+    public void testReconcileUpdatesUserQuotaValues(String username, VertxTestContext testContext) throws Exception {
         KafkaUserQuotas initialQuotas = new KafkaUserQuotas();
         initialQuotas.setConsumerByteRate(2_000_000);
         initialQuotas.setProducerByteRate(1_000_000);
@@ -377,25 +317,25 @@ public class KafkaUserQuotasIT {
         kuq.reconcile(username, updatedQuotas)
             .onComplete(testContext.succeeding(rr -> testContext.verify(() -> {
                 assertThat(kuq.exists(username), is(true));
-                assertThat(kuq.getQuotas(username).getJsonObject("config").getString("consumer_byte_rate"), is("4000000"));
-                assertThat(kuq.getQuotas(username).getJsonObject("config").getString("producer_byte_rate"), is("3000000"));
-                assertThat(kuq.getQuotas(username).getJsonObject("config").getString("request_percentage"), is("75"));
-                assertThat(kuq.isPathExist("/config/users/" + kuq.encodeUsername(username)), is(true));
+                assertThat(kuq.describeUserQuotas(username).getConsumerByteRate(), is(4000000));
+                assertThat(kuq.describeUserQuotas(username).getProducerByteRate(), is(3000000));
+                assertThat(kuq.describeUserQuotas(username).getRequestPercentage(), is(75));
+                assertThat(isPathExist("/config/users/" + encodeUsername(username)), is(true));
                 async.flag();
             })));
     }
 
     @Test
-    public void testReconcileUpdatesTlsUserQuotasWithFieldRemovals(VertxTestContext testContext)  {
+    public void testReconcileUpdatesTlsUserQuotasWithFieldRemovals(VertxTestContext testContext) throws Exception {
         testReconcileUpdatesUserQuotasWithFieldRemovals("CN=updateTestUser", testContext);
     }
 
     @Test
-    public void testReconcileUpdatesRegularUserQuotasWithFieldRemovals(VertxTestContext testContext)  {
+    public void testReconcileUpdatesRegularUserQuotasWithFieldRemovals(VertxTestContext testContext) throws Exception {
         testReconcileUpdatesUserQuotasWithFieldRemovals("updateTestUser", testContext);
     }
 
-    public void testReconcileUpdatesUserQuotasWithFieldRemovals(String username, VertxTestContext testContext)  {
+    public void testReconcileUpdatesUserQuotasWithFieldRemovals(String username, VertxTestContext testContext) throws Exception {
         KafkaUserQuotas initialQuotas = new KafkaUserQuotas();
         initialQuotas.setConsumerByteRate(2_000_000);
         initialQuotas.setProducerByteRate(1_000_000);
@@ -412,26 +352,26 @@ public class KafkaUserQuotasIT {
         kuq.reconcile(username, updatedQuotas)
             .onComplete(testContext.succeeding(rr -> testContext.verify(() -> {
                 assertThat(kuq.exists(username), is(true));
-                assertThat(kuq.getQuotas(username).getJsonObject("config").getString("consumer_byte_rate"), is("4000000"));
-                assertThat(kuq.getQuotas(username).getJsonObject("config").getString("producer_byte_rate"), is("3000000"));
-                assertThat(kuq.getQuotas(username).getJsonObject("config").getString("request_percentage"), is(nullValue()));
-                assertThat(kuq.isPathExist("/config/users/" + kuq.encodeUsername(username)), is(true));
+                assertThat(kuq.describeUserQuotas(username).getConsumerByteRate(), is(4000000));
+                assertThat(kuq.describeUserQuotas(username).getProducerByteRate(), is(3000000));
+                assertThat(kuq.describeUserQuotas(username).getRequestPercentage(), is(nullValue()));
+                assertThat(isPathExist("/config/users/" + encodeUsername(username)), is(true));
                 async.flag();
             })));
 
     }
 
     @Test
-    public void testReconcileDeletesTlsUserForNullQuota(VertxTestContext testContext)  {
+    public void testReconcileDeletesTlsUserForNullQuota(VertxTestContext testContext) throws Exception {
         testReconcileDeletesUserForNullQuota("CN=deleteTestUser", testContext);
     }
 
     @Test
-    public void testReconcileDeletesRegularUserForNullQuota(VertxTestContext testContext)  {
+    public void testReconcileDeletesRegularUserForNullQuota(VertxTestContext testContext) throws Exception {
         testReconcileDeletesUserForNullQuota("deleteTestUser", testContext);
     }
 
-    public void testReconcileDeletesUserForNullQuota(String username, VertxTestContext testContext)  {
+    public void testReconcileDeletesUserForNullQuota(String username, VertxTestContext testContext) throws Exception {
         KafkaUserQuotas initialQuotas = new KafkaUserQuotas();
         initialQuotas.setConsumerByteRate(2_000_000);
         initialQuotas.setProducerByteRate(1_000_000);
@@ -448,9 +388,15 @@ public class KafkaUserQuotasIT {
             })));
     }
 
-    @Test
-    public void testEncodeUser()    {
-        assertThat(KafkaUserQuotasOperator.encodeUsername("jack"), is("jack"));
-        assertThat(KafkaUserQuotasOperator.encodeUsername("CN=grealish"), is("CN%3Dgrealish"));
+    private boolean isPathExist(String path) {
+        return zkClient.exists(path);
+    }
+
+    private String encodeUsername(String username) {
+        try {
+            return URLEncoder.encode(username, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Failed to encode username", e);
+        }
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR fixes https://github.com/strimzi/strimzi-kafka-operator/issues/3112 actually removing the ZooKeeper dependency from the `KafkaUserQuotasOperator` and using the Admin Client API instead. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

