### PR TITLE
Prepare KRAO for deprecated properties

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -274,7 +274,7 @@ public abstract class AbstractOperator<
         return result.future();
     }
 
-    private void addWarningsToStatus(Status status, Set<Condition> unknownAndDeprecatedConditions)   {
+    protected void addWarningsToStatus(Status status, Set<Condition> unknownAndDeprecatedConditions)   {
         if (status != null)  {
             status.addConditions(unknownAndDeprecatedConditions);
         }
@@ -388,8 +388,9 @@ public abstract class AbstractOperator<
      * if the resource can safely be reconciled (e.g. it merely using deprecated API).
      * @param resource The custom resource
      * @throws InvalidResourceException if the resource cannot be safely reconciled.
+     * @return set of conditions
      */
-    /*test*/ Set<Condition> validate(T resource) {
+    /*test*/ public Set<Condition> validate(T resource) {
         if (resource != null) {
             Set<Condition> warningConditions = new LinkedHashSet<>(0);
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -15,7 +15,9 @@ import io.vertx.core.AsyncResult;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 public class StatusUtils {
     private static final String V1ALPHA1 = Constants.RESOURCE_GROUP_NAME + "/" + Constants.V1ALPHA1;
@@ -99,7 +101,12 @@ public class StatusUtils {
             status.setObservedGeneration(resource.getMetadata().getGeneration());
         }
         Condition condition = StatusUtils.buildCondition(type, conditionStatus, null);
-        status.setConditions(Collections.singletonList(condition));
+        List<Condition> conditionList = new ArrayList<>();
+        if (status.getConditions() != null) {
+            conditionList.addAll(status.getConditions());
+        }
+        conditionList.add(condition);
+        status.setConditions(conditionList);
     }
 
     public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, String type) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -100,12 +100,18 @@ public class StatusUtils {
         if (resource.getMetadata().getGeneration() != null)    {
             status.setObservedGeneration(resource.getMetadata().getGeneration());
         }
-        Condition condition = StatusUtils.buildCondition(type, conditionStatus, null);
         List<Condition> conditionList = new ArrayList<>();
-        if (status.getConditions() != null) {
-            conditionList.addAll(status.getConditions());
-        }
+        Condition condition = StatusUtils.buildCondition(type, conditionStatus, null);
         conditionList.add(condition);
+
+        if (status.getConditions() != null) {
+            status.getConditions().forEach(cond -> {
+                if ("UnknownFields".equals(cond.getReason()) || "DeprecatedFields".equals(cond.getReason())) {
+                    conditionList.add(cond);
+                }
+            });
+        }
+
         status.setConditions(conditionList);
     }
 


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement / new feature

### Description
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/3637

The `KafkaRebalanceAssemblyOperator` does not put any warning about deprecated properties used in the CR.
Since there is no deprecated property yet, I marked one of the present ones as deprecated just for the test and then reverted it.
The status of the KafkaRebalance CR with deprecated property then looks like this:
```
status:
  conditions:
  - lastTransitionTime: 2021-01-20T12:26:14.219971Z
    status: "True"
    type: ProposalReady
  - lastTransitionTime: 2021-01-20T13:52:50.022206Z
    message: In API version kafka.strimzi.io/v1alpha1 the property goals at path spec.goals
      has been deprecated. This feature should now be configured at path test.
    reason: DeprecatedFields
    status: "True"
    type: Warning
  - lastTransitionTime: 2021-01-20T13:52:50.708662Z
    status: "True"
    type: ProposalReady
```
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

