### PR TITLE
Update the REALEASE.md guide in developer docs

### DIFF
--- a/development-docs/RELEASE.md
+++ b/development-docs/RELEASE.md
@@ -9,24 +9,37 @@
 The `release` target will not build the Docker images - they should be built and pushed automatically by Travis CI when the release is tagged in the GitHub repository. It also doesn't deploy the Java artifacts anywhere. They are only used to create the Docker images.
 
 The release process should normally look like this:
+
 1. Create a release branch
-2. Run `make clean`
-3. Export the desired version into the environment variable `RELEASE_VERSION`
-4. Run `make release`
+2. On the `master` git branch of the operators repository:
+  * Update the versions to the next SNAPSHOT version using the `next_version` `make` target. For example to update the next version to `0.6.0-SNAPSHOT` run: `make NEXT_VERSION=0.6.0-SNAPSHOT next_version`.
+
+3. Run `make clean`
+4. Export the desired version into the environment variable `RELEASE_VERSION`
+5. Run `make release`
 5. Commit the changes to the existing files (do not add the newly created top level TAR.GZ, ZIP archives or .yaml files into Git)
 6. Push the changes to the release branch on GitHub
 7. Create the tag and push it to GitHub. Tag name determines the tag of the resulting Docker images. Therefore the Git tag name has to be the same as the `RELEASE_VERSION`, i.e. `git tag ${RELEASE_VERSION}`,
-8. Once the CI build for the tag is finished and the Docker images are pushed to Docker Hub, Create a GitHub release and tag based on the release branch. Attach the TAR.GZ/ZIP archives, YAML files (for installation from URL) from step 4 and the Helm Chart to the release
-9. On the `master` git branch
-  * Update the versions to the next SNAPSHOT version using the `next_version` `make` target. For example to update the next version to `0.6.0-SNAPSHOT` run: `make NEXT_VERSION=0.6.0-SNAPSHOT next_version`.
-  * Copy the `helm-charts/index.yaml` from the `release` branch to `master`.
-10. Update the website
-  * Add release documentation to `strimzi.github.io/docs/`. Update references to docs in `strimzi.github.io/documentation/index.md` and `strimzi.github.io/documentation/archive/index.md`. Update also the link from the start page: `strimzi.github.io/index.md`.
-  * Update the Helm Chart repository file by copying `strimzi-kafka-operator/helm-charts/index.yaml` to `strimzi.github.io/charts/index.yaml`.
-  * Update the Quickstarts for OKD and Minikube to use the latest stuff.
+8. Once the CI build for the tag is finished, and the Docker images are pushed to Docker Hub, Create a GitHub release and tag based on the release branch. Attach the TAR.GZ/ZIP archives, YAML files (for installation from URL) from step 5 and the Helm Chart to the release
+9. _(only for GA, not for RCs)_ Update the website
   * Update the `_redirects` file to make sure the `/install/latest` redirect points to the new release.
-11. The maven artifacts (`api` module) will be automatically staged from TravisCI during the tag build. It has to be releases from [Sonatype](https://oss.sonatype.org/#stagingRepositories) to get to the main Maven repositories.
-12. Update the Strimzi manifest files in Operate Hub [community operators](https://github.com/operator-framework/community-operators) repository and submit a pull request upstream. *Note*: Instructions for this step need updating.
+  * Update the `_data/releases.yaml` file to add new release
+  * Update the documentation: 
+    * Create new directories `docs/operators/<new-version>` and `docs/operators/<new-version>/full` in the website repository
+    * Copy files from the operators repository `documentation/htmlnoheader` to `docs/operators/<new-version>` in the website repository
+    * Copy files from the operators repository `documentation/html` to `docs/operators/<new-version>/full` in the website repository
+    * Create new files `contributing.md`, `deploying.md`, `overview.md`, `quickstart.md`, and `using.md` in `docs/operators/<new-version>` - the content of these files should be the same as for older versions, so you can copy them and update the version number.
+    * Delete the old HTML files and images from `docs/operators/latest` and `docs/operators/latest/full` (keep the `*.md` files) 
+    * Copy files from the operators repository `documentation/htmlnoheader` to `docs/operators/latest` in the website repository
+    * Copy files from the operators repository `documentation/html` to `docs/operators/latest/full` in the website repository
+  * Update the Helm Chart repository file by copying `helm-charts/helm3/index.yaml` in the operators GitHub repository to `charts/index.yaml` in the website GitHub repsoitory.
+
+10. _(only for GA, not for RCs)_ The maven artifacts (`api` module) will be automatically staged from TravisCI during the tag build. It has to be releases from [Sonatype](https://oss.sonatype.org/#stagingRepositories) to get to the main Maven repositories.
+11. _(only for GA, not for RCs)_ On the `master` git branch of the operators repository:
+  * Copy the `helm-charts/index.yaml` from the `release` branch to `master`.
+
+12. _(only for GA, not for RCs)_ Update the Strimzi manifest files in Operate Hub [community operators](https://github.com/operator-framework/community-operators) repository and submit a pull request upstream. *Note*: Instructions for this step need updating.
+13. _(only for GA, not for RCs)_ Add the new version to the `systemtest/src/main/resources/StrimziUpgradeST.json` file for the upgrade tests
 
 ## Updating Kafka Bridge version
 


### PR DESCRIPTION
### Type of change

- Task

### Description

The RELEASE.md guide which is part of the developer docs and describes how to do Strimzi releases was slightly outdated - especially with regards to the website updates. This PR tries to bring it up to date.