### PR TITLE
Fix Cruise Control crash loop when updating container configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add annotations that enable the operator to restart Kafka Connect connectors or tasks. The annotations can be applied to the KafkaConnector and the KafkaMirrorMaker2 custom resources.
 * Add support for JMX options configuration of all Kafka Connect (KC, KC2SI, MM2)
 * Updated Cruise Control to version 2.5.32
+* Fix Cruise Control crash loop when updating container configurations
 
 ### Deprecations and removals
 

--- a/docker-images/kafka/cruise-control-scripts/cruise_control_config_generator.sh
+++ b/docker-images/kafka/cruise-control-scripts/cruise_control_config_generator.sh
@@ -29,7 +29,7 @@ min.insync.replicas=$MIN_INSYNC_REPLICAS
 EOF
 
 # Write all webserver access logs to stdout
-ln -s /dev/stdout $CC_ACCESS_LOG
+ln -sf /dev/stdout $CC_ACCESS_LOG
 
 # Write the config file
 cat <<EOF


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Since version 0.21, Strimzi mounts a volume for a container's /tmp directory instead of relying on the container's filesystem [1]. This means that when containers are rolled, the same /tmp directory that was mounted in the previous container is then mounted in the new container. The problem occurs when rolling the Cruise Control container, the cruise_control_config_generator script [2] attempts to create symlink to a file on the volume and if a symlink already exists, the script fails, resulting in the following error:

```
 Preparing certificates for internal communication                                                                                                                                                                               
 Adding /etc/tls-sidecar/cluster-ca-certs/ca.crt to truststore /tmp/cruise-control/replication.truststore.p12 with alias ca                                                                                                      
 Certificate was added to keystore                                                                                                                                                                                               
 Preparing certificates for internal communication is complete                                                                                                                                                                   
 Starting Cruise Control with configuration:                                                                                                                                                                                     
 ln: failed to create symbolic link '/tmp/access.log': File exists                                                                                                                                                               
 2021-01-28 23:33:51,804 ERROR Uncaught exception on thread Thread[main,5,main] (com.linkedin.kafka.cruisecontrol.KafkaCruiseControlMain) [main]                                                                                 
 org.apache.kafka.common.config.ConfigException: Missing required configuration "bootstrap.servers" which has no default value.                                                                                                  
     at org.apache.kafka.common.config.ConfigDef.parseValue(ConfigDef.java:478)                                                                                                                                                  
     at org.apache.kafka.common.config.ConfigDef.parse(ConfigDef.java:468)                                                                                                                                                       
     at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:108)                                                                                                                                            
     at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:142)                                                                                                                                            
     at com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig.<init>(KafkaCruiseControlConfig.java:459)                                                                                                               
     at com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig.<init>(KafkaCruiseControlConfig.java:455)                                                                                                               
     at com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.readConfig(KafkaCruiseControlUtils.java:774)                                                                                                                    
     at com.linkedin.kafka.cruisecontrol.KafkaCruiseControlMain.main(KafkaCruiseControlMain.java:35)                                                                                                                             
 stream closed
```
Since the symlink was already created by the previous container, the new rolled container will fail with this error when trying to create a new symlink, throwing the Cruise Control pod into a crash loop.

To fix this we can simply add the `-f` argument to the symlink command [2] which will remove any existing symlinks on the volume before trying to creating a new one. This will prevent the config generator script from failing and misgenerating the Cruise Control config file which is causing the crash loop.

**To Reproduce**

Update an existing Cruise Control instance with a configuration to make the containers roll, e.g.
```
apiVersion: kafka.strimzi.io/v1beta1
kind: Kafka
metadata:
  name: my-cluster
spec:
  ...
  cruiseControl:
    resources:
      requests:
        cpu: 1
        memory: 256Mi
      limits:
        cpu: 2
        memory: 500Mi
```

**Expected behavior**
The Cruise Control pod should roll without error when applying configuration changes to `spec.cruiseControl` section of the Kafka resource.

**Environment (please complete the following information):**
 - Kubernetes v1.20.0 (via minikube)

**Additional context**
[1] https://github.com/strimzi/strimzi-kafka-operator/pull/4162
[2] https://github.com/strimzi/strimzi-kafka-operator/blob/master/docker-images/kafka/cruise-control-scripts/cruise_control_config_generator.sh#L32
~                                                                                                                                                        

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

