### PR TITLE
Add Kafka 2.7.0 to 0.21.0 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Add support for rolling individual Kafka or ZooKeeper pods through the Cluster Operator using an annotation
 * Add support for Topology Spread Constraints in Pod templates
 * Make Kafka `cluster-id` (KIP-78) available on Kafka CRD status
+* Add support for Kafka 2.7.0
 
 ### Deprecations and removals
 * The `metrics` field in the Strimzi custom resources has been deprecated and will be removed in the future. For configuring metrics, use the new `metricsConfig` field and pass the configuration via ConfigMap.


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

As one user noted on Slack, the CHANGELOG for 0.21.0 seems to be missing any mention of the Kafka 2.7.0 support. Since this is important feature, it should be covered. This PR adds it there. Once merged into master it can be also merged into the release branch for 0.21.0.