### PR TITLE
Update the Helm Chart index after the 0.21.0 release

### DIFF
--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -2,6 +2,33 @@ apiVersion: v1
 entries:
   strimzi-kafka-operator:
   - apiVersion: v2
+    appVersion: 0.21.0
+    created: "2021-01-15T20:06:21.560196+01:00"
+    description: 'Strimzi: Apache Kafka running on Kubernetes'
+    digest: 807252a88f3279a59be42e8c3d9b65a8b7c048f5674de7293797c0d34c81581e
+    home: https://strimzi.io/
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    keywords:
+    - kafka
+    - queue
+    - stream
+    - event
+    - messaging
+    - datastore
+    - topic
+    maintainers:
+    - name: Frawless
+    - name: ppatierno
+    - name: samuel-hawker
+    - name: scholzj
+    - name: tombentley
+    name: strimzi-kafka-operator
+    sources:
+    - https://github.com/strimzi/strimzi-kafka-operator
+    urls:
+    - https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.21.0/strimzi-kafka-operator-helm-3-chart-0.21.0.tgz
+    version: 0.21.0
+  - apiVersion: v2
     appVersion: 0.20.1
     created: "2020-12-14T15:41:24.87515+01:00"
     description: 'Strimzi: Apache Kafka running on Kubernetes'
@@ -686,4 +713,4 @@ entries:
     urls:
     - https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.6.0/strimzi-kafka-operator-0.6.0.tgz
     version: 0.6.0
-generated: "2020-12-14T15:41:24.86417+01:00"
+generated: "2021-01-15T20:06:21.548447+01:00"


### PR DESCRIPTION
### Type of change

- Task

### Description

As with every release, this PR updates the Helm Chart index file with the 0.21.0 release so that we can build on top of it in the next releases.