### PR TITLE
Allow to pass additional options to Kaniko executor for Kafka Connect builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 0.22.0
 
 * Add annotations that enable the operator to restart Kafka Connect connectors or tasks. The annotations can be applied to the KafkaConnector and the KafkaMirrorMaker2 custom resources.
+* Add additional configuration options for the Kaniko executor used by the Kafka Connect Build on Kubernetes
 * Add support for JMX options configuration of all Kafka Connect (KC, KC2SI, MM2)
 * Updated Cruise Control to version 2.5.32
 * Fix Cruise Control crash loop when updating container configurations

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DockerOutput.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DockerOutput.java
@@ -12,6 +12,8 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
+import java.util.List;
+
 /**
  * Represents Docker output from the build
  */
@@ -32,7 +34,7 @@ public class DockerOutput extends Output {
 
     private String image;
     private String pushSecret;
-    private String additionalKanikoOptions;
+    private List<String> additionalKanikoOptions;
 
     @Description("Must be `" + TYPE_DOCKER + "`")
     @Override
@@ -62,17 +64,17 @@ public class DockerOutput extends Output {
     }
 
     @Description("Configures additional options which will be passed to the Kaniko executor when building the new Connect image. " +
-            "For example `--reproducible --single-snapshot`. Allowed options are: " + ALLOWED_KANIKO_OPTIONS + " " +
+            "Allowed options are: " + ALLOWED_KANIKO_OPTIONS + ". " +
             "These options will be used only on Kubernetes where the Kaniko executor is used. " +
             "They will be ignored on OpenShift. " +
             "The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. " +
             "Changing this field does not trigger new build of the Kafka Connect image.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public String getAdditionalKanikoOptions() {
+    public List<String> getAdditionalKanikoOptions() {
         return additionalKanikoOptions;
     }
 
-    public void setAdditionalKanikoOptions(String additionalKanikoOptions) {
+    public void setAdditionalKanikoOptions(List<String> additionalKanikoOptions) {
         this.additionalKanikoOptions = additionalKanikoOptions;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DockerOutput.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DockerOutput.java
@@ -25,8 +25,14 @@ import lombok.EqualsAndHashCode;
 public class DockerOutput extends Output {
     private static final long serialVersionUID = 1L;
 
+    public static final String ALLOWED_KANIKO_OPTIONS = "--customPlatform, --insecure, --insecure-pull, " +
+            "--insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, " +
+            "--skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, " +
+            "--use-new-run";
+
     private String image;
     private String pushSecret;
+    private String additionalKanikoOptions;
 
     @Description("Must be `" + TYPE_DOCKER + "`")
     @Override
@@ -53,5 +59,20 @@ public class DockerOutput extends Output {
 
     public void setPushSecret(String pushSecret) {
         this.pushSecret = pushSecret;
+    }
+
+    @Description("Configures additional options which will be passed to the Kaniko executor when building the new Connect image. " +
+            "For example `--reproducible --single-snapshot`. Allowed options are: " + ALLOWED_KANIKO_OPTIONS + " " +
+            "These options will be used only on Kubernetes where the Kaniko executor is used. " +
+            "They will be ignored on OpenShift. " +
+            "The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. " +
+            "Changing this field does not trigger new build of the Kafka Connect image.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getAdditionalKanikoOptions() {
+        return additionalKanikoOptions;
+    }
+
+    public void setAdditionalKanikoOptions(String additionalKanikoOptions) {
+        this.additionalKanikoOptions = additionalKanikoOptions;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
@@ -164,7 +164,7 @@ public class KafkaConnectBuild extends AbstractModel {
     private static void validateAdditionalKanikoOptions(List<String> desiredOptions)    {
         List<String> allowedOptions = Arrays.asList(DockerOutput.ALLOWED_KANIKO_OPTIONS.split("\\s*,+\\s*"));
         List<String> forbiddenOptions = desiredOptions.stream()
-                .filter(option -> !allowedOptions.stream().anyMatch(allowed -> option.startsWith(allowed)))
+                .filter(option -> allowedOptions.stream().noneMatch(option::startsWith))
                 .collect(Collectors.toList());
 
         if (!forbiddenOptions.isEmpty())    {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
@@ -92,9 +92,8 @@ public class KafkaConnectBuild extends AbstractModel {
 
                 if (dockerOutput.getAdditionalKanikoOptions() != null
                         && !dockerOutput.getAdditionalKanikoOptions().isEmpty())  {
-                    List<String> desiredOptions = Arrays.asList(dockerOutput.getAdditionalKanikoOptions().split("\\s+"));
-                    validateAdditionalKanikoOptions(desiredOptions);
-                    build.additionalKanikoOptions = desiredOptions;
+                    validateAdditionalKanikoOptions(dockerOutput.getAdditionalKanikoOptions());
+                    build.additionalKanikoOptions = dockerOutput.getAdditionalKanikoOptions();
                 }
             }
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
@@ -163,7 +163,8 @@ public class KafkaConnectBuild extends AbstractModel {
     private static void validateAdditionalKanikoOptions(List<String> desiredOptions)    {
         List<String> allowedOptions = Arrays.asList(DockerOutput.ALLOWED_KANIKO_OPTIONS.split("\\s*,+\\s*"));
         List<String> forbiddenOptions = desiredOptions.stream()
-                .filter(option -> allowedOptions.stream().noneMatch(option::startsWith))
+                .map(option -> option.contains("=") ? option.substring(0, option.indexOf("=")) : option)
+                .filter(option -> allowedOptions.stream().noneMatch(option::equals))
                 .collect(Collectors.toList());
 
         if (!forbiddenOptions.isEmpty())    {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
@@ -302,7 +302,7 @@ public class KafkaConnectBuild extends AbstractModel {
     protected List<Container> getContainers(ImagePullPolicy imagePullPolicy) {
         List<Container> containers = new ArrayList<>(1);
 
-        List<String> args = new ArrayList<>(4);
+        List<String> args = additionalKanikoOptions != null ? new ArrayList<>(4 + additionalKanikoOptions.size()) : new ArrayList<>(4);
         args.add("--dockerfile=/dockerfile/Dockerfile");
         args.add("--context=dir://workspace");
         args.add("--image-name-with-digest-file=/dev/termination-log");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -467,7 +467,7 @@ public class KafkaConnectBuildTest {
 
         KafkaConnectBuild build = KafkaConnectBuild.fromCrd(kc, VERSIONS);
 
-        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null);
+        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null, null);
         assertThat(pod.getSpec().getContainers().get(0).getArgs(), is(expectedArgs));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -484,7 +484,7 @@ public class KafkaConnectBuildTest {
                         .withNewDockerOutput()
                             .withImage("my-image:latest")
                             .withNewPushSecret("my-docker-credentials")
-                            .withAdditionalKanikoOptions("--reproducible", "--build-arg", "--single-snapshot", "--digest-file=/dev/null", "--log-format=json")
+                            .withAdditionalKanikoOptions("--reproducible", "--reproducible-something", "--build-arg", "--single-snapshot", "--digest-file=/dev/null", "--log-format=json")
                         .endDockerOutput()
                         .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
                                 new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
@@ -494,6 +494,6 @@ public class KafkaConnectBuildTest {
 
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaConnectBuild.fromCrd(kc, VERSIONS));
 
-        assertThat(e.getMessage(), containsString(".spec.build.additionalKanikoOptions contains forbidden options: [--build-arg, --digest-file=/dev/null]"));
+        assertThat(e.getMessage(), containsString(".spec.build.additionalKanikoOptions contains forbidden options: [--reproducible-something, --build-arg, --digest-file]"));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -21,9 +21,12 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -43,6 +46,11 @@ public class KafkaConnectBuildTest {
             .withUrl("https://mydomain.tld/my2.jar")
             .withSha512sum("sha-512-checksum")
             .build();
+
+    private final List<String> defaultArgs = List.of("--dockerfile=/dockerfile/Dockerfile",
+            "--context=dir://workspace",
+            "--image-name-with-digest-file=/dev/termination-log",
+            "--destination=my-image:latest");
 
     @Test
     public void testFromCrd()   {
@@ -183,6 +191,7 @@ public class KafkaConnectBuildTest {
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
         assertThat(pod.getMetadata().getLabels(), is(expectedDeploymentLabels));
         assertThat(pod.getSpec().getContainers().size(), is(1));
+        assertThat(pod.getSpec().getContainers().get(0).getArgs(), is(defaultArgs));
         assertThat(pod.getSpec().getContainers().get(0).getName(), is(KafkaConnectResources.buildPodName(this.cluster)));
         assertThat(pod.getSpec().getContainers().get(0).getImage(), is(build.image));
         assertThat(pod.getSpec().getContainers().get(0).getPorts().size(), is(0));
@@ -229,6 +238,7 @@ public class KafkaConnectBuildTest {
 
         Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null, null);
         assertThat(pod.getSpec().getVolumes().size(), is(2));
+        assertThat(pod.getSpec().getContainers().get(0).getArgs(), is(defaultArgs));
         assertThat(pod.getSpec().getVolumes().get(0).getName(), is("workspace"));
         assertThat(pod.getSpec().getVolumes().get(0).getEmptyDir(), is(notNullValue()));
         assertThat(pod.getSpec().getVolumes().get(1).getName(), is("dockerfile"));
@@ -427,5 +437,65 @@ public class KafkaConnectBuildTest {
         BuildConfig bc = build.generateBuildConfig(dockerfile);
         assertThat(bc.getMetadata().getLabels().entrySet().containsAll(buildConfigLabels.entrySet()), is(true));
         assertThat(bc.getMetadata().getAnnotations().entrySet().containsAll(buildConfigAnnos.entrySet()), is(true));
+    }
+
+    @Test
+    public void testValidKanikoOptions()   {
+        List<String> expectedArgs = new ArrayList<>(defaultArgs);
+        expectedArgs.add("--reproducible");
+        expectedArgs.add("--single-snapshot");
+        expectedArgs.add("--log-format=json");
+
+        KafkaConnect kc = new KafkaConnectBuilder()
+                .withNewMetadata()
+                    .withName(cluster)
+                    .withNamespace(namespace)
+                .endMetadata()
+                .withNewSpec()
+                    .withBootstrapServers("my-kafka:9092")
+                    .withNewBuild()
+                        .withNewDockerOutput()
+                            .withImage("my-image:latest")
+                            .withNewPushSecret("my-docker-credentials")
+                            .withAdditionalKanikoOptions("--reproducible --single-snapshot --log-format=json")
+                        .endDockerOutput()
+                        .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
+                                new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
+                    .endBuild()
+                .endSpec()
+                .build();
+
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(kc, VERSIONS);
+
+        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null);
+        assertThat(pod.getSpec().getContainers().get(0).getArgs(), is(expectedArgs));
+    }
+
+    @Test
+    public void testInvalidKanikoOptions()   {
+        KafkaConnect kc = new KafkaConnectBuilder()
+                .withNewMetadata()
+                    .withName(cluster)
+                    .withNamespace(namespace)
+                .endMetadata()
+                .withNewSpec()
+                    .withBootstrapServers("my-kafka:9092")
+                    .withNewBuild()
+                        .withNewDockerOutput()
+                            .withImage("my-image:latest")
+                            .withNewPushSecret("my-docker-credentials")
+                            .withAdditionalKanikoOptions("--reproducible --build-arg --single-snapshot --digest-file=/dev/null --log-format=json")
+                        .endDockerOutput()
+                        .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
+                                new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
+                    .endBuild()
+                .endSpec()
+                .build();
+
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> {
+            KafkaConnectBuild.fromCrd(kc, VERSIONS);
+        });
+
+        assertThat(e.getMessage(), containsString(".spec.build.additionalKanikoOptions contains forbidden options: [--build-arg, --digest-file=/dev/null]"));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -492,9 +492,7 @@ public class KafkaConnectBuildTest {
                 .endSpec()
                 .build();
 
-        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> {
-            KafkaConnectBuild.fromCrd(kc, VERSIONS);
-        });
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaConnectBuild.fromCrd(kc, VERSIONS));
 
         assertThat(e.getMessage(), containsString(".spec.build.additionalKanikoOptions contains forbidden options: [--build-arg, --digest-file=/dev/null]"));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -457,7 +457,7 @@ public class KafkaConnectBuildTest {
                         .withNewDockerOutput()
                             .withImage("my-image:latest")
                             .withNewPushSecret("my-docker-credentials")
-                            .withAdditionalKanikoOptions("--reproducible --single-snapshot --log-format=json")
+                            .withAdditionalKanikoOptions("--reproducible", "--single-snapshot", "--log-format=json")
                         .endDockerOutput()
                         .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
                                 new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
@@ -484,7 +484,7 @@ public class KafkaConnectBuildTest {
                         .withNewDockerOutput()
                             .withImage("my-image:latest")
                             .withNewPushSecret("my-docker-credentials")
-                            .withAdditionalKanikoOptions("--reproducible --build-arg --single-snapshot --digest-file=/dev/null --log-format=json")
+                            .withAdditionalKanikoOptions("--reproducible", "--build-arg", "--single-snapshot", "--digest-file=/dev/null", "--log-format=json")
                         .endDockerOutput()
                         .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
                                 new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2370,12 +2370,14 @@ The `type` property is a discriminator that distinguishes use of the `DockerOutp
 It must have the value `docker` for the type `DockerOutput`.
 [options="header"]
 |====
-|Property           |Description
-|image       1.2+<.<|The full name which should be used for tagging and pushing the newly built image. For example `quay.io/my-organization/my-custom-connect:latest`. Required.
+|Property                        |Description
+|image                    1.2+<.<|The full name which should be used for tagging and pushing the newly built image. For example `quay.io/my-organization/my-custom-connect:latest`. Required.
 |string
-|pushSecret  1.2+<.<|Container Registry Secret with the credentials for pushing the newly built image.
+|pushSecret               1.2+<.<|Container Registry Secret with the credentials for pushing the newly built image.
 |string
-|type        1.2+<.<|Must be `docker`.
+|additionalKanikoOptions  1.2+<.<|Configures additional options which will be passed to the Kaniko executor when building the new Connect image. For example `--reproducible --single-snapshot`. Allowed options are: --customPlatform, --insecure, --insecure-pull, --insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run These options will be used only on Kubernetes where the Kaniko executor is used. They will be ignored on OpenShift. The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. Changing this field does not trigger new build of the Kafka Connect image.
+|string
+|type                     1.2+<.<|Must be `docker`.
 |string
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2375,8 +2375,8 @@ It must have the value `docker` for the type `DockerOutput`.
 |string
 |pushSecret               1.2+<.<|Container Registry Secret with the credentials for pushing the newly built image.
 |string
-|additionalKanikoOptions  1.2+<.<|Configures additional options which will be passed to the Kaniko executor when building the new Connect image. For example `--reproducible --single-snapshot`. Allowed options are: --customPlatform, --insecure, --insecure-pull, --insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run These options will be used only on Kubernetes where the Kaniko executor is used. They will be ignored on OpenShift. The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. Changing this field does not trigger new build of the Kafka Connect image.
-|string
+|additionalKanikoOptions  1.2+<.<|Configures additional options which will be passed to the Kaniko executor when building the new Connect image. Allowed options are: --customPlatform, --insecure, --insecure-pull, --insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run. These options will be used only on Kubernetes where the Kaniko executor is used. They will be ignored on OpenShift. The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. Changing this field does not trigger new build of the Kafka Connect image.
+|string array
 |type                     1.2+<.<|Must be `docker`.
 |string
 |====

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1651,6 +1651,9 @@ spec:
                 output:
                   type: object
                   properties:
+                    additionalKanikoOptions:
+                      type: string
+                      description: 'Configures additional options which will be passed to the Kaniko executor when building the new Connect image. For example `--reproducible --single-snapshot`. Allowed options are: --customPlatform, --insecure, --insecure-pull, --insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run These options will be used only on Kubernetes where the Kaniko executor is used. They will be ignored on OpenShift. The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. Changing this field does not trigger new build of the Kafka Connect image.'
                     image:
                       type: string
                       description: The name of the image which will be built. Required.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1652,8 +1652,10 @@ spec:
                   type: object
                   properties:
                     additionalKanikoOptions:
-                      type: string
-                      description: 'Configures additional options which will be passed to the Kaniko executor when building the new Connect image. For example `--reproducible --single-snapshot`. Allowed options are: --customPlatform, --insecure, --insecure-pull, --insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run These options will be used only on Kubernetes where the Kaniko executor is used. They will be ignored on OpenShift. The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. Changing this field does not trigger new build of the Kafka Connect image.'
+                      type: array
+                      items:
+                        type: string
+                      description: 'Configures additional options which will be passed to the Kaniko executor when building the new Connect image. Allowed options are: --customPlatform, --insecure, --insecure-pull, --insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run. These options will be used only on Kubernetes where the Kaniko executor is used. They will be ignored on OpenShift. The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. Changing this field does not trigger new build of the Kafka Connect image.'
                     image:
                       type: string
                       description: The name of the image which will be built. Required.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -1507,8 +1507,10 @@ spec:
                   type: object
                   properties:
                     additionalKanikoOptions:
-                      type: string
-                      description: 'Configures additional options which will be passed to the Kaniko executor when building the new Connect image. For example `--reproducible --single-snapshot`. Allowed options are: --customPlatform, --insecure, --insecure-pull, --insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run These options will be used only on Kubernetes where the Kaniko executor is used. They will be ignored on OpenShift. The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. Changing this field does not trigger new build of the Kafka Connect image.'
+                      type: array
+                      items:
+                        type: string
+                      description: 'Configures additional options which will be passed to the Kaniko executor when building the new Connect image. Allowed options are: --customPlatform, --insecure, --insecure-pull, --insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run. These options will be used only on Kubernetes where the Kaniko executor is used. They will be ignored on OpenShift. The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. Changing this field does not trigger new build of the Kafka Connect image.'
                     image:
                       type: string
                       description: The name of the image which will be built. Required.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -1506,6 +1506,9 @@ spec:
                 output:
                   type: object
                   properties:
+                    additionalKanikoOptions:
+                      type: string
+                      description: 'Configures additional options which will be passed to the Kaniko executor when building the new Connect image. For example `--reproducible --single-snapshot`. Allowed options are: --customPlatform, --insecure, --insecure-pull, --insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run These options will be used only on Kubernetes where the Kaniko executor is used. They will be ignored on OpenShift. The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. Changing this field does not trigger new build of the Kafka Connect image.'
                     image:
                       type: string
                       description: The name of the image which will be built. Required.

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1799,6 +1799,20 @@ spec:
                 output:
                   type: object
                   properties:
+                    additionalKanikoOptions:
+                      type: string
+                      description: 'Configures additional options which will be passed
+                        to the Kaniko executor when building the new Connect image.
+                        For example `--reproducible --single-snapshot`. Allowed options
+                        are: --customPlatform, --insecure, --insecure-pull, --insecure-registry,
+                        --log-format, --log-timestamp, --registry-mirror, --reproducible,
+                        --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull,
+                        --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run
+                        These options will be used only on Kubernetes where the Kaniko
+                        executor is used. They will be ignored on OpenShift. The options
+                        are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko
+                        GitHub repository^]. Changing this field does not trigger
+                        new build of the Kafka Connect image.'
                     image:
                       type: string
                       description: The name of the image which will be built. Required.

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1800,14 +1800,15 @@ spec:
                   type: object
                   properties:
                     additionalKanikoOptions:
-                      type: string
+                      type: array
+                      items:
+                        type: string
                       description: 'Configures additional options which will be passed
                         to the Kaniko executor when building the new Connect image.
-                        For example `--reproducible --single-snapshot`. Allowed options
-                        are: --customPlatform, --insecure, --insecure-pull, --insecure-registry,
-                        --log-format, --log-timestamp, --registry-mirror, --reproducible,
-                        --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull,
-                        --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run
+                        Allowed options are: --customPlatform, --insecure, --insecure-pull,
+                        --insecure-registry, --log-format, --log-timestamp, --registry-mirror,
+                        --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull,
+                        --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run.
                         These options will be used only on Kubernetes where the Kaniko
                         executor is used. They will be ignored on OpenShift. The options
                         are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -1636,14 +1636,15 @@ spec:
                   type: object
                   properties:
                     additionalKanikoOptions:
-                      type: string
+                      type: array
+                      items:
+                        type: string
                       description: 'Configures additional options which will be passed
                         to the Kaniko executor when building the new Connect image.
-                        For example `--reproducible --single-snapshot`. Allowed options
-                        are: --customPlatform, --insecure, --insecure-pull, --insecure-registry,
-                        --log-format, --log-timestamp, --registry-mirror, --reproducible,
-                        --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull,
-                        --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run
+                        Allowed options are: --customPlatform, --insecure, --insecure-pull,
+                        --insecure-registry, --log-format, --log-timestamp, --registry-mirror,
+                        --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull,
+                        --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run.
                         These options will be used only on Kubernetes where the Kaniko
                         executor is used. They will be ignored on OpenShift. The options
                         are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -1635,6 +1635,20 @@ spec:
                 output:
                   type: object
                   properties:
+                    additionalKanikoOptions:
+                      type: string
+                      description: 'Configures additional options which will be passed
+                        to the Kaniko executor when building the new Connect image.
+                        For example `--reproducible --single-snapshot`. Allowed options
+                        are: --customPlatform, --insecure, --insecure-pull, --insecure-registry,
+                        --log-format, --log-timestamp, --registry-mirror, --reproducible,
+                        --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull,
+                        --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run
+                        These options will be used only on Kubernetes where the Kaniko
+                        executor is used. They will be ignored on OpenShift. The options
+                        are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko
+                        GitHub repository^]. Changing this field does not trigger
+                        new build of the Kafka Connect image.'
                     image:
                       type: string
                       description: The name of the image which will be built. Required.


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The Kaniko executor used for the Kafka Connect builds has all kind of options which might be useful in some situation. From logging configuration, to handling insecure container registries etc. It might be useful in some situation to be able to configure these.

This PR adds a new field `additionalKanikoOptions` which allows to configure such options. The options are validated through allow-list so that they don't conflict with the options which Strimzi needs to configure. This should close #4180.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md