### PR TITLE
Fix the network-policies handling when metrics config from CM is used

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
@@ -34,7 +34,7 @@ import java.util.Map;
         "affinity", "tolerations", "logging", "metrics", "metricsConfig", "tracing",
         "template", "externalConfiguration"})
 @EqualsAndHashCode(doNotUseGetters = true)
-public abstract class AbstractKafkaConnectSpec extends Spec {
+public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfigurableMetrics {
     private static final long serialVersionUID = 1L;
 
     private Logging logging;
@@ -149,10 +149,12 @@ public abstract class AbstractKafkaConnectSpec extends Spec {
 
     @Description("Metrics configuration.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Override
     public MetricsConfig getMetricsConfig() {
         return metricsConfig;
     }
 
+    @Override
     public void setMetricsConfig(MetricsConfig metricsConfig) {
         this.metricsConfig = metricsConfig;
     }
@@ -163,10 +165,12 @@ public abstract class AbstractKafkaConnectSpec extends Spec {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Description("The Prometheus JMX Exporter configuration. " +
             "See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.")
+    @Override
     public Map<String, Object> getMetrics() {
         return metrics;
     }
 
+    @Override
     public void setMetrics(Map<String, Object> metrics) {
         this.metrics = metrics;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
@@ -32,7 +32,7 @@ import lombok.EqualsAndHashCode;
         "template", "brokerCapacity",
         "config", "metrics", "metricsConfig"})
 @EqualsAndHashCode
-public class CruiseControlSpec implements UnknownPropertyPreserving, Serializable {
+public class CruiseControlSpec implements HasConfigurableMetrics, UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 
     // For the full configuration list refer to https://github.com/linkedin/cruise-control/wiki/Configurations
@@ -106,20 +106,24 @@ public class CruiseControlSpec implements UnknownPropertyPreserving, Serializabl
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("The Prometheus JMX Exporter configuration. " +
             "See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.")
+    @Override
     public Map<String, Object> getMetrics() {
         return metrics;
     }
 
+    @Override
     public void setMetrics(Map<String, Object> metrics) {
         this.metrics = metrics;
     }
 
     @Description("Metrics configuration.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Override
     public MetricsConfig getMetricsConfig() {
         return metricsConfig;
     }
 
+    @Override
     public void setMetricsConfig(MetricsConfig metricsConfig) {
         this.metricsConfig = metricsConfig;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/HasConfigurableMetrics.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/HasConfigurableMetrics.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import java.util.Map;
+
+public interface HasConfigurableMetrics {
+    Map<String, Object> getMetrics();
+    void setMetrics(Map<String, Object> metrics);
+    MetricsConfig getMetricsConfig();
+    void setMetricsConfig(MetricsConfig metricsConfig);
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/HasConfigurableMetrics.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/HasConfigurableMetrics.java
@@ -6,6 +6,10 @@ package io.strimzi.api.kafka.model;
 
 import java.util.Map;
 
+/**
+ * This interface is used for sections of our custom resources which support configurable metrics - either using the
+ * inlined Map or using the reference to the ConfigMp with the configuration.
+ */
 public interface HasConfigurableMetrics {
     Map<String, Object> getMetrics();
     void setMetrics(Map<String, Object> metrics);

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
@@ -45,7 +45,7 @@ import java.util.Map;
         "jvmOptions", "jmxOptions", "resources",
         "metrics", "metricsConfig", "logging", "tlsSidecar", "template"})
 @EqualsAndHashCode
-public class KafkaClusterSpec implements UnknownPropertyPreserving, Serializable {
+public class KafkaClusterSpec implements HasConfigurableMetrics, UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -241,20 +241,24 @@ public class KafkaClusterSpec implements UnknownPropertyPreserving, Serializable
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("The Prometheus JMX Exporter configuration. " +
             "See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.")
+    @Override
     public Map<String, Object> getMetrics() {
         return metrics;
     }
 
+    @Override
     public void setMetrics(Map<String, Object> metrics) {
         this.metrics = metrics;
     }
 
     @Description("Metrics configuration.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Override
     public MetricsConfig getMetricsConfig() {
         return metricsConfig;
     }
 
+    @Override
     public void setMetricsConfig(MetricsConfig metricsConfig) {
         this.metricsConfig = metricsConfig;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
@@ -36,7 +36,7 @@ import java.util.Map;
         "affinity", "tolerations", "jvmOptions",
         "logging", "metrics", "metricsConfig", "tracing", "template"})
 @EqualsAndHashCode
-public class KafkaMirrorMakerSpec extends Spec {
+public class KafkaMirrorMakerSpec extends Spec implements HasConfigurableMetrics {
     private static final long serialVersionUID = 1L;
 
     private static final int DEFAULT_REPLICAS = 3;
@@ -129,20 +129,24 @@ public class KafkaMirrorMakerSpec extends Spec {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Description("The Prometheus JMX Exporter configuration. " +
             "See {JMXExporter} for details of the structure of this configuration.")
+    @Override
     public Map<String, Object> getMetrics() {
         return metrics;
     }
 
+    @Override
     public void setMetrics(Map<String, Object> metrics) {
         this.metrics = metrics;
     }
 
     @Description("Metrics configuration.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Override
     public MetricsConfig getMetricsConfig() {
         return metricsConfig;
     }
 
+    @Override
     public void setMetricsConfig(MetricsConfig metricsConfig) {
         this.metricsConfig = metricsConfig;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
@@ -42,7 +42,7 @@ import java.util.Map;
         "jvmOptions", "resources",
          "metrics", "metricsConfig", "logging", "template"})
 @EqualsAndHashCode
-public class ZookeeperClusterSpec implements UnknownPropertyPreserving, Serializable {
+public class ZookeeperClusterSpec implements HasConfigurableMetrics, UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -186,20 +186,24 @@ public class ZookeeperClusterSpec implements UnknownPropertyPreserving, Serializ
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("The Prometheus JMX Exporter configuration. " +
             "See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.")
+    @Override
     public Map<String, Object> getMetrics() {
         return metrics;
     }
 
+    @Override
     public void setMetrics(Map<String, Object> metrics) {
         this.metrics = metrics;
     }
 
     @Description("Metrics configuration.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Override
     public MetricsConfig getMetricsConfig() {
         return metricsConfig;
     }
 
+    @Override
     public void setMetricsConfig(MetricsConfig metricsConfig) {
         this.metricsConfig = metricsConfig;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -173,7 +173,7 @@ public class CruiseControl extends AbstractModel {
     @SuppressWarnings("deprecation")
     public static CruiseControl fromCrd(Kafka kafkaAssembly, KafkaVersion.Lookup versions) {
         CruiseControl cruiseControl = null;
-        CruiseControlSpec spec  = kafkaAssembly.getSpec().getCruiseControl();
+        CruiseControlSpec spec = kafkaAssembly.getSpec().getCruiseControl();
         KafkaClusterSpec kafkaClusterSpec = kafkaAssembly.getSpec().getKafka();
 
         if (spec != null) {
@@ -214,12 +214,8 @@ public class CruiseControl extends AbstractModel {
             cruiseControl.brokerInboundNetworkKiBPerSecondCapacity = capacity.getInboundNetworkKiBPerSecond();
             cruiseControl.brokerOuboundNetworkKiBPerSecondCapacity = capacity.getOutboundNetworkKiBPerSecond();
 
-            Map<String, Object> metrics = spec.getMetrics();
-            if (metrics != null) {
-                cruiseControl.setMetricsEnabled(true);
-                cruiseControl.setMetricsConfig(metrics.entrySet());
-            }
-            cruiseControl.setMetricsConfigInCm(spec.getMetricsConfig());
+            // Parse different types of metrics configurations
+            ModelUtils.parseMetrics(cruiseControl, spec);
 
             if (spec.getReadinessProbe() != null) {
                 cruiseControl.setReadinessProbe(spec.getReadinessProbe());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -477,12 +477,8 @@ public class KafkaCluster extends AbstractModel {
         }
         result.setConfiguration(configuration);
 
-        Map<String, Object> metrics = kafkaClusterSpec.getMetrics();
-        if (metrics != null) {
-            result.setMetricsEnabled(true);
-            result.setMetricsConfig(metrics.entrySet());
-        }
-        result.setMetricsConfigInCm(kafkaClusterSpec.getMetricsConfig());
+        // Parse different types of metrics configurations
+        ModelUtils.parseMetrics(result, kafkaClusterSpec);
 
         if (oldStorage != null) {
             Storage newStorage = kafkaClusterSpec.getStorage();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -243,12 +243,9 @@ public class KafkaConnectCluster extends AbstractModel {
         }
         kafkaConnect.setInitImage(initImage);
 
-        Map<String, Object> metrics = spec.getMetrics();
-        if (metrics != null) {
-            kafkaConnect.setMetricsEnabled(true);
-            kafkaConnect.setMetricsConfig(metrics.entrySet());
-        }
-        kafkaConnect.setMetricsConfigInCm(spec.getMetricsConfig());
+        // Parse different types of metrics configurations
+        ModelUtils.parseMetrics(kafkaConnect, spec);
+
         kafkaConnect.setBootstrapServers(spec.getBootstrapServers());
 
         kafkaConnect.setTls(spec.getTls());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -156,15 +156,8 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
             }
             kafkaMirrorMakerCluster.setJvmOptions(spec.getJvmOptions());
 
-            Map<String, Object> metrics = spec.getMetrics();
-            if (metrics != null) {
-                kafkaMirrorMakerCluster.setMetricsEnabled(true);
-                kafkaMirrorMakerCluster.setMetricsConfig(metrics.entrySet());
-            }
-            kafkaMirrorMakerCluster.setMetricsConfigInCm(spec.getMetricsConfig());
-
-            /*setClientAuth(kafkaMirrorMakerCluster, spec.getConsumer());
-            setClientAuth(kafkaMirrorMakerCluster, spec.getProducer());*/
+            // Parse different types of metrics configurations
+            ModelUtils.parseMetrics(kafkaMirrorMakerCluster, spec);
 
             if (spec.getTemplate() != null) {
                 KafkaMirrorMakerTemplate template = spec.getTemplate();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -519,12 +519,12 @@ public class ModelUtils {
      * @param resourceWithMetrics       The section of the resource with metrics configuration
      */
     public static void parseMetrics(AbstractModel model, HasConfigurableMetrics resourceWithMetrics)   {
-        if (resourceWithMetrics.getMetrics() != null) {
-            model.setMetricsEnabled(true);
-            model.setMetricsConfig(resourceWithMetrics.getMetrics().entrySet());
-        } else if (resourceWithMetrics.getMetricsConfig() != null)    {
+        if (resourceWithMetrics.getMetricsConfig() != null)    {
             model.setMetricsEnabled(true);
             model.setMetricsConfigInCm(resourceWithMetrics.getMetricsConfig());
+        } else if (resourceWithMetrics.getMetrics() != null) {
+            model.setMetricsEnabled(true);
+            model.setMetricsConfig(resourceWithMetrics.getMetrics().entrySet());
         }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
 import io.strimzi.api.kafka.model.CertificateAuthority;
+import io.strimzi.api.kafka.model.HasConfigurableMetrics;
 import io.strimzi.api.kafka.model.SystemProperty;
 import io.strimzi.api.kafka.model.storage.JbodStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
@@ -509,6 +510,21 @@ public class ModelUtils {
                 peer.setNamespaceSelector(new LabelSelector());
             }
         }
+    }
 
+    /**
+     * Checks if the section of the custom resource has any metrics configuration and sets it in the AbstractModel.
+     *
+     * @param model                     The cluster model where the metrics will be configured
+     * @param resourceWithMetrics       The section of the resource with metrics configuration
+     */
+    public static void parseMetrics(AbstractModel model, HasConfigurableMetrics resourceWithMetrics)   {
+        if (resourceWithMetrics.getMetrics() != null) {
+            model.setMetricsEnabled(true);
+            model.setMetricsConfig(resourceWithMetrics.getMetrics().entrySet());
+        } else if (resourceWithMetrics.getMetricsConfig() != null)    {
+            model.setMetricsEnabled(true);
+            model.setMetricsConfigInCm(resourceWithMetrics.getMetricsConfig());
+        }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -237,12 +237,8 @@ public class ZookeeperCluster extends AbstractModel {
             zk.setJavaSystemProperties(zookeeperClusterSpec.getJvmOptions().getJavaSystemProperties());
         }
 
-        Map<String, Object> metrics = zookeeperClusterSpec.getMetrics();
-        if (metrics != null) {
-            zk.setMetricsEnabled(true);
-            zk.setMetricsConfig(metrics.entrySet());
-        }
-        zk.setMetricsConfigInCm(zookeeperClusterSpec.getMetricsConfig());
+        // Parse different types of metrics configurations
+        ModelUtils.parseMetrics(zk, zookeeperClusterSpec);
 
         if (oldStorage != null) {
             Storage newStorage = zookeeperClusterSpec.getStorage();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -3521,7 +3521,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     metricsCm = Future.succeededFuture(null);
                 }
 
-                CompositeFuture.join(metricsCm, loggingCmFut).compose(metricsAndLoggingCm -> {
+                return CompositeFuture.join(metricsCm, loggingCmFut).compose(metricsAndLoggingCm -> {
                     ConfigMap logAndMetricsConfigMap = cruiseControl.generateMetricsAndLogConfigMap(metricsAndLoggingCm.resultAt(1), metricsAndLoggingCm.resultAt(0));
 
                     Map<String, String> annotations = singletonMap(CruiseControl.ANNO_STRIMZI_IO_LOGGING, logAndMetricsConfigMap.getData().get(ANCILLARY_CM_KEY_LOG_CONFIG));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -116,7 +116,6 @@ public class KafkaMirrorMaker2ClusterTest {
 
     private final KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(ResourceUtils.createEmptyKafkaMirrorMaker2(namespace, cluster))
             .withNewSpec()
-                //.withMetricsConfig(jmxMetricsConfig)
                 .withImage(image)
                 .withReplicas(replicas)
                 .withReadinessProbe(new Probe(healthDelay, healthTimeout))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -421,4 +421,9 @@ public class ModelUtilsTest {
         ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(peer, "my-ns", "my-operator-ns", nsLabels);
         assertThat(peer.getNamespaceSelector().getMatchLabels(), is(nsLabels.toMap()));
     }
+
+    @Test
+    public void testMetricsParsing()    {
+
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -421,9 +421,4 @@ public class ModelUtilsTest {
         ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(peer, "my-ns", "my-operator-ns", nsLabels);
         assertThat(peer.getNamespaceSelector().getMatchLabels(), is(nsLabels.toMap()));
     }
-
-    @Test
-    public void testMetricsParsing()    {
-
-    }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the new metrics configuration from ConfigMap is used, the Prometheus JMX Exporter port is not opened properly on the network policies and that makes the metrics not accessible. This PR properly sets the `metricsEnabled` value when one of the currently supported options is used.

This is a bug in the 0.21.0 release. It needs to be backported to 0.21 release branch and we need to do 0.21.1 release.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally