### PR TITLE
[DOC] complete the Kafka status example

### DIFF
--- a/documentation/contributing/introduction.adoc
+++ b/documentation/contributing/introduction.adoc
@@ -76,7 +76,7 @@ Upgrade instructions are provided for Strimzi and Kafka upgrades.
 The _Strimzi Quick Start guide_ provides instructions for evaluating Strimzi using _Minikube_.
 The steps describe how to get a Strimzi deployment up-and-running as quickly as possible.
 
-In contrast to the __Deploying and Upgrading Strimzi_ guide, this guide provides a reduced set of instructions for a specific type of deployment, with minimal configuration.
+In contrast to the _Deploying and Upgrading Strimzi_ guide, this guide provides a reduced set of instructions for a specific type of deployment, with minimal configuration.
 
 === Using Strimzi
 

--- a/documentation/contributing/introduction.adoc
+++ b/documentation/contributing/introduction.adoc
@@ -61,7 +61,7 @@ The guide also describes how Strimzi _Operators_ help manage a deployment.
 
 The guide contains high-level outlines of the processes required to deploy, configure, secure and monitor a deployment of Strimzi.
 
-=== Deploying Strimzi
+=== Deploying and Upgrading Strimzi
 
 The _Deploying and Upgrading Strimzi_ guide provides instructions on all the options available for deploying and upgrading Strimzi.
 The guide describes what is deployed, and the order of deployment required to run Apache Kafka in a Kubernetes cluster.
@@ -76,7 +76,7 @@ Upgrade instructions are provided for Strimzi and Kafka upgrades.
 The _Strimzi Quick Start guide_ provides instructions for evaluating Strimzi using _Minikube_.
 The steps describe how to get a Strimzi deployment up-and-running as quickly as possible.
 
-In contrast to the _Deploying_ guide, this guide provides a reduced set of instructions for a specific type of deployment, with minimal configuration.
+In contrast to the __Deploying and Upgrading Strimzi_ guide, this guide provides a reduced set of instructions for a specific type of deployment, with minimal configuration.
 
 === Using Strimzi
 

--- a/documentation/modules/configuring/proc-config-kafka-connect-s2i-migration.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect-s2i-migration.adoc
@@ -7,13 +7,13 @@
 
 [role="_abstract"]
 Support for Kafka Connect with S2I and the `KafkaConnectS2I` resource is planned for deprecation.
-The decision follows the introduction of `build` configuration properties to the `KafkaConnect` resource,
+This follows the introduction of `build` configuration properties to the `KafkaConnect` resource,
 which are used to build a container image with the connector plugins you require for your data connections automatically.
 
 This procedure describes how to migrate your Kafka Connect with S2I instance to a standard Kafka Connect instance.
-To do this, you configure a new `KafkaConnect` custom resource to replace the `KafkaConnectS2I` resource, which is deleted.
+To do this, you configure a new `KafkaConnect` custom resource to replace the `KafkaConnectS2I` resource, which is then deleted.
 
-WARNING: The migration process involves downtime from the moment `KafkaConnectS2I` instance is deleted until the new `KafkaConnect` instance has been successfully deployed.
+WARNING: The migration process involves downtime from the moment the `KafkaConnectS2I` instance is deleted until the new `KafkaConnect` instance has been successfully deployed.
 During this time, connectors will not be running and processing data. However, after the changeover they should continue from the point at which they stopped.
 
 .Prerequisites
@@ -25,7 +25,7 @@ During this time, connectors will not be running and processing data. However, a
 .Procedure
 
 . Create a new `KafkaConnect` custom resource using the same name as the name used for the `KafkaconnectS2I` resource.
-. Copy the `KafkaconnectS2I` resource properties to the `KafkaConnect` resource.
+. Copy the `KafkaConnectS2I` resource properties to the `KafkaConnect` resource.
 . If specified, make sure you use the same `spec.config` properties:
 +
 --
@@ -60,7 +60,7 @@ Replace _MY-KAFKA-CONNECT-S2I_ with the name of the `KafkaConnectS2I` resource.
 +
 Wait until the Kafka Connect with S2I deployment and pods are deleted.
 +
-IMPORTANT: No other resources must be deleted.
+WARNING: No other resources must be deleted.
 
 . Deploy the new `KafkaConnect` resource:
 +
@@ -75,7 +75,7 @@ Wait until the new image is built, the deployment is created, and the pods have 
 +
 [source,shell,subs="+quotes"]
 ----
-kubectl get kctr --selector strimzi.io/cluster=_MY-CONNECT-CLUSTER_ -o name
+kubectl get kctr --selector strimzi.io/cluster=_MY-KAFKA-CONNECT-CLUSTER_ -o name
 ----
 +
 Replace _MY-KAFKA-CONNECT-CLUSTER_ with the name of your Kafka Connect cluster.
@@ -87,6 +87,6 @@ Even if you are using the Kafka Connect REST API to manage them, you should not 
 [role="_additional-resources"]
 .Additional resources
 * xref:proc-kafka-connect-config-str[Configuring Kafka Connect]
-* {BookURLDeploying}#creating-new-image-using-kafka-connect-build-str[Creating a new container image automatically using Strimzi]
-* {BookURLDeploying}#creating-new-image-from-base-str[Creating a Docker image from the Kafka Connect base image]
-* {BookURLDeploying}#con-creating-managing-connectors-str[Creating and managing connectors]
+* link:{BookURLDeploying}#creating-new-image-using-kafka-connect-build-str[Creating a new container image automatically using Strimzi]
+* link:{BookURLDeploying}#creating-new-image-from-base-str[Creating a Docker image from the Kafka Connect base image]
+* link:{BookURLDeploying}#con-creating-managing-connectors-str[Creating and managing connectors]

--- a/documentation/modules/managing/con-custom-resources-status.adoc
+++ b/documentation/modules/managing/con-custom-resources-status.adoc
@@ -85,7 +85,7 @@ spec:
   # ...
 status:
   conditions: <1>
-  - lastTransitionTime: _YEAR_-_MONTH_-23T23:46:57+0000
+  - lastTransitionTime: 2021-07-23T23:46:57+0000
     status: "True"
     type: Ready <2>
   observedGeneration: 4 <3>

--- a/documentation/modules/managing/con-custom-resources-status.adoc
+++ b/documentation/modules/managing/con-custom-resources-status.adoc
@@ -74,7 +74,7 @@ When performing an update on a custom resource using `kubectl edit`, for example
 Here we see the `status` property specified for a Kafka custom resource.
 
 .Kafka custom resource with status
-[source,yaml,subs="attributes+"]
+[source,shell,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
 kind: Kafka
@@ -83,7 +83,7 @@ spec:
   # ...
 status:
   conditions: <1>
-  - lastTransitionTime: 2019-07-23T23:46:57+0000
+  - lastTransitionTime: _YEAR_-_MONTH_-23T23:46:57+0000
     status: "True"
     type: Ready <2>
   observedGeneration: 4 <3>
@@ -110,12 +110,14 @@ status:
       ...
       -----END CERTIFICATE-----
     type: external
-    # ...
+  clusterId: _CLUSTER-ID_ <5>
+# ...
 ----
 <1> Status `conditions` describe criteria related to the status that cannot be deduced from the existing resource information, or are specific to the instance of a resource.
 <2> The `Ready` condition indicates whether the Cluster Operator currently considers the Kafka cluster able to handle traffic.
 <3> The `observedGeneration` indicates the generation of the `Kafka` custom resource that was last reconciled by the Cluster Operator.
 <4> The `listeners` describe the current Kafka bootstrap addresses by type.
+<5> The Kafka cluster id.
 +
 IMPORTANT: The address in the custom resource status for external listeners with type `nodeport` is currently not supported.
 

--- a/documentation/modules/managing/con-custom-resources-status.adoc
+++ b/documentation/modules/managing/con-custom-resources-status.adoc
@@ -58,6 +58,8 @@ The `status` property of a resource provides information on the resource's:
 
 The `status` property also provides resource-specific information. For example:
 
+* `KafkaStatus` provides information on listener addresses and the id of the Kafka cluster.
+
 * `KafkaConnectStatus` provides the REST API endpoint for Kafka Connect connectors.
 
 * `KafkaUserStatus` provides the user name of the Kafka user and the `Secret` in which their credentials are stored.

--- a/documentation/modules/proc-configuring-kafka-user.adoc
+++ b/documentation/modules/proc-configuring-kafka-user.adoc
@@ -81,4 +81,4 @@ kubectl apply -f _USER-CONFIG-FILE_
 The user is created, as well as a Secret with the same name as the `KafkaUser` resource.
 The Secret contains a private and public key for TLS client authentication.
 
-For information on configuring a Kafka client with properties for secure connection to Kafka brokers, see link:{BookURLDeploying}#setup-external-clients-str[Setting up access for clients outside of Kubernetes^] in the _Deploying Strimzi_ guide.
+For information on configuring a Kafka client with properties for secure connection to Kafka brokers, see link:{BookURLDeploying}#setup-external-clients-str[Setting up access for clients outside of Kubernetes^] in the _Deploying and Upgrading Strimzi_ guide.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

With the introduction of `clusterId` to `KafkaStatus`, I've updated the example _Kafka custom resource with status_ to include it.

Plus couple of consistency changes.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

