### PR TITLE
Update grafana version to 7.3.7

### DIFF
--- a/examples/metrics/grafana-dashboards/strimzi-cruise-control.json
+++ b/examples/metrics/grafana-dashboards/strimzi-cruise-control.json
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "6.3.0"
+      "version": "7.3.7"
     },
     {
       "type": "panel",

--- a/examples/metrics/grafana-dashboards/strimzi-kafka-bridge.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kafka-bridge.json
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "6.2.5"
+      "version": "7.3.7"
     },
     {
       "type": "panel",

--- a/examples/metrics/grafana-dashboards/strimzi-kafka-connect.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kafka-connect.json
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.2.0"
+      "version": "7.3.7"
     },
     {
       "type": "panel",

--- a/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
@@ -15,7 +15,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.2.0"
+      "version": "7.3.7"
     },
     {
       "type": "panel",

--- a/examples/metrics/grafana-dashboards/strimzi-kafka-mirror-maker-2.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kafka-mirror-maker-2.json
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.2.0"
+      "version": "7.3.7"
     },
     {
       "type": "panel",

--- a/examples/metrics/grafana-dashboards/strimzi-kafka.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kafka.json
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.2.0"
+      "version": "7.3.7"
     },
     {
       "type": "panel",

--- a/examples/metrics/grafana-dashboards/strimzi-operators.json
+++ b/examples/metrics/grafana-dashboards/strimzi-operators.json
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.2.0"
+      "version": "7.3.7"
     },
     {
       "type": "panel",

--- a/examples/metrics/grafana-dashboards/strimzi-zookeeper.json
+++ b/examples/metrics/grafana-dashboards/strimzi-zookeeper.json
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.2.4"
+      "version": "7.3.7"
     },
     {
       "type": "panel",

--- a/examples/metrics/grafana-install/grafana.yaml
+++ b/examples/metrics/grafana-install/grafana.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: grafana/grafana:6.3.0
+        image: grafana/grafana:7.3.7
         ports:
         - name: grafana
           containerPort: 3000


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement

### Description
Currently we are using [v6.3.0](https://github.com/grafana/grafana/releases/tag/v6.3.0) which is over 5000 commits behind the master. Upgrading to 7.3.7.

Proof it still works:
![Snímek z 2021-01-21 12-42-10](https://user-images.githubusercontent.com/19408098/105346618-249ff300-5be6-11eb-864b-9f14abab1e20.png)

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards

