### PR TITLE
[Doc] Namespace for KafkaConnectors and Kafka Connect

### DIFF
--- a/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
+++ b/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
@@ -20,9 +20,9 @@ Use the `KafkaConnectS2I` resource if you are using the {docs-okd-s2i} framework
 .Additional resources
 
 * link:{BookURLDeploying}#con-creating-managing-connectors-str[Creating and managing connectors^]
-* link:{BookURLDeploying}#proc-deploying-kafkaconnector-str[Deploying a `KafkaConnector` resource to Kafka Connect^]
-* link:{BookURLDeploying}#proc-manual-restart-connector-str[Restart a Kafka connector by annotating a `KafkaConnector` resource^]
-* link:{BookURLDeploying}#proc-manual-restart-connector-task-str[Restart a Kafka connector task by annotating a `KafkaConnector` resource^]
+* link:{BookURLDeploying}#proc-deploying-kafkaconnector-str[Deploying a KafkaConnector resource to Kafka Connect^]
+* link:{BookURLDeploying}#proc-manual-restart-connector-str[Restart a Kafka connector by annotating a KafkaConnector resource^]
+* link:{BookURLDeploying}#proc-manual-restart-connector-task-str[Restart a Kafka connector task by annotating a KafkaConnector resource^]
 
 
 //procedure to configure Kafka Connect

--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
@@ -20,10 +20,10 @@ The procedures in this section show how to:
 * xref:deploying-kafka-connect-{context}[Deploy a Kafka Connect cluster using a `KafkaConnect` resource]
 * xref:con-kafka-connect-multiple-instances-{context}[Run multiple Kafka Connect instances]
 * xref:using-kafka-connect-with-plug-ins-{context}[Create a Kafka Connect image containing the connectors you need to make your connection]
-* xref:con-creating-managing-connectors-{context}[Create and manage connectors using a `KafkaConnector` resource or the Kafka Connect REST API]
-* xref:proc-deploying-kafkaconnector-{context}[Deploy a `KafkaConnector` resource to Kafka Connect]
-* xref:proc-manual-restart-connector-{context}[Restart a Kafka connector by annotating a `KafkaConnector` resource]
-* xref:proc-manual-restart-connector-task-{context}[Restart a Kafka connector task by annotating a `KafkaConnector` resource]
+* xref:con-creating-managing-connectors-{context}[Create and manage connectors using a KafkaConnector resource or the Kafka Connect REST API]
+* xref:proc-deploying-kafkaconnector-{context}[Deploy a KafkaConnector resource to Kafka Connect]
+* xref:proc-manual-restart-connector-{context}[Restart a Kafka connector by annotating a KafkaConnector resource]
+* xref:proc-manual-restart-connector-task-{context}[Restart a Kafka connector task by annotating a KafkaConnector resource]
 
 NOTE: The term _connector_ is used interchangeably to mean a connector instance running within a Kafka Connect cluster, or a connector class.
 In this guide, the term _connector_ is used when the meaning is clear from the context.

--- a/documentation/modules/configuring/proc-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect.adoc
@@ -11,12 +11,13 @@ Use the properties of the `KafkaConnect` or `KafkaConnectS2I` resource to config
 The example shown in this procedure is for the `KafkaConnect` resource, but the properties are the same for the `KafkaConnectS2I` resource.
 
 .Kafka connector configuration
-`KafkaConnector` resources allow you to create and manage connector instances for Kafka Connect in a Kubernetes-native way.
+KafkaConnector resources allow you to create and manage connector instances for Kafka Connect in a Kubernetes-native way.
 
-In the configuration, you enable `KafkaConnectors` for a Kafka Connect cluster by adding the `strimzi.io/use-connector-resources` annotation.
+In the configuration, you enable KafkaConnectors for a Kafka Connect cluster by adding the `strimzi.io/use-connector-resources` annotation.
 You can also specify external configuration for Kafka Connect connectors through the `externalConfiguration` property.
 
-Connectors are created, reconfigured, and deleted using the Kafka Connect HTTP REST interface, or by using `KafkaConnectors`.
+Connectors are created, reconfigured, and deleted using the Kafka Connect HTTP REST interface, or by using KafkaConnectors.
+KafkaConnector resources must be deployed to the same namespace as the Kafka connect cluster they link to.
 For more information on these methods, see link:{BookURLDeploying}#con-creating-managing-connectors-str[Creating and managing connectors^] in the _Deploying and Upgrading Strimzi_ guide.
 
 The connector configuration is passed to Kafka Connect as part of an HTTP request and stored within Kafka itself.
@@ -140,7 +141,7 @@ spec:
           value: "6831"
 ----
 <1> Use `KafkaConnect` or `KafkaConnectS2I`, as required.
-<2> Enables `KafkaConnectors` for the Kafka Connect cluster.
+<2> Enables KafkaConnectors for the Kafka Connect cluster.
 <3> xref:con-common-configuration-replicas-reference[The number of replica nodes].
 <4> Authentication for the Kafka Connect cluster, using the xref:type-KafkaClientAuthenticationTls-reference[TLS mechanism], as shown here, using xref:type-KafkaClientAuthenticationOAuth-reference[OAuth bearer tokens], or a SASL-based xref:type-KafkaClientAuthenticationScramSha512-reference[SCRAM-SHA-512] or xref:type-KafkaClientAuthenticationPlain-reference[PLAIN] mechanism.
 By default, Kafka Connect connects to Kafka brokers using a plain text connection.

--- a/documentation/modules/configuring/proc-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect.adoc
@@ -17,7 +17,7 @@ In the configuration, you enable KafkaConnectors for a Kafka Connect cluster by 
 You can also specify external configuration for Kafka Connect connectors through the `externalConfiguration` property.
 
 Connectors are created, reconfigured, and deleted using the Kafka Connect HTTP REST interface, or by using KafkaConnectors.
-KafkaConnector resources must be deployed to the same namespace as the Kafka connect cluster they link to.
+KafkaConnector resources must be deployed to the same namespace as the Kafka Connect cluster they link to.
 For more information on these methods, see link:{BookURLDeploying}#con-creating-managing-connectors-str[Creating and managing connectors^] in the _Deploying and Upgrading Strimzi_ guide.
 
 The connector configuration is passed to Kafka Connect as part of an HTTP request and stored within Kafka itself.

--- a/documentation/modules/deploying/con-deploy-kafka-connect-managing-connectors.adoc
+++ b/documentation/modules/deploying/con-deploy-kafka-connect-managing-connectors.adoc
@@ -36,7 +36,7 @@ Using the APIs, you can:
 
 KafkaConnectors allow you to create and manage connector instances for Kafka Connect in a Kubernetes-native way, so an HTTP client such as cURL is not required.
 Like other Kafka resources, you declare a connector’s desired state in a KafkaConnector YAML file that is deployed to your Kubernetes cluster to create the connector instance.
-KafkaConnector resources must be deployed to the same namespace as the Kafka connect cluster they link to.
+KafkaConnector resources must be deployed to the same namespace as the Kafka Connect cluster they link to.
 
 You manage a running connector instance by updating its corresponding KafkaConnector resource, and then applying the updates.
 You remove a connector by deleting its corresponding KafkaConnector.

--- a/documentation/modules/deploying/con-deploy-kafka-connect-managing-connectors.adoc
+++ b/documentation/modules/deploying/con-deploy-kafka-connect-managing-connectors.adoc
@@ -19,7 +19,7 @@ Sink connector:: A sink connector is a runtime entity that fetches messages from
 
 Strimzi provides two APIs for creating and managing connectors:
 
-* `KafkaConnector` resources (referred to as `KafkaConnectors`)
+* KafkaConnector resources (referred to as KafkaConnectors)
 * Kafka Connect REST API
 
 Using the APIs, you can:
@@ -27,22 +27,24 @@ Using the APIs, you can:
 * Check the status of a connector instance
 * Reconfigure a running connector
 * Increase or decrease the number of tasks for a connector instance
-* Restart failed tasks (not supported by `KafkaConnector` resource)
+* Restart failed tasks (not supported by KafkaConnector resource)
 * Pause a connector instance
 * Resume a previously paused connector instance
 * Delete a connector instance
 
-== `KafkaConnector` resources
+== KafkaConnector resources
 
-`KafkaConnectors` allow you to create and manage connector instances for Kafka Connect in a Kubernetes-native way, so an HTTP client such as cURL is not required.
-Like other Kafka resources, you declare a connector’s desired state in a `KafkaConnector` YAML file that is deployed to your Kubernetes cluster to create the connector instance.
+KafkaConnectors allow you to create and manage connector instances for Kafka Connect in a Kubernetes-native way, so an HTTP client such as cURL is not required.
+Like other Kafka resources, you declare a connector’s desired state in a KafkaConnector YAML file that is deployed to your Kubernetes cluster to create the connector instance.
+KafkaConnector resources must be deployed to the same namespace as the Kafka connect cluster they link to.
 
-You manage a running connector instance by updating its corresponding `KafkaConnector`, and then applying the updates. You remove a connector by deleting its corresponding `KafkaConnector`.
+You manage a running connector instance by updating its corresponding KafkaConnector resource, and then applying the updates.
+You remove a connector by deleting its corresponding KafkaConnector.
 
-To ensure compatibility with earlier versions of Strimzi, `KafkaConnectors` are disabled by default. To enable them for a Kafka Connect cluster, you must use annotations on the `KafkaConnect` resource.
+To ensure compatibility with earlier versions of Strimzi, KafkaConnectors are disabled by default. To enable them for a Kafka Connect cluster, you must use annotations on the `KafkaConnect` resource.
 For instructions, see link:{BookURLUsing}#proc-kafka-connect-config-str[Configuring Kafka Connect^] in the _Using Strimzi_ guide.
 
-When `KafkaConnectors` are enabled, the Cluster Operator begins to watch for them. It updates the configurations of running connector instances to match the configurations defined in their `KafkaConnectors`.
+When KafkaConnectors are enabled, the Cluster Operator begins to watch for them. It updates the configurations of running connector instances to match the configurations defined in their KafkaConnectors.
 
 Strimzi includes an example `KafkaConnector`, named `examples/connect/source-connector.yaml`. You can use this example to create and manage a `FileStreamSourceConnector`.
 
@@ -50,6 +52,6 @@ Strimzi includes an example `KafkaConnector`, named `examples/connect/source-con
 
 The Kafka Connect REST API is available on port 8083 as the `<connect-cluster-name>-connect-api` service.
 
-If `KafkaConnectors` are enabled, manual changes made directly using the Kafka Connect REST API are reverted by the Cluster Operator.
+If KafkaConnectors are enabled, manual changes made directly using the Kafka Connect REST API are reverted by the Cluster Operator.
 
 The operations supported by the REST API are described in the link:https://kafka.apache.org/documentation/#connect_rest[Apache Kafka documentation^].

--- a/documentation/modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc
@@ -61,7 +61,7 @@ $ kubectl apply -f _KAFKA-CONNECT-CONFIG-FILE_
 
 . Wait for the new container image to build, and for the Kafka Connect cluster to be deployed.
 
-. Use the Kafka Connect REST API or the `KafkaConnector` custom resources to use the connector plugins you added.
+. Use the Kafka Connect REST API or the KafkaConnector custom resources to use the connector plugins you added.
 
 .Additional resources
 

--- a/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
@@ -49,7 +49,7 @@ spec:
 ----
 +
 <1> Name of the KafkaConnector resource, which is used as the name of the connector. Use any name that is valid for a Kubernetes resource.
-<2> Name of the Kafka Connect cluster to create the connector in. Connectors must be deployed to the same namespace as the Kafka connect cluster they link to.
+<2> Name of the Kafka Connect cluster to create the connector instance in. Connectors must be deployed to the same namespace as the Kafka Connect cluster they link to.
 <3> Full name or alias of the connector class. This should be present in the image being used by the Kafka Connect cluster.
 <4> Maximum number of Kafka Connect `Tasks` that the connector can create.
 <5> xref:kafkaconnector-configs[Connector configuration] as key-value pairs.

--- a/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
@@ -3,12 +3,12 @@
 // assembly-kafka-connect.adoc
 
 [id='proc-deploying-kafkaconnector-{context}']
-= Deploying the example `KafkaConnector` resources
+= Deploying the example KafkaConnector resources
 
-Strimzi includes an example `KafkaConnector` in `examples/connect/source-connector.yaml`. 
-This creates a basic `FileStreamSourceConnector` instance that sends each line of the Kafka license file (an example file source) to a single Kafka topic. 
+Strimzi includes an example `KafkaConnector` in `examples/connect/source-connector.yaml`.
+This creates a basic `FileStreamSourceConnector` instance that sends each line of the Kafka license file (an example file source) to a single Kafka topic.
 
-This procedure describes how to create: 
+This procedure describes how to create:
 
 * A `FileStreamSourceConnector` that reads data from the Kafka license file (the source) and writes the data as messages to a Kafka topic.
 
@@ -24,7 +24,7 @@ The `FileStreamSourceConnector` and `FileStreamSinkConnector` are provided as ex
 .Prerequisites
 
 * A Kafka Connect deployment
-* link:{BookURLUsing}#proc-enabling-kafkaconnectors-deployment-configuration-kafka-connect[`KafkaConnectors` are enabled^]
+* link:{BookURLUsing}#proc-kafka-connect-config-str[KafkaConnectors are enabled in the Kafka Connect deployment^]
 * The Cluster Operator is running
 
 .Procedure
@@ -48,12 +48,12 @@ spec:
     # ...
 ----
 +
-<1> Name of the `KafkaConnector` resource, which is used as the name of the connector. Use any name that is valid for a Kubernetes resource.
-<2> Name of the Kafka Connect cluster to create the connector in.
+<1> Name of the KafkaConnector resource, which is used as the name of the connector. Use any name that is valid for a Kubernetes resource.
+<2> Name of the Kafka Connect cluster to create the connector in. Connectors must be deployed to the same namespace as the Kafka connect cluster they link to.
 <3> Full name or alias of the connector class. This should be present in the image being used by the Kafka Connect cluster.
 <4> Maximum number of Kafka Connect `Tasks` that the connector can create.
-<5> xref:#kafkaconnector-configs[Connector configuration] as key-value pairs.
-<6> This example source connector configuration reads data from the `/opt/kafka/LICENSE` file. 
+<5> xref:kafkaconnector-configs[Connector configuration] as key-value pairs.
+<6> This example source connector configuration reads data from the `/opt/kafka/LICENSE` file.
 <7> Kafka topic to publish the source data to.
 
 . Create the source `KafkaConnector` in your Kubernetes cluster:
@@ -82,7 +82,7 @@ metadata:
     strimzi.io/cluster: my-connect
 spec:
   class: org.apache.kafka.connect.file.FileStreamSinkConnector <1>
-  tasksMax: 2 
+  tasksMax: 2
   config: <2>
     file: "/tmp/my-file" <3>
     topics: my-topic <4>
@@ -123,9 +123,9 @@ kubectl exec _MY-CLUSTER_-kafka-0 -i -t -- bin/kafka-console-consumer.sh --boots
 [discrete]
 == Source and sink connector configuration options
 
-The connector configuration is defined in the `spec.config` property of the `KafkaConnector` resource.
+The connector configuration is defined in the `spec.config` property of the KafkaConnector resource.
 
-The `FileStreamSourceConnector` and `FileStreamSinkConnector` classes support the same configuration options as the Kafka Connect REST API. 
+The `FileStreamSourceConnector` and `FileStreamSinkConnector` classes support the same configuration options as the Kafka Connect REST API.
 Other connectors support different configuration options.
 
 .Configuration options for the `FileStreamSource` connector class

--- a/documentation/modules/managing/con-custom-resources-status.adoc
+++ b/documentation/modules/managing/con-custom-resources-status.adoc
@@ -30,7 +30,7 @@ m¦KafkaConnectS2I
 
 m¦KafkaConnector
 ¦xref:type-KafkaConnectorStatus-reference[]
-¦`KafkaConnector` resources, if deployed.
+¦KafkaConnector resources, if deployed.
 
 m¦KafkaMirrorMaker
 ¦xref:type-KafkaMirrorMakerStatus-reference[]

--- a/documentation/modules/overview/con-configuration-points-connect.adoc
+++ b/documentation/modules/overview/con-configuration-points-connect.adoc
@@ -91,10 +91,10 @@ spec:
 [discrete]
 == Managing connectors
 
-You can use the `KafkaConnector` resource or the link:https://kafka.apache.org/documentation/#connect_rest[Kafka Connect REST API] to create and manage connector instances in a Kafka Connect cluster.
-The `KafkaConnector` resource offers a Kubernetes-native approach, and is managed by the Cluster Operator.
+You can use the KafkaConnector resource or the link:https://kafka.apache.org/documentation/#connect_rest[Kafka Connect REST API] to create and manage connector instances in a Kafka Connect cluster.
+The KafkaConnector resource offers a Kubernetes-native approach, and is managed by the Cluster Operator.
 
-The `spec` for the `KafkaConnector` resource specifies the connector class and configuration settings, as well as the maximum number of connector _tasks_ to handle the data.
+The `spec` for the KafkaConnector resource specifies the connector class and configuration settings, as well as the maximum number of connector _tasks_ to handle the data.
 
 [discrete]
 == Example YAML showing KafkaConnector configuration
@@ -115,7 +115,8 @@ spec:
     # ...
 ----
 
-You enable `KafkaConnectors` by adding an annotation to the `KafkaConnect` resource.
+You enable KafkaConnectors by adding an annotation to the `KafkaConnect` resource.
+KafkaConnector resources must be deployed to the same namespace as the Kafka connect cluster they link to.
 
 [discrete]
 == Example YAML showing annotation to enable KafkaConnector

--- a/documentation/modules/overview/con-configuration-points-connect.adoc
+++ b/documentation/modules/overview/con-configuration-points-connect.adoc
@@ -116,7 +116,7 @@ spec:
 ----
 
 You enable KafkaConnectors by adding an annotation to the `KafkaConnect` resource.
-KafkaConnector resources must be deployed to the same namespace as the Kafka connect cluster they link to.
+KafkaConnector resources must be deployed to the same namespace as the Kafka Connect cluster they link to.
 
 [discrete]
 == Example YAML showing annotation to enable KafkaConnector

--- a/documentation/modules/proc-manual-restart-connector-task.adoc
+++ b/documentation/modules/proc-manual-restart-connector-task.adoc
@@ -13,11 +13,11 @@ This procedure describes how to manually trigger a restart of a Kafka connector 
 
 .Procedure
 
-. Find the name of the `KafkaConnector` custom resource that controls the Kafka connector task you want to restart:
+. Find the name of the KafkaConnector custom resource that controls the Kafka connector task you want to restart:
 [source,shell,subs=+quotes]
 kubectl get KafkaConnector
 
-. Find the ID of the task to be restarted from the `KafkaConnector` custom resource.
+. Find the ID of the task to be restarted from the KafkaConnector custom resource.
 Task IDs are non-negative integers, starting from 0:
 [source,shell,subs=+quotes]
 kubectl describe KafkaConnector _KafkaConnector-name_
@@ -30,4 +30,4 @@ kubectl annotate KafkaConnector _KafkaConnector-name_ strimzi.io/restart-task=0
 
 . Wait for the next reconciliation to occur (every two minutes by default).
 The Kafka connector task is restarted, as long as the annotation was detected by the reconciliation process.
-When Kafka Connect accepts the restart request, the annotation is removed from the `KafkaConnector` custom resource.
+When Kafka Connect accepts the restart request, the annotation is removed from the KafkaConnector custom resource.

--- a/documentation/modules/proc-manual-restart-connector-task.adoc
+++ b/documentation/modules/proc-manual-restart-connector-task.adoc
@@ -22,7 +22,7 @@ Task IDs are non-negative integers, starting from 0:
 [source,shell,subs=+quotes]
 kubectl describe KafkaConnector _KafkaConnector-name_
 
-. To restart the connector task, annotate the `KafkaConnector` resource in Kubernetes.
+. To restart the connector task, annotate the KafkaConnector resource in Kubernetes.
 For example, using `kubectl annotate` to restart task 0:
 [source,shell,subs=+quotes]
 kubectl annotate KafkaConnector _KafkaConnector-name_ strimzi.io/restart-task=0

--- a/documentation/modules/proc-manual-restart-connector.adoc
+++ b/documentation/modules/proc-manual-restart-connector.adoc
@@ -13,7 +13,7 @@ This procedure describes how to manually trigger a restart of a Kafka connector 
 
 .Procedure
 
-. Find the name of the `KafkaConnector` custom resource that controls the Kafka connector you want to restart:
+. Find the name of the KafkaConnector custom resource that controls the Kafka connector you want to restart:
 [source,shell,subs=+quotes]
 kubectl get KafkaConnector
 
@@ -24,4 +24,4 @@ kubectl annotate KafkaConnector _KafkaConnector-name_ strimzi.io/restart=true
 
 . Wait for the next reconciliation to occur (every two minutes by default).
 The Kafka connector is restarted, as long as the annotation was detected by the reconciliation process.
-When Kafka Connect accepts the restart request, the annotation is removed from the `KafkaConnector` custom resource.
+When Kafka Connect accepts the restart request, the annotation is removed from the KafkaConnector custom resource.

--- a/documentation/modules/proc-manual-restart-connector.adoc
+++ b/documentation/modules/proc-manual-restart-connector.adoc
@@ -17,7 +17,7 @@ This procedure describes how to manually trigger a restart of a Kafka connector 
 [source,shell,subs=+quotes]
 kubectl get KafkaConnector
 
-. To restart the connector, annotate the `KafkaConnector` resource in Kubernetes.
+. To restart the connector, annotate the KafkaConnector resource in Kubernetes.
 For example, using `kubectl annotate`:
 [source,shell,subs=+quotes]
 kubectl annotate KafkaConnector _KafkaConnector-name_ strimzi.io/restart=true


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Updates to _Using_, _Deploying_ and _Overview_ guides to make clear that KafkaConnector resources must be deployed to the same namespace as the Kafka Connect cluster they connect to.

Also, link fix and change to formatting for KafkaConnector/KafkaConnectors resource names (no monospace)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

