### PR TITLE
Remove duplicate dependency on junit-platform-commons in system tests

### DIFF
--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -225,10 +225,6 @@
             <artifactId>config-model</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-commons</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
             <version>${bouncycastle.version}</version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `junit-platform-commons` dependency is listed twice in the `systemtests` `pom.xml` file. As a result, Maven is complaining:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.strimzi:systemtest:jar:0.22.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.junit.platform:junit-platform-commons:jar -> version ${junit.platform.version} vs (?) @ line 227, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

This PR removes the duplicate to leave it there only once.