### PR TITLE
Extend the timeout of the Build pipeline to 70 minutes

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -24,7 +24,7 @@ jobs:
           jdk_version: '11'
           jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
     # Set timeout for jobs
-    timeoutInMinutes: 60
+    timeoutInMinutes: 70
     # Base system
     pool:
       vmImage: $(image)


### PR DESCRIPTION
### Type of change

- Task

### Description

After the move to Quay.io and after the new Topic Operator Kafka store, the build pipeline in master sometimes runs into the 60 minute limit and timeouts. This Pr increases the timeout to 70 minutes.