### PR TITLE
Fix Jenkins PR pipeline

### DIFF
--- a/.jenkins/jenkins.groovy
+++ b/.jenkins/jenkins.groovy
@@ -22,9 +22,6 @@ def installYq(String workspace) {
 def buildStrimziImages() {
     sh(script: "MVN_ARGS='-Dsurefire.rerunFailingTestsCount=5 -Dfailsafe.rerunFailingTestsCount=2' make docker_build")
     sh(script: "make docker_tag")
-    // Create namespace for images
-    sh(script: "kubectl create namespace ${env.DOCKER_ORG}")
-    sh(script: "make docker_push")
 }
 
 def runSystemTests(String workspace, String testCases, String testProfile, String excludeGroups) {

--- a/.jenkins/jenkins.groovy
+++ b/.jenkins/jenkins.groovy
@@ -22,10 +22,8 @@ def installYq(String workspace) {
 def buildStrimziImages() {
     sh(script: "MVN_ARGS='-Dsurefire.rerunFailingTestsCount=5 -Dfailsafe.rerunFailingTestsCount=2' make docker_build")
     sh(script: "make docker_tag")
-    // Login to internal registries
-    sh(script: "docker login ${env.DOCKER_REGISTRY} -u \$(oc whoami) -p \$(oc whoami -t)")
     // Create namespace for images
-    sh(script: "oc create namespace ${env.DOCKER_ORG}")
+    sh(script: "kubectl create namespace ${env.DOCKER_ORG}")
     sh(script: "make docker_push")
 }
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

In my last run of PR job I found issue with build when we didn't specified the `test_only` option -> the build failed because of login into OC (which is not being installed after latest changes) and then with OC credentials logging into local docker registry, where the builded images were pushed. For running PR jobs we don't really need to push docker images into local reg, so I deleted this "option".

After these changes, the PR jobs should be fixed.

### Checklist

- [ ] Make sure all tests pass

