### PR TITLE
Support zip artifacts for KC Build

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Artifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Artifact.java
@@ -42,7 +42,7 @@ public abstract class Artifact implements UnknownPropertyPreserving, Serializabl
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Artifact type. " +
-            "Currently, the supported artifact types are `tgz`, `jar` and `zip`.")
+            "Currently, the supported artifact types are `tgz`, `jar`, and `zip`.")
     public abstract String getType();
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Artifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Artifact.java
@@ -26,7 +26,8 @@ import java.util.Map;
 @JsonSubTypes(
         {
             @JsonSubTypes.Type(value = JarArtifact.class, name = Artifact.TYPE_JAR),
-            @JsonSubTypes.Type(value = TgzArtifact.class, name = Artifact.TYPE_TGZ)
+            @JsonSubTypes.Type(value = TgzArtifact.class, name = Artifact.TYPE_TGZ),
+            @JsonSubTypes.Type(value = ZipArtifact.class, name = Artifact.TYPE_ZIP)
         }
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -36,11 +37,12 @@ public abstract class Artifact implements UnknownPropertyPreserving, Serializabl
 
     public static final String TYPE_JAR = "jar";
     public static final String TYPE_TGZ = "tgz";
+    public static final String TYPE_ZIP = "zip";
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Artifact type. " +
-            "Currently, the supported artifact types are `tgz` and `jar`.")
+            "Currently, the supported artifact types are `tgz`, `jar` and `zip`.")
     public abstract String getType();
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ZipArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ZipArtifact.java
@@ -12,7 +12,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
 /**
- * TGZ artifact represents an artifact which is downloaded and unpacked using `unzip`
+ * ZIP artifact represents an artifact which is downloaded and unpacked using `unzip`
  */
 @Buildable(
         editableEnabled = false,

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ZipArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ZipArtifact.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.connect.build;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.Constants;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+/**
+ * TGZ artifact represents an artifact which is downloaded and unpacked using `unzip`
+ */
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "url", "sha512sum" })
+@EqualsAndHashCode
+public class ZipArtifact extends DownloadableArtifact {
+    private static final long serialVersionUID = 1L;
+
+    @Description("Must be `" + TYPE_ZIP + "`")
+    @Override
+    public String getType() {
+        return TYPE_ZIP;
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfileTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfileTest.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.connect.build.BuildBuilder;
 import io.strimzi.api.kafka.model.connect.build.JarArtifactBuilder;
 import io.strimzi.api.kafka.model.connect.build.PluginBuilder;
 import io.strimzi.api.kafka.model.connect.build.TgzArtifactBuilder;
+import io.strimzi.api.kafka.model.connect.build.ZipArtifactBuilder;
 import org.junit.jupiter.api.Test;
 
 import static io.strimzi.operator.cluster.model.KafkaBrokerConfigurationBuilderTest.IsEquivalent.isEquivalent;
@@ -31,8 +32,17 @@ public class KafkaConnectDockerfileTest {
             .withUrl("https://mydomain.tld/my.tgz")
             .build();
 
+    private final Artifact zipArtifactNoChecksum = new ZipArtifactBuilder()
+            .withUrl("https://mydomain.tld/my.zip")
+            .build();
+
     private final Artifact tgzArtifactWithChecksum = new TgzArtifactBuilder()
             .withUrl("https://mydomain.tld/my2.tgz")
+            .withSha512sum("sha-512-checksum")
+            .build();
+
+    private final Artifact zipArtifactWithChecksum = new ZipArtifactBuilder()
+            .withUrl("https://mydomain.tld/my2.zip")
             .withSha512sum("sha-512-checksum")
             .build();
 
@@ -148,6 +158,51 @@ public class KafkaConnectDockerfileTest {
     }
 
     @Test
+    public void testNoChecksumZipArtifact()   {
+        Build connectBuild = new BuildBuilder()
+                .withPlugins(new PluginBuilder()
+                        .withName("my-connector-plugin")
+                        .withArtifacts(zipArtifactNoChecksum)
+                        .build())
+                .build();
+
+        KafkaConnectDockerfile df = new KafkaConnectDockerfile("myImage:latest", connectBuild);
+
+        assertThat(df.getDockerfile(), isEquivalent("FROM myImage:latest",
+                "USER root:root",
+                "RUN mkdir -p /opt/kafka/plugins/my-connector-plugin/d8d533bc \\",
+                "      && curl -L --output /opt/kafka/plugins/my-connector-plugin/my.zip https://mydomain.tld/my.zip \\",
+                "      && unzip /opt/kafka/plugins/my-connector-plugin/my.zip -d /opt/kafka/plugins/my-connector-plugin/d8d533bc \\",
+                "      && find /opt/kafka/plugins/my-connector-plugin/d8d533bc -type l | xargs rm -f \\",
+                "      && rm -vf /opt/kafka/plugins/my-connector-plugin/my.zip",
+                "USER 1001"));
+    }
+
+    @Test
+    public void testChecksumZipArtifact()   {
+        Build connectBuild = new BuildBuilder()
+                .withPlugins(new PluginBuilder()
+                        .withName("my-connector-plugin")
+                        .withArtifacts(zipArtifactWithChecksum)
+                        .build())
+                .build();
+
+        KafkaConnectDockerfile df = new KafkaConnectDockerfile("myImage:latest", connectBuild);
+
+        assertThat(df.getDockerfile(), isEquivalent("FROM myImage:latest",
+                "USER root:root",
+                "RUN mkdir -p /opt/kafka/plugins/my-connector-plugin/90e04094 \\",
+                "      && curl -L --output /opt/kafka/plugins/my-connector-plugin/my2.zip https://mydomain.tld/my2.zip \\",
+                "      && echo \"sha-512-checksum /opt/kafka/plugins/my-connector-plugin/my2.zip\" > /opt/kafka/plugins/my-connector-plugin/my2.zip.sha512 \\",
+                "      && sha512sum --check /opt/kafka/plugins/my-connector-plugin/my2.zip.sha512 \\",
+                "      && rm -f /opt/kafka/plugins/my-connector-plugin/my2.zip.sha512 \\",
+                "      && unzip /opt/kafka/plugins/my-connector-plugin/my2.zip -d /opt/kafka/plugins/my-connector-plugin/90e04094 \\",
+                "      && find /opt/kafka/plugins/my-connector-plugin/90e04094 -type l | xargs rm -f \\",
+                "      && rm -vf /opt/kafka/plugins/my-connector-plugin/my2.zip",
+                "USER 1001"));
+    }
+
+    @Test
     public void testChecksumTgzArtifact()   {
         Build connectBuild = new BuildBuilder()
                 .withPlugins(new PluginBuilder()
@@ -194,6 +249,35 @@ public class KafkaConnectDockerfileTest {
                 "      && rm -f /opt/kafka/plugins/my-connector-plugin/my2.tgz.sha512 \\",
                 "      && tar xvfz /opt/kafka/plugins/my-connector-plugin/my2.tgz -C /opt/kafka/plugins/my-connector-plugin/638bd501 \\",
                 "      && rm -vf /opt/kafka/plugins/my-connector-plugin/my2.tgz",
+                "USER 1001"));
+    }
+
+    @Test
+    public void testMultipleZipArtifact()   {
+        Build connectBuild = new BuildBuilder()
+                .withPlugins(new PluginBuilder()
+                        .withName("my-connector-plugin")
+                        .withArtifacts(zipArtifactNoChecksum, zipArtifactWithChecksum)
+                        .build())
+                .build();
+
+        KafkaConnectDockerfile df = new KafkaConnectDockerfile("myImage:latest", connectBuild);
+
+        assertThat(df.getDockerfile(), isEquivalent("FROM myImage:latest",
+                "USER root:root",
+                "RUN mkdir -p /opt/kafka/plugins/my-connector-plugin/d8d533bc \\",
+                "      && curl -L --output /opt/kafka/plugins/my-connector-plugin/my.zip https://mydomain.tld/my.zip \\",
+                "      && unzip /opt/kafka/plugins/my-connector-plugin/my.zip -d /opt/kafka/plugins/my-connector-plugin/d8d533bc \\",
+                "      && find /opt/kafka/plugins/my-connector-plugin/d8d533bc -type l | xargs rm -f \\",
+                "      && rm -vf /opt/kafka/plugins/my-connector-plugin/my.zip",
+                "RUN mkdir -p /opt/kafka/plugins/my-connector-plugin/90e04094 \\",
+                "      && curl -L --output /opt/kafka/plugins/my-connector-plugin/my2.zip https://mydomain.tld/my2.zip \\",
+                "      && echo \"sha-512-checksum /opt/kafka/plugins/my-connector-plugin/my2.zip\" > /opt/kafka/plugins/my-connector-plugin/my2.zip.sha512 \\",
+                "      && sha512sum --check /opt/kafka/plugins/my-connector-plugin/my2.zip.sha512 \\",
+                "      && rm -f /opt/kafka/plugins/my-connector-plugin/my2.zip.sha512 \\",
+                "      && unzip /opt/kafka/plugins/my-connector-plugin/my2.zip -d /opt/kafka/plugins/my-connector-plugin/90e04094 \\",
+                "      && find /opt/kafka/plugins/my-connector-plugin/90e04094 -type l | xargs rm -f \\",
+                "      && rm -vf /opt/kafka/plugins/my-connector-plugin/my2.zip",
                 "USER 1001"));
     }
 

--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -7,6 +7,7 @@ ARG strimzi_version
 ARG TARGETPLATFORM
 
 RUN yum -y install gettext nmap-ncat stunnel net-tools && yum clean all -y
+RUN yum -y install unzip && yum clean all -y
 
 # Add kafka user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2358,7 +2358,7 @@ Used in: xref:type-Build-{context}[`Build`]
 |name       1.2+<.<|The unique name of the connector plugin. Will be used to generate the path where the connector artifacts will be stored. The name has to be unique within the KafkaConnect resource. The name has to follow the following pattern: `^[a-z][-_a-z0-9]*[a-z]$`. Required.
 |string
 |artifacts  1.2+<.<|List of artifacts which belong to this connector plugin. Required.
-|xref:type-JarArtifact-{context}[`JarArtifact`], xref:type-TgzArtifact-{context}[`TgzArtifact`] array
+|xref:type-JarArtifact-{context}[`JarArtifact`], xref:type-TgzArtifact-{context}[`TgzArtifact`], xref:type-ZipArtifact-{context}[`ZipArtifact`] array
 |====
 
 [id='type-JarArtifact-{context}']
@@ -2392,6 +2392,23 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |sha512sum  1.2+<.<|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified.
 |string
 |type       1.2+<.<|Must be `tgz`.
+|string
+|====
+
+[id='type-ZipArtifact-{context}']
+### `ZipArtifact` schema reference
+
+Used in: xref:type-Plugin-{context}[`Plugin`]
+
+
+[options="header"]
+|====
+|Property          |Description
+|url        1.2+<.<|URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required.
+|string
+|sha512sum  1.2+<.<|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified.
+|string
+|type       1.2+<.<|Must be `zip`.
 |string
 |====
 

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1698,7 +1698,7 @@ spec:
                                 - jar
                                 - tgz
                                 - zip
-                              description: Artifact type. Currently, the supported artifact types are `tgz`, `jar` and `zip`.
+                              description: Artifact type. Currently, the supported artifact types are `tgz`, `jar`, and `zip`.
                             url:
                               type: string
                               pattern: ^(https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1697,7 +1697,8 @@ spec:
                               enum:
                                 - jar
                                 - tgz
-                              description: Artifact type. Currently, the supported artifact types are `tgz` and `jar`.
+                                - zip
+                              description: Artifact type. Currently, the supported artifact types are `tgz`, `jar` and `zip`.
                             url:
                               type: string
                               pattern: ^(https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -1552,7 +1552,8 @@ spec:
                               enum:
                                 - jar
                                 - tgz
-                              description: Artifact type. Currently, the supported artifact types are `tgz` and `jar`.
+                                - zip
+                              description: Artifact type. Currently, the supported artifact types are `tgz`, `jar` and `zip`.
                             url:
                               type: string
                               pattern: ^(https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -1553,7 +1553,7 @@ spec:
                                 - jar
                                 - tgz
                                 - zip
-                              description: Artifact type. Currently, the supported artifact types are `tgz`, `jar` and `zip`.
+                              description: Artifact type. Currently, the supported artifact types are `tgz`, `jar`, and `zip`.
                             url:
                               type: string
                               pattern: ^(https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1858,7 +1858,7 @@ spec:
                               - tgz
                               - zip
                               description: Artifact type. Currently, the supported
-                                artifact types are `tgz`, `jar` and `zip`.
+                                artifact types are `tgz`, `jar`, and `zip`.
                             url:
                               type: string
                               pattern: ^(https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1856,8 +1856,9 @@ spec:
                               enum:
                               - jar
                               - tgz
+                              - zip
                               description: Artifact type. Currently, the supported
-                                artifact types are `tgz` and `jar`.
+                                artifact types are `tgz`, `jar` and `zip`.
                             url:
                               type: string
                               pattern: ^(https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -1692,8 +1692,9 @@ spec:
                               enum:
                               - jar
                               - tgz
+                              - zip
                               description: Artifact type. Currently, the supported
-                                artifact types are `tgz` and `jar`.
+                                artifact types are `tgz`, `jar` and `zip`.
                             url:
                               type: string
                               pattern: ^(https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -1694,7 +1694,7 @@ spec:
                               - tgz
                               - zip
                               description: Artifact type. Currently, the supported
-                                artifact types are `tgz`, `jar` and `zip`.
+                                artifact types are `tgz`, `jar`, and `zip`.
                             url:
                               type: string
                               pattern: ^(https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement / new feature

### Description
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/4178

https://github.com/strimzi/strimzi-kafka-operator/pull/4168 introduced building from tar.gz and jar artifacts. This PR adds support for zip artifacts. 
The difference between tar.gz and zip is that zip is able to pack symlinks what can lead to the security risk. That is the reason why all the symlinks are removed from the unpacked archive.

This PR can be tested with this resource:
https://pastebin.com/8pR4e52w

### Checklist
- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

