### PR TITLE
[DOC] Add build config to example Kafka Connect config procedure

### DIFF
--- a/documentation/modules/configuring/proc-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect.adoc
@@ -13,17 +13,18 @@ The example shown in this procedure is for the `KafkaConnect` resource, but the 
 .Kafka connector configuration
 KafkaConnector resources allow you to create and manage connector instances for Kafka Connect in a Kubernetes-native way.
 
-In the configuration, you enable KafkaConnectors for a Kafka Connect cluster by adding the `strimzi.io/use-connector-resources` annotation.
-You can also specify external configuration for Kafka Connect connectors through the `externalConfiguration` property.
+In your Kafka Connect configuration, you enable KafkaConnectors for a Kafka Connect cluster by adding the `strimzi.io/use-connector-resources` annotation.
+You can also add `build` configuration so that Strimzi automatically builds a container image with the connector plugins you require for your data connections.
+External configuration for Kafka Connect connectors is specified through the `externalConfiguration` property.
 
-Connectors are created, reconfigured, and deleted using the Kafka Connect HTTP REST interface, or by using KafkaConnectors.
+To manage connectors, you can use the Kafka Connect REST API, or use KafkaConnector custom resources.
 KafkaConnector resources must be deployed to the same namespace as the Kafka Connect cluster they link to.
-For more information on these methods, see link:{BookURLDeploying}#con-creating-managing-connectors-str[Creating and managing connectors^] in the _Deploying and Upgrading Strimzi_ guide.
+For more information on using these methods to create, reconfigure, or delete connectors, see link:{BookURLDeploying}#con-creating-managing-connectors-str[Creating and managing connectors^] in the _Deploying and Upgrading Strimzi_ guide.
 
-The connector configuration is passed to Kafka Connect as part of an HTTP request and stored within Kafka itself.
+Connector configuration is passed to Kafka Connect as part of an HTTP request and stored within Kafka itself.
 ConfigMaps and Secrets are standard Kubernetes resources used for storing configurations and confidential data.
 You can use ConfigMaps and Secrets to configure certain elements of a connector.
-You can then reference the configuration values in HTTP REST commands (this keeps the configuration separate and more secure, if needed).
+You can then reference the configuration values in HTTP REST commands, which keeps the configuration separate and more secure, if needed.
 This method applies especially to confidential data, such as usernames, passwords, or certificates.
 
 .Prerequisites
@@ -42,7 +43,7 @@ See the _Deploying and Upgrading Strimzi_ guide for instructions on running a:
 +
 The properties you can configure are shown in this example configuration:
 +
-[source,yaml,subs=attributes+]
+[source,yaml,subs=attributes+,options="nowrap"]
 ----
 apiVersion: {KafkaApiVersion}
 kind: KafkaConnect <1>
@@ -77,7 +78,23 @@ spec:
     config.storage.replication.factor: 3
     offset.storage.replication.factor: 3
     status.storage.replication.factor: 3
-  externalConfiguration: <8>
+  build: <8>
+    output: <9>
+      type: docker
+      image: my-registry.io/my-org/my-connect-cluster:latest
+      pushSecret: my-registry-credentials
+    plugins: <10>
+      - name: debezium-postgres-connector
+        artifacts:
+          - type: tgz
+            url: https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/1.3.1.Final/debezium-connector-postgres-1.3.1.Final-plugin.tar.gz
+            sha512sum: 962a12151bdf9a5a30627eebac739955a4fd95a08d373b86bdcea2b4d0c27dd6e1edd5cb548045e115e33a9e69b1b2a352bee24df035a0447cb820077af00c03
+      - name: camel-telegram
+        artifacts:
+          - type: tgz
+            url: https://repo.maven.apache.org/maven2/org/apache/camel/kafkaconnector/camel-telegram-kafka-connector/0.7.0/camel-telegram-kafka-connector-0.7.0-package.tar.gz
+            sha512sum: a9b1ac63e3284bea7836d7d24d84208c49cdf5600070e6bd1535de654f6920b74ad950d51733e8020bf4187870699819f54ef5859c7846ee4081507f48873479
+  externalConfiguration: <11>
     env:
       - name: AWS_ACCESS_KEY_ID
         valueFrom:
@@ -89,36 +106,36 @@ spec:
           secretKeyRef:
             name: aws-creds
             key: awsSecretAccessKey
-  resources: <9>
+  resources: <12>
     requests:
       cpu: "1"
       memory: 2Gi
     limits:
       cpu: "2"
       memory: 2Gi
-  logging: <10>
+  logging: <13>
     type: inline
     loggers:
       log4j.rootLogger: "INFO"
-  readinessProbe: <11>
+  readinessProbe: <14>
     initialDelaySeconds: 15
     timeoutSeconds: 5
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5
-  metricsConfig: <12>
+  metricsConfig: <15>
     type: jmxPrometheusExporter
     valueFrom:
       configMapKeyRef:
         name: my-config-map
         key: my-key
-  jvmOptions: <13>
+  jvmOptions: <16>
     "-Xmx": "1g"
     "-Xms": "1g"
-  image: my-org/my-image:latest <14>
+  image: my-org/my-image:latest <17>
   rack:
-    topologyKey: topology.kubernetes.io/zone <15>
-  template: <16>
+    topologyKey: topology.kubernetes.io/zone <18>
+  template: <19>
     pod:
       affinity:
         podAntiAffinity:
@@ -131,7 +148,7 @@ spec:
                       - postgresql
                       - mongodb
               topologyKey: "kubernetes.io/hostname"
-    connectContainer: <17>
+    connectContainer: <20>
       env:
         - name: JAEGER_SERVICE_NAME
           value: my-jaeger-service
@@ -149,16 +166,19 @@ By default, Kafka Connect connects to Kafka brokers using a plain text connectio
 <6> xref:con-common-configuration-trusted-certificates-reference[TLS encryption] with key names under which TLS certificates are stored in X.509 format for the cluster. If certificates are stored in the same secret, it can be listed multiple times.
 <7> xref:property-kafka-connect-config-reference[Kafka Connect configuration] of _workers_ (not connectors).
 Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi.
-<8> xref:type-ExternalConfiguration-reference[External configuration for Kafka connectors] using environment variables, as shown here, or volumes.
-<9> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
-<10> Specified xref:property-kafka-connect-logging-reference[Kafka Connect loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. For the Kafka Connect `log4j.rootLogger` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
-<11> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
-<12> xref:con-common-configuration-prometheus-reference[Prometheus metrics], which are enabled by referencing a ConfigMap containing configuration for the Prometheus JMX exporter in this example. You can enable metrics without further configuration using a reference to a ConfigMap containing an empty file under `metricsConfig.valueFrom.configMapKeyRef.key`.
-<13> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka Connect.
-<14> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
-<15> xref:type-Rack-reference[Rack awareness] is configured to spread replicas across different racks. A `topologykey` must match the label of a cluster node.
-<16> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<17> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
+<8> xref:type-Build-reference[Build configuration properties] for building a container image with connector plugins automatically.
+<9> (Required) Configuration of the container registry where new images are pushed.
+<10> (Required) List of connector plugins and their artifacts to add to the new container image. Each plugin must be configured with at least one `artifact`.
+<11> xref:type-ExternalConfiguration-reference[External configuration for Kafka connectors] using environment variables, as shown here, or volumes.
+<12> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
+<13> Specified xref:property-kafka-connect-logging-reference[Kafka Connect loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. For the Kafka Connect `log4j.rootLogger` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<14> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
+<15> xref:con-common-configuration-prometheus-reference[Prometheus metrics], which are enabled by referencing a ConfigMap containing configuration for the Prometheus JMX exporter in this example. You can enable metrics without further configuration using a reference to a ConfigMap containing an empty file under `metricsConfig.valueFrom.configMapKeyRef.key`.
+<16> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka Connect.
+<17> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
+<18> xref:type-Rack-reference[Rack awareness] is configured to spread replicas across different racks. A `topologykey` must match the label of a cluster node.
+<19> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
+<20> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
 
 . Create or update the resource:
 +

--- a/documentation/modules/configuring/proc-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect.adoc
@@ -14,7 +14,7 @@ The example shown in this procedure is for the `KafkaConnect` resource, but the 
 KafkaConnector resources allow you to create and manage connector instances for Kafka Connect in a Kubernetes-native way.
 
 In your Kafka Connect configuration, you enable KafkaConnectors for a Kafka Connect cluster by adding the `strimzi.io/use-connector-resources` annotation.
-You can also add `build` configuration so that Strimzi automatically builds a container image with the connector plugins you require for your data connections.
+You can also add a `build` configuration so that Strimzi automatically builds a container image with the connector plugins you require for your data connections.
 External configuration for Kafka Connect connectors is specified through the `externalConfiguration` property.
 
 To manage connectors, you can use the Kafka Connect REST API, or use KafkaConnector custom resources.

--- a/documentation/modules/overview/con-configuration-points-connect.adoc
+++ b/documentation/modules/overview/con-configuration-points-connect.adoc
@@ -66,7 +66,6 @@ The `plugins` properties describe the type of artifact and the URL from which th
 
 .Example Kafka Connect configuration to create a new image automatically
 [source,shell,subs="+quotes,attributes"]
-
 ----
 apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnect

--- a/documentation/modules/overview/con-configuration-points-connect.adoc
+++ b/documentation/modules/overview/con-configuration-points-connect.adoc
@@ -65,7 +65,8 @@ The `output` properties describe the type and name of the image, and optionally 
 The `plugins` properties describe the type of artifact and the URL from which the artifact is downloaded. Additionally, you can specify a SHA-512 checksum to verify the artifact before unpacking it.
 
 .Example Kafka Connect configuration to create a new image automatically
-[source,yaml,subs=quotes,attributes]
+[source,shell,subs="+quotes,attributes"]
+
 ----
 apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnect


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

As we already describe the `use-connector-resources` annotation and `externalConfiguration`, I thought we should add `build` config to the Kafka Connect config example in the _Using Guide_.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

