### PR TITLE
Fix default docker registry in dev guide

### DIFF
--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -178,7 +178,7 @@ Target `docker_tag` tags the Docker images built by the `docker_build` target. T
 To configure the `docker_tag` and `docker_push` targets you can set following environment variables:
 * `DOCKER_ORG` configures the Docker organization for tagging/pushing the images (defaults to the value of the `$USER` environment variable)
 * `DOCKER_TAG` configured Docker tag (default is `latest`)
-* `DOCKER_REGISTRY` configures the Docker registry where the image will be pushed (default is `docker.io`)
+* `DOCKER_REGISTRY` configures the Docker registry where the image will be pushed (default is `quay.io`)
 
 ## Docker build options
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Trivial PR about specifying `quay.io` as default container registry instead of `docker.io`.

### Checklist

- [x] Update documentation