### PR TITLE
Fix unescaped dot in the make release targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ release_helm_version:
 		$(SED) -i 's/\(tagPrefix: \).*/\1$(RELEASE_VERSION)/g' $$CHART_PATH/values.yaml;	\
 		$(SED) -i 's/\(image\.tag[^\n]*| \)`.*`/\1`$(RELEASE_VERSION)`/g' $$CHART_PATH/README.md;	\
 		$(SED) -i 's/\(image\.tagPrefix[^\n]*| \)`.*`/\1`$(RELEASE_VERSION)`/g' $$CHART_PATH/README.md;	\
-		$(SED) -i '/name: quay.io\/kafka-bridge/{n;s/\(tag: \).*/\1$(BRIDGE_VERSION)/g}' $$CHART_PATH/values.yaml;	\
+		$(SED) -i '/name: quay\.io\/kafka-bridge/{n;s/\(tag: \).*/\1$(BRIDGE_VERSION)/g}' $$CHART_PATH/values.yaml;	\
 		$(SED) -i 's/\(kafkaBridge.image\.tag[^\n]*| \)`.*`/\1`$(BRIDGE_VERSION)`/g' $$CHART_PATH/README.md;	\
 	done
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

During the work on 0.21.0 I noticed a bug in the release targets where in the container registry name we have an unescaped `.`. As a result, the bridge version is changed to the operators version which is not correct. I fixed it provisionally in the release branch. This PR fixes it in master.