### PR TITLE
State metric contains a message

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -94,7 +94,7 @@ public abstract class AbstractOperator<
     private final AtomicInteger pausedResourceCounter;
     private final AtomicInteger resourceCounter;
     private final Timer reconciliationsTimer;
-    private final Map<Tags, AtomicInteger> resourcesStateCounter;
+    private final Map<String, AtomicInteger> resourcesStateCounter;
 
     public AbstractOperator(Vertx vertx, String kind, O resourceOperator, MetricsProvider metrics, Labels selectorLabels) {
         this.vertx = vertx;
@@ -495,7 +495,7 @@ public abstract class AbstractOperator<
      */
     private void handleResult(Reconciliation reconciliation, AsyncResult<Void> result, Timer.Sample reconciliationTimerSample) {
         if (result.succeeded()) {
-            updateResourceState(reconciliation, true);
+            updateResourceState(reconciliation, true, null);
             successfulReconciliationsCounter.increment();
             reconciliationTimerSample.stop(reconciliationsTimer);
             log.info("{}: reconciled", reconciliation);
@@ -503,14 +503,14 @@ public abstract class AbstractOperator<
             Throwable cause = result.cause();
 
             if (cause instanceof InvalidConfigParameterException) {
-                updateResourceState(reconciliation, false);
+                updateResourceState(reconciliation, false, cause);
                 failedReconciliationsCounter.increment();
                 reconciliationTimerSample.stop(reconciliationsTimer);
                 log.warn("{}: Failed to reconcile {}", reconciliation, cause.getMessage());
             } else if (cause instanceof UnableToAcquireLockException) {
                 lockedReconciliationsCounter.increment();
             } else  {
-                updateResourceState(reconciliation, false);
+                updateResourceState(reconciliation, false, cause);
                 failedReconciliationsCounter.increment();
                 reconciliationTimerSample.stop(reconciliationsTimer);
                 log.warn("{}: Failed to reconcile", reconciliation, cause);
@@ -537,31 +537,38 @@ public abstract class AbstractOperator<
      * @param reconciliation reconciliation to use to update the resource state metric
      * @param ready if reconcile was successful and the resource is ready
      */
-    private void updateResourceState(Reconciliation reconciliation, boolean ready) {
-        Tags metricTags = Tags.of(
+    private void updateResourceState(Reconciliation reconciliation, boolean ready, Throwable cause) {
+        String key = reconciliation.namespace() + ":" + reconciliation.kind() + "/" + reconciliation.name();
+
+        Tags metricTagsWithReason = Tags.of(
                 Tag.of("kind", reconciliation.kind()),
                 Tag.of("name", reconciliation.name()),
-                Tag.of("resource-namespace", reconciliation.namespace()));
+                Tag.of("resource-namespace", reconciliation.namespace()),
+                Tag.of("failure-reason", cause == null ? "none" : cause.getMessage()));
 
         T cr = resourceOperator.get(reconciliation.namespace(), reconciliation.name());
-        if (cr != null) {
-            resourcesStateCounter.computeIfAbsent(metricTags, tags ->
-                    metrics.gauge(METRICS_PREFIX + "resource.state", "Current state of the resource: 1 ready, 0 fail", tags)
-            );
-            resourcesStateCounter.get(metricTags).set(ready ? 1 : 0);
-            log.debug("{}: Updated metric " + METRICS_PREFIX + "resource.state{} = {}", reconciliation, metricTags, ready ? 1 : 0);
-        } else {
-            Optional<Meter> gauge = metrics.meterRegistry().getMeters()
-                    .stream()
-                    .filter(meter -> meter.getId().getName().equals(METRICS_PREFIX + "resource.state") &&
-                            meter.getId().getTags().equals(metricTags.stream().collect(Collectors.toList()))
-                    ).findFirst();
 
-            if (gauge.isPresent()) {
-                metrics.meterRegistry().remove(gauge.get().getId());
-                resourcesStateCounter.remove(metricTags);
-                log.debug("{}: Removed metric " + METRICS_PREFIX + "resource.state{}", reconciliation, metricTags);
-            }
+        Optional<Meter> gauge = metrics.meterRegistry().getMeters()
+                .stream()
+                .filter(meter -> meter.getId().getName().equals(METRICS_PREFIX + "resource.state") &&
+                        meter.getId().getTags().contains(Tag.of("kind", reconciliation.kind())) &&
+                        meter.getId().getTags().contains(Tag.of("name", reconciliation.name())) &&
+                        meter.getId().getTags().contains(Tag.of("resource-namespace", reconciliation.namespace()))
+                ).findFirst();
+
+        if (gauge.isPresent()) {
+            // remove metric so it can be re-added with new tags
+            metrics.meterRegistry().remove(gauge.get().getId());
+            resourcesStateCounter.remove(key);
+            log.debug("{}: Removed metric " + METRICS_PREFIX + "resource.state{}", reconciliation, key);
+        }
+
+        if (cr != null) {
+            resourcesStateCounter.computeIfAbsent(key, tags ->
+                    metrics.gauge(METRICS_PREFIX + "resource.state", "Current state of the resource: 1 ready, 0 fail", metricTagsWithReason)
+            );
+            resourcesStateCounter.get(key).set(ready ? 1 : 0);
+            log.debug("{}: Updated metric " + METRICS_PREFIX + "resource.state{} = {}", reconciliation, metricTagsWithReason, ready ? 1 : 0);
         }
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -544,7 +544,7 @@ public abstract class AbstractOperator<
                 Tag.of("kind", reconciliation.kind()),
                 Tag.of("name", reconciliation.name()),
                 Tag.of("resource-namespace", reconciliation.namespace()),
-                Tag.of("failure-reason", cause == null ? "none" : cause.getMessage()));
+                Tag.of("failure-reason", cause == null ? "none" : cause.getMessage() == null ? "unknown error" : cause.getMessage()));
 
         T cr = resourceOperator.get(reconciliation.namespace(), reconciliation.name());
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -540,19 +540,11 @@ public abstract class AbstractOperator<
     private void updateResourceState(Reconciliation reconciliation, boolean ready, Throwable cause) {
         String key = reconciliation.namespace() + ":" + reconciliation.kind() + "/" + reconciliation.name();
 
-        Tags metricTags;
-        if (cause == null) {
-            metricTags = Tags.of(
-                    Tag.of("kind", reconciliation.kind()),
-                    Tag.of("name", reconciliation.name()),
-                    Tag.of("resource-namespace", reconciliation.namespace()));
-        } else {
-            metricTags = Tags.of(
+        Tags metricTags = Tags.of(
                     Tag.of("kind", reconciliation.kind()),
                     Tag.of("name", reconciliation.name()),
                     Tag.of("resource-namespace", reconciliation.namespace()),
-                    Tag.of("reason", cause.getMessage() == null ? "unknown error" : cause.getMessage()));
-        }
+                    Tag.of("reason", cause == null ? "none" : cause.getMessage() == null ? "unknown error" : cause.getMessage()));
 
         T cr = resourceOperator.get(reconciliation.namespace(), reconciliation.name());
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
@@ -124,8 +124,10 @@ public class OperatorMetricsTest {
                 return Future.failedFuture(new RuntimeException("Test error"));
             }
 
-            protected void validate(HasMetadata resource) {
+            @Override
+            public Set<Condition> validate(CustomResource resource) {
                 // Do nothing
+                return emptySet();
             }
 
             @Override
@@ -156,6 +158,7 @@ public class OperatorMetricsTest {
                             .tag("kind", "TestResource")
                             .tag("name", "my-resource")
                             .tag("resource-namespace", "my-namespace")
+                            .tag("reason", "Test error")
                             .gauge().value(), is(0.0));
 
                     async.flag();
@@ -226,7 +229,9 @@ public class OperatorMetricsTest {
                 return Future.failedFuture(new UnableToAcquireLockException());
             }
 
+            @Override
             public Set<Condition> validate(CustomResource resource) {
+                // Do nothing
                 return emptySet();
             }
 
@@ -285,7 +290,9 @@ public class OperatorMetricsTest {
                 return null;
             }
 
+            @Override
             public Set<Condition> validate(CustomResource resource) {
+                // Do nothing
                 return emptySet();
             }
 
@@ -346,7 +353,9 @@ public class OperatorMetricsTest {
                 return Future.succeededFuture(resources);
             }
 
+            @Override
             public Set<Condition> validate(CustomResource resource) {
+                // Do nothing
                 return emptySet();
             }
 
@@ -410,10 +419,10 @@ public class OperatorMetricsTest {
         return metrics;
     }
 
-    private abstract static class MyResource extends CustomResource {
+    protected abstract static class MyResource extends CustomResource {
     }
 
-    private AbstractWatchableStatusedResourceOperator resourceOperatorWithExistingResource()    {
+    protected AbstractWatchableStatusedResourceOperator resourceOperatorWithExistingResource()    {
         return new AbstractWatchableStatusedResourceOperator(vertx, null, "TestResource") {
             @Override
             public Future updateStatusAsync(HasMetadata resource) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -259,23 +259,24 @@ public class MetricsST extends AbstractST {
         }
 
         assertCoMetricResources(Kafka.RESOURCE_KIND, 2);
-        assertCoMetricResourceState(Kafka.RESOURCE_KIND, metricsClusterName, 1);
-        assertCoMetricResourceState(Kafka.RESOURCE_KIND, SECOND_CLUSTER, 1);
+        assertCoMetricResourceState(Kafka.RESOURCE_KIND, metricsClusterName, 1, "none");
+        assertCoMetricResourceState(Kafka.RESOURCE_KIND, SECOND_CLUSTER, 1, "none");
 
         assertCoMetricResources(KafkaBridge.RESOURCE_KIND, 1);
-        assertCoMetricResourceState(KafkaBridge.RESOURCE_KIND, BRIDGE_CLUSTER, 1);
+        assertCoMetricResourceState(KafkaBridge.RESOURCE_KIND, BRIDGE_CLUSTER, 1, "none");
 
         assertCoMetricResources(KafkaConnect.RESOURCE_KIND, 1);
-        assertCoMetricResourceState(KafkaConnect.RESOURCE_KIND, metricsClusterName, 1);
+        assertCoMetricResourceState(KafkaConnect.RESOURCE_KIND, metricsClusterName, 1, "none");
 
         assertCoMetricResources(KafkaConnectS2I.RESOURCE_KIND, 0);
-        assertCoMetricResourceState(KafkaConnectS2I.RESOURCE_KIND, metricsClusterName, 0);
+        assertCoMetricResourceState(KafkaConnectS2I.RESOURCE_KIND, metricsClusterName, 0, "Both KafkaConnect and KafkaConnectS2I exist with the same name. " +
+                "KafkaConnect is older and will be used while this custom resource will be ignored.");
 
         assertCoMetricResources(KafkaMirrorMaker.RESOURCE_KIND, 0);
         assertCoMetricResourceStateNotExists(KafkaMirrorMaker.RESOURCE_KIND, metricsClusterName);
 
         assertCoMetricResources(KafkaMirrorMaker2.RESOURCE_KIND, 1);
-        assertCoMetricResourceState(KafkaMirrorMaker2.RESOURCE_KIND, MIRROR_MAKER_CLUSTER, 1);
+        assertCoMetricResourceState(KafkaMirrorMaker2.RESOURCE_KIND, MIRROR_MAKER_CLUSTER, 1, "none");
 
         assertCoMetricResources(KafkaConnector.RESOURCE_KIND, 0);
         assertCoMetricResourceStateNotExists(KafkaConnector.RESOURCE_KIND, metricsClusterName);
@@ -652,8 +653,8 @@ public class MetricsST extends AbstractST {
         assertThat(values.isEmpty(), is(true));
     }
 
-    private void assertCoMetricResourceState(String kind, String name, int value) {
-        Pattern pattern = Pattern.compile("strimzi_resource_state\\{kind=\"" + kind + "\",name=\"" + name + "\",resource_namespace=\"" + NAMESPACE + "\",} ([\\d.][^\\n]+)", Pattern.CASE_INSENSITIVE);
+    private void assertCoMetricResourceState(String kind, String name, int value, String reason) {
+        Pattern pattern = Pattern.compile("strimzi_resource_state\\{kind=\"" + kind + "\",name=\"" + name + "\",reason=\"" + reason + "\",resource_namespace=\"" + NAMESPACE + "\",} ([\\d.][^\\n]+)", Pattern.CASE_INSENSITIVE);
         ArrayList<Double> values = MetricsUtils.collectSpecificMetric(pattern, clusterOperatorMetricsData);
         assertThat("strimzi_resource_state for " + kind + " is not " + value, values.stream().mapToDouble(i -> i).sum(), is((double) value));
     }


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement / new feature

### Description
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/4327

Currently, the state metric gives just info on whether the resource is ready or not. In case of not-ready, we cannot say, whether it is still created or failed. This PR adds a message to the metrics tags.

The metric in case of ready resource:
```
strimzi_resource_state{container="strimzi-cluster-operator", endpoint="http", failure_reason="none", instance="10.129.2.121:8080", job="myproject/cluster-operator-metrics", kind="Kafka", name="my-cluster", namespace="myproject", pod="strimzi-cluster-operator-56b59d667d-vj7ln", resource_namespace="myproject"} | 1
```

The metric in case of *not* ready resource:
```
strimzi_resource_state{container="strimzi-cluster-operator", endpoint="http", failure_reason="Version 2.8.0 is not supported. Supported versions are: 2.5.0, 2.5.1, 2.6.0, 2.7.0.", instance="10.129.2.121:8080", job="myproject/cluster-operator-metrics", kind="Kafka", name="my-cluster", namespace="myproject", pod="strimzi-cluster-operator-56b59d667d-vj7ln", resource_namespace="myproject"} 0
```

### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

