### PR TITLE
NEW(Exec) Do not print stderror when zero return code

### DIFF
--- a/test/src/main/java/io/strimzi/test/executor/Exec.java
+++ b/test/src/main/java/io/strimzi/test/executor/Exec.java
@@ -171,7 +171,7 @@ public class Exec {
                         LOGGER.info("{}", cutExecutorLog(executor.out()));
                         LOGGER.info("======STDOUT END======");
                     }
-                    if (!executor.err().isEmpty()) {
+                    if (!executor.err().isEmpty() && ret != 0) {
                         LOGGER.info("======STDERR START=======");
                         LOGGER.info("{}", cutExecutorLog(executor.err()));
                         LOGGER.info("======STDERR END======");


### PR DESCRIPTION
Experimental small enhancement:

Do not print stderr in systemtests, when running script returns 0. 
This is just an idea and can be refused. I am still 50/50 for usage of it.

### Checklist

- [ ] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
