### PR TITLE
Deprecate KafkaConnectS2I

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Deprecations and removals
 
+* The `KafkaConnectS2I` custom resource is deprecated and will be removed in the future. You can use the new [`KafkaConnect` build feature](https://strimzi.io/docs/operators/latest/full/deploying.html#creating-new-image-using-kafka-connect-build-str) instead.
 * Removed support for Helm2 charts as that version is now unsupported. There is no longer the need for separate `helm2` and `helm3` binaries, only `helm` (version 3) is required.
 * The following annotations are deprecated for a long time and will be removed in 0.23.0:
   * `cluster.operator.strimzi.io/delete-claim` (used internally only - replaced by `strimzi.io/delete-claim`)

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
@@ -17,6 +17,7 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
+import io.strimzi.api.annotations.DeprecatedType;
 import io.strimzi.api.kafka.model.status.KafkaConnectS2IStatus;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -91,6 +92,8 @@ import static java.util.Collections.unmodifiableList;
 @EqualsAndHashCode
 @Version(Constants.V1BETA1)
 @Group(Constants.STRIMZI_GROUP)
+@Deprecated
+@DeprecatedType(replacedWithType = io.strimzi.api.kafka.model.connect.build.Build.class)
 public class KafkaConnectS2I extends CustomResource<KafkaConnectS2ISpec, KafkaConnectS2IStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -54,6 +54,8 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
         super(resource, APPLICATION_NAME);
     }
 
+    // Deprecation is suppressed because of KafkaConnectS2I
+    @SuppressWarnings("deprecation")
     public static KafkaConnectS2ICluster fromCrd(KafkaConnectS2I kafkaConnectS2I, KafkaVersion.Lookup versions) {
         KafkaConnectS2ISpec spec = kafkaConnectS2I.getSpec();
         KafkaConnectS2ICluster cluster = fromSpec(spec, versions, new KafkaConnectS2ICluster(kafkaConnectS2I));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -197,6 +197,8 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
      * @param watchNamespaceOrWildcard The namespace to watch.
      * @return A future which completes when the watch has been set up.
      */
+    // Deprecation is suppressed because of KafkaConnectS2I
+    @SuppressWarnings("deprecation")
     public static Future<Void> createConnectorWatch(AbstractConnectOperator<KubernetesClient, KafkaConnect, KafkaConnectList, Resource<KafkaConnect>, KafkaConnectSpec, KafkaConnectStatus> connectOperator,
                                                     AbstractConnectOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IList, Resource<KafkaConnectS2I>, KafkaConnectS2ISpec, KafkaConnectS2IStatus> connectS2IOperator,
                                                     String watchNamespaceOrWildcard) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -59,6 +59,8 @@ import java.util.function.Function;
  *     <li>A Kafka Connect Deployment and related Services</li>
  * </ul>
  */
+// Deprecation is suppressed because of KafkaConnectS2I
+@SuppressWarnings("deprecation")
 public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<KubernetesClient, KafkaConnect, KafkaConnectList, Resource<KafkaConnect>, KafkaConnectSpec, KafkaConnectStatus> {
     private static final Logger log = LogManager.getLogger(KafkaConnectAssemblyOperator.class.getName());
     private final DeploymentOperator deploymentOperations;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -55,6 +55,8 @@ import java.util.function.Function;
  *     <li>A BuildConfig</li>
  * </ul>
  */
+// Deprecation is suppressed because of KafkaConnectS2I
+@SuppressWarnings("deprecation")
 public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IList, Resource<KafkaConnectS2I>, KafkaConnectS2ISpec, KafkaConnectS2IStatus> {
     private static final Logger log = LogManager.getLogger(KafkaConnectS2IAssemblyOperator.class.getName());
     

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -53,7 +53,8 @@ import io.fabric8.openshift.client.OpenShiftClient;
 import io.strimzi.operator.common.operator.resource.StorageClassOperator;
 import io.vertx.core.Vertx;
 
-@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
+// Deprecation is suppressed because of KafkaConnectS2I
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "deprecation"})
 public class ResourceOperatorSupplier {
     public final SecretOperator secretOperations;
     public final ServiceOperator serviceOperations;

--- a/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
+++ b/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
@@ -18,7 +18,7 @@ Use the `KafkaConnectS2I` resource if you are using the {docs-okd-s2i} framework
 * The full schema of the `KafkaConnectS2I` resource is described in xref:type-KafkaConnectS2I-reference[].
 
 IMPORTANT: With the introduction of `build` configuration to the `KafkaConnect` resource, Strimzi can now automatically build a container image with the connector plugins you require for your data connections.
-As a result, support for Kafka Connect with Source-to-Image (S2I) is _planned for deprecation_. To prepare for this change, you can xref:proc-migrating-kafka-connect-s2i-{context}[migrate Kafka Connect S2I instances to Kafka Connect instances].
+As a result, support for Kafka Connect with Source-to-Image (S2I) is deprecated. To prepare for this change, you can xref:proc-migrating-kafka-connect-s2i-{context}[migrate Kafka Connect S2I instances to Kafka Connect instances].
 
 .Additional resources
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2505,6 +2505,9 @@ Used in: xref:type-KafkaConnectS2IStatus-{context}[`KafkaConnectS2IStatus`], xre
 [id='type-KafkaConnectS2I-{context}']
 ### `KafkaConnectS2I` schema reference
 
+*The type `KafkaConnectS2I` has been deprecated.*
+Please use xref:type-Build-{context}[`Build`] instead.
+
 
 [options="header"]
 |====

--- a/documentation/modules/configuring/proc-config-kafka-connect-s2i-migration.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect-s2i-migration.adoc
@@ -6,7 +6,7 @@
 = Migrating from Kafka Connect with S2I to Kafka Connect
 
 [role="_abstract"]
-Support for Kafka Connect with S2I and the `KafkaConnectS2I` resource is planned for deprecation.
+Support for Kafka Connect with S2I and the `KafkaConnectS2I` resource is deprecated.
 This follows the introduction of `build` configuration properties to the `KafkaConnect` resource,
 which are used to build a container image with the connector plugins you require for your data connections automatically.
 

--- a/documentation/modules/deploying/proc-deploy-kafka-connect-openshift-builds-image.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-openshift-builds-image.adoc
@@ -17,7 +17,7 @@ It creates a new Kafka Connect image from this directory, which can then be used
 When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the `/tmp/kafka-plugins/s2i` directory.
 
 IMPORTANT: With the introduction of `build` configuration to the `KafkaConnect` resource, Strimzi can now automatically build a container image with the connector plugins you require for your data connections.
-As a result, support for Kafka Connect with Source-to-Image (S2I) is _planned for deprecation_. To prepare for this change, you can link:{BookURLUsing}#proc-migrating-kafka-connect-s2i-{context}[migrate Kafka Connect S2I instances to Kafka Connect instances].
+As a result, support for Kafka Connect with Source-to-Image (S2I) is deprecated. To prepare for this change, you can link:{BookURLUsing}#proc-migrating-kafka-connect-s2i-{context}[migrate Kafka Connect S2I instances to Kafka Connect instances].
 
 .Procedure
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -114,7 +114,9 @@ public class ResourceManager {
         editor.accept(resource);
         namedResource.replace(resource);
     }
-    @SuppressWarnings("unchecked")
+
+    // Deprecation is suppressed because of KafkaConnectS2I
+    @SuppressWarnings({"unchecked", "deprecation"})
     public static <T extends HasMetadata> T deleteLater(MixedOperation<T, ?, ?> operation, T resource) {
         LOGGER.debug("Scheduled deletion of {} {} in namespace {}",
                 resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace() == null ? "(not set)" : resource.getMetadata().getNamespace());
@@ -307,6 +309,8 @@ public class ResourceManager {
                 .forEach(p -> PodUtils.deletePodWithWait(p.getMetadata().getName()));
     }
 
+    // Deprecation is suppressed because of KafkaConnectS2I
+    @SuppressWarnings("deprecation")
     private static void waitForDeletion(KafkaConnectS2I kafkaConnectS2I) {
         LOGGER.info("Waiting when all the Pods are terminated for KafkaConnectS2I {}", kafkaConnectS2I.getMetadata().getName());
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
@@ -21,6 +21,8 @@ public class ResourceOperation {
         return getTimeoutForResourceReadiness("default");
     }
 
+    // Deprecation is suppressed because of KafkaConnectS2I
+    @SuppressWarnings("deprecation")
     public static long getTimeoutForResourceReadiness(String kind) {
         long timeout;
 
@@ -79,6 +81,8 @@ public class ResourceOperation {
         return getTimeoutForResourceDeletion("default");
     }
 
+    // Deprecation is suppressed because of KafkaConnectS2I
+    @SuppressWarnings("deprecation")
     public static long getTimeoutForResourceDeletion(String kind) {
         long timeout;
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
@@ -26,6 +26,8 @@ import java.util.function.Consumer;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
 import static io.strimzi.systemtest.resources.ResourceManager.CR_CREATION_TIMEOUT;
 
+// Deprecation is suppressed because of KafkaConnectS2I
+@SuppressWarnings("deprecation")
 public class KafkaConnectS2IResource {
 
     public static MixedOperation<KafkaConnectS2I, KafkaConnectS2IList, Resource<KafkaConnectS2I>> kafkaConnectS2IClient() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
@@ -21,6 +21,8 @@ public class KafkaConnectS2IUtils {
      * @param clusterName The name of the Kafka ConnectS2I cluster.
      * @param status desired status value
      */
+    // Deprecation is suppressed because of KafkaConnectS2I
+    @SuppressWarnings("deprecation")
     public static void waitForConnectS2IStatus(String clusterName, Enum<?>  status) {
         KafkaConnectS2I kafkaConnectS2I = KafkaConnectS2IResource.kafkaConnectS2IClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
         ResourceManager.waitForResourceStatus(KafkaConnectS2IResource.kafkaConnectS2IClient(), kafkaConnectS2I, status);


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR deprecates the Kafka Connect S2I which is being replaced with the Kafka Connect _build_. This marks the API class `KafkaConnectS2I` deprecated, updates the docs and suppresses the _deprecation_ warnings in the rest of the code.

This should close #2160

### Checklist

- [x] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md