### PR TITLE
ST: Change connector in s2i tests and make it working again

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -56,7 +56,7 @@ public class ClientUtils {
     public static void waitForClientSuccess(String jobName, String namespace, int messageCount) {
         LOGGER.info("Waiting for producer/consumer:{} will be finished", jobName);
         TestUtils.waitFor("job finished", Constants.GLOBAL_POLL_INTERVAL, timeoutForClientFinishJob(messageCount),
-            () -> kubeClient().getJobStatus(jobName));
+            () -> kubeClient().namespace(namespace).getJobStatus(jobName));
     }
 
     private static long timeoutForClientFinishJob(int messagesCount) {


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix
- Refactoring

### Description

This PR fixes issues with `ConnectS2IST`, where MongoDB plugin was too old. We decided to remove it and use there `camel-timer-kafka-connector` instead.

I verified it manually against OCP4 and it's working fine.

We should cherry-pick it to `release-0.21.x`

### Checklist

- [x] Make sure all tests pass

