### PR TITLE
Added implementation of Namespaced interface for custom resources

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -87,7 +88,7 @@ import static java.util.Collections.unmodifiableList;
 @EqualsAndHashCode
 @Version(Constants.V1BETA1)
 @Group(Constants.STRIMZI_GROUP)
-public class Kafka extends CustomResource<KafkaSpec, KafkaStatus> implements UnknownPropertyPreserving {
+public class Kafka extends CustomResource<KafkaSpec, KafkaStatus> implements Namespaced, UnknownPropertyPreserving {
 
     public static final String V1BETA2 = Constants.V1BETA2;
     public static final String V1BETA1 = Constants.V1BETA1;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -88,7 +89,7 @@ import static java.util.Collections.unmodifiableList;
 @EqualsAndHashCode
 @Version(Constants.V1ALPHA1)
 @Group(Constants.STRIMZI_GROUP)
-public class KafkaBridge extends CustomResource<KafkaBridgeSpec, KafkaBridgeStatus> implements UnknownPropertyPreserving {
+public class KafkaBridge extends CustomResource<KafkaBridgeSpec, KafkaBridgeStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -87,7 +88,7 @@ import static java.util.Collections.unmodifiableList;
 @EqualsAndHashCode
 @Version(Constants.V1BETA1)
 @Group(Constants.STRIMZI_GROUP)
-public class KafkaConnect extends CustomResource<KafkaConnectSpec, KafkaConnectStatus> implements UnknownPropertyPreserving {
+public class KafkaConnect extends CustomResource<KafkaConnectSpec, KafkaConnectStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -90,7 +91,7 @@ import static java.util.Collections.unmodifiableList;
 @EqualsAndHashCode
 @Version(Constants.V1BETA1)
 @Group(Constants.STRIMZI_GROUP)
-public class KafkaConnectS2I extends CustomResource<KafkaConnectS2ISpec, KafkaConnectS2IStatus> implements UnknownPropertyPreserving {
+public class KafkaConnectS2I extends CustomResource<KafkaConnectS2ISpec, KafkaConnectS2IStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -89,7 +90,7 @@ import static java.util.Collections.unmodifiableList;
 @ToString
 @Version(Constants.V1ALPHA1)
 @Group(Constants.STRIMZI_GROUP)
-public class KafkaConnector extends CustomResource<KafkaConnectorSpec, KafkaConnectorStatus> implements UnknownPropertyPreserving {
+public class KafkaConnector extends CustomResource<KafkaConnectorSpec, KafkaConnectorStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
     public static final String V1ALPHA1 = Constants.V1ALPHA1;
     public static final List<String> VERSIONS = unmodifiableList(asList(V1ALPHA1));

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -100,7 +101,7 @@ import static java.util.Collections.unmodifiableList;
 @EqualsAndHashCode
 @Version(Constants.V1BETA1)
 @Group(Constants.STRIMZI_GROUP)
-public class KafkaMirrorMaker extends CustomResource<KafkaMirrorMakerSpec, KafkaMirrorMakerStatus> implements UnknownPropertyPreserving {
+public class KafkaMirrorMaker extends CustomResource<KafkaMirrorMakerSpec, KafkaMirrorMakerStatus> implements Namespaced, UnknownPropertyPreserving {
 
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -82,7 +83,7 @@ import static java.util.Collections.unmodifiableList;
 @EqualsAndHashCode
 @Version(Constants.V1ALPHA1)
 @Group(Constants.STRIMZI_GROUP)
-public class KafkaMirrorMaker2 extends CustomResource<KafkaMirrorMaker2Spec, KafkaMirrorMaker2Status> implements UnknownPropertyPreserving {
+public class KafkaMirrorMaker2 extends CustomResource<KafkaMirrorMaker2Spec, KafkaMirrorMaker2Status> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -71,7 +72,7 @@ import static java.util.Collections.unmodifiableList;
 @EqualsAndHashCode
 @Version(Constants.V1ALPHA1)
 @Group(Constants.STRIMZI_GROUP)
-public class KafkaRebalance extends CustomResource<KafkaRebalanceSpec, KafkaRebalanceStatus> implements UnknownPropertyPreserving {
+public class KafkaRebalance extends CustomResource<KafkaRebalanceSpec, KafkaRebalanceStatus> implements Namespaced, UnknownPropertyPreserving {
 
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -93,7 +94,7 @@ import static java.util.Collections.unmodifiableList;
 @EqualsAndHashCode
 @Version(Constants.V1BETA1)
 @Group(Constants.STRIMZI_GROUP)
-public class KafkaTopic extends CustomResource<KafkaTopicSpec, KafkaTopicStatus> implements UnknownPropertyPreserving {
+public class KafkaTopic extends CustomResource<KafkaTopicSpec, KafkaTopicStatus> implements Namespaced, UnknownPropertyPreserving {
 
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -93,7 +94,7 @@ import static java.util.Collections.unmodifiableList;
 @EqualsAndHashCode
 @Version(Constants.V1BETA1)
 @Group(Constants.STRIMZI_GROUP)
-public class KafkaUser extends CustomResource<KafkaUserSpec, KafkaUserStatus> implements UnknownPropertyPreserving {
+public class KafkaUser extends CustomResource<KafkaUserSpec, KafkaUserStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

With the latest fabric8 5.0.0 version, the `CustomResource` derived classes are "cluster" scope by default when they are used via the Strimzi API and using a corresponding Kubernetes client handling them (creation, update, and so on). Of course, the Strimzi operator ones (i.e. `Kafka`, `KafkaBridge` and so on) have to be "namespace" scoped (as declared in the generated CRD) and for that, they need to implement the `Namespaced` interface.
The current tests aren't hitting this problem because when they create a Kubernetes client for the custom resource, they are using the creation via a CRD context and that one is created using the `Crds.crd` method which actually define the right scope for each resource.
Instead, if the Kubernetes client constructor is used without providing such a CRD context parameter (which is possible), the resource is handled as "cluster" scope (due to the missing `Namespaced` interface implementation) and any operation fails with the following error:

```shell
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://192.168.49.2:8443/apis/kafka.strimzi.io/v1beta1/kafkas. Message: 404 page not found
```

In the above output, the `/namespaces/<my-namespace>` part in the path is actually missing due that problem.
This PR fixes this issue.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Make sure all tests pass