### PR TITLE
Use Strimzi version in the filenames of the agents added to the Kafka libs directory

### DIFF
--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -52,9 +52,9 @@ COPY ./exporter-scripts $KAFKA_EXPORTER_HOME
 #####
 # Add Strimzi agents
 #####
-COPY ./tmp/kafka-agent.jar ${KAFKA_HOME}/libs/
-COPY ./tmp/mirror-maker-agent.jar ${KAFKA_HOME}/libs/
-COPY ./tmp/tracing-agent.jar ${KAFKA_HOME}/libs/
+COPY ./tmp/kafka-agent-${STRIMZI_VERSION}.jar ${KAFKA_HOME}/libs/
+COPY ./tmp/mirror-maker-agent-${STRIMZI_VERSION}.jar ${KAFKA_HOME}/libs/
+COPY ./tmp/tracing-agent-${STRIMZI_VERSION}.jar ${KAFKA_HOME}/libs/
 
 #####
 # Add 3rd party libs

--- a/docker-images/kafka/Makefile
+++ b/docker-images/kafka/Makefile
@@ -9,17 +9,17 @@ clean:
 
 .kafka-agent.tmp: ../../kafka-agent/target/kafka-agent-$(RELEASE_VERSION).jar
 	test -d tmp || mkdir tmp
-	cp ../../kafka-agent/target/kafka-agent-$(RELEASE_VERSION).jar tmp/kafka-agent.jar
+	cp ../../kafka-agent/target/kafka-agent-$(RELEASE_VERSION).jar tmp/kafka-agent-$(RELEASE_VERSION).jar
 	touch .kafka-agent.tmp
 
 .mirror-maker-agent.tmp: ../../mirror-maker-agent/target/mirror-maker-agent-$(RELEASE_VERSION).jar
 	test -d tmp || mkdir tmp
-	cp ../../mirror-maker-agent/target/mirror-maker-agent-$(RELEASE_VERSION).jar tmp/mirror-maker-agent.jar
+	cp ../../mirror-maker-agent/target/mirror-maker-agent-$(RELEASE_VERSION).jar tmp/mirror-maker-agent-$(RELEASE_VERSION).jar
 	touch .mirror-maker-agent.tmp
 
 .tracing-agent.tmp: ../../tracing-agent/target/tracing-agent-$(RELEASE_VERSION).jar
 	test -d tmp || mkdir tmp
-	cp ../../tracing-agent/target/tracing-agent-$(RELEASE_VERSION).jar tmp/tracing-agent.jar
+	cp ../../tracing-agent/target/tracing-agent-$(RELEASE_VERSION).jar tmp/tracing-agent-$(RELEASE_VERSION).jar
 	touch .tracing-agent.tmp
 
 .thirdparty-libs-$(THIRD_PARTY_LIBS).tmp: kafka-thirdparty-libs/$(THIRD_PARTY_LIBS)/pom.xml


### PR DESCRIPTION
### Type of change

- Task

### Description

We add several JARs from Strimzi into the `libs` directory of Kafka in our Kafka container images. Currently, they are named just as `tracing-agent.jar` etc. That makes it hard to understand what Strimzi version do they come from. This PR adds Strimzi version into their file name as it is with other JARs in the `libs` directory.