### PR TITLE
Fix broken links in the OAuth documentation

### DIFF
--- a/documentation/modules/oauth/con-oauth-reauthentication.adoc
+++ b/documentation/modules/oauth/con-oauth-reauthentication.adoc
@@ -25,4 +25,4 @@ For more information about the re-authentication mechanism, which was added in K
 
 * xref:proc-oauth-authentication-broker-config-{context}[]
 
-* xref:appendix_crds#type-KafkaListenerAuthenticationOAuth-reference[KafkaListenerAuthenticationOAuth schema reference]
+* xref:type-KafkaListenerAuthenticationOAuth-reference[KafkaListenerAuthenticationOAuth schema reference]

--- a/documentation/modules/oauth/proc-oauth-authentication-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authentication-broker-config.adoc
@@ -22,7 +22,7 @@ When configuring the Kafka broker you have two options for the mechanism used to
 
 For more information on the configuration of OAuth 2.0 authentication for Kafka broker listeners, see:
 
-* xref:appendix_crds#type-KafkaListenerAuthenticationOAuth-reference[KafkaListenerAuthenticationOAuth schema reference]
+* xref:type-KafkaListenerAuthenticationOAuth-reference[KafkaListenerAuthenticationOAuth schema reference]
 * xref:assembly-securing-access-{context}[Managing access to Kafka]
 
 .Prerequisites

--- a/documentation/modules/oauth/proc-oauth-kafka-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-kafka-config.adoc
@@ -19,7 +19,7 @@ In this scenario, the Kafka component and the authorization server are running i
 
 For more information on the configuration of OAuth 2.0 authentication for Kafka components, see:
 
-* xref:appendix_crds#type-KafkaClientAuthenticationOAuth-reference[KafkaClientAuthenticationOAuth schema reference]
+* xref:type-KafkaClientAuthenticationOAuth-reference[KafkaClientAuthenticationOAuth schema reference]
 
 .Prerequisites
 
@@ -56,7 +56,7 @@ For OAuth 2.0 authentication, you can use:
 * TLS
 --
 +
-xref:appendix_crds#type-KafkaClientAuthenticationOAuth-reference[KafkaClientAuthenticationOAuth schema reference provides examples of each].
+xref:type-KafkaClientAuthenticationOAuth-reference[KafkaClientAuthenticationOAuth schema reference provides examples of each].
 +
 For example, here OAuth 2.0 is assigned to the Kafka Bridge client using a client ID and secret, and TLS:
 +


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The documentation for Strimzi 0.21.0 has several broker links which just return 404. This PR fixes them. This should be cherry-picked for 0.21.1.