### PR TITLE
[systemtest] Small fixes to the tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -85,8 +85,8 @@ class MirrorMaker2ST extends AbstractST {
     private static final String MIRRORMAKER2_TOPIC_NAME = "mirrormaker2-topic-example";
     private final int messagesCount = 200;
 
-    private String kafkaClusterSourceName = clusterName + "-source";
-    private String kafkaClusterTargetName = clusterName + "-target";
+    private String kafkaClusterSourceName;
+    private String kafkaClusterTargetName;
 
     @SuppressWarnings({"checkstyle:MethodLength"})
     @Test
@@ -895,6 +895,9 @@ class MirrorMaker2ST extends AbstractST {
 
     @BeforeAll
     void setup() {
+        kafkaClusterSourceName = clusterName + "-source";
+        kafkaClusterTargetName = clusterName + "-target";
+
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
@@ -72,8 +72,8 @@ public class MirrorMakerST extends AbstractST {
 
     public static final String NAMESPACE = "mm-cluster-test";
     private final int messagesCount = 200;
-    private String kafkaClusterSourceName = clusterName + "-source";
-    private String kafkaClusterTargetName = clusterName + "-target";
+    private String kafkaClusterSourceName;
+    private String kafkaClusterTargetName;
 
     @Test
     void testMirrorMaker() {
@@ -836,6 +836,9 @@ public class MirrorMakerST extends AbstractST {
     
     @BeforeAll
     void setupEnvironment() {
+        kafkaClusterSourceName = clusterName + "-source";
+        kafkaClusterTargetName = clusterName + "-target";
+
         ResourceManager.setClassResources();
         installClusterOperator(NAMESPACE);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
@@ -6,6 +6,7 @@ package io.strimzi.systemtest.security;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeerBuilder;
@@ -283,8 +284,9 @@ public class NetworkPoliciesST extends AbstractST {
             .endSpec()
             .build());
 
-        kubeClient().getClient().namespaces().withName(NAMESPACE).edit(ns -> new NamespaceBuilder()
-            .editMetadata()
+        Namespace actualNamespace = kubeClient().getClient().namespaces().withName(NAMESPACE).get();
+        kubeClient().getClient().namespaces().withName(NAMESPACE).edit(ns -> new NamespaceBuilder(actualNamespace)
+            .editOrNewMetadata()
                 .addToLabels(labels)
             .endMetadata()
             .build());


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Fixes

### Description

In `MirrorMaker2ST`, `MirrorMakerST` and `ConnectS2IST` we used the static final vars for resource cluster names, unfortunately the `clusterName` inside of the var hasn't any name, so it contained just `null`, so in some test cases, the name looked like `null-s2i`.

In the `testNPWhenOperatorIsInDifferentNamespaceThanOperand` there was problem with editing/replacing namespace spec after the Fabric8 upgrade.

### Checklist

- [ ] Make sure all tests pass


