### PR TITLE
Add annotations & labels to Operator

### DIFF
--- a/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -159,6 +159,8 @@ the documentation for more details.
 | `createGlobalResources`              | Allow creation of cluster-scoped resources| `true`                                               |
 | `tolerations`                        | Add tolerations to Operator Pod           | `[]`                                                 |
 | `affinity`                           | Add affinities to Operator Pod            | `{}`                                                 |
+| `annotations`                        | Add annotations to Operator Pod           | `{}`                                                 |
+| `labels`                             | Add labels to Operator Pod                | `{}`                                                 |
 | `nodeSelector`                       | Add a node selector to Operator Pod       | `{}`                                                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -19,6 +19,13 @@ spec:
       labels:
         name: strimzi-cluster-operator
         strimzi.io/kind: cluster-operator
+        {{- with .Values.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: strimzi-cluster-operator
       {{- if .Values.image.imagePullSecrets }}

--- a/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -19,6 +19,8 @@ kubernetesServiceDnsDomain: cluster.local
 
 tolerations: []
 affinity: {}
+annotations: {}
+labels: {}
 nodeSelector: {}
 
 # Docker images that operator uses to provision various components of Strimzi.  To use your own registry prefix the


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description
Ability to add annotations & labels to operator. Issue - https://github.com/strimzi/strimzi-kafka-operator/issues/4278

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

