### PR TITLE
Added arm64 for TINI and Kafka Exporter in Dockerfile for base and Kafka

### DIFF
--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -1,5 +1,6 @@
 FROM centos:7
 ARG JAVA_VERSION=11
+ARG TARGETPLATFORM
 
 RUN yum -y update \
     && yum -y install java-${JAVA_VERSION}-openjdk-headless openssl bind-utils \

--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -9,7 +9,16 @@ RUN yum -y update \
 # Add Tini
 #####
 ENV TINI_VERSION v0.18.0
-ENV TINI_SHA256=12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
-RUN echo "${TINI_SHA256} */usr/bin/tini" | sha256sum -c \
-    && chmod +x /usr/bin/tini
+ENV TINI_SHA256_AMD64=12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855
+ENV TINI_SHA256_ARM64=7c5463f55393985ee22357d976758aaaecd08defb3c5294d353732018169b019
+
+RUN set -ex; \
+    if [[ ${TARGETPLATFORM} = "linux/arm64" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o /usr/bin/tini; \
+        echo "${TINI_SHA256_ARM64} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    else \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o /usr/bin/tini; \
+        echo "${TINI_SHA256_AMD64} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    fi

--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -4,6 +4,7 @@ ARG KAFKA_DIST_DIR
 ARG KAFKA_VERSION
 ARG THIRD_PARTY_LIBS
 ARG strimzi_version
+ARG TARGETPLATFORM
 
 RUN yum -y install gettext nmap-ncat stunnel net-tools && yum clean all -y
 

--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -26,14 +26,25 @@ COPY ./scripts/ $KAFKA_HOME
 #####
 ENV KAFKA_EXPORTER_HOME=/opt/kafka-exporter
 ENV KAFKA_EXPORTER_VERSION=1.2.0
-ENV KAFKA_EXPORTER_CHECKSUM="7afa40365ddf0cb0a88457684bd64d565e250c7e5a4536ba7f9d37d02d2808c3b07766f94e0b1338beb296573ade29db630948c931be44bde416c0410b5d783b  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz"
+ENV KAFKA_EXPORTER_CHECKSUM_AMD64="7afa40365ddf0cb0a88457684bd64d565e250c7e5a4536ba7f9d37d02d2808c3b07766f94e0b1338beb296573ade29db630948c931be44bde416c0410b5d783b  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz"
+ENV KAFKA_EXPORTER_CHECKSUM_ARM64="1b36d0dc45b9dc20d90f88ee43b84277154d6d589c19b0674b10b4c3e48ce31e5410094deeae4426e069f9d30108bb26dcb84fab2e87e2841dadb75e58fb5916  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz"
 
-RUN curl -LO https://github.com/danielqsj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz \
-    && echo $KAFKA_EXPORTER_CHECKSUM > kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz.sha512 \
-    && sha512sum --check kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz.sha512 \
-    && mkdir $KAFKA_EXPORTER_HOME \
-    && tar xvfz kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz -C $KAFKA_EXPORTER_HOME --strip-components=1 \
-    && rm -f kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz*
+RUN set -ex; \
+    if [[ ${TARGETPLATFORM} = "linux/arm64" ]]; then \
+        curl -LO https://github.com/danielqsj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz; \
+        echo $KAFKA_EXPORTER_CHECKSUM_ARM64 > kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz.sha512; \
+        sha512sum --check kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz.sha512; \
+        mkdir $KAFKA_EXPORTER_HOME; \
+        tar xvfz kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz -C $KAFKA_EXPORTER_HOME --strip-components=1; \
+        rm -f kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz*; \
+    else \
+        curl -LO https://github.com/danielqsj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz; \
+        echo $KAFKA_EXPORTER_CHECKSUM_AMD64 > kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz.sha512; \
+        sha512sum --check kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz.sha512; \
+        mkdir $KAFKA_EXPORTER_HOME; \
+        tar xvfz kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz -C $KAFKA_EXPORTER_HOME --strip-components=1; \
+        rm -f kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz*; \
+    fi
 
 COPY ./exporter-scripts $KAFKA_EXPORTER_HOME
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Added TINI and Kafka exporter in DockerFile of `base` and `kafka` for `arm64`

### Help Needed

Currently this has been tested like the below (which might not be correct)

Amd64, which compiles perfectly
```
ubuntu@soo-cheri:~/Documents/strimzi-kafka-operator$ echo $DOCKER_BUILD_ARGS 
--platform linux/amd64
ubuntu@soo-cheri:~/Documents/strimzi-kafka-operator$ echo $DOCKER_BUILDX 
buildx
ubuntu@soo-cheri:~/Documents/strimzi-kafka-operator$ MVN_ARGS="-Dmaven.javadoc.skip=true -DskipITs -DskipTests" make docker_build
```

and for `arm64`, I do get the below error, any help to resolve this is appreciated

```
# Build Docker image ...
docker build --platform linux/arm64 --build-arg JAVA_VERSION=11  --build-arg strimzi_version=0.20.0 -t strimzi/operator:latest ./
Sending build context to Docker daemon  54.93MB
Step 1/10 : FROM strimzi/base:latest
 ---> a34ad7c39bd5
Step 2/10 : RUN useradd -r -m -u 1001 -g 0 strimzi
 ---> Using cache
 ---> 9103bae38841
Step 3/10 : ARG strimzi_version=1.0-SNAPSHOT
 ---> Using cache
 ---> 07255d44155d
Step 4/10 : ENV STRIMZI_VERSION ${strimzi_version}
 ---> Using cache
 ---> e626b5e6b2cd
Step 5/10 : ENV STRIMZI_HOME=/opt/strimzi
 ---> Using cache
 ---> eed736739fb4
Step 6/10 : RUN mkdir -p ${STRIMZI_HOME}/bin
 ---> Using cache
 ---> 3b5db1985912
Step 7/10 : WORKDIR ${STRIMZI_HOME}
 ---> Using cache
 ---> 24ef35790c90
Step 8/10 : COPY scripts/ tmp/bin/ bin/
 ---> Using cache
 ---> b268dc3e343d
Step 9/10 : COPY tmp/lib/ lib/
failed to get destination image "sha256:b268dc3e343dcb363a8aa218dc80f4eb75b966420cc4338a8932601814e8a9a1": image with reference sha256:b268dc3e343dcb363a8aa218dc80f4eb75b966420cc4338a8932601814e8a9a1 was found but does not match the specified platform: wanted linux/arm64, actual: linux/amd64
make[2]: *** [../../Makefile.docker:21: docker_build_default] Error 1
make[2]: Leaving directory '/home/bitvijays/Documents/strimzi-kafka-operator/docker-images/operator'
make[1]: *** [Makefile:12: docker_build] Error 2
make[1]: Leaving directory '/home/bitvijays/Documents/strimzi-kafka-operator/docker-images'
make: *** [Makefile:167: docker-images] Error 2
```
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

