### PR TITLE
update active controller Prometheus alert to account for multiple clusters

### DIFF
--- a/examples/metrics/prometheus-install/prometheus-rules.yaml
+++ b/examples/metrics/prometheus-install/prometheus-rules.yaml
@@ -26,7 +26,7 @@ spec:
         summary: 'Kafka under replicated partitions'
         description: 'There are {{ $value }} under replicated partitions on {{ $labels.kubernetes_pod_name }}'
     - alert: AbnormalControllerState
-      expr: sum(kafka_controller_kafkacontroller_activecontrollercount) != 1
+      expr: sum(kafka_controller_kafkacontroller_activecontrollercount) by (strimzi_io_name) != 1
       for: 10s
       labels:
         severity: warning


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The current Prometheus alert expression for active controller count does not take into account the possibility of more than one Strimzi cluster being present. When _n_ Strimzi clusters are present, the current expression will also return _n_ (as each cluster rightly has an active controller) and thus triggers a false positive alert. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

