### PR TITLE
Make grafana sane again

### DIFF
--- a/examples/metrics/grafana-dashboards/strimzi-cruise-control.json
+++ b/examples/metrics/grafana-dashboards/strimzi-cruise-control.json
@@ -94,7 +94,7 @@
           "value": 2
         }
       ],
-      "maxDataPoints": 100,
+      "maxDataPoints": 1,
       "nullPointMode": "connected",
       "nullText": null,
       "options": {},
@@ -122,6 +122,7 @@
         {
           "expr": "kafka_cruisecontrol_loadmonitor_total_monitored_windows_value{namespace=\"$kubernetes_namespace\",strimzi_io_cluster=\"$strimzi_cluster_name\"}",
           "format": "time_series",
+          "instant": true,
           "hide": false,
           "intervalFactor": 1,
           "legendFormat": "",
@@ -180,7 +181,7 @@
           "value": 2
         }
       ],
-      "maxDataPoints": 100,
+      "maxDataPoints": 1,
       "nullPointMode": "connected",
       "nullText": null,
       "options": {},
@@ -206,6 +207,7 @@
         {
           "expr": "kafka_cruisecontrol_loadmonitor_valid_windows_value{namespace=\"$kubernetes_namespace\",strimzi_io_cluster=\"$strimzi_cluster_name\"}",
           "format": "time_series",
+          "instant": true,
           "hide": false,
           "intervalFactor": 1,
           "refId": "A"
@@ -263,7 +265,7 @@
           "value": 2
         }
       ],
-      "maxDataPoints": 100,
+      "maxDataPoints": 1,
       "nullPointMode": "connected",
       "nullText": null,
       "options": {},
@@ -289,6 +291,7 @@
         {
           "expr": "kafka_cruisecontrol_executor_ongoing_execution_non_kafka_assigner_value{namespace=\"$kubernetes_namespace\",strimzi_io_cluster=\"$strimzi_cluster_name\"}",
           "format": "time_series",
+          "instant": true,
           "hide": false,
           "intervalFactor": 1,
           "refId": "A"
@@ -346,7 +349,7 @@
           "value": 2
         }
       ],
-      "maxDataPoints": 100,
+      "maxDataPoints": 1,
       "nullPointMode": "connected",
       "nullText": null,
       "options": {},
@@ -372,6 +375,7 @@
         {
           "expr": "kafka_cruisecontrol_anomalydetector_balancedness_score_value{namespace=\"$kubernetes_namespace\",strimzi_io_cluster=\"$strimzi_cluster_name\"}",
           "format": "time_series",
+          "instant": true,
           "hide": false,
           "intervalFactor": 1,
           "refId": "A"
@@ -429,7 +433,7 @@
           "value": 2
         }
       ],
-      "maxDataPoints": 100,
+      "maxDataPoints": 1,
       "nullPointMode": "connected",
       "nullText": null,
       "options": {},
@@ -455,6 +459,7 @@
         {
           "expr": "kafka_cruisecontrol_loadmonitor_monitored_partitions_percentage_value{namespace=\"$kubernetes_namespace\",strimzi_io_cluster=\"$strimzi_cluster_name\"}",
           "format": "time_series",
+          "instant": true,
           "hide": false,
           "intervalFactor": 1,
           "refId": "A"


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/4266

If the cruise control pod is rolled, old metrics stay in place for a while and the new one appears. So there are two entries of metric for the query which can work with just one entry. I reduced possible datapoints to 1 and set the grafana panel as instant. With some (race) circumstances, the `Only queries that return single series/table is supported` message appears however it disappears in a bit.

![Snímek z 2021-01-21 16-18-50](https://user-images.githubusercontent.com/19408098/105370937-6475d300-5c04-11eb-8ead-41ac261529eb.png)
Left before, right after the changes.


### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards

