### PR TITLE
Trigger user-certificate renewal even when it expires independently on the CA

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -210,7 +210,8 @@ public class KafkaUserModel {
                         && userCrt != null
                         && !userCrt.isEmpty()
                         && userKey != null
-                        && !userKey.isEmpty()) {
+                        && !userKey.isEmpty()
+                        && !clientsCa.isExpiring(userSecret, "user.crt")) {
 
                     if (userKeyStore != null
                             && !userKeyStore.isEmpty()
@@ -224,7 +225,6 @@ public class KafkaUserModel {
                                 decodeFromSecret(userSecret, "user.p12"),
                                 new String(decodeFromSecret(userSecret, "user.password"), StandardCharsets.US_ASCII));
                     } else {
-
                         // coming from an older operator version, the user secret exists but without keystore and password
                         try {
                             this.userCertAndKey = clientsCa.addKeyAndCertToKeyStore(name,


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It can happen that the user configures the Kafka cluster with a custom clients CA and also configures some certificate validity which is shorter than the CA validity. In such case, the user certificate needs to renew even when the CA does not change. This does not work in the User Operator because it never checks the expiration of the certificate. It just waits for the CA certificate to change (which would if the CA expires, but not with a custom CA which might have different validity then the user certs).

This PR adds the expiration check for the user certificates and issues a new cert if it expires independently on the CA.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally