### PR TITLE
Keep a copy of the Kaniko builder under the Strimzi repositories

### DIFF
--- a/docker-images/build.sh
+++ b/docker-images/build.sh
@@ -9,6 +9,7 @@ base_images="base"
 java_images="operator jmxtrans"
 kafka_image="kafka"
 kafka_images="kafka test-client"
+other_images="kaniko-executor"
 
 function dependency_check { 
 
@@ -157,6 +158,12 @@ function build {
     for image in $java_images
     do
         DOCKER_BUILD_ARGS="$DOCKER_BUILD_ARGS --build-arg JAVA_VERSION=${java_version} $(alternate_base $image)" make -C "$image" "$targets"
+    done
+
+    # Images not depending on Kafka version and not based on Java
+    for image in $other_images
+    do
+        make -C "$image" "$targets"
     done
 
     if [[ $targets == *"docker_build"* ]]

--- a/docker-images/kaniko-executor/Makefile
+++ b/docker-images/kaniko-executor/Makefile
@@ -1,0 +1,14 @@
+PROJECT_NAME := kaniko-executor
+KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.3.0
+
+docker_build:
+	# The Kaniko executor image used for building new Kafka Connect images with additional connectors is not build from
+	# scratch. We just pull the one released by Kaniko, retag it and push it to our repository to have our versioning on
+	# it and have it stored there in our other images.
+	$(DOCKER_CMD) pull $(KANIKO_EXECUTOR)
+	$(DOCKER_CMD) tag $(KANIKO_EXECUTOR) strimzi/$(PROJECT_NAME):latest
+	$(DOCKER_CMD) tag $(KANIKO_EXECUTOR) strimzi/$(PROJECT_NAME):$(BUILD_TAG)
+
+include ../../Makefile.docker
+
+.PHONY: build clean release

--- a/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -142,10 +142,10 @@ the documentation for more details.
 | `kafkaBridge.image.repository`       | Kafka Bridge image repository             | `strimzi`                                            |
 | `kafkaBridge.image.name`             | Kafka Bridge image name                   | `kafka-bridge                                        |
 | `kafkaBridge.image.tag`              | Kafka Bridge image tag                    | `0.19.0`                                             |
-| `kanikoExecutor.image.registry`      | Kaniko Executor image registry            | `gcr.io`                                             |
-| `kanikoExecutor.image.repository`    | Kaniko Executor image repository          | `kaniko-project`                                     |
-| `kanikoExecutor.image.name`          | Kaniko Executor image name                | `executor`                                           |
-| `kanikoExecutor.image.tag`           | Kaniko Executor image tag                 | `v1.3.0`                                             |
+| `kanikoExecutor.image.registry`      | Kaniko Executor image registry            | `quay.io`                                            |
+| `kanikoExecutor.image.repository`    | Kaniko Executor image repository          | `strimzi`                                            |
+| `kanikoExecutor.image.name`          | Kaniko Executor image name                | `kaniko-executor`                                    |
+| `kanikoExecutor.image.tag`           | Kaniko Executor image tag                 | `latest`                                             |
 | `resources.limits.memory`            | Memory constraint for limits              | `256Mi`                                              |
 | `resources.limits.cpu`               | CPU constraint for limits                 | `1000m`                                              |
 | `resources.requests.memory`          | Memory constraint for requests            | `256Mi`                                              |

--- a/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -118,10 +118,10 @@ tlsSidecarCruiseControl:
     tagPrefix: latest
 kanikoExecutor:
   image:
-    registry: gcr.io
-    repository: kaniko-project
-    name: executor
-    tag: v1.3.0
+    registry: quay.io
+    repository: strimzi
+    name: kaniko-executor
+    tag: latest
 resources:
   limits:
     memory: 384Mi

--- a/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -95,7 +95,7 @@ spec:
             - name: STRIMZI_DEFAULT_JMXTRANS_IMAGE
               value: quay.io/strimzi/jmxtrans:latest
             - name: STRIMZI_DEFAULT_KANIKO_EXECUTOR_IMAGE
-              value: gcr.io/kaniko-project/executor:v1.3.0
+              value: quay.io/strimzi/kaniko-executor:latest
             - name: STRIMZI_OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As described in #4181 ... Currently, we are using the Kaniko container image directly from their repository. I'm not sure this is optimal - it is not visible that we use it. It is also stored in different infra etc. It might make sense to maintain a copy of it under our own container repository. I think Kaniko is trusted community, but we never know if they for example have to move the images etc. So keeping our own copy makes sense.

This PR does not build Kaniko from source code => it just pulls the image build by the Kaniko community, retags it and pushes it to Strimzi Quay.io registry.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging