### PR TITLE
Change namespace name for bc-listener tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/BackwardsCompatibleListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/BackwardsCompatibleListenersST.java
@@ -52,7 +52,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Tag(REGRESSION)
 public class BackwardsCompatibleListenersST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(BackwardsCompatibleListenersST.class);
-    public static final String NAMESPACE = "kafka-listeners-bc-cluster-test";
+    public static final String NAMESPACE = "bc-listeners";
 
     /**
      * Test sending messages over tls transport using mutual tls auth


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

_Select the type of your PR_

- Bugfix

### Description

After change for clusterName (from static to random), we hit the route name length limit in `BackwardsCompatibleListenersST`. This PR changes the length of the namespace name, which solves the issue.

Before: `my-cluster-1410123328-kafka-bootstrap-kafka-listeners-bc-cluster-test`  - 69 chars
Now: `my-cluster-1410123328-kafka-bootstrap-bc-listeners` - 50

This should be cherry-picked to `release-0.21.x`

### Checklist

- [ ] Make sure all tests pass


