### PR TITLE
Fixed typo in Kafka resource version

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -85,7 +85,7 @@ import static java.util.Collections.unmodifiableList;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
 @EqualsAndHashCode
-@Version(Constants.V1BETA2)
+@Version(Constants.V1BETA1)
 @Group(Constants.STRIMZI_GROUP)
 public class Kafka extends CustomResource<KafkaSpec, KafkaStatus> implements UnknownPropertyPreserving {
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

While developing an application that uses strimzi api library 0.22.0-SNAPSHOT (for the need of the fabric8 5.0.0 update) and creates a watch on a `Kafka` resource, I am getting the following exception.

`io.fabric8.kubernetes.client.KubernetesClientException: 404 page not found`

It should be related to the fact that the `Kafka` resource is marked with `@Version(Constants.V1BETA2)` so the Kubernetes custom resource client is trying to create the watcher with an HTTP call on a path with v1beta2 while the current master CRDs support v1beta1 and not v1beta2 yet.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

