### PR TITLE
Continue with Kafka Connect build from previous reconciliation

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
@@ -125,9 +125,21 @@ public class KafkaConnectResources {
      * Returns the name of the Kafka Connect {@code BuildConfig} for a {@code KafkaConnect} build that builds the new image.
      *
      * @param clusterName  The {@code metadata.name} of the {@code KafkaConnect} resource.
-     * @return The name of the corresponding Kafka Connect build {@code Pod}.
+     * @return The name of the corresponding Kafka Connect {@code BuildConfig}.
      */
     public static String buildConfigName(String clusterName) {
         return deploymentName(clusterName) + "-build";
+    }
+
+    /**
+     * Returns the name of the Kafka Connect {@code Build} for a {@code KafkaConnect} build that builds the new image.
+     *
+     * @param clusterName  The {@code metadata.name} of the {@code KafkaConnect} resource.
+     * @param buildVersion The version of the build for which the name should be generated
+     *
+     * @return The name of the corresponding Kafka Connect {@code BuildConfig} {@code Build}.
+     */
+    public static String buildName(String clusterName, Long buildVersion) {
+        return buildConfigName(clusterName) + "-" + buildVersion;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
@@ -365,11 +365,13 @@ public class KafkaConnectBuild extends AbstractModel {
                 .build();
     }
 
-    public BuildRequest generateBuildRequest()  {
+    public BuildRequest generateBuildRequest(String buildRevision)  {
         return new BuildRequestBuilder()
                 .withNewMetadata()
                     .withName(KafkaConnectResources.buildConfigName(cluster))
                     .withNamespace(namespace)
+                    .withAnnotations(Collections.singletonMap(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, buildRevision))
+                    .withLabels(getLabelsWithStrimziName(name, templateBuildConfigLabels).toMap())
                 .endMetadata()
                 .build();
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
@@ -32,6 +32,7 @@ import io.strimzi.api.kafka.model.connect.build.ImageStreamOutput;
 import io.strimzi.api.kafka.model.connect.build.Plugin;
 import io.strimzi.api.kafka.model.template.KafkaConnectTemplate;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.common.Annotations;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -177,13 +178,14 @@ public class KafkaConnectBuild extends AbstractModel {
      * @param isOpenShift       Flag defining whether we are running on OpenShift
      * @param imagePullPolicy   Image pull policy
      * @param imagePullSecrets  Image pull secrets
+     * @param newBuildRevision  Revision of the build which will be build used for annotation
      *
      * @return  Pod which will build the new container image
      */
-    public Pod generateBuilderPod(boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets) {
+    public Pod generateBuilderPod(boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets, String newBuildRevision) {
         return createPod(
                 KafkaConnectResources.buildPodName(cluster),
-                Collections.emptyMap(),
+                Collections.singletonMap(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, newBuildRevision),
                 getVolumes(isOpenShift),
                 null,
                 getContainers(imagePullPolicy),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.openshift.api.model.Build;
+
+public class KafkaConnectBuildUtils {
+    /**
+     * Checks if Pod already completed
+     *
+     * @param pod   Pod which should be checked for completion
+     *
+     * @return      True if the Pod is already complete, false otherwise
+     */
+    public static boolean buildPodComplete(Pod pod)   {
+        return pod.getStatus() != null
+                && pod.getStatus().getContainerStatuses() != null
+                && pod.getStatus().getContainerStatuses().size() > 0
+                && pod.getStatus().getContainerStatuses().get(0) != null
+                && pod.getStatus().getContainerStatuses().get(0).getState() != null
+                && pod.getStatus().getContainerStatuses().get(0).getState().getTerminated() != null;
+    }
+
+    /**
+     * Checks if the pod completed with success
+     *
+     * @param pod   Pod which should be checked for completion
+     *
+     * @return      True if the Pod is complete with success, false otherwise
+     */
+    public static boolean buildPodSucceeded(Pod pod)   {
+        return buildPodComplete(pod)
+                && pod.getStatus().getContainerStatuses().get(0).getState().getTerminated().getExitCode() == 0;
+    }
+
+    /**
+     * Checks if the pod completed with error
+     *
+     * @param pod   Pod which should be checked for completion
+     *
+     * @return      True if the Pod is complete with error, false otherwise
+     */
+    public static boolean buildPodFailed(Pod pod)   {
+        return buildPodComplete(pod)
+                && pod.getStatus().getContainerStatuses().get(0).getState().getTerminated().getExitCode() != 0;
+    }
+
+    /**
+     * Checks if the build completed with error
+     *
+     * @param build Build which should be checked for completion
+     *
+     * @return      True if the Build is complete with error, false otherwise
+     */
+    public static boolean buildFailed(Build build)   {
+        return build.getStatus() != null
+                && ("Failed".equals(build.getStatus().getPhase()) || "Error".equals(build.getStatus().getPhase()) || "Cancelled".equals(build.getStatus().getPhase()));
+    }
+
+    /**
+     * Checks if the build completed with success
+     *
+     * @param build Build which should be checked for completion
+     *
+     * @return      True if the Build is complete with success, false otherwise
+     */
+    public static boolean buildSucceeded(Build build)   {
+        return build.getStatus() != null && "Complete".equals(build.getStatus().getPhase());
+    }
+
+    /**
+     * Checks if the build completed with wuccess
+     *
+     * @param build Build which should be checked for completion
+     *
+     * @return      True if the Build is complete with any result, false otherwise
+     */
+    public static boolean buildComplete(Build build)   {
+        return buildSucceeded(build) || buildFailed(build);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -25,6 +25,7 @@ import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaConnectBuild;
+import io.strimzi.operator.cluster.model.KafkaConnectBuildUtils;
 import io.strimzi.operator.cluster.model.KafkaConnectCluster;
 import io.strimzi.operator.cluster.model.KafkaConnectDockerfile;
 import io.strimzi.operator.cluster.model.KafkaVersion;
@@ -310,15 +311,15 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                     if (pod != null)    {
                         String existingBuildRevision = Annotations.stringAnnotation(pod, Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null);
                         if (newBuildRevision.equals(existingBuildRevision)
+                                && !KafkaConnectBuildUtils.buildPodFailed(pod)
                                 && !buildState.forceRebuild) {
-                            // Builder pod exists, and is building the same Dockerfile and we are not asked to re-build
-                            // by the annotation => We re-use the existing build
+                            // Builder pod exists, is not failed, and is building the same Dockerfile and we are not
+                            // asked to force re-build by the annotation => we re-use the existing build
                             log.info("Previous build exists with the same Dockerfile and will be reused.");
                             return kubernetesBuildWaitForFinish(namespace, connectBuild, buildState, newBuildRevision);
-
                         } else {
-                            // Pod exists, but for different Dockerfile => start new build
-                            log.info("Previous build exists, but uses different Dockerfile. New build will be started.");
+                            // Pod exists, but it either failed or is for different Dockerfile => start new build
+                            log.info("Previous build exists, but uses different Dockerfile or failed. New build will be started.");
                             return podOperator.reconcile(namespace, KafkaConnectResources.buildPodName(connectBuild.getCluster()), null)
                                     .compose(ignore -> kubernetesBuildStart(namespace, connectBuild, dockerFileConfigMap, newBuildRevision))
                                     .compose(ignore -> kubernetesBuildWaitForFinish(namespace, connectBuild, buildState, newBuildRevision));
@@ -349,23 +350,16 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
     }
 
     /**
-     * Checks if the cuilder Pod finished the build
+     * Checks if the builder Pod finished the build
      *
      * @param namespace             Namespace where the Kafka Connect is deployed
-     * @param connectBuild          The KafkaConnectBuild model with the build definitions
+     * @param podName               The name of the Pod which should be checked whether it finished
      *
      * @return                      True if the build already finished, false if it is still building
      */
-    private boolean kubernetesBuildPodReady(String namespace, KafkaConnectBuild connectBuild)   {
-        Pod buildPod = podOperator.get(namespace, KafkaConnectResources.buildPodName(connectBuild.getCluster()));
-
-        // Check if build is complete now (either with success or failure)
-        return buildPod.getStatus() != null
-                && buildPod.getStatus().getContainerStatuses() != null
-                && buildPod.getStatus().getContainerStatuses().size() > 0
-                && buildPod.getStatus().getContainerStatuses().get(0) != null
-                && buildPod.getStatus().getContainerStatuses().get(0).getState() != null
-                && buildPod.getStatus().getContainerStatuses().get(0).getState().getTerminated() != null;
+    private boolean kubernetesBuildPodFinished(String namespace, String podName)   {
+        Pod buildPod = podOperator.get(namespace, podName);
+        return KafkaConnectBuildUtils.buildPodComplete(buildPod);
     }
 
     /**
@@ -379,17 +373,18 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
      * @return                      Future which completes when the build is finished (or fails if it fails)
      */
     private Future<Void> kubernetesBuildWaitForFinish(String namespace, KafkaConnectBuild connectBuild, BuildState buildState, String newBuildRevision)  {
-        return podOperator.waitFor(namespace, KafkaConnectResources.buildPodName(connectBuild.getCluster()), "complete", 1_000, connectBuildTimeoutMs, (ignore1, ignore2) -> kubernetesBuildPodReady(namespace, connectBuild))
+        return podOperator.waitFor(namespace, KafkaConnectResources.buildPodName(connectBuild.getCluster()), "complete", 1_000, connectBuildTimeoutMs, (ignore1, ignore2) -> kubernetesBuildPodFinished(namespace, KafkaConnectResources.buildPodName(connectBuild.getCluster())))
                 .compose(ignore -> podOperator.getAsync(namespace, KafkaConnectResources.buildPodName(connectBuild.getCluster())))
                 .compose(pod -> {
-                    ContainerStateTerminated state = pod.getStatus().getContainerStatuses().get(0).getState().getTerminated();
-                    if (state.getExitCode() == 0) {
+                    if (KafkaConnectBuildUtils.buildPodSucceeded(pod)) {
+                        ContainerStateTerminated state = pod.getStatus().getContainerStatuses().get(0).getState().getTerminated();
                         buildState.desiredImage = state.getMessage().trim();
                         buildState.desiredBuildRevision = newBuildRevision;
                         log.info("Build completed successfully. New image is {}.", buildState.desiredImage);
                         return Future.succeededFuture();
                     } else {
-                        log.info("Build failed with code {}: {}", state.getExitCode(), state.getMessage());
+                        ContainerStateTerminated state = pod.getStatus().getContainerStatuses().get(0).getState().getTerminated();
+                        log.warn("Build failed with code {}: {}", state.getExitCode(), state.getMessage());
                         return Future.failedFuture("The Kafka Connect build failed");
                     }
                 })
@@ -404,30 +399,96 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
      *
      * @param namespace             Namespace where the Kafka Connect is deployed
      * @param connectBuild          The KafkaConnectBuild model with the build definitions
+     * @param buildState            State object of the Kafka Connect build used to pass information around
      * @param dockerfile            The generated Dockerfile
      * @param newBuildRevision      New build revision (hash of the Dockerfile)
      *
      * @return                      Future which completes when the build is finished (or fails if it fails)
      */
     private Future<Void> openShiftBuild(String namespace, KafkaConnectBuild connectBuild, BuildState buildState, KafkaConnectDockerfile dockerfile, String newBuildRevision)   {
+        return buildConfigOperator.getAsync(namespace, KafkaConnectResources.buildConfigName(connectBuild.getCluster()))
+                .compose(buildConfig -> {
+                    if (buildConfig != null
+                            && buildConfig.getStatus() != null
+                            && buildConfig.getStatus().getLastVersion() != null) {
+                        Long lastVersion = buildConfig.getStatus().getLastVersion();
+                        return buildOperator.getAsync(namespace, KafkaConnectResources.buildName(connectBuild.getCluster(), lastVersion));
+                    } else {
+                        return Future.succeededFuture();
+                    }
+                })
+                .compose(build -> {
+                    if (build != null)  {
+                        String existingBuildRevision = Annotations.stringAnnotation(build, Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null);
+                        if (newBuildRevision.equals(existingBuildRevision)
+                                && !KafkaConnectBuildUtils.buildFailed(build)
+                                && !buildState.forceRebuild) {
+                            // Build exists, is not failed, and is building the same Dockerfile and we are not
+                            // asked to force re-build by the annotation => we re-use the existing build
+                            log.info("Previous build exists with the same Dockerfile and will be reused.");
+                            buildState.currentBuildName = build.getMetadata().getName();
+                            return openShiftBuildWaitForFinish(namespace, connectBuild, buildState, newBuildRevision);
+                        } else {
+                            // Build exists, but it either failed or is for different Dockerfile => start new build
+                            return openShiftBuildStart(namespace, connectBuild, buildState, dockerfile, newBuildRevision)
+                                    .compose(ignore -> openShiftBuildWaitForFinish(namespace, connectBuild, buildState, newBuildRevision));
+                        }
+                    } else {
+                        return openShiftBuildStart(namespace, connectBuild, buildState, dockerfile, newBuildRevision)
+                                .compose(ignore -> openShiftBuildWaitForFinish(namespace, connectBuild, buildState, newBuildRevision));
+                    }
+                });
+    }
+
+    /**
+     * Starts the Kafka Connect Build on OpenShift.
+     *
+     * @param namespace             Namespace where the Kafka Connect is deployed
+     * @param connectBuild          The KafkaConnectBuild model with the build definitions
+     * @param buildState            State object of the Kafka Connect build used to pass information around
+     * @param dockerfile            The generated Dockerfile
+     * @param newBuildRevision      New build revision (hash of the Dockerfile)
+     *
+     * @return                      Future which completes when the build is finished (or fails if it fails)
+     */
+    private Future<Void> openShiftBuildStart(String namespace, KafkaConnectBuild connectBuild, BuildState buildState, KafkaConnectDockerfile dockerfile, String newBuildRevision)   {
         return configMapOperations.reconcile(namespace, KafkaConnectResources.dockerFileConfigMapName(connectBuild.getCluster()), null)
-                .compose(ignore -> podOperator.reconcile(namespace, KafkaConnectResources.buildPodName(connectBuild.getCluster()), null))
                 .compose(ignore -> buildConfigOperator.reconcile(namespace, KafkaConnectResources.buildConfigName(connectBuild.getCluster()), connectBuild.generateBuildConfig(dockerfile)))
-                .compose(ignore -> buildConfigOperator.startBuild(namespace, KafkaConnectResources.buildConfigName(connectBuild.getCluster()), connectBuild.generateBuildRequest()))
+                .compose(ignore -> buildConfigOperator.startBuild(namespace, KafkaConnectResources.buildConfigName(connectBuild.getCluster()), connectBuild.generateBuildRequest(newBuildRevision)))
                 .compose(build -> {
                     buildState.currentBuildName = build.getMetadata().getName();
-                    return buildOperator.waitFor(namespace, buildState.currentBuildName, "complete", 1_000, connectBuildTimeoutMs, (ignore1, ignore2) -> {
-                        Build runningBuild = buildOperator.get(namespace, buildState.currentBuildName);
+                    return Future.succeededFuture();
+                });
+    }
 
-                        // Check if build is complete now (either with success or failure)
-                        return runningBuild.getStatus() != null
-                                && ("Complete".equals(runningBuild.getStatus().getPhase()) || "Failed".equals(runningBuild.getStatus().getPhase()) || "Error".equals(runningBuild.getStatus().getPhase()) || "Cancelled".equals(runningBuild.getStatus().getPhase()));
-                    });
-                })
+    /**
+     * Checks if the Build finished
+     *
+     * @param namespace             Namespace where the Kafka Connect is deployed
+     * @param buildName             Name of the Build which should be checked
+     *
+     * @return                      True if the Build already finished, false if it is still building
+     */
+    private boolean openShiftBuildFinished(String namespace, String buildName) {
+        Build runningBuild = buildOperator.get(namespace, buildName);
+        return KafkaConnectBuildUtils.buildComplete(runningBuild);
+    }
+
+    /**
+     * Waits for the Kafka Connect build to finish and collects the results from it
+     *
+     * @param namespace             Namespace where the Kafka Connect is deployed
+     * @param connectBuild          The KafkaConnectBuild model with the build definitions
+     * @param buildState            State object of the Kafka Connect build used to pass information around
+     * @param newBuildRevision      New build revision (hash of the Dockerfile)
+     *
+     * @return                      Future which completes when the build is finished (or fails if it fails)
+     */
+    private Future<Void> openShiftBuildWaitForFinish(String namespace, KafkaConnectBuild connectBuild, BuildState buildState, String newBuildRevision)   {
+        return buildOperator.waitFor(namespace, buildState.currentBuildName, "complete", 1_000, connectBuildTimeoutMs, (ignore1, ignore2) -> openShiftBuildFinished(namespace, buildState.currentBuildName))
                 .compose(ignore -> buildOperator.getAsync(namespace, buildState.currentBuildName))
                 .compose(build -> {
-                    if (build.getStatus() != null
-                            && "Complete".equals(build.getStatus().getPhase()))   {
+                    if (KafkaConnectBuildUtils.buildSucceeded(build))   {
                         // Build completed successfully. Lets extract the new image
                         if (build.getStatus().getOutputDockerImageReference() != null
                                 && build.getStatus().getOutput() != null
@@ -443,7 +504,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                             log.info("Build {} completed successfully. New image is {}.", buildState.currentBuildName, buildState.desiredImage);
                             return Future.succeededFuture();
                         } else {
-                            log.info("Build {} completed successfully. But the new container image was not found.", buildState.currentBuildName);
+                            log.warn("Build {} completed successfully. But the new container image was not found.", buildState.currentBuildName);
                             return Future.failedFuture("The Kafka Connect build " + buildState.currentBuildName + " completed, but the new container image was not found");
                         }
                     } else {
@@ -451,12 +512,13 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                         if (build.getStatus() != null) {
                             log.info("Build {} failed with code {}: {}", buildState.currentBuildName, build.getStatus().getPhase(), build.getStatus().getLogSnippet());
                         } else {
-                            log.info("Build {} failed for unknown reason", buildState.currentBuildName);
+                            log.warn("Build {} failed for unknown reason", buildState.currentBuildName);
                         }
 
                         return Future.failedFuture("The Kafka Connect build " + buildState.currentBuildName + " failed");
                     }
                 })
+                .compose(ignore -> podOperator.reconcile(namespace, KafkaConnectResources.buildPodName(connectBuild.getCluster()), null))
                 .mapEmpty();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -170,7 +170,7 @@ public class KafkaConnectBuildTest {
 
         KafkaConnectBuild build = KafkaConnectBuild.fromCrd(kc, VERSIONS);
 
-        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null);
+        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null, null);
         assertThat(pod.getMetadata().getName(), is(KafkaConnectResources.buildPodName(cluster)));
         assertThat(pod.getMetadata().getNamespace(), is(namespace));
 
@@ -227,7 +227,7 @@ public class KafkaConnectBuildTest {
 
         KafkaConnectBuild build = KafkaConnectBuild.fromCrd(kc, VERSIONS);
 
-        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null);
+        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null, null);
         assertThat(pod.getSpec().getVolumes().size(), is(2));
         assertThat(pod.getSpec().getVolumes().get(0).getName(), is("workspace"));
         assertThat(pod.getSpec().getVolumes().get(0).getEmptyDir(), is(notNullValue()));
@@ -416,7 +416,7 @@ public class KafkaConnectBuildTest {
 
         KafkaConnectBuild build = KafkaConnectBuild.fromCrd(kc, VERSIONS);
 
-        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null);
+        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null, null);
         assertThat(pod.getMetadata().getLabels().entrySet().containsAll(buildPodLabels.entrySet()), is(true));
         assertThat(pod.getMetadata().getAnnotations().entrySet().containsAll(buildPodAnnos.entrySet()), is(true));
         assertThat(pod.getSpec().getPriorityClassName(), is("top-priority"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorTest.java
@@ -15,6 +15,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildBuilder;
 import io.fabric8.openshift.api.model.BuildConfig;
+import io.fabric8.openshift.api.model.BuildConfigBuilder;
 import io.fabric8.openshift.api.model.BuildRequest;
 import io.strimzi.api.kafka.KafkaConnectorList;
 import io.strimzi.api.kafka.model.KafkaConnect;
@@ -314,6 +315,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         // Mock and capture BuildConfig ops
         ArgumentCaptor<BuildConfig> buildConfigCaptor = ArgumentCaptor.forClass(BuildConfig.class);
         when(mockBcOps.reconcile(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)), buildConfigCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
+        when(mockBcOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)))).thenReturn(Future.succeededFuture(null));
 
         Build builder = new BuildBuilder()
                 .withNewMetadata()
@@ -1084,6 +1086,187 @@ public class KafkaConnectBuildAssemblyOperatorTest {
                     .withContainerStatuses(new ContainerStatusBuilder().withNewState().withNewTerminated().withExitCode(0).withMessage("my-connect-build@sha256:blablabla").endTerminated().endState().build())
                 .endStatus()
                 .build();
+
+        when(mockPodOps.waitFor(eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)), anyString(), anyLong(), anyLong(), any(BiPredicate.class))).thenReturn(Future.succeededFuture((Void) null));
+        when(mockPodOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)))).thenReturn(Future.succeededFuture(runningBuild), Future.succeededFuture(terminatedPod));
+
+        // Mock and capture BuildConfig ops
+        when(mockBcOps.reconcile(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)), eq(null))).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
+
+        // Mock and capture NP ops
+        when(mockNetPolOps.reconcile(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
+
+        // Mock and capture PDB ops
+        when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock and capture KafkaConnect ops for status update
+        ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
+        when(mockConnectOps.updateStatusAsync(connectCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock KafkaConnect API client
+        KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
+
+        // Prepare and run reconciliation
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
+
+        KafkaConnectCluster connect = KafkaConnectCluster.fromCrd(kc, VERSIONS);
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, NAME))
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                // Verify Deployment
+                List<Deployment> capturedDeps = depCaptor.getAllValues();
+                assertThat(capturedDeps, hasSize(1));
+                Deployment dep = capturedDeps.get(0);
+                assertThat(dep.getMetadata().getName(), is(connect.getName()));
+                assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub()));
+
+                // Verify ConfigMap
+                List<ConfigMap> capturedCms = dockerfileCaptor.getAllValues();
+                assertThat(capturedCms, hasSize(1));
+                ConfigMap dockerfileCm = capturedCms.get(0);
+                assertThat(dockerfileCm.getData().containsKey("Dockerfile"), is(true));
+                assertThat(dockerfileCm.getData().get("Dockerfile"), is(build.generateDockerfile().getDockerfile()));
+
+                // Verify builder Pod
+                List<Pod> capturedBuilderPods = builderPodCaptor.getAllValues();
+                assertThat(capturedBuilderPods, hasSize(3));
+                assertThat(capturedBuilderPods.stream().filter(pod -> pod != null).collect(Collectors.toList()), hasSize(1));
+
+                // Verify status
+                List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                assertThat(capturedConnects, hasSize(1));
+                KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
+                assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
+
+                async.flag();
+            })));
+    }
+
+    @SuppressWarnings({"checkstyle:MethodLength"})
+    @Test
+    public void testRestartPreviousBuildDueToFailureOnKube(VertxTestContext context) {
+        Plugin plugin1 = new PluginBuilder()
+                .withName("plugin1")
+                .withArtifacts(new JarArtifactBuilder().withUrl("https://my-domain.tld/my.jar").build())
+                .build();
+
+        Plugin plugin2 = new PluginBuilder()
+                .withName("plugin2")
+                .withArtifacts(new JarArtifactBuilder().withUrl("https://my-domain.tld/my2.jar").build())
+                .build();
+
+        KafkaConnect oldKc = new KafkaConnectBuilder()
+                .withNewMetadata()
+                    .withName(NAME)
+                    .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(1)
+                    .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
+                    .withNewBuild()
+                        .withNewDockerOutput()
+                            .withImage("my-connect-build:latest")
+                            .withNewPushSecret("my-docker-credentials")
+                        .endDockerOutput()
+                        .withPlugins(plugin1, plugin2)
+                    .endBuild()
+                .endSpec()
+                .build();
+
+        KafkaConnectCluster oldConnect = KafkaConnectCluster.fromCrd(oldKc, VERSIONS);
+        KafkaConnectBuild oldBuild = KafkaConnectBuild.fromCrd(oldKc, VERSIONS);
+
+        KafkaConnect kc = new KafkaConnectBuilder(oldKc)
+                .editSpec()
+                    .editBuild()
+                        .withPlugins(plugin1, plugin2)
+                    .endBuild()
+                .endSpec()
+                .build();
+
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(kc, VERSIONS);
+
+        // Prepare and get mocks
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
+        CrdOperator mockConnectOps = supplier.connectOperator;
+        CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        PodOperator mockPodOps = supplier.podOperations;
+        BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
+
+        // Mock KafkaConnector ops
+        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+
+        // Mock KafkaConnect ops
+        when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
+        when(mockConnectOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(kc));
+
+        // Mock KafkaConnectS2I ops
+        when(mockConnectS2IOps.getAsync(NAMESPACE, NAME)).thenReturn(Future.succeededFuture(null));
+
+        // Mock and capture service ops
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(anyString(), anyString(), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock and capture deployment ops
+        ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
+        when(mockDepOps.reconcile(anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
+            Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
+            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, "oldhashstub");
+            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:olddigest");
+            return Future.succeededFuture(dep);
+        });
+        when(mockDepOps.scaleUp(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
+        when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
+        when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock and capture CM ops
+        when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
+        ArgumentCaptor<ConfigMap> dockerfileCaptor = ArgumentCaptor.forClass(ConfigMap.class);
+        when(mockCmOps.reconcile(anyString(), eq(KafkaConnectResources.dockerFileConfigMapName(NAME)), dockerfileCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
+
+        // Mock and capture Pod ops
+        ArgumentCaptor<Pod> builderPodCaptor = ArgumentCaptor.forClass(Pod.class);
+        when(mockPodOps.reconcile(eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)), builderPodCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
+
+        Pod runningBuild = new PodBuilder()
+                .withNewMetadata()
+                    .withName(KafkaConnectResources.buildPodName(NAME))
+                    .withNamespace(NAMESPACE)
+                    .withAnnotations(singletonMap(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub()))
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .withNewStatus()
+                    .withContainerStatuses(new ContainerStatusBuilder().withNewState().withNewTerminated().withExitCode(1).endTerminated().endState().build())
+                .endStatus()
+                .build();
+
+        Pod terminatedPod = new PodBuilder()
+                .withNewMetadata()
+                    .withName(KafkaConnectResources.buildPodName(NAME))
+                    .withNamespace(NAMESPACE)
+                    .withAnnotations(singletonMap(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub()))
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .withNewStatus()
+                    .withContainerStatuses(new ContainerStatusBuilder().withNewState().withNewTerminated().withExitCode(0).withMessage("my-connect-build@sha256:blablabla").endTerminated().endState().build())
+                .endStatus()
+                .build();
         when(mockPodOps.waitFor(eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)), anyString(), anyLong(), anyLong(), any(BiPredicate.class))).thenReturn(Future.succeededFuture((Void) null));
         when(mockPodOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)))).thenReturn(Future.succeededFuture(runningBuild), Future.succeededFuture(terminatedPod));
 
@@ -1519,6 +1702,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         // Mock and capture BuildConfig ops
         ArgumentCaptor<BuildConfig> buildConfigCaptor = ArgumentCaptor.forClass(BuildConfig.class);
         when(mockBcOps.reconcile(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)), buildConfigCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
+        when(mockBcOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)))).thenReturn(Future.succeededFuture(null));
 
         Build builder = new BuildBuilder()
                 .withNewMetadata()
@@ -1799,6 +1983,7 @@ public class KafkaConnectBuildAssemblyOperatorTest {
         // Mock and capture BuildConfig ops
         ArgumentCaptor<BuildConfig> buildConfigCaptor = ArgumentCaptor.forClass(BuildConfig.class);
         when(mockBcOps.reconcile(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)), buildConfigCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
+        when(mockBcOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)))).thenReturn(Future.succeededFuture(null));
 
         Build builder = new BuildBuilder()
                 .withNewMetadata().withNamespace(NAMESPACE).withName("build-1")
@@ -1849,6 +2034,586 @@ public class KafkaConnectBuildAssemblyOperatorTest {
                 Deployment dep = capturedDeps.get(0);
                 assertThat(dep.getMetadata().getName(), is(connect.getName()));
                 assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:rebuiltblablabla"));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub()));
+
+                // Verify BuildConfig
+                List<BuildConfig> capturedBcs = buildConfigCaptor.getAllValues();
+                assertThat(capturedBcs, hasSize(1));
+                BuildConfig buildConfig = capturedBcs.get(0);
+                assertThat(buildConfig.getSpec().getSource().getDockerfile(), is(build.generateDockerfile().getDockerfile()));
+
+                // Verify status
+                List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                assertThat(capturedConnects, hasSize(1));
+                KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
+                assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
+
+                async.flag();
+            })));
+    }
+
+    @SuppressWarnings({"checkstyle:MethodLength"})
+    @Test
+    public void testContinueWithPreviousBuildOnOpenShift(VertxTestContext context) {
+        Plugin plugin1 = new PluginBuilder()
+                .withName("plugin1")
+                .withArtifacts(new JarArtifactBuilder().withUrl("https://my-domain.tld/my.jar").build())
+                .build();
+
+        Plugin plugin2 = new PluginBuilder()
+                .withName("plugin2")
+                .withArtifacts(new JarArtifactBuilder().withUrl("https://my-domain.tld/my2.jar").build())
+                .build();
+
+        KafkaConnect oldKc = new KafkaConnectBuilder()
+                .withNewMetadata()
+                    .withName(NAME)
+                    .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(1)
+                    .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
+                    .withNewBuild()
+                        .withNewDockerOutput()
+                            .withImage("my-connect-build:latest")
+                            .withNewPushSecret("my-docker-credentials")
+                        .endDockerOutput()
+                        .withPlugins(plugin1)
+                    .endBuild()
+                .endSpec()
+                .build();
+
+        KafkaConnectCluster oldConnect = KafkaConnectCluster.fromCrd(oldKc, VERSIONS);
+        KafkaConnectBuild oldBuild = KafkaConnectBuild.fromCrd(oldKc, VERSIONS);
+
+        KafkaConnect kc = new KafkaConnectBuilder(oldKc)
+                .editSpec()
+                    .editBuild()
+                        .withPlugins(plugin1, plugin2)
+                    .endBuild()
+                .endSpec()
+                .build();
+
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(kc, VERSIONS);
+
+        // Prepare and get mocks
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
+        CrdOperator mockConnectOps = supplier.connectOperator;
+        CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        PodOperator mockPodOps = supplier.podOperations;
+        BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+        BuildOperator mockBuildOps = supplier.buildOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
+
+        // Mock KafkaConnector ops
+        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+
+        // Mock KafkaConnect ops
+        when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
+        when(mockConnectOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(kc));
+
+        // Mock KafkaConnectS2I ops
+        when(mockConnectS2IOps.getAsync(NAMESPACE, NAME)).thenReturn(Future.succeededFuture(null));
+
+        // Mock and capture service ops
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(anyString(), anyString(), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock and capture deployment ops
+        ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
+        when(mockDepOps.reconcile(anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
+            Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
+            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub());
+            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:olddigest");
+            return Future.succeededFuture(dep);
+        });
+        when(mockDepOps.scaleUp(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
+        when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
+        when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock and capture CM ops
+        when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
+
+        // Mock and capture Pod ops
+        when(mockPodOps.reconcile(eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)), eq(null))).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
+
+        // Mock and capture Build ops
+        Build oldBuilder = new BuildBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(KafkaConnectResources.buildName(NAME, 1L))
+                    .withAnnotations(singletonMap(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub()))
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .withNewStatus()
+                    .withPhase("Running")
+                .endStatus()
+                .build();
+
+        Build newBuilder = new BuildBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(KafkaConnectResources.buildName(NAME, 1L))
+                    .withAnnotations(singletonMap(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub()))
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .withNewStatus()
+                    .withPhase("Complete")
+                    .withNewOutputDockerImageReference("my-connect-build:latest")
+                    .withNewOutput()
+                        .withNewTo()
+                            .withImageDigest("sha256:blablabla")
+                        .endTo()
+                    .endOutput()
+                .endStatus()
+                .build();
+
+        when(mockBuildOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.buildName(NAME, 1L)))).thenReturn(Future.succeededFuture(oldBuilder));
+        when(mockBuildOps.waitFor(eq(NAMESPACE), eq(KafkaConnectResources.buildName(NAME, 1L)), anyString(), anyLong(), anyLong(), any(BiPredicate.class))).thenReturn(Future.succeededFuture());
+        when(mockBuildOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.buildName(NAME, 1L)))).thenReturn(Future.succeededFuture(newBuilder));
+
+        // Mock and capture BuildConfig ops
+        ArgumentCaptor<BuildConfig> buildConfigCaptor = ArgumentCaptor.forClass(BuildConfig.class);
+        when(mockBcOps.reconcile(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)), buildConfigCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
+
+        BuildConfig oldBuildConfig = new BuildConfigBuilder(oldBuild.generateBuildConfig(oldBuild.generateDockerfile()))
+                .withNewStatus()
+                    .withLastVersion(1L)
+                .endStatus()
+                .build();
+
+        when(mockBcOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)))).thenReturn(Future.succeededFuture(oldBuildConfig));
+
+        ArgumentCaptor<BuildRequest> buildRequestCaptor = ArgumentCaptor.forClass(BuildRequest.class);
+        when(mockBcOps.startBuild(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)), buildRequestCaptor.capture())).thenReturn(Future.succeededFuture(newBuilder));
+
+
+        // Mock and capture NP ops
+        when(mockNetPolOps.reconcile(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
+
+        // Mock and capture PDB ops
+        when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock and capture KafkaConnect ops for status update
+        ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
+        when(mockConnectOps.updateStatusAsync(connectCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock KafkaConnect API client
+        KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
+
+        // Prepare and run reconciliation
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
+                supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
+
+        KafkaConnectCluster connect = KafkaConnectCluster.fromCrd(kc, VERSIONS);
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, NAME))
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                // Verify Deployment
+                List<Deployment> capturedDeps = depCaptor.getAllValues();
+                assertThat(capturedDeps, hasSize(1));
+                Deployment dep = capturedDeps.get(0);
+                assertThat(dep.getMetadata().getName(), is(connect.getName()));
+                assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub()));
+
+                // Verify BuildConfig
+                List<BuildConfig> capturedBcs = buildConfigCaptor.getAllValues();
+                assertThat(capturedBcs, hasSize(0));
+
+                // Verify status
+                List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                assertThat(capturedConnects, hasSize(1));
+                KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
+                assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
+
+                async.flag();
+            })));
+    }
+
+    @SuppressWarnings({"checkstyle:MethodLength"})
+    @Test
+    public void testRestartPreviousBuildOnOpenShift(VertxTestContext context) {
+        Plugin plugin1 = new PluginBuilder()
+                .withName("plugin1")
+                .withArtifacts(new JarArtifactBuilder().withUrl("https://my-domain.tld/my.jar").build())
+                .build();
+
+        Plugin plugin2 = new PluginBuilder()
+                .withName("plugin2")
+                .withArtifacts(new JarArtifactBuilder().withUrl("https://my-domain.tld/my2.jar").build())
+                .build();
+
+        KafkaConnect oldKc = new KafkaConnectBuilder()
+                .withNewMetadata()
+                    .withName(NAME)
+                    .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(1)
+                    .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
+                    .withNewBuild()
+                        .withNewDockerOutput()
+                            .withImage("my-connect-build:latest")
+                            .withNewPushSecret("my-docker-credentials")
+                        .endDockerOutput()
+                        .withPlugins(plugin1)
+                    .endBuild()
+                .endSpec()
+                .build();
+
+        KafkaConnectCluster oldConnect = KafkaConnectCluster.fromCrd(oldKc, VERSIONS);
+        KafkaConnectBuild oldBuild = KafkaConnectBuild.fromCrd(oldKc, VERSIONS);
+
+        KafkaConnect kc = new KafkaConnectBuilder(oldKc)
+                .editSpec()
+                    .editBuild()
+                        .withPlugins(plugin1, plugin2)
+                    .endBuild()
+                .endSpec()
+                .build();
+
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(kc, VERSIONS);
+
+        // Prepare and get mocks
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
+        CrdOperator mockConnectOps = supplier.connectOperator;
+        CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        PodOperator mockPodOps = supplier.podOperations;
+        BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+        BuildOperator mockBuildOps = supplier.buildOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
+
+        // Mock KafkaConnector ops
+        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+
+        // Mock KafkaConnect ops
+        when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
+        when(mockConnectOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(kc));
+
+        // Mock KafkaConnectS2I ops
+        when(mockConnectS2IOps.getAsync(NAMESPACE, NAME)).thenReturn(Future.succeededFuture(null));
+
+        // Mock and capture service ops
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(anyString(), anyString(), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock and capture deployment ops
+        ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
+        when(mockDepOps.reconcile(anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
+            Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
+            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub());
+            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:olddigest");
+            return Future.succeededFuture(dep);
+        });
+        when(mockDepOps.scaleUp(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
+        when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
+        when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock and capture CM ops
+        when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
+
+        // Mock and capture Pod ops
+        when(mockPodOps.reconcile(eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)), eq(null))).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
+
+        // Mock and capture Build ops
+        Build oldBuilder = new BuildBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(KafkaConnectResources.buildName(NAME, 1L))
+                    .withAnnotations(singletonMap(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub()))
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .withNewStatus()
+                    .withPhase("Running")
+                .endStatus()
+                .build();
+
+        Build newBuilder = new BuildBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(KafkaConnectResources.buildName(NAME, 2L))
+                    .withAnnotations(singletonMap(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub()))
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .withNewStatus()
+                    .withPhase("Complete")
+                    .withNewOutputDockerImageReference("my-connect-build:latest")
+                    .withNewOutput()
+                        .withNewTo()
+                            .withImageDigest("sha256:blablabla")
+                        .endTo()
+                    .endOutput()
+                .endStatus()
+                .build();
+
+        when(mockBuildOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.buildName(NAME, 1L)))).thenReturn(Future.succeededFuture(oldBuilder));
+        when(mockBuildOps.waitFor(eq(NAMESPACE), eq(KafkaConnectResources.buildName(NAME, 2L)), anyString(), anyLong(), anyLong(), any(BiPredicate.class))).thenReturn(Future.succeededFuture());
+        when(mockBuildOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.buildName(NAME, 2L)))).thenReturn(Future.succeededFuture(newBuilder));
+
+        // Mock and capture BuildConfig ops
+        ArgumentCaptor<BuildConfig> buildConfigCaptor = ArgumentCaptor.forClass(BuildConfig.class);
+        when(mockBcOps.reconcile(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)), buildConfigCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
+
+        BuildConfig oldBuildConfig = new BuildConfigBuilder(oldBuild.generateBuildConfig(oldBuild.generateDockerfile()))
+                .withNewStatus()
+                    .withLastVersion(1L)
+                .endStatus()
+                .build();
+
+        when(mockBcOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)))).thenReturn(Future.succeededFuture(oldBuildConfig));
+
+        ArgumentCaptor<BuildRequest> buildRequestCaptor = ArgumentCaptor.forClass(BuildRequest.class);
+        when(mockBcOps.startBuild(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)), buildRequestCaptor.capture())).thenReturn(Future.succeededFuture(newBuilder));
+
+
+        // Mock and capture NP ops
+        when(mockNetPolOps.reconcile(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
+
+        // Mock and capture PDB ops
+        when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock and capture KafkaConnect ops for status update
+        ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
+        when(mockConnectOps.updateStatusAsync(connectCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock KafkaConnect API client
+        KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
+
+        // Prepare and run reconciliation
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
+                supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
+
+        KafkaConnectCluster connect = KafkaConnectCluster.fromCrd(kc, VERSIONS);
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, NAME))
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                // Verify Deployment
+                List<Deployment> capturedDeps = depCaptor.getAllValues();
+                assertThat(capturedDeps, hasSize(1));
+                Deployment dep = capturedDeps.get(0);
+                assertThat(dep.getMetadata().getName(), is(connect.getName()));
+                assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub()));
+
+                // Verify BuildConfig
+                List<BuildConfig> capturedBcs = buildConfigCaptor.getAllValues();
+                assertThat(capturedBcs, hasSize(1));
+                BuildConfig buildConfig = capturedBcs.get(0);
+                assertThat(buildConfig.getSpec().getSource().getDockerfile(), is(build.generateDockerfile().getDockerfile()));
+
+                // Verify status
+                List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                assertThat(capturedConnects, hasSize(1));
+                KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
+                assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
+
+                async.flag();
+            })));
+    }
+
+    @SuppressWarnings({"checkstyle:MethodLength"})
+    @Test
+    public void testRestartPreviousBuildDueToFailureOnOpenShift(VertxTestContext context) {
+        Plugin plugin1 = new PluginBuilder()
+                .withName("plugin1")
+                .withArtifacts(new JarArtifactBuilder().withUrl("https://my-domain.tld/my.jar").build())
+                .build();
+
+        Plugin plugin2 = new PluginBuilder()
+                .withName("plugin2")
+                .withArtifacts(new JarArtifactBuilder().withUrl("https://my-domain.tld/my2.jar").build())
+                .build();
+
+        KafkaConnect oldKc = new KafkaConnectBuilder()
+                .withNewMetadata()
+                    .withName(NAME)
+                    .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(1)
+                    .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
+                    .withNewBuild()
+                        .withNewDockerOutput()
+                            .withImage("my-connect-build:latest")
+                            .withNewPushSecret("my-docker-credentials")
+                        .endDockerOutput()
+                        .withPlugins(plugin1)
+                    .endBuild()
+                .endSpec()
+                .build();
+
+        KafkaConnectCluster oldConnect = KafkaConnectCluster.fromCrd(oldKc, VERSIONS);
+        KafkaConnectBuild oldBuild = KafkaConnectBuild.fromCrd(oldKc, VERSIONS);
+
+        KafkaConnect kc = new KafkaConnectBuilder(oldKc)
+                .editSpec()
+                    .editBuild()
+                        .withPlugins(plugin1, plugin2)
+                    .endBuild()
+                .endSpec()
+                .build();
+
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(kc, VERSIONS);
+
+        // Prepare and get mocks
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
+        CrdOperator mockConnectOps = supplier.connectOperator;
+        CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        PodOperator mockPodOps = supplier.podOperations;
+        BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+        BuildOperator mockBuildOps = supplier.buildOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
+
+        // Mock KafkaConnector ops
+        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+
+        // Mock KafkaConnect ops
+        when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
+        when(mockConnectOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(kc));
+
+        // Mock KafkaConnectS2I ops
+        when(mockConnectS2IOps.getAsync(NAMESPACE, NAME)).thenReturn(Future.succeededFuture(null));
+
+        // Mock and capture service ops
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(anyString(), anyString(), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock and capture deployment ops
+        ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
+        when(mockDepOps.reconcile(anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
+            Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
+            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub());
+            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:olddigest");
+            return Future.succeededFuture(dep);
+        });
+        when(mockDepOps.scaleUp(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
+        when(mockDepOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
+        when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock and capture CM ops
+        when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
+
+        // Mock and capture Pod ops
+        when(mockPodOps.reconcile(eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)), eq(null))).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
+
+        // Mock and capture Build ops
+        Build oldBuilder = new BuildBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(KafkaConnectResources.buildName(NAME, 1L))
+                    .withAnnotations(singletonMap(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub()))
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .withNewStatus()
+                    .withPhase("Failed")
+                .endStatus()
+                .build();
+
+        Build newBuilder = new BuildBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(KafkaConnectResources.buildName(NAME, 2L))
+                    .withAnnotations(singletonMap(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub()))
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .withNewStatus()
+                    .withPhase("Complete")
+                    .withNewOutputDockerImageReference("my-connect-build:latest")
+                    .withNewOutput()
+                        .withNewTo()
+                            .withImageDigest("sha256:blablabla")
+                        .endTo()
+                    .endOutput()
+                .endStatus()
+                .build();
+
+        when(mockBuildOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.buildName(NAME, 1L)))).thenReturn(Future.succeededFuture(oldBuilder));
+        when(mockBuildOps.waitFor(eq(NAMESPACE), eq(KafkaConnectResources.buildName(NAME, 2L)), anyString(), anyLong(), anyLong(), any(BiPredicate.class))).thenReturn(Future.succeededFuture());
+        when(mockBuildOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.buildName(NAME, 2L)))).thenReturn(Future.succeededFuture(newBuilder));
+
+        // Mock and capture BuildConfig ops
+        ArgumentCaptor<BuildConfig> buildConfigCaptor = ArgumentCaptor.forClass(BuildConfig.class);
+        when(mockBcOps.reconcile(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)), buildConfigCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
+
+        BuildConfig oldBuildConfig = new BuildConfigBuilder(oldBuild.generateBuildConfig(oldBuild.generateDockerfile()))
+                .withNewStatus()
+                    .withLastVersion(1L)
+                .endStatus()
+                .build();
+
+        when(mockBcOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)))).thenReturn(Future.succeededFuture(oldBuildConfig));
+
+        ArgumentCaptor<BuildRequest> buildRequestCaptor = ArgumentCaptor.forClass(BuildRequest.class);
+        when(mockBcOps.startBuild(eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)), buildRequestCaptor.capture())).thenReturn(Future.succeededFuture(newBuilder));
+
+
+        // Mock and capture NP ops
+        when(mockNetPolOps.reconcile(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
+
+        // Mock and capture PDB ops
+        when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock and capture KafkaConnect ops for status update
+        ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
+        when(mockConnectOps.updateStatusAsync(connectCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock KafkaConnect API client
+        KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
+
+        // Prepare and run reconciliation
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
+                supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
+
+        KafkaConnectCluster connect = KafkaConnectCluster.fromCrd(kc, VERSIONS);
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, NAME))
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                // Verify Deployment
+                List<Deployment> capturedDeps = depCaptor.getAllValues();
+                assertThat(capturedDeps, hasSize(1));
+                Deployment dep = capturedDeps.get(0);
+                assertThat(dep.getMetadata().getName(), is(connect.getName()));
+                assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
                 assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub()));
 
                 // Verify BuildConfig


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Right now, the Kafka Connect build starts a new build in every reconciliation. Even if the previous one for example took just too long time and timed out the original reconciliation. This change checks if the previous build exists and is still for the same Dockerfile. And if it is, it will use the existing build and wait for it instead of starting a new one. That should make it easier to get the build finished even when it is taking too much time for example because of slow pushing do Docker registry.

This should close #4195.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging