### PR TITLE
Update Cruise Control to 2.5.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Add annotations that enable the operator to restart Kafka Connect connectors or tasks. The annotations can be applied to the KafkaConnector and the KafkaMirrorMaker2 custom resources.
 * Add support for JMX options configuration of all Kafka Connect (KC, KC2SI, MM2)
+* Updated Cruise Control to version 2.5.32
 
 ### Deprecations and removals
 

--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -17,7 +17,7 @@
     </licenses>
 
     <properties>
-        <mockserver.version>5.10.0</mockserver.version>
+        <mockserver.version>5.11.1</mockserver.version>
     </properties>
 
     <dependencies>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.6.1</strimzi-oauth.version>
-        <cruise-control.version>2.5.21</cruise-control.version>
+        <cruise-control.version>2.5.32</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
     </properties>
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.6.1</strimzi-oauth.version>
-        <cruise-control.version>2.5.21</cruise-control.version>
+        <cruise-control.version>2.5.32</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
     </properties>
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.6.1</strimzi-oauth.version>
-        <cruise-control.version>2.5.27</cruise-control.version>
+        <cruise-control.version>2.5.32</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
     </properties>
 

--- a/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.5.21</cruise-control.version>
+        <cruise-control.version>2.5.32</cruise-control.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement

### Description

This PR updated Cruise Control to 2.5.32 which includes some needed dependency upgrades as well as bug fixes and optimizations.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md