### PR TITLE
Add last warning before removing deprecated annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 ### Deprecations and removals
 
 * Removed support for Helm2 charts as that version is now unsupported. There is no longer the need for separate `helm2` and `helm3` binaries, only `helm` (version 3) is required.
+* The following annotations are deprecated for a long time and will be removed in 0.23.0:
+  * `cluster.operator.strimzi.io/delete-claim` (used internally only - replaced by `strimzi.io/delete-claim`)
+  * `operator.strimzi.io/generation` (used internally only - replaced by `strimzi.io/generation`)
+  * `operator.strimzi.io/delete-pod-and-pvc` (use `strimzi.io/delete-pod-and-pvc` instead)
+  * `operator.strimzi.io/manual-rolling-update` (use `strimzi.io/manual-rolling-update` instead)
 
 ## 0.21.0
 


### PR DESCRIPTION
### Type of change

- Task

### Description

As discussed and agreed on the Strimzi Community meeting on 14th January, we should remove the deprecated annotations in Strimzi 0.23. This PR adds the last warning before removal to the CHANGELOG.md so that it is covered in the 0.22.0 release notes.

Issue #4251 tracks the removal of the annotations in 0.23.