### PR TITLE
Renamed Condition to KafkaCondition

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaCondition.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaCondition.java
@@ -27,7 +27,7 @@ import static java.util.Collections.emptyMap;
 @JsonPropertyOrder({ "type", "status", "lastTransitionTime", "reason", "message" })
 @EqualsAndHashCode
 @ToString
-public class Condition implements UnknownPropertyPreserving, Serializable {
+public class KafkaCondition implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 
     private String status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/Status.java
@@ -33,33 +33,33 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString
 public abstract class Status implements UnknownPropertyPreserving, Serializable {
-    private List<Condition> conditions;
+    private List<KafkaCondition> conditions;
     private long observedGeneration;
     private Map<String, Object> additionalProperties;
 
     @Description("List of status conditions")
-    public List<Condition> getConditions() {
+    public List<KafkaCondition> getConditions() {
         return conditions;
     }
 
-    public void setConditions(List<Condition> conditions) {
+    public void setConditions(List<KafkaCondition> conditions) {
         this.conditions = conditions;
     }
 
-    private List<Condition> prepareConditionsUpdate() {
-        List<Condition> oldConditions = getConditions();
-        List<Condition> newConditions = oldConditions != null ? new ArrayList<>(oldConditions) : new ArrayList<>(0);
+    private List<KafkaCondition> prepareConditionsUpdate() {
+        List<KafkaCondition> oldConditions = getConditions();
+        List<KafkaCondition> newConditions = oldConditions != null ? new ArrayList<>(oldConditions) : new ArrayList<>(0);
         return newConditions;
     }
 
-    public void addCondition(Condition condition) {
-        List<Condition> newConditions = prepareConditionsUpdate();
+    public void addCondition(KafkaCondition condition) {
+        List<KafkaCondition> newConditions = prepareConditionsUpdate();
         newConditions.add(condition);
         setConditions(Collections.unmodifiableList(newConditions));
     }
 
-    public void addConditions(Collection<Condition> conditions) {
-        List<Condition> newConditions = prepareConditionsUpdate();
+    public void addConditions(Collection<KafkaCondition> conditions) {
+        List<KafkaCondition> newConditions = prepareConditionsUpdate();
         newConditions.addAll(conditions);
         setConditions(Collections.unmodifiableList(newConditions));
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -73,7 +73,7 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.api.kafka.model.MetricsConfig;
 import io.strimzi.api.kafka.model.SystemProperty;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.api.kafka.model.storage.JbodStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorageOverride;
@@ -280,7 +280,7 @@ public abstract class AbstractModel {
     protected List<TopologySpreadConstraint> templatePodTopologySpreadConstraints;
     protected PodManagementPolicy templatePodManagementPolicy = PodManagementPolicy.PARALLEL;
 
-    protected List<Condition> warningConditions = new ArrayList<>(0);
+    protected List<KafkaCondition> warningConditions = new ArrayList<>(0);
 
     /**
      * Constructor
@@ -1527,7 +1527,7 @@ public abstract class AbstractModel {
      *
      * @param warning  Condition which will be added to the warning conditions
      */
-    public void addWarningCondition(Condition warning) {
+    public void addWarningCondition(KafkaCondition warning) {
         warningConditions.add(warning);
     }
 
@@ -1536,7 +1536,7 @@ public abstract class AbstractModel {
      *
      * @return  List of warning conditions.
      */
-    public List<Condition> getWarningConditions() {
+    public List<KafkaCondition> getWarningConditions() {
         return warningConditions;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -69,7 +69,7 @@ import io.strimzi.api.kafka.model.listener.NodeAddressType;
 import io.strimzi.api.kafka.model.listener.arraylistener.ArrayOrObjectKafkaListeners;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.api.kafka.model.storage.JbodStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
@@ -496,7 +496,7 @@ public class KafkaCluster extends AbstractModel {
                         "result, all storage changes will be ignored. Use DEBUG level logging for more information " +
                         "about the detected changes.", kafkaAssembly.getMetadata().getNamespace(), kafkaAssembly.getMetadata().getName());
 
-                Condition warning = StatusUtils.buildWarningCondition("KafkaStorage",
+                KafkaCondition warning = StatusUtils.buildWarningCondition("KafkaStorage",
                         "The desired Kafka storage configuration contains changes which are not allowed. As a " +
                                 "result, all storage changes will be ignored. Use DEBUG level logging for more information " +
                                 "about the detected changes.");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -39,7 +39,7 @@ import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.api.kafka.model.ZookeeperClusterSpec;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.api.kafka.model.storage.EphemeralStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
@@ -255,7 +255,7 @@ public class ZookeeperCluster extends AbstractModel {
                         "a result, all storage changes will be ignored. Use DEBUG level logging for more information " +
                         "about the detected changes.", kafkaAssembly.getMetadata().getNamespace(), kafkaAssembly.getMetadata().getName());
 
-                Condition warning = StatusUtils.buildWarningCondition("ZooKeeperStorage",
+                KafkaCondition warning = StatusUtils.buildWarningCondition("ZooKeeperStorage",
                         "The desired ZooKeeper storage configuration contains changes which are not allowed. As a " +
                                 "result, all storage changes will be ignored. Use DEBUG level logging for more information " +
                                 "about the detected changes.");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -38,7 +38,7 @@ import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectorSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.api.kafka.model.status.KafkaConnectS2IStatus;
 import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
 import io.strimzi.api.kafka.model.status.KafkaConnectorStatus;
@@ -563,7 +563,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         }
     }
 
-    private Future<List<Condition>> maybeRestartConnector(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, String connectorName, CustomResource resource, List<Condition> conditions) {
+    private Future<List<KafkaCondition>> maybeRestartConnector(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, String connectorName, CustomResource resource, List<KafkaCondition> conditions) {
         if (hasRestartAnnotation(resource, connectorName)) {
             log.debug("{}: Restarting connector {}", reconciliation, connectorName);
             return apiClient.restart(host, port, connectorName)
@@ -581,7 +581,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         }
     }
 
-    private Future<List<Condition>> maybeRestartConnectorTask(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, String connectorName, CustomResource resource, List<Condition> conditions) {
+    private Future<List<KafkaCondition>> maybeRestartConnectorTask(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, String connectorName, CustomResource resource, List<KafkaCondition> conditions) {
         int taskID = getRestartTaskAnnotationTaskID(resource, connectorName);
         if (taskID >= 0) {
             log.debug("{}: Restarting connector task {}:{}", reconciliation, connectorName, taskID);
@@ -665,9 +665,9 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
 
     protected class ConnectorStatusAndConditions {
         Map<String, Object> statusResult;
-        List<Condition> conditions;
+        List<KafkaCondition> conditions;
 
-        ConnectorStatusAndConditions(Map<String, Object> statusResult, List<Condition> conditions) {
+        ConnectorStatusAndConditions(Map<String, Object> statusResult, List<KafkaCondition> conditions) {
             this.statusResult = statusResult;
             this.conditions = conditions;
         }
@@ -681,7 +681,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         return statusResult -> Future.succeededFuture(new ConnectorStatusAndConditions(statusResult));
     }
 
-    Function<Map<String, Object>, Future<ConnectorStatusAndConditions>> createConnectorStatusAndConditions(List<Condition> conditions) {
+    Function<Map<String, Object>, Future<ConnectorStatusAndConditions>> createConnectorStatusAndConditions(List<KafkaCondition> conditions) {
         return statusResult -> Future.succeededFuture(new ConnectorStatusAndConditions(statusResult, conditions));
     }
 
@@ -692,7 +692,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         }
 
         Map<String, Object> statusResult = null;
-        List<Condition> conditions = Collections.emptyList();
+        List<KafkaCondition> conditions = Collections.emptyList();
         if (connectorStatus != null) {
             statusResult = connectorStatus.statusResult;
             conditions = connectorStatus.conditions;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -38,14 +38,14 @@ import io.strimzi.api.kafka.model.KafkaSpec;
 import io.strimzi.api.kafka.model.listener.NodeAddressType;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBroker;
-import io.strimzi.api.kafka.model.status.Condition;
-import io.strimzi.api.kafka.model.status.ConditionBuilder;
 import io.strimzi.api.kafka.model.status.KafkaStatus;
 import io.strimzi.api.kafka.model.status.KafkaStatusBuilder;
 import io.strimzi.api.kafka.model.status.ListenerAddress;
 import io.strimzi.api.kafka.model.status.ListenerAddressBuilder;
 import io.strimzi.api.kafka.model.status.ListenerStatus;
 import io.strimzi.api.kafka.model.status.ListenerStatusBuilder;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
+import io.strimzi.api.kafka.model.status.KafkaConditionBuilder;
 import io.strimzi.api.kafka.model.storage.JbodStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.certs.CertManager;
@@ -228,14 +228,14 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
         reconcile(reconcileState).onComplete(reconcileResult -> {
             KafkaStatus status = reconcileState.kafkaStatus;
-            Condition condition;
+            KafkaCondition condition;
 
             if (kafkaAssembly.getMetadata().getGeneration() != null)    {
                 status.setObservedGeneration(kafkaAssembly.getMetadata().getGeneration());
             }
 
             if (reconcileResult.succeeded())    {
-                condition = new ConditionBuilder()
+                condition = new KafkaConditionBuilder()
                         .withLastTransitionTime(ModelUtils.formatTimestamp(dateSupplier()))
                         .withType("Ready")
                         .withStatus("True")
@@ -244,7 +244,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 status.addCondition(condition);
                 createOrUpdatePromise.complete(status);
             } else {
-                condition = new ConditionBuilder()
+                condition = new KafkaConditionBuilder()
                         .withLastTransitionTime(ModelUtils.formatTimestamp(dateSupplier()))
                         .withType("NotReady")
                         .withStatus("True")
@@ -519,7 +519,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     if (kafka != null && kafka.getStatus() == null) {
                         log.debug("{}: Setting the initial status for a new resource", reconciliation);
 
-                        Condition deployingCondition = new ConditionBuilder()
+                        KafkaCondition deployingCondition = new KafkaConditionBuilder()
                                 .withLastTransitionTime(ModelUtils.formatTimestamp(dateSupplier()))
                                 .withType("NotReady")
                                 .withStatus("True")
@@ -551,7 +551,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          */
         Future<ReconciliationState> checkKafkaSpec() {
             KafkaSpecChecker checker = new KafkaSpecChecker(kafkaAssembly.getSpec(), versions, kafkaCluster, zkCluster);
-            List<Condition> warnings = checker.run();
+            List<KafkaCondition> warnings = checker.run();
             kafkaStatus.addConditions(warnings);
             return Future.succeededFuture(this);
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -17,7 +17,7 @@ import java.util.stream.Stream;
 
 import io.fabric8.kubernetes.client.CustomResource;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Spec;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.ReconciliationException;
@@ -168,7 +168,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                 .compose(i -> mirrorMaker2HasZeroReplicas ? Future.succeededFuture() : reconcileConnectors(reconciliation, kafkaMirrorMaker2, mirrorMaker2Cluster, kafkaMirrorMaker2Status, desiredLogging.get()))
                 .map((Void) null)
                 .onComplete(reconciliationResult -> {
-                    List<Condition> conditions = kafkaMirrorMaker2Status.getConditions();
+                    List<KafkaCondition> conditions = kafkaMirrorMaker2Status.getConditions();
                     StatusUtils.setStatusConditionAndObservedGeneration(kafkaMirrorMaker2, kafkaMirrorMaker2Status, reconciliationResult);
 
                     if (!mirrorMaker2HasZeroReplicas) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -16,7 +16,7 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.KafkaRebalanceBuilder;
 import io.strimzi.api.kafka.model.KafkaRebalanceSpec;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.api.kafka.model.status.KafkaRebalanceStatus;
 import io.strimzi.api.kafka.model.status.KafkaRebalanceStatusBuilder;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceAnnotation;
@@ -216,10 +216,10 @@ public class KafkaRebalanceAssemblyOperator
      * @throws RuntimeException If there is more than one Condition instance in the supplied status whose type matches one of the
      *                          {@link KafkaRebalanceState} enum values.
      */
-    /* test */ protected Condition rebalanceStateCondition(KafkaRebalanceStatus status) {
+    /* test */ protected KafkaCondition rebalanceStateCondition(KafkaRebalanceStatus status) {
         if (status.getConditions() != null) {
 
-            List<Condition> statusConditions = status.getConditions()
+            List<KafkaCondition> statusConditions = status.getConditions()
                     .stream()
                     .filter(condition -> condition.getType() != null)
                     .filter(condition -> Arrays.stream(KafkaRebalanceState.values())
@@ -249,7 +249,7 @@ public class KafkaRebalanceAssemblyOperator
      *                          {@link KafkaRebalanceState} enum values.
      */
     private String rebalanceStateConditionType(KafkaRebalanceStatus status) {
-        Condition rebalanceStateCondition = rebalanceStateCondition(status);
+        KafkaCondition rebalanceStateCondition = rebalanceStateCondition(status);
         return rebalanceStateCondition != null ? rebalanceStateCondition.getType() : null;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecChecker.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecChecker.java
@@ -5,7 +5,7 @@
 package io.strimzi.operator.cluster.operator.resource;
 
 import io.strimzi.api.kafka.model.KafkaSpec;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaConfiguration;
 import io.strimzi.operator.cluster.model.KafkaVersion;
@@ -54,8 +54,8 @@ public class KafkaSpecChecker {
         }
     }
 
-    public List<Condition> run() {
-        List<Condition> warnings = new ArrayList<>();
+    public List<KafkaCondition> run() {
+        List<KafkaCondition> warnings = new ArrayList<>();
         checkKafkaLogMessageFormatVersion(warnings);
         checkKafkaInterBrokerProtocolVersion(warnings);
         checkKafkaStorage(warnings);
@@ -73,7 +73,7 @@ public class KafkaSpecChecker {
      *
      * @param warnings List to add a warning to, if appropriate.
      */
-    private void checkKafkaLogMessageFormatVersion(List<Condition> warnings) {
+    private void checkKafkaLogMessageFormatVersion(List<KafkaCondition> warnings) {
         String logMsgFormatVersion = kafkaCluster.getConfiguration().getConfigOption(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION);
 
         if (logMsgFormatVersion != null) {
@@ -94,7 +94,7 @@ public class KafkaSpecChecker {
      *
      * @param warnings List to add a warning to, if appropriate.
      */
-    private void checkKafkaInterBrokerProtocolVersion(List<Condition> warnings) {
+    private void checkKafkaInterBrokerProtocolVersion(List<KafkaCondition> warnings) {
         String interBrokerProtocolVersion = kafkaCluster.getConfiguration().getConfigOption(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION);
 
         if (interBrokerProtocolVersion != null) {
@@ -113,7 +113,7 @@ public class KafkaSpecChecker {
      *
      * @param warnings List to add a warning to, if appropriate.
      */
-    private void checkKafkaStorage(List<Condition> warnings) {
+    private void checkKafkaStorage(List<KafkaCondition> warnings) {
         if (kafkaCluster.getReplicas() == 1 && StorageUtils.usesEphemeral(kafkaCluster.getStorage())) {
             warnings.add(StatusUtils.buildWarningCondition("KafkaStorage",
                     "A Kafka cluster with a single replica and ephemeral storage will lose topic messages after any restart or rolling update."));
@@ -126,7 +126,7 @@ public class KafkaSpecChecker {
      *
      * @param warnings List to add a warning to, if appropriate.
      */
-    private void checkZooKeeperStorage(List<Condition> warnings) {
+    private void checkZooKeeperStorage(List<KafkaCondition> warnings) {
         if (zkCluster.getReplicas() == 1 && StorageUtils.usesEphemeral(zkCluster.getStorage())) {
             warnings.add(StatusUtils.buildWarningCondition("ZooKeeperStorage",
                     "A ZooKeeper cluster with a single replica and ephemeral storage will be in a defective state after any restart or rolling update. It is recommended that a minimum of three replicas are used."));
@@ -139,7 +139,7 @@ public class KafkaSpecChecker {
      *
      * @param warnings List to add a warning to, if appropriate.
      */
-    private void checkZooKeeperReplicas(List<Condition> warnings) {
+    private void checkZooKeeperReplicas(List<KafkaCondition> warnings) {
         if (zkCluster.getReplicas() == 2) {
             warnings.add(StatusUtils.buildWarningCondition("ZooKeeperReplicas",
                     "Running ZooKeeper with two nodes is not advisable as both replicas will be needed to avoid downtime. It is recommended that a minimum of three replicas are used."));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StatusDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StatusDiffTest.java
@@ -4,13 +4,13 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import io.strimzi.api.kafka.model.status.Condition;
-import io.strimzi.api.kafka.model.status.ConditionBuilder;
 import io.strimzi.api.kafka.model.status.KafkaStatusBuilder;
 import io.strimzi.api.kafka.model.status.KafkaStatus;
 import io.strimzi.api.kafka.model.status.ListenerAddressBuilder;
 import io.strimzi.api.kafka.model.status.ListenerStatus;
 import io.strimzi.api.kafka.model.status.ListenerStatusBuilder;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
+import io.strimzi.api.kafka.model.status.KafkaConditionBuilder;
 import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
@@ -47,13 +47,13 @@ public class StatusDiffTest {
                         .build())
                 .build();
 
-        Condition condition1 = new ConditionBuilder()
+        KafkaCondition condition1 = new KafkaConditionBuilder()
                 .withNewLastTransitionTime(ModelUtils.formatTimestamp(new Date()))
                 .withNewType("Ready")
                 .withNewStatus("True")
                 .build();
 
-        Condition condition2 = new ConditionBuilder()
+        KafkaCondition condition2 = new KafkaConditionBuilder()
                 .withNewLastTransitionTime(ModelUtils.formatTimestamp(new Date()))
                 .withNewType("Ready2")
                 .withNewStatus("True")
@@ -126,13 +126,13 @@ public class StatusDiffTest {
                         .build())
                 .build();
 
-        Condition condition1 = new ConditionBuilder()
+        KafkaCondition condition1 = new KafkaConditionBuilder()
                 .withNewLastTransitionTime(ModelUtils.formatTimestamp(new Date()))
                 .withNewType("Ready")
                 .withNewStatus("True")
                 .build();
 
-        Condition condition2 = new ConditionBuilder()
+        KafkaCondition condition2 = new KafkaConditionBuilder()
                 .withNewLastTransitionTime(ModelUtils.formatTimestamp(new SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse("2011-01-01 00:00:00")))
                 .withNewType("Ready")
                 .withNewStatus("True")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/AbstractResourceStateMatchers.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/AbstractResourceStateMatchers.java
@@ -6,7 +6,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
@@ -57,11 +57,11 @@ public class AbstractResourceStateMatchers {
      * @param state he expected rebalance state to be searched for.
      * @return
      */
-    public static Matcher<List<Condition>> hasStateInConditions(KafkaRebalanceState state) {
+    public static Matcher<List<KafkaCondition>> hasStateInConditions(KafkaRebalanceState state) {
         return new TypeSafeDiagnosingMatcher<>() {
 
             @Override
-            protected boolean matchesSafely(List<Condition> conditions, Description mismatchDescription) {
+            protected boolean matchesSafely(List<KafkaCondition> conditions, Description mismatchDescription) {
                 mismatchDescription.appendText("was ").appendValue(conditions);
 
                 List<String> foundStatuses = new ArrayList<>();
@@ -71,7 +71,7 @@ public class AbstractResourceStateMatchers {
                     return false;
                 }
 
-                for (Condition condition : conditions) {
+                for (KafkaCondition condition : conditions) {
                     if (condition == null) {
                         continue;
                     }
@@ -94,11 +94,11 @@ public class AbstractResourceStateMatchers {
         };
     }
 
-    public static Matcher<Condition> hasStateInCondition(KafkaRebalanceState state, Class reason, String message) {
+    public static Matcher<KafkaCondition> hasStateInCondition(KafkaRebalanceState state, Class reason, String message) {
         return new TypeSafeDiagnosingMatcher<>() {
 
             @Override
-            protected boolean matchesSafely(Condition condition, Description mismatchDescription) {
+            protected boolean matchesSafely(KafkaCondition condition, Description mismatchDescription) {
                 mismatchDescription.appendText("was ").appendValue(condition);
 
                 if (condition == null) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -20,7 +20,7 @@ import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.api.kafka.model.connect.ConnectorPluginBuilder;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.api.kafka.model.status.Status;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
@@ -410,10 +410,10 @@ public class ConnectorMockTest {
             .inNamespace(NAMESPACE)
             .withName(connectorName);
         waitForStatus(resource, connectorName, s -> {
-            List<Condition> conditions = s.getStatus().getConditions();
+            List<KafkaCondition> conditions = s.getStatus().getConditions();
             boolean conditionFound = false;
             if (conditions != null && !conditions.isEmpty()) {
-                for (Condition condition: conditions) {
+                for (KafkaCondition condition: conditions) {
                     if (conditionType.equals(condition.getType()) && conditionReason.equals(condition.getReason())) {
                         conditionFound = true;
                         break;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorUnsupportedFieldsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorUnsupportedFieldsTest.java
@@ -9,7 +9,7 @@ import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.listener.KafkaListenersBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.ArrayOrObjectKafkaListeners;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.api.kafka.model.status.KafkaStatus;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.KubernetesVersion;
@@ -129,14 +129,14 @@ public class KafkaAssemblyOperatorUnsupportedFieldsTest {
                     assertThat(kafkaCaptor.getValue().getStatus(), is(notNullValue()));
                     KafkaStatus status = kafkaCaptor.getValue().getStatus();
 
-                    Condition ready = status.getConditions().stream()
+                    KafkaCondition ready = status.getConditions().stream()
                             .filter(condition -> "Ready".equals(condition.getType()))
                             .findFirst()
                             .orElse(null);
                     assertThat(ready, is(notNullValue()));
                     assertThat(ready.getStatus(), is("True"));
 
-                    Condition toWarning = status.getConditions().stream()
+                    KafkaCondition toWarning = status.getConditions().stream()
                             .filter(condition -> "Warning".equals(condition.getType()) && "TopicOperator".equals(condition.getReason()))
                             .findFirst().orElse(null);
                     assertThat(toWarning, is(nullValue()));
@@ -201,14 +201,14 @@ public class KafkaAssemblyOperatorUnsupportedFieldsTest {
                     assertThat(kafkaCaptor.getValue().getStatus(), is(notNullValue()));
                     KafkaStatus status = kafkaCaptor.getValue().getStatus();
 
-                    Condition ready = status.getConditions().stream()
+                    KafkaCondition ready = status.getConditions().stream()
                             .filter(condition -> "Ready".equals(condition.getType()))
                             .findFirst()
                             .orElse(null);
                     assertThat(ready, is(notNullValue()));
                     assertThat(ready.getStatus(), is("True"));
 
-                    Condition toWarning = status.getConditions().stream()
+                    KafkaCondition toWarning = status.getConditions().stream()
                             .filter(condition -> "Warning".equals(condition.getType()) && "TopicOperator".equals(condition.getReason()))
                             .findFirst().orElse(null);
                     assertThat(toWarning, is(notNullValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -14,7 +14,7 @@ import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.KafkaRebalanceBuilder;
 import io.strimzi.api.kafka.model.KafkaRebalanceSpec;
 import io.strimzi.api.kafka.model.KafkaRebalanceSpecBuilder;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceAnnotation;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
 import io.strimzi.operator.KubernetesVersion;
@@ -462,7 +462,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 // the resource moved from New to NotReady due to the error
                 KafkaRebalance kr1 = Crds.kafkaRebalanceOperation(kubernetesClient).inNamespace(CLUSTER_NAMESPACE).withName(RESOURCE_NAME).get();
                 assertThat(kr1, StateMatchers.hasState());
-                Condition condition = kcrao.rebalanceStateCondition(kr1.getStatus());
+                KafkaCondition condition = kcrao.rebalanceStateCondition(kr1.getStatus());
                 assertThat(condition, StateMatchers.hasStateInCondition(KafkaRebalanceState.NotReady, CruiseControlRestException.class,
                         "Error processing POST request '/rebalance' due to: " +
                                 "'java.lang.IllegalArgumentException: Missing hard goals [NetworkInboundCapacityGoal, DiskCapacityGoal, RackAwareGoal, NetworkOutboundCapacityGoal, CpuCapacityGoal, ReplicaCapacityGoal] " +
@@ -546,7 +546,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 // the resource moved from New to NotReady due to the error
                 KafkaRebalance kr1 = Crds.kafkaRebalanceOperation(kubernetesClient).inNamespace(CLUSTER_NAMESPACE).withName(RESOURCE_NAME).get();
                 assertThat(kr1, StateMatchers.hasState());
-                Condition condition = kcrao.rebalanceStateCondition(kr1.getStatus());
+                KafkaCondition condition = kcrao.rebalanceStateCondition(kr1.getStatus());
                 assertThat(condition, StateMatchers.hasStateInCondition(KafkaRebalanceState.NotReady, CruiseControlRestException.class,
                         "Error processing POST request '/rebalance' due to: " +
                                 "'java.lang.IllegalArgumentException: Missing hard goals [NetworkInboundCapacityGoal, DiskCapacityGoal, RackAwareGoal, NetworkOutboundCapacityGoal, CpuCapacityGoal, ReplicaCapacityGoal] " +
@@ -930,7 +930,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         context.verify(() -> {
             KafkaRebalance kafkaRebalance = Crds.kafkaRebalanceOperation(kubernetesClient).inNamespace(namespace).withName(resource).get();
             assertThat(kafkaRebalance, StateMatchers.hasState());
-            Condition condition = kcrao.rebalanceStateCondition(kafkaRebalance.getStatus());
+            KafkaCondition condition = kcrao.rebalanceStateCondition(kafkaRebalance.getStatus());
             assertThat(Collections.singletonList(condition), StateMatchers.hasStateInConditions(state));
         });
     }
@@ -940,7 +940,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
             KafkaRebalance kafkaRebalance = Crds.kafkaRebalanceOperation(kubernetesClient).inNamespace(namespace).withName(resource).get();
 
             assertThat(kafkaRebalance, StateMatchers.hasState());
-            Condition condition = kcrao.rebalanceStateCondition(kafkaRebalance.getStatus());
+            KafkaCondition condition = kcrao.rebalanceStateCondition(kafkaRebalance.getStatus());
             assertThat(condition, StateMatchers.hasStateInCondition(state, reason, message));
         });
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -12,7 +12,7 @@ import io.strimzi.api.kafka.model.KafkaRebalanceSpec;
 import io.strimzi.api.kafka.model.KafkaRebalanceSpecBuilder;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceAnnotation;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.api.kafka.model.status.KafkaRebalanceStatus;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
@@ -108,7 +108,7 @@ public class KafkaRebalanceStateMachineTest {
 
         // there is no actual status and related condition when a KafkaRebalance is just created
         if (currentState != KafkaRebalanceState.New) {
-            Condition currentRebalanceCondition = new Condition();
+            KafkaCondition currentRebalanceCondition = new KafkaCondition();
             currentRebalanceCondition.setType(currentState.toString());
             currentRebalanceCondition.setStatus("True");
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -17,7 +17,7 @@ import io.strimzi.api.kafka.model.listener.NodeAddressType;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBroker;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBrokerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
-import io.strimzi.api.kafka.model.status.ConditionBuilder;
+import io.strimzi.api.kafka.model.status.KafkaConditionBuilder;
 import io.strimzi.api.kafka.model.status.KafkaStatus;
 import io.strimzi.api.kafka.model.status.ListenerAddress;
 import io.strimzi.api.kafka.model.status.ListenerAddressBuilder;
@@ -121,7 +121,7 @@ public class KafkaStatusTest {
                 .endSpec()
                 .withNewStatus()
                     .withObservedGeneration(1L)
-                    .withConditions(new ConditionBuilder()
+                    .withConditions(new KafkaConditionBuilder()
                             .withNewLastTransitionTime(ModelUtils.formatTimestamp(new SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse("2011-01-01 00:00:00")))
                             .withNewType("NotReady")
                             .withNewStatus("True")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecCheckerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecCheckerTest.java
@@ -6,7 +6,7 @@ package io.strimzi.operator.cluster.operator.resource;
 
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.api.kafka.model.storage.EphemeralStorage;
 import io.strimzi.api.kafka.model.storage.EphemeralStorageBuilder;
 import io.strimzi.api.kafka.model.storage.JbodStorageBuilder;
@@ -69,9 +69,9 @@ public class KafkaSpecCheckerTest {
                 .endSpec()
             .build();
         KafkaSpecChecker checker = generateChecker(kafka);
-        List<Condition> warnings = checker.run();
+        List<KafkaCondition> warnings = checker.run();
         assertThat(warnings, hasSize(1));
-        Condition warning = warnings.get(0);
+        KafkaCondition warning = warnings.get(0);
         assertThat(warning.getReason(), is("KafkaStorage"));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("A Kafka cluster with a single replica and ephemeral storage will lose topic messages after any restart or rolling update."));
@@ -91,9 +91,9 @@ public class KafkaSpecCheckerTest {
                 .endSpec()
             .build();
         KafkaSpecChecker checker = generateChecker(kafka);
-        List<Condition> warnings = checker.run();
+        List<KafkaCondition> warnings = checker.run();
         assertThat(warnings, hasSize(1));
-        Condition warning = warnings.get(0);
+        KafkaCondition warning = warnings.get(0);
         assertThat(warning.getReason(), is("KafkaStorage"));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("A Kafka cluster with a single replica and ephemeral storage will lose topic messages after any restart or rolling update."));
@@ -111,9 +111,9 @@ public class KafkaSpecCheckerTest {
                 .endSpec()
             .build();
         KafkaSpecChecker checker = generateChecker(kafka);
-        List<Condition> warnings = checker.run();
+        List<KafkaCondition> warnings = checker.run();
         assertThat(warnings, hasSize(1));
-        Condition warning = warnings.get(0);
+        KafkaCondition warning = warnings.get(0);
         assertThat(warning.getReason(), is("ZooKeeperStorage"));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("A ZooKeeper cluster with a single replica and ephemeral storage will be in a defective state after any restart or rolling update. It is recommended that a minimum of three replicas are used."));
@@ -123,9 +123,9 @@ public class KafkaSpecCheckerTest {
     public void checkZookeeperReplicas() {
         Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 2, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT);
         KafkaSpecChecker checker = generateChecker(kafka);
-        List<Condition> warnings = checker.run();
+        List<KafkaCondition> warnings = checker.run();
         assertThat(warnings, hasSize(1));
-        Condition warning = warnings.get(0);
+        KafkaCondition warning = warnings.get(0);
         assertThat(warning.getReason(), is("ZooKeeperReplicas"));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("Running ZooKeeper with two nodes is not advisable as both replicas will be needed to avoid downtime. It is recommended that a minimum of three replicas are used."));
@@ -135,9 +135,9 @@ public class KafkaSpecCheckerTest {
     public void checkZookeeperEvenReplicas() {
         Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 4, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT);
         KafkaSpecChecker checker = generateChecker(kafka);
-        List<Condition> warnings = checker.run();
+        List<KafkaCondition> warnings = checker.run();
         assertThat(warnings, hasSize(1));
-        Condition warning = warnings.get(0);
+        KafkaCondition warning = warnings.get(0);
         assertThat(warning.getReason(), is("ZooKeeperReplicas"));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("Running ZooKeeper with an odd number of replicas is recommended."));
@@ -157,9 +157,9 @@ public class KafkaSpecCheckerTest {
                 .endSpec()
             .build();
         KafkaSpecChecker checker = generateChecker(kafka);
-        List<Condition> warnings = checker.run();
+        List<KafkaCondition> warnings = checker.run();
         assertThat(warnings, hasSize(1));
-        Condition warning = warnings.get(0);
+        KafkaCondition warning = warnings.get(0);
         assertThat(warning.getReason(), is("KafkaLogMessageFormatVersion"));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("log.message.format.version does not match the Kafka cluster version, which suggests that an upgrade is incomplete."));
@@ -175,9 +175,9 @@ public class KafkaSpecCheckerTest {
                 .build();
 
         KafkaSpecChecker checker = generateChecker(kafka);
-        List<Condition> warnings = checker.run();
+        List<KafkaCondition> warnings = checker.run();
         assertThat(warnings, hasSize(1));
-        Condition warning = warnings.get(0);
+        KafkaCondition warning = warnings.get(0);
         assertThat(warning.getReason(), is("KafkaLogMessageFormatVersion"));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("log.message.format.version does not match the Kafka cluster version, which suggests that an upgrade is incomplete."));
@@ -193,7 +193,7 @@ public class KafkaSpecCheckerTest {
                 .build();
 
         KafkaSpecChecker checker = generateChecker(kafka);
-        List<Condition> warnings = checker.run();
+        List<KafkaCondition> warnings = checker.run();
         assertThat(warnings, hasSize(0));
     }
 
@@ -207,7 +207,7 @@ public class KafkaSpecCheckerTest {
                 .build();
 
         KafkaSpecChecker checker = generateChecker(kafka);
-        List<Condition> warnings = checker.run();
+        List<KafkaCondition> warnings = checker.run();
         assertThat(warnings, hasSize(0));
     }
 
@@ -225,9 +225,9 @@ public class KafkaSpecCheckerTest {
                 .endSpec()
             .build();
         KafkaSpecChecker checker = generateChecker(kafka);
-        List<Condition> warnings = checker.run();
+        List<KafkaCondition> warnings = checker.run();
         assertThat(warnings, hasSize(1));
-        Condition warning = warnings.get(0);
+        KafkaCondition warning = warnings.get(0);
         assertThat(warning.getReason(), is("KafkaInterBrokerProtocolVersion"));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("inter.broker.protocol.version does not match the Kafka cluster version, which suggests that an upgrade is incomplete."));
@@ -243,9 +243,9 @@ public class KafkaSpecCheckerTest {
                 .build();
 
         KafkaSpecChecker checker = generateChecker(kafka);
-        List<Condition> warnings = checker.run();
+        List<KafkaCondition> warnings = checker.run();
         assertThat(warnings, hasSize(1));
-        Condition warning = warnings.get(0);
+        KafkaCondition warning = warnings.get(0);
         assertThat(warning.getReason(), is("KafkaInterBrokerProtocolVersion"));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("inter.broker.protocol.version does not match the Kafka cluster version, which suggests that an upgrade is incomplete."));
@@ -261,7 +261,7 @@ public class KafkaSpecCheckerTest {
                 .build();
 
         KafkaSpecChecker checker = generateChecker(kafka);
-        List<Condition> warnings = checker.run();
+        List<KafkaCondition> warnings = checker.run();
         assertThat(warnings, hasSize(0));
     }
 
@@ -275,7 +275,7 @@ public class KafkaSpecCheckerTest {
                 .build();
 
         KafkaSpecChecker checker = generateChecker(kafka);
-        List<Condition> warnings = checker.run();
+        List<KafkaCondition> warnings = checker.run();
         assertThat(warnings, hasSize(0));
     }
 
@@ -285,7 +285,7 @@ public class KafkaSpecCheckerTest {
                 emptyMap(), null, emptyMap(), emptyMap(),
                 new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
         KafkaSpecChecker checker = generateChecker(kafka);
-        List<Condition> warnings = checker.run();
+        List<KafkaCondition> warnings = checker.run();
         assertThat(warnings, hasSize(2));
     }
 }

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1864,7 +1864,7 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 |====
 |Property                   |Description
 |conditions          1.2+<.<|List of status conditions.
-|xref:type-Condition-{context}[`Condition`] array
+|xref:type-KafkaCondition-{context}[`KafkaCondition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
 |listeners           1.2+<.<|Addresses of the internal and external listeners.
@@ -1873,8 +1873,8 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 |string
 |====
 
-[id='type-Condition-{context}']
-### `Condition` schema reference
+[id='type-KafkaCondition-{context}']
+### `KafkaCondition` schema reference
 
 Used in: xref:type-KafkaBridgeStatus-{context}[`KafkaBridgeStatus`], xref:type-KafkaConnectorStatus-{context}[`KafkaConnectorStatus`], xref:type-KafkaConnectS2IStatus-{context}[`KafkaConnectS2IStatus`], xref:type-KafkaConnectStatus-{context}[`KafkaConnectStatus`], xref:type-KafkaMirrorMaker2Status-{context}[`KafkaMirrorMaker2Status`], xref:type-KafkaMirrorMakerStatus-{context}[`KafkaMirrorMakerStatus`], xref:type-KafkaRebalanceStatus-{context}[`KafkaRebalanceStatus`], xref:type-KafkaStatus-{context}[`KafkaStatus`], xref:type-KafkaTopicStatus-{context}[`KafkaTopicStatus`], xref:type-KafkaUserStatus-{context}[`KafkaUserStatus`]
 
@@ -2405,7 +2405,7 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |====
 |Property                   |Description
 |conditions          1.2+<.<|List of status conditions.
-|xref:type-Condition-{context}[`Condition`] array
+|xref:type-KafkaCondition-{context}[`KafkaCondition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
 |url                 1.2+<.<|The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
@@ -2532,7 +2532,7 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 |====
 |Property                   |Description
 |conditions          1.2+<.<|List of status conditions.
-|xref:type-Condition-{context}[`Condition`] array
+|xref:type-KafkaCondition-{context}[`KafkaCondition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
 |url                 1.2+<.<|The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
@@ -2589,7 +2589,7 @@ Used in: xref:type-KafkaTopic-{context}[`KafkaTopic`]
 |====
 |Property                   |Description
 |conditions          1.2+<.<|List of status conditions.
-|xref:type-Condition-{context}[`Condition`] array
+|xref:type-KafkaCondition-{context}[`KafkaCondition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
 |====
@@ -2819,7 +2819,7 @@ Used in: xref:type-KafkaUser-{context}[`KafkaUser`]
 |====
 |Property                   |Description
 |conditions          1.2+<.<|List of status conditions.
-|xref:type-Condition-{context}[`Condition`] array
+|xref:type-KafkaCondition-{context}[`KafkaCondition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
 |username            1.2+<.<|Username.
@@ -3000,7 +3000,7 @@ Used in: xref:type-KafkaMirrorMaker-{context}[`KafkaMirrorMaker`]
 |====
 |Property                   |Description
 |conditions          1.2+<.<|List of status conditions.
-|xref:type-Condition-{context}[`Condition`] array
+|xref:type-KafkaCondition-{context}[`KafkaCondition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
 |labelSelector       1.2+<.<|Label selector for pods providing this resource.
@@ -3187,7 +3187,7 @@ Used in: xref:type-KafkaBridge-{context}[`KafkaBridge`]
 |====
 |Property                   |Description
 |conditions          1.2+<.<|List of status conditions.
-|xref:type-Condition-{context}[`Condition`] array
+|xref:type-KafkaCondition-{context}[`KafkaCondition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
 |url                 1.2+<.<|The URL at which external client applications can access the Kafka Bridge.
@@ -3240,7 +3240,7 @@ Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
 |====
 |Property                   |Description
 |conditions          1.2+<.<|List of status conditions.
-|xref:type-Condition-{context}[`Condition`] array
+|xref:type-KafkaCondition-{context}[`KafkaCondition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
 |connectorStatus     1.2+<.<|The connector status, as reported by the Kafka Connect REST API.
@@ -3412,7 +3412,7 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |====
 |Property                   |Description
 |conditions          1.2+<.<|List of status conditions.
-|xref:type-Condition-{context}[`Condition`] array
+|xref:type-KafkaCondition-{context}[`KafkaCondition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
 |url                 1.2+<.<|The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
@@ -3477,7 +3477,7 @@ Used in: xref:type-KafkaRebalance-{context}[`KafkaRebalance`]
 |====
 |Property                   |Description
 |conditions          1.2+<.<|List of status conditions.
-|xref:type-Condition-{context}[`Condition`] array
+|xref:type-KafkaCondition-{context}[`KafkaCondition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
 |sessionId           1.2+<.<|The session identifier for requests to Cruise Control pertaining to this KafkaRebalance resource. This is used by the Kafka Rebalance operator to track the status of ongoing rebalancing operations.

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -15,8 +15,8 @@ import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Meter;
 import io.strimzi.api.kafka.model.Spec;
-import io.strimzi.api.kafka.model.status.Condition;
-import io.strimzi.api.kafka.model.status.ConditionBuilder;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
+import io.strimzi.api.kafka.model.status.KafkaConditionBuilder;
 import io.strimzi.api.kafka.model.status.Status;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.cluster.model.StatusDiff;
@@ -195,7 +195,7 @@ public abstract class AbstractOperator<
                     InvalidResourceException exception = new InvalidResourceException("Spec cannot be null");
 
                     S status = createStatus();
-                    Condition errorCondition = new ConditionBuilder()
+                    KafkaCondition errorCondition = new KafkaConditionBuilder()
                             .withLastTransitionTime(StatusUtils.iso8601Now())
                             .withType("NotReady")
                             .withStatus("True")
@@ -213,7 +213,7 @@ public abstract class AbstractOperator<
                     return createOrUpdate.future();
                 }
 
-                Set<Condition> unknownAndDeprecatedConditions = validate(cr);
+                Set<KafkaCondition> unknownAndDeprecatedConditions = validate(cr);
 
                 log.info("{}: {} {} will be checked for creation or modification", reconciliation, kind, name);
 
@@ -274,7 +274,7 @@ public abstract class AbstractOperator<
         return result.future();
     }
 
-    private void addWarningsToStatus(Status status, Set<Condition> unknownAndDeprecatedConditions)   {
+    private void addWarningsToStatus(Status status, Set<KafkaCondition> unknownAndDeprecatedConditions)   {
         if (status != null)  {
             status.addConditions(unknownAndDeprecatedConditions);
         }
@@ -389,9 +389,9 @@ public abstract class AbstractOperator<
      * @param resource The custom resource
      * @throws InvalidResourceException if the resource cannot be safely reconciled.
      */
-    /*test*/ Set<Condition> validate(T resource) {
+    /*test*/ Set<KafkaCondition> validate(T resource) {
         if (resource != null) {
-            Set<Condition> warningConditions = new LinkedHashSet<>(0);
+            Set<KafkaCondition> warningConditions = new LinkedHashSet<>(0);
 
             ResourceVisitor.visit(resource, new ValidationVisitor(resource, log, warningConditions));
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/ValidationVisitor.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/ValidationVisitor.java
@@ -9,7 +9,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.annotations.DeprecatedType;
 import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.operator.common.operator.resource.StatusUtils;
 import org.apache.logging.log4j.Logger;
 
@@ -23,10 +23,10 @@ import java.util.Set;
 public class ValidationVisitor implements ResourceVisitor.Visitor {
     private final Logger logger;
     private final HasMetadata resource;
-    private final Set<Condition> warningConditions;
+    private final Set<KafkaCondition> warningConditions;
     private final String transitionTime = StatusUtils.iso8601Now();
 
-    public ValidationVisitor(HasMetadata resource, Logger logger, Set<Condition> warningConditions) {
+    public ValidationVisitor(HasMetadata resource, Logger logger, Set<KafkaCondition> warningConditions) {
         this.resource = resource;
         this.logger = logger;
         this.warningConditions = warningConditions;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -7,8 +7,8 @@ package io.strimzi.operator.common.operator.resource;
 
 import io.fabric8.kubernetes.client.CustomResource;
 import io.strimzi.api.kafka.model.Constants;
-import io.strimzi.api.kafka.model.status.Condition;
-import io.strimzi.api.kafka.model.status.ConditionBuilder;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
+import io.strimzi.api.kafka.model.status.KafkaConditionBuilder;
 import io.strimzi.api.kafka.model.status.Status;
 import io.vertx.core.AsyncResult;
 
@@ -28,20 +28,20 @@ public class StatusUtils {
         return ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
     }
 
-    public static Condition buildConditionFromException(String type, String status, Throwable error) {
+    public static KafkaCondition buildConditionFromException(String type, String status, Throwable error) {
         return buildCondition(type, status, error);
     }
 
-    public static Condition buildCondition(String type, String status, Throwable error) {
-        Condition readyCondition;
+    public static KafkaCondition buildCondition(String type, String status, Throwable error) {
+        KafkaCondition readyCondition;
         if (error == null) {
-            readyCondition = new ConditionBuilder()
+            readyCondition = new KafkaConditionBuilder()
                     .withLastTransitionTime(iso8601Now())
                     .withType(type)
                     .withStatus(status)
                     .build();
         } else {
-            readyCondition = new ConditionBuilder()
+            readyCondition = new KafkaConditionBuilder()
                     .withLastTransitionTime(iso8601Now())
                     .withType(type)
                     .withStatus(status)
@@ -52,12 +52,12 @@ public class StatusUtils {
         return readyCondition;
     }
 
-    public static Condition buildWarningCondition(String reason, String message) {
+    public static KafkaCondition buildWarningCondition(String reason, String message) {
         return buildWarningCondition(reason, message, iso8601Now());
     }
 
-    public static Condition buildWarningCondition(String reason, String message, String transitionTime) {
-        return new ConditionBuilder()
+    public static KafkaCondition buildWarningCondition(String reason, String message, String transitionTime) {
+        return new KafkaConditionBuilder()
                 .withLastTransitionTime(transitionTime)
                 .withType("Warning")
                 .withStatus("True")
@@ -66,8 +66,8 @@ public class StatusUtils {
                 .build();
     }
 
-    public static Condition buildRebalanceCondition(String type) {
-        return new ConditionBuilder()
+    public static KafkaCondition buildRebalanceCondition(String type) {
+        return new KafkaConditionBuilder()
                 .withLastTransitionTime(iso8601Now())
                 .withType(type)
                 .withStatus("True")
@@ -86,7 +86,7 @@ public class StatusUtils {
         if (resource.getMetadata().getGeneration() != null)    {
             status.setObservedGeneration(resource.getMetadata().getGeneration());
         }
-        Condition readyCondition = StatusUtils.buildConditionFromException(type, conditionStatus, error);
+        KafkaCondition readyCondition = StatusUtils.buildConditionFromException(type, conditionStatus, error);
         status.setConditions(Collections.singletonList(readyCondition));
     }
 
@@ -98,7 +98,7 @@ public class StatusUtils {
         if (resource.getMetadata().getGeneration() != null)    {
             status.setObservedGeneration(resource.getMetadata().getGeneration());
         }
-        Condition condition = StatusUtils.buildCondition(type, conditionStatus, null);
+        KafkaCondition condition = StatusUtils.buildCondition(type, conditionStatus, null);
         status.setConditions(Collections.singletonList(condition));
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
@@ -13,7 +13,7 @@ import io.fabric8.kubernetes.model.annotation.Version;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.strimzi.api.kafka.model.Spec;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.api.kafka.model.status.Status;
 import io.strimzi.operator.common.model.NamespaceAndName;
 import io.strimzi.operator.common.operator.resource.AbstractWatchableStatusedResourceOperator;
@@ -73,7 +73,7 @@ public class OperatorMetricsTest {
                 return Future.succeededFuture();
             }
 
-            public Set<Condition> validate(CustomResource resource) {
+            public Set<KafkaCondition> validate(CustomResource resource) {
                 return emptySet();
             }
 
@@ -173,7 +173,7 @@ public class OperatorMetricsTest {
                 return Future.failedFuture(new UnableToAcquireLockException());
             }
 
-            public Set<Condition> validate(CustomResource resource) {
+            public Set<KafkaCondition> validate(CustomResource resource) {
                 return emptySet();
             }
 
@@ -232,7 +232,7 @@ public class OperatorMetricsTest {
                 return null;
             }
 
-            public Set<Condition> validate(CustomResource resource) {
+            public Set<KafkaCondition> validate(CustomResource resource) {
                 return emptySet();
             }
 
@@ -293,7 +293,7 @@ public class OperatorMetricsTest {
                 return Future.succeededFuture(resources);
             }
 
-            public Set<Condition> validate(CustomResource resource) {
+            public Set<KafkaCondition> validate(CustomResource resource) {
                 return emptySet();
             }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/ValidationVisitorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/ValidationVisitorTest.java
@@ -7,7 +7,7 @@ package io.strimzi.operator.common.model;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.logging.TestLogger;
 import org.apache.logging.log4j.Level;
@@ -40,11 +40,11 @@ public class ValidationVisitorTest {
                 .withApiVersion("v1alpha1")
             .build();
 
-        Set<Condition> warningConditions = new HashSet<>();
+        Set<KafkaCondition> warningConditions = new HashSet<>();
 
         ResourceVisitor.visit(k, new ValidationVisitor(resource, logger, warningConditions));
 
-        List<String> warningMessages = warningConditions.stream().map(Condition::getMessage).collect(Collectors.toList());
+        List<String> warningMessages = warningConditions.stream().map(KafkaCondition::getMessage).collect(Collectors.toList());
 
         assertThat(warningMessages, hasItem("Contains object at path spec.kafka with an unknown property: foo"));
         assertThat(warningMessages, hasItem("In API version v1alpha1 the property topicOperator at path spec.topicOperator has been deprecated. " +
@@ -88,11 +88,11 @@ public class ValidationVisitorTest {
                 .withApiVersion("v1alpha1")
                 .build();
 
-        Set<Condition> warningConditions = new HashSet<>();
+        Set<KafkaCondition> warningConditions = new HashSet<>();
 
         ResourceVisitor.visit(k, new ValidationVisitor(resource, logger, warningConditions));
 
-        List<String> warningMessages = warningConditions.stream().map(Condition::getMessage).collect(Collectors.toList());
+        List<String> warningMessages = warningConditions.stream().map(KafkaCondition::getMessage).collect(Collectors.toList());
 
         assertThat(warningMessages, hasItem("In API version v1alpha1 the property topicOperator at path spec.topicOperator has been deprecated. " +
                 "This feature should now be configured at path spec.entityOperator.topicOperator."));

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractCustomResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractCustomResourceOperatorIT.java
@@ -10,8 +10,8 @@ import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.strimzi.api.kafka.model.status.Condition;
-import io.strimzi.api.kafka.model.status.ConditionBuilder;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
+import io.strimzi.api.kafka.model.status.KafkaConditionBuilder;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.test.k8s.KubeClusterResource;
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClient, T extends CustomResource, L extends CustomResourceList<T>> {
     protected static final Logger log = LogManager.getLogger(AbstractCustomResourceOperatorIT.class);
     protected static final String RESOURCE_NAME = "my-test-resource";
-    protected static final Condition READY_CONDITION = new ConditionBuilder()
+    protected static final KafkaCondition READY_CONDITION = new KafkaConditionBuilder()
             .withType("Ready")
             .withStatus("True")
             .build();

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaBridgeCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaBridgeCrdOperatorIT.java
@@ -11,7 +11,7 @@ import io.strimzi.api.kafka.KafkaBridgeList;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridgeBuilder;
-import io.strimzi.api.kafka.model.status.ConditionBuilder;
+import io.strimzi.api.kafka.model.status.KafkaConditionBuilder;
 
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -75,7 +75,7 @@ public class KafkaBridgeCrdOperatorIT extends AbstractCustomResourceOperatorIT<K
     protected KafkaBridge getResourceWithNewReadyStatus(KafkaBridge resourceInCluster) {
         return new KafkaBridgeBuilder(resourceInCluster)
                 .withNewStatus()
-                .withConditions(new ConditionBuilder()
+                .withConditions(new KafkaConditionBuilder()
                         .withType("Ready")
                         .withStatus("True")
                         .build())

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
@@ -15,7 +15,7 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.listener.KafkaListenersBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.ArrayOrObjectKafkaListeners;
-import io.strimzi.api.kafka.model.status.ConditionBuilder;
+import io.strimzi.api.kafka.model.status.KafkaConditionBuilder;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxTestContext;
@@ -65,7 +65,7 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
                     .endZookeeper()
                 .endSpec()
                 .withNewStatus()
-                    .addToConditions(new ConditionBuilder().withNewStatus("Ready").withNewMessage("Kafka is ready").build())
+                    .addToConditions(new KafkaConditionBuilder().withNewStatus("Ready").withNewMessage("Kafka is ready").build())
                 .endStatus()
                 .build();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -32,7 +32,7 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.Spec;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.api.kafka.model.status.Status;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
@@ -400,9 +400,9 @@ public class ResourceManager {
                 List<String> log = new ArrayList<>(asList("\n", kind, " status:\n", "\nConditions:\n"));
 
                 if (customResource.getStatus() != null) {
-                    List<Condition> conditions = customResource.getStatus().getConditions();
+                    List<KafkaCondition> conditions = customResource.getStatus().getConditions();
                     if (conditions != null) {
-                        for (Condition condition : customResource.getStatus().getConditions()) {
+                        for (KafkaCondition condition : customResource.getStatus().getConditions()) {
                             if (condition.getMessage() != null) {
                                 log.add("\tType: " + condition.getType() + "\n");
                                 log.add("\tMessage: " + condition.getMessage() + "\n");

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
@@ -6,7 +6,7 @@ package io.strimzi.systemtest.utils.kafkaUtils;
 
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -95,8 +95,8 @@ public class KafkaConnectUtils {
     public static void waitForKafkaConnectCondition(String conditionReason, String conditionType, String namespace, String clusterName) {
         TestUtils.waitFor("Wait for KafkaConnect '" + conditionReason + "' condition with type '" + conditionType + "'.",
                 Constants.GLOBAL_POLL_INTERVAL, CO_OPERATION_TIMEOUT_SHORT * 2, () -> {
-                List<Condition> conditions = KafkaConnectResource.kafkaConnectClient().inNamespace(namespace).withName(clusterName).get().getStatus().getConditions();
-                for (Condition condition : conditions) {
+                List<KafkaCondition> conditions = KafkaConnectResource.kafkaConnectClient().inNamespace(namespace).withName(clusterName).get().getStatus().getConditions();
+                for (KafkaCondition condition : conditions) {
                     if (condition.getReason().matches(conditionReason) && condition.getType().matches(conditionType)) {
                         return true;
                     }
@@ -108,8 +108,8 @@ public class KafkaConnectUtils {
     public static void waitUntilKafkaConnectStatusConditionContainsMessage(String clusterName, String namespace, String message) {
         TestUtils.waitFor("KafkaConnect Status with message [" + message + "]",
             Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT, () -> {
-                List<Condition> conditions = KafkaConnectResource.kafkaConnectClient().inNamespace(namespace).withName(clusterName).get().getStatus().getConditions();
-                for (Condition condition : conditions) {
+                List<KafkaCondition> conditions = KafkaConnectResource.kafkaConnectClient().inNamespace(namespace).withName(clusterName).get().getStatus().getConditions();
+                for (KafkaCondition condition : conditions) {
                     if (condition.getMessage().matches(message)) {
                         return true;
                     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
@@ -5,7 +5,7 @@
 package io.strimzi.systemtest.utils.kafkaUtils;
 
 import io.strimzi.api.kafka.model.KafkaRebalance;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceAnnotation;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
 import io.strimzi.operator.common.Annotations;
@@ -27,9 +27,9 @@ public class KafkaRebalanceUtils {
 
     private KafkaRebalanceUtils() {}
 
-    private static Condition rebalanceStateCondition(String resourceName) {
+    private static KafkaCondition rebalanceStateCondition(String resourceName) {
 
-        List<Condition> statusConditions = KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(kubeClient().getNamespace())
+        List<KafkaCondition> statusConditions = KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(kubeClient().getNamespace())
                 .withName(resourceName).get().getStatus().getConditions().stream()
                 .filter(condition -> condition.getType() != null)
                 .filter(condition -> Arrays.stream(KafkaRebalanceState.values()).anyMatch(stateValue -> stateValue.toString().equals(condition.getType())))

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.api.kafka.model.status.ListenerStatus;
 import io.strimzi.kafka.config.model.ConfigModel;
 import io.strimzi.kafka.config.model.ConfigModels;
@@ -86,8 +86,8 @@ public class KafkaUtils {
     public static void waitUntilKafkaStatusConditionContainsMessage(String clusterName, String namespace, String message, long timeout) {
         TestUtils.waitFor("Kafka Status with message [" + message + "]",
             Constants.GLOBAL_POLL_INTERVAL, timeout, () -> {
-                List<Condition> conditions = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get().getStatus().getConditions();
-                for (Condition condition : conditions) {
+                List<KafkaCondition> conditions = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get().getStatus().getConditions();
+                for (KafkaCondition condition : conditions) {
                     if (condition.getMessage().matches(message)) {
                         return true;
                     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -11,7 +11,7 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.interfaces.IndicativeSentences;
 import io.strimzi.systemtest.interfaces.TestSeparator;
@@ -636,11 +636,11 @@ public abstract class AbstractST implements TestSeparator {
         );
     }
 
-    protected void verifyCRStatusCondition(Condition condition, String status, Enum<?> type) {
+    protected void verifyCRStatusCondition(KafkaCondition condition, String status, Enum<?> type) {
         verifyCRStatusCondition(condition, null, null, status, type);
     }
 
-    protected void verifyCRStatusCondition(Condition condition, String message, String reason, String status, Enum<?> type) {
+    protected void verifyCRStatusCondition(KafkaCondition condition, String message, String reason, String status, Enum<?> type) {
         assertThat(condition.getStatus(), is(status));
         assertThat(condition.getType(), is(type.toString()));
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/ClusterOperatorRbacST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/ClusterOperatorRbacST.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.systemtest.operators;
 
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.KubernetesResource;
@@ -82,7 +82,7 @@ public class ClusterOperatorRbacST extends AbstractST {
             .build());
 
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(clusterName, NAMESPACE, ".*Forbidden!.*");
-        Condition kafkaStatusCondition = KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(clusterName).get().getStatus().getConditions().get(0);
+        KafkaCondition kafkaStatusCondition = KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(clusterName).get().getStatus().getConditions().get(0);
         assertTrue(kafkaStatusCondition.getMessage().contains("Configured service account doesn't have access."));
         assertThat(kafkaStatusCondition.getType(), is(NotReady.toString()));
 
@@ -93,7 +93,7 @@ public class ClusterOperatorRbacST extends AbstractST {
             .build());
 
         KafkaConnectUtils.waitUntilKafkaConnectStatusConditionContainsMessage(clusterName, NAMESPACE, ".*Forbidden!.*");
-        Condition kafkaConnectStatusCondition = KafkaConnectResource.kafkaConnectClient().inNamespace(NAMESPACE).withName(clusterName).get().getStatus().getConditions().get(0);
+        KafkaCondition kafkaConnectStatusCondition = KafkaConnectResource.kafkaConnectClient().inNamespace(NAMESPACE).withName(clusterName).get().getStatus().getConditions().get(0);
         assertTrue(kafkaConnectStatusCondition.getMessage().contains("Configured service account doesn't have access."));
         assertThat(kafkaConnectStatusCondition.getType(), is(NotReady.toString()));
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
@@ -17,7 +17,7 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.api.kafka.model.status.KafkaBridgeStatus;
 import io.strimzi.api.kafka.model.status.KafkaConnectS2IStatus;
 import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
@@ -147,7 +147,7 @@ class CustomResourceStatusST extends AbstractST {
         KafkaUserResource.createAndWaitForReadiness(KafkaUserResource.tlsUser(CUSTOM_RESOURCE_STATUS_CLUSTER_NAME, userName).build());
 
         LOGGER.info("Checking status of deployed KafkaUser");
-        Condition kafkaCondition = KafkaUserResource.kafkaUserClient().inNamespace(NAMESPACE).withName(userName).get().getStatus().getConditions().get(0);
+        KafkaCondition kafkaCondition = KafkaUserResource.kafkaUserClient().inNamespace(NAMESPACE).withName(userName).get().getStatus().getConditions().get(0);
         LOGGER.info("KafkaUser Status: {}", kafkaCondition.getStatus());
         LOGGER.info("KafkaUser Type: {}", kafkaCondition.getType());
         assertThat("KafkaUser is in wrong state!", kafkaCondition.getType(), is(Ready.toString()));
@@ -163,7 +163,7 @@ class CustomResourceStatusST extends AbstractST {
         KafkaUserUtils.waitForKafkaUserNotReady(userName);
 
         LOGGER.info("Checking status of deployed KafkaUser {}", userName);
-        Condition kafkaCondition = KafkaUserResource.kafkaUserClient().inNamespace(NAMESPACE).withName(userName).get().getStatus().getConditions().get(0);
+        KafkaCondition kafkaCondition = KafkaUserResource.kafkaUserClient().inNamespace(NAMESPACE).withName(userName).get().getStatus().getConditions().get(0);
         LOGGER.info("KafkaUser Status: {}", kafkaCondition.getStatus());
         LOGGER.info("KafkaUser Type: {}", kafkaCondition.getType());
         LOGGER.info("KafkaUser Message: {}", kafkaCondition.getMessage());

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -10,7 +10,7 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserScramSha512ClientAuthentication;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
@@ -68,7 +68,7 @@ class UserST extends AbstractST {
 
         KafkaUserUtils.waitUntilKafkaUserStatusConditionIsPresent(userWithCorrectName);
 
-        Condition condition = KafkaUserResource.kafkaUserClient().inNamespace(NAMESPACE).withName(userWithCorrectName).get().getStatus().getConditions().get(0);
+        KafkaCondition condition = KafkaUserResource.kafkaUserClient().inNamespace(NAMESPACE).withName(userWithCorrectName).get().getStatus().getConditions().get(0);
 
         verifyCRStatusCondition(condition, "True", Ready);
 
@@ -343,7 +343,7 @@ class UserST extends AbstractST {
             }
 
             LOGGER.info("Checking status of KafkaUser {}", userName);
-            Condition kafkaCondition = KafkaUserResource.kafkaUserClient().inNamespace(NAMESPACE).withName(userName).get()
+            KafkaCondition kafkaCondition = KafkaUserResource.kafkaUserClient().inNamespace(NAMESPACE).withName(userName).get()
                     .getStatus().getConditions().get(0);
             LOGGER.info("KafkaUser condition status: {}", kafkaCondition.getStatus());
             LOGGER.info("KafkaUser condition type: {}", kafkaCondition.getType());

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AbstractNamespaceST.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.systemtest.watcher;
 
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
@@ -45,14 +45,14 @@ public abstract class AbstractNamespaceST extends AbstractST {
         LOGGER.info("Check if Kafka Cluster {} in namespace {}", clusterName, namespace);
 
         TestUtils.waitFor("Kafka Cluster status is not in desired state: Ready", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
-            Condition kafkaCondition = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get()
+            KafkaCondition kafkaCondition = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get()
                     .getStatus().getConditions().get(0);
             LOGGER.info("Kafka condition status: {}", kafkaCondition.getStatus());
             LOGGER.info("Kafka condition type: {}", kafkaCondition.getType());
             return kafkaCondition.getType().equals(Ready.toString());
         });
 
-        Condition kafkaCondition = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get()
+        KafkaCondition kafkaCondition = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get()
                 .getStatus().getConditions().get(0);
 
         assertThat(kafkaCondition.getType(), is(Ready.toString()));

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
@@ -10,7 +10,7 @@ import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaUser;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
@@ -165,7 +165,7 @@ class AllNamespaceST extends AbstractNamespaceST {
         String startingNamespace = cluster.setNamespace(SECOND_NAMESPACE);
         KafkaUser user = KafkaUserResource.createAndWaitForReadiness(KafkaUserResource.tlsUser(MAIN_NAMESPACE_CLUSTER_NAME, USER_NAME).build());
 
-        Condition kafkaCondition = KafkaUserResource.kafkaUserClient().inNamespace(SECOND_NAMESPACE).withName(USER_NAME)
+        KafkaCondition kafkaCondition = KafkaUserResource.kafkaUserClient().inNamespace(SECOND_NAMESPACE).withName(USER_NAME)
                 .get().getStatus().getConditions().get(0);
         LOGGER.info("KafkaUser condition status: {}", kafkaCondition.getStatus());
         LOGGER.info("KafkaUser condition type: {}", kafkaCondition.getType());

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -14,7 +14,7 @@ import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaCondition;
 import io.strimzi.api.kafka.model.status.KafkaTopicStatus;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeClusterResource;
@@ -329,7 +329,7 @@ public abstract class TopicOperatorBaseIT {
                 if (status != null
                         && Objects.equals(status.getObservedGeneration(), kafkaTopic.getMetadata().getGeneration())
                         && status.getConditions() != null) {
-                    List<Condition> conditions = status.getConditions();
+                    List<KafkaCondition> conditions = status.getConditions();
                     assertThat(conditions.size() > 0, is(true));
                     if (conditions.stream().anyMatch(condition ->
                             "Ready".equals(condition.getType()) &&
@@ -358,9 +358,9 @@ public abstract class TopicOperatorBaseIT {
                 if (status != null
                         && Objects.equals(status.getObservedGeneration(), kafkaTopic.getMetadata().getGeneration())
                         && status.getConditions() != null) {
-                    List<Condition> conditions = status.getConditions();
+                    List<KafkaCondition> conditions = status.getConditions();
                     assertThat(conditions.size() > 0, is(true));
-                    Optional<Condition> unreadyCondition = conditions.stream().filter(condition ->
+                    Optional<KafkaCondition> unreadyCondition = conditions.stream().filter(condition ->
                             "NotReady".equals(condition.getType()) &&
                                     "True".equals(condition.getStatus())).findFirst();
                     if (unreadyCondition.isPresent()) {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Using the Strimzi API in another application happens that the `Condition` class we provide clashes with the `Condition` class in the fabric8 Kubernetes client. Other than this, the same fabric8 provides specific classes like `PodCondition`, `DeploymentCondition` and so on. 
For avoiding clashes and following kind of the same pattern, this PR just renames `Condition` to `KafkaCondition`.

Maybe is it a kind of breaking changes in the API if someone is using them but I think it worths it. I can add this to the CHANGELOG if you agree to this change.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Update CHANGELOG.md
