### PR TITLE
Remove DeploymentConfig readiness workaround

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperator.java
@@ -10,7 +10,6 @@ import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.DeploymentConfigList;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.dsl.DeployableScalableResource;
-import io.fabric8.openshift.client.internal.readiness.OpenShiftReadiness;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
@@ -120,10 +119,7 @@ public class DeploymentConfigOperator extends AbstractScalableResourceOperator<O
         DeploymentConfig resource = resourceOp.get();
         
         if (resource != null)   {
-            // resourceOp.isReady() does not work because of https://github.com/fabric8io/kubernetes-client/issues/2537
-            // This method provides a temporary workaround by calling OpenShiftReadiness.isDeploymentConfigReady(...) directly.
-            // TODO: This should be changed to resourceOp.isReady() after https://github.com/fabric8io/kubernetes-client/issues/2537 is fixed.
-            return Boolean.TRUE.equals(OpenShiftReadiness.isDeploymentConfigReady(resource));
+            return Boolean.TRUE.equals(resourceOp.isReady());
         } else {
             return false;
         }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperatorTest.java
@@ -12,8 +12,6 @@ import io.fabric8.openshift.api.model.DeploymentConfigList;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.dsl.DeployableScalableResource;
 import io.vertx.core.Vertx;
-import io.vertx.junit5.VertxTestContext;
-import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.when;
 
@@ -53,33 +51,5 @@ public class DeploymentConfigOperatorTest extends ScalableResourceOperatorTest<O
     @Override
     protected DeploymentConfigOperator createResourceOperations(Vertx vertx, OpenShiftClient mockClient) {
         return new DeploymentConfigOperator(vertx, mockClient);
-    }
-
-    @Test
-    @Override
-    public void testWaitUntilReadySuccessfulImmediately(VertxTestContext context) {
-        // This test has to be skipped because of https://github.com/fabric8io/kubernetes-client/issues/2537 which
-        // doesn't allow easy mocking of the readiness states
-        // TODO: This dummy method should be removed after https://github.com/fabric8io/kubernetes-client/issues/2537 is fixed
-        context.completeNow();
-
-    }
-
-    @Test
-    @Override
-    public void testWaitUntilReadySuccessfulAfterOneCall(VertxTestContext context) {
-        // This test has to be skipped because of https://github.com/fabric8io/kubernetes-client/issues/2537 which
-        // doesn't allow easy mocking of the readiness states
-        // TODO: This dummy method should be removed after https://github.com/fabric8io/kubernetes-client/issues/2537 is fixed
-        context.completeNow();
-    }
-
-    @Test
-    @Override
-    public void testWaitUntilReadySuccessfulAfterTwoCalls(VertxTestContext context) {
-        // This test has to be skipped because of https://github.com/fabric8io/kubernetes-client/issues/2537 which
-        // doesn't allow easy mocking of the readiness states
-        // TODO: This dummy method should be removed after https://github.com/fabric8io/kubernetes-client/issues/2537 is fixed
-        context.completeNow();
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/EndpointOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/EndpointOperatorTest.java
@@ -14,7 +14,7 @@ import io.vertx.core.Vertx;
 
 import static org.mockito.Mockito.when;
 
-public class EndpointOperatorTest extends AbtractReadyResourceOperatorTest<KubernetesClient, Endpoints, EndpointsList, Resource<Endpoints>> {
+public class EndpointOperatorTest extends AbstractReadyResourceOperatorTest<KubernetesClient, Endpoints, EndpointsList, Resource<Endpoints>> {
 
     @Override
     protected Class<KubernetesClient> clientType() {

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodOperatorTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 public class PodOperatorTest extends
-        AbtractReadyResourceOperatorTest<KubernetesClient, Pod, PodList, PodResource<Pod>> {
+        AbstractReadyResourceOperatorTest<KubernetesClient, Pod, PodList, PodResource<Pod>> {
     @Test
     public void testCreateReadUpdate(VertxTestContext context) {
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool", 10);

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ScalableResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ScalableResourceOperatorTest.java
@@ -13,6 +13,6 @@ public abstract class ScalableResourceOperatorTest<C extends KubernetesClient,
             T extends HasMetadata,
             L extends KubernetesResourceList<T>,
             R extends Resource<T>>
-        extends AbtractReadyResourceOperatorTest<C, T, L, R> {
+        extends AbstractReadyResourceOperatorTest<C, T, L, R> {
 
 }

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -40,7 +40,6 @@ import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.internal.readiness.OpenShiftReadiness;
 import okhttp3.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -379,10 +378,7 @@ public class KubeClient {
      * Gets deployment config status
      */
     public boolean getDeploymentConfigReadiness(String deploymentConfigName) {
-        // isReady() does not work because of https://github.com/fabric8io/kubernetes-client/issues/2537
-        // This method provides a temporary workaround by calling OpenShiftReadiness.isDeploymentConfigReady(...) directly.
-        // TODO: This should be changed to isReady() after https://github.com/fabric8io/kubernetes-client/issues/2537 is fixed.
-        return OpenShiftReadiness.isDeploymentConfigReady(getDeploymentConfig(deploymentConfigName));
+        return Boolean.TRUE.equals(client.adapt(OpenShiftClient.class).deploymentConfigs().inNamespace(getNamespace()).withName(deploymentConfigName).isReady());
     }
 
     // ==================================


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

As described in #3779, a bug in Fabric8 4.12 forced us to use a workaround for DeploymentConfig readiness check. This is now fixed for some time. This PR removes the workaround.

It also renames the `AbtractReadyResourceOperatorTest.java` file which has a typo in its name (Abtract => Abstract).

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging