### PR TITLE
Longer timeout, fail Session start promise

### DIFF
--- a/topic-operator/design/topic-store.md
+++ b/topic-operator/design/topic-store.md
@@ -108,7 +108,7 @@ Other configuration options are listed here:
     /** The (gRPC) application server for the Kafka Streams based TopicStore */
     public static final Value<String> APPLICATION_SERVER = new Value<>(TC_APPLICATION_SERVER, STRING, "localhost:9000");
     /** The stale timeout for the Kafka Streams based TopicStore */
-    public static final Value<Long> STALE_RESULT_TIMEOUT_MS = new Value<>(TC_STALE_RESULT_TIMEOUT_MS, DURATION, "1000");
+    public static final Value<Long> STALE_RESULT_TIMEOUT_MS = new Value<>(TC_STALE_RESULT_TIMEOUT_MS, DURATION, "5000");
     /** Is distributed KeyValue store used for the Kafka Streams based TopicStore */
     public static final Value<Boolean> DISTRIBUTED_STORE = new Value<>(TC_DISTRIBUTED_STORE, BOOLEAN, "false");
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
@@ -187,7 +187,7 @@ public class Config {
     /** The (gRPC) application server for the Kafka Streams based TopicStore */
     public static final Value<String> APPLICATION_SERVER = new Value<>(TC_APPLICATION_SERVER, STRING, "localhost:9000");
     /** The stale timeout for the Kafka Streams based TopicStore */
-    public static final Value<Long> STALE_RESULT_TIMEOUT_MS = new Value<>(TC_STALE_RESULT_TIMEOUT_MS, DURATION, "1000");
+    public static final Value<Long> STALE_RESULT_TIMEOUT_MS = new Value<>(TC_STALE_RESULT_TIMEOUT_MS, DURATION, "5000");
     /** Is distributed KeyValue store used for the Kafka Streams based TopicStore */
     public static final Value<Boolean> DISTRIBUTED_STORE = new Value<>(TC_DISTRIBUTED_STORE, BOOLEAN, "false");
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -199,10 +199,19 @@ public class Session extends AbstractVerticle {
                         cs = ksc.start(config, kafkaClientProps).thenCompose(s -> CompletableFuture.completedFuture(ksc));
                     }
                     topicStore = ConcurrentUtil.result(
-                            cs.thenApply(s -> {
-                                service = s;
-                                return s.store;
+                            cs.handle((s, t) -> {
+                                if (t != null) {
+                                    LOGGER.error("Failed to create topic store.", t);
+                                    start.fail(t);
+                                    return null; // [1]
+                                } else {
+                                    service = s;
+                                    return s.store;
+                                }
                             }));
+                    if (topicStore == null) {
+                        return; // [1]
+                    }
                 }
 
                 LOGGER.debug("Using TopicStore {}", topicStore);


### PR DESCRIPTION
Change KafkaStreamsTopicStore timeout to 5sec,
better handle KafkaStreamsTopicStore creation failure.

Signed-off-by: Ales Justin <ales.justin@gmail.com>
