### PR TITLE
Fix KafkaRebalance status when deprecated or unknown property is in spec

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -48,6 +48,7 @@ import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -320,8 +321,7 @@ public class KafkaRebalanceAssemblyOperator
 
     private Future<Void> reconcile(Reconciliation reconciliation, String host,
                                    CruiseControlApi apiClient, KafkaRebalance kafkaRebalance,
-                                   KafkaRebalanceState currentState, KafkaRebalanceAnnotation rebalanceAnnotation,
-                                   Set<Condition> unknownAndDeprecatedConditions) {
+                                   KafkaRebalanceState currentState, KafkaRebalanceAnnotation rebalanceAnnotation) {
 
         log.info("{}: Rebalance action from state [{}]", reconciliation, currentState);
 
@@ -335,7 +335,6 @@ public class KafkaRebalanceAssemblyOperator
                return kafkaRebalanceOperator.getAsync(reconciliation.namespace(), reconciliation.name())
                             .compose(currentKafkaRebalance -> {
                                 if (currentKafkaRebalance != null) {
-                                    addWarningsToStatus(desiredStatus, unknownAndDeprecatedConditions);
                                     return updateStatus(currentKafkaRebalance, desiredStatus, null)
                                             .compose(updatedKafkaRebalance -> {
                                                 log.info("{}: State updated to [{}] with annotation {}={} ",
@@ -367,7 +366,6 @@ public class KafkaRebalanceAssemblyOperator
                                 }
                             }, exception -> {
                                     log.error("{}: Status updated to [NotReady] due to error: {}", reconciliation, exception.getMessage());
-                                    addWarningsToStatus(desiredStatus, unknownAndDeprecatedConditions);
                                     return updateStatus(kafkaRebalance, new KafkaRebalanceStatus(), exception)
                                             .mapEmpty();
                                 }); },
@@ -388,7 +386,7 @@ public class KafkaRebalanceAssemblyOperator
                                                                         KafkaRebalanceAnnotation rebalanceAnnotation, RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder) {
         switch (currentState) {
             case New:
-                return onNew(reconciliation, host, apiClient, rebalanceOptionsBuilder);
+                return onNew(reconciliation, host, apiClient, rebalanceOptionsBuilder, kafkaRebalance);
             case PendingProposal:
                 return onPendingProposal(reconciliation, host, apiClient, kafkaRebalance, rebalanceAnnotation, rebalanceOptionsBuilder);
             case ProposalReady:
@@ -396,10 +394,10 @@ public class KafkaRebalanceAssemblyOperator
             case Rebalancing:
                 return onRebalancing(reconciliation, host, apiClient, kafkaRebalance, rebalanceAnnotation);
             case Stopped:
-                return onStop(reconciliation, host, apiClient, rebalanceAnnotation, rebalanceOptionsBuilder);
+                return onStop(reconciliation, host, apiClient, rebalanceAnnotation, rebalanceOptionsBuilder, kafkaRebalance);
             case Ready:
                 // Rebalance Complete
-                return Future.succeededFuture(kafkaRebalance.getStatus());
+                return Future.succeededFuture(buildRebalanceStatusFromPreviousStatus(kafkaRebalance.getStatus(), validate(kafkaRebalance)));
             case NotReady:
                 // Error case
                 return onNotReady(reconciliation, host, apiClient, kafkaRebalance, rebalanceAnnotation, rebalanceOptionsBuilder);
@@ -408,18 +406,37 @@ public class KafkaRebalanceAssemblyOperator
         }
     }
 
-    private KafkaRebalanceStatus buildRebalanceStatus(String sessionID, KafkaRebalanceState cruiseControlState) {
+    private KafkaRebalanceStatus buildRebalanceStatus(String sessionID, KafkaRebalanceState cruiseControlState, Set<Condition> validation) {
+        List<Condition> conditions = new ArrayList<>();
+        conditions.add(StatusUtils.buildRebalanceCondition(cruiseControlState.toString()));
+        conditions.addAll(validation);
         return new KafkaRebalanceStatusBuilder()
                 .withSessionId(sessionID)
-                .withConditions(StatusUtils.buildRebalanceCondition(cruiseControlState.toString()))
+                .withConditions(conditions)
                 .build();
     }
 
-    private KafkaRebalanceStatus buildRebalanceStatus(String sessionID, KafkaRebalanceState cruiseControlState, Map<String, Object> optimizationResult) {
+    private KafkaRebalanceStatus buildRebalanceStatusFromPreviousStatus(KafkaRebalanceStatus currentStatus, Set<Condition> validation) {
+        List<Condition> conditions = new ArrayList<>();
+        conditions.addAll(validation);
+
+        Condition currentState = rebalanceStateCondition(currentStatus);
+        conditions.add(currentState);
+
+        return new KafkaRebalanceStatusBuilder()
+                .withSessionId(currentStatus.getSessionId())
+                .withConditions(conditions)
+                .build();
+    }
+
+    private KafkaRebalanceStatus buildRebalanceStatus(String sessionID, KafkaRebalanceState cruiseControlState, Map<String, Object> optimizationResult, Set<Condition> validation) {
+        List<Condition> conditions = new ArrayList<>();
+        conditions.add(StatusUtils.buildRebalanceCondition(cruiseControlState.toString()));
+        conditions.addAll(validation);
         return new KafkaRebalanceStatusBuilder()
                 .withSessionId(sessionID)
                 .withOptimizationResult(optimizationResult)
-                .withConditions(StatusUtils.buildRebalanceCondition(cruiseControlState.toString()))
+                .withConditions(conditions)
                 .build();
     }
 
@@ -438,8 +455,8 @@ public class KafkaRebalanceAssemblyOperator
      */
     private Future<KafkaRebalanceStatus> onNew(Reconciliation reconciliation,
                                                String host, CruiseControlApi apiClient,
-                                               RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder) {
-        return requestRebalance(reconciliation, host, apiClient, true, rebalanceOptionsBuilder);
+                                               RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder, KafkaRebalance kafkaRebalance) {
+        return requestRebalance(reconciliation, host, apiClient, true, rebalanceOptionsBuilder, kafkaRebalance);
     }
 
     /**
@@ -463,7 +480,7 @@ public class KafkaRebalanceAssemblyOperator
         if (rebalanceAnnotation == KafkaRebalanceAnnotation.refresh) {
             // The user has fixed the error on the resource and want to 'refresh'
             // This actually requests a new rebalance proposal
-            return onNew(reconciliation, host, apiClient, rebalanceOptionsBuilder);
+            return onNew(reconciliation, host, apiClient, rebalanceOptionsBuilder, kafkaRebalance);
         } else {
             // Stay in the current NotReady state, returning null as next state
             return Future.succeededFuture();
@@ -507,10 +524,10 @@ public class KafkaRebalanceAssemblyOperator
                                 if (rebalanceAnnotation(currentKafkaRebalance) == KafkaRebalanceAnnotation.stop) {
                                     log.debug("{}: Stopping current Cruise Control proposal request timer", reconciliation);
                                     vertx.cancelTimer(t);
-                                    p.complete(buildRebalanceStatus(null, KafkaRebalanceState.Stopped));
+                                    p.complete(buildRebalanceStatus(null, KafkaRebalanceState.Stopped, validate(currentKafkaRebalance)));
                                 } else {
                                     requestRebalance(reconciliation, host, apiClient, true, rebalanceOptionsBuilder,
-                                            currentKafkaRebalance.getStatus().getSessionId())
+                                            currentKafkaRebalance.getStatus().getSessionId(), currentKafkaRebalance)
                                         .onSuccess(rebalanceStatus -> {
                                             // If the returned status has an optimization result then the rebalance proposal
                                             // is ready, so stop the polling
@@ -576,16 +593,17 @@ public class KafkaRebalanceAssemblyOperator
         switch (rebalanceAnnotation) {
             case none:
                 log.debug("{}: No {} annotation set", reconciliation, ANNO_STRIMZI_IO_REBALANCE);
-                return Future.succeededFuture(kafkaRebalance.getStatus());
+                KafkaRebalanceStatus stat = buildRebalanceStatusFromPreviousStatus(kafkaRebalance.getStatus(), validate(kafkaRebalance));
+                return Future.succeededFuture(buildRebalanceStatusFromPreviousStatus(kafkaRebalance.getStatus(), validate(kafkaRebalance)));
             case approve:
                 log.debug("{}: Annotation {}={}", reconciliation, ANNO_STRIMZI_IO_REBALANCE, KafkaRebalanceAnnotation.approve);
-                return requestRebalance(reconciliation, host, apiClient, false, rebalanceOptionsBuilder);
+                return requestRebalance(reconciliation, host, apiClient, false, rebalanceOptionsBuilder, kafkaRebalance);
             case refresh:
                 log.debug("{}: Annotation {}={}", reconciliation, ANNO_STRIMZI_IO_REBALANCE, KafkaRebalanceAnnotation.refresh);
-                return requestRebalance(reconciliation, host, apiClient, true, rebalanceOptionsBuilder);
+                return requestRebalance(reconciliation, host, apiClient, true, rebalanceOptionsBuilder, kafkaRebalance);
             default:
                 log.warn("{}: Ignore annotation {}={}", reconciliation, ANNO_STRIMZI_IO_REBALANCE, rebalanceAnnotation);
-                return Future.succeededFuture(kafkaRebalance.getStatus());
+                return Future.succeededFuture(buildRebalanceStatusFromPreviousStatus(kafkaRebalance.getStatus(), validate(kafkaRebalance)));
         }
     }
 
@@ -632,7 +650,7 @@ public class KafkaRebalanceAssemblyOperator
                                     log.debug("{}: Stopping current Cruise Control rebalance user task", reconciliation);
                                     vertx.cancelTimer(t);
                                     apiClient.stopExecution(host, CruiseControl.REST_API_PORT)
-                                        .onSuccess(r -> p.complete(buildRebalanceStatus(null, KafkaRebalanceState.Stopped)))
+                                        .onSuccess(r -> p.complete(buildRebalanceStatus(null, KafkaRebalanceState.Stopped, validate(kafkaRebalance))))
                                         .onFailure(e -> {
                                             log.error("{}: Cruise Control stopping execution failed", reconciliation, e.getCause());
                                             p.fail(e.getCause());
@@ -648,7 +666,7 @@ public class KafkaRebalanceAssemblyOperator
                                                     vertx.cancelTimer(t);
                                                     log.info("{}: Rebalance ({}) is now complete", reconciliation, sessionId);
                                                     p.complete(buildRebalanceStatus(
-                                                        null, KafkaRebalanceState.Ready, taskStatusJson.getJsonObject(CC_REST_API_SUMMARY).getMap()));
+                                                        null, KafkaRebalanceState.Ready, taskStatusJson.getJsonObject(CC_REST_API_SUMMARY).getMap(), validate(kafkaRebalance)));
                                                     break;
                                                 case COMPLETED_WITH_ERROR:
                                                     // TODO: There doesn't seem to be a way to retrieve the actual error message from the user tasks endpoint?
@@ -657,7 +675,7 @@ public class KafkaRebalanceAssemblyOperator
                                                     //       details of any issues while rebalancing.
                                                     log.error("{}: Rebalance ({}) optimization proposal has failed to complete", reconciliation, sessionId);
                                                     vertx.cancelTimer(t);
-                                                    p.complete(buildRebalanceStatus(sessionId, KafkaRebalanceState.NotReady));
+                                                    p.complete(buildRebalanceStatus(sessionId, KafkaRebalanceState.NotReady, validate(kafkaRebalance)));
                                                     break;
                                                 case IN_EXECUTION: // Rebalance is still in progress
                                                     // We need to check that the status has been updated with the ongoing optimisation proposal
@@ -670,7 +688,7 @@ public class KafkaRebalanceAssemblyOperator
                                                         // Cancel the timer so that the status is returned and updated.
                                                         vertx.cancelTimer(t);
                                                         p.complete(buildRebalanceStatus(
-                                                            sessionId, KafkaRebalanceState.Rebalancing, taskStatusJson.getJsonObject(CC_REST_API_SUMMARY).getMap()));
+                                                            sessionId, KafkaRebalanceState.Rebalancing, taskStatusJson.getJsonObject(CC_REST_API_SUMMARY).getMap(), validate(kafkaRebalance)));
                                                     }
                                                     ccApiErrorCount.set(0);
                                                     // TODO: Find out if there is any way to check the progress of a rebalance.
@@ -736,12 +754,12 @@ public class KafkaRebalanceAssemblyOperator
     private Future<KafkaRebalanceStatus> onStop(Reconciliation reconciliation,
                                                 String host, CruiseControlApi apiClient,
                                                 KafkaRebalanceAnnotation rebalanceAnnotation,
-                                                RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder) {
+                                                RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder, KafkaRebalance kafkaRebalance) {
         if (rebalanceAnnotation == KafkaRebalanceAnnotation.refresh) {
-            return requestRebalance(reconciliation, host, apiClient, true, rebalanceOptionsBuilder);
+            return requestRebalance(reconciliation, host, apiClient, true, rebalanceOptionsBuilder, kafkaRebalance);
         } else {
             log.warn("{}: Ignore annotation {}={}", reconciliation, ANNO_STRIMZI_IO_REBALANCE, rebalanceAnnotation);
-            return Future.succeededFuture(buildRebalanceStatus(null, KafkaRebalanceState.Stopped));
+            return Future.succeededFuture(buildRebalanceStatus(null, KafkaRebalanceState.Stopped, validate(kafkaRebalance)));
         }
     }
 
@@ -801,11 +819,10 @@ public class KafkaRebalanceAssemblyOperator
                                 }
                                 currentState = KafkaRebalanceState.valueOf(rebalanceStateType);
                             }
-                            Set<Condition> unknownAndDeprecatedConditions = validate(currentKafkaRebalance);
                             // Check annotation
                             KafkaRebalanceAnnotation rebalanceAnnotation = rebalanceAnnotation(currentKafkaRebalance);
                             return reconcile(reconciliation, cruiseControlHost(clusterName, clusterNamespace),
-                                        apiClient, currentKafkaRebalance, currentState, rebalanceAnnotation, unknownAndDeprecatedConditions).mapEmpty();
+                                        apiClient, currentKafkaRebalance, currentState, rebalanceAnnotation).mapEmpty();
 
                         }, exception -> Future.failedFuture(exception).mapEmpty());
                 }, exception -> updateStatus(kafkaRebalance, new KafkaRebalanceStatus(), exception).mapEmpty());
@@ -813,12 +830,13 @@ public class KafkaRebalanceAssemblyOperator
 
     private Future<KafkaRebalanceStatus> requestRebalance(Reconciliation reconciliation,
                                                           String host, CruiseControlApi apiClient,
-                                                          boolean dryrun, RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder) {
-        return requestRebalance(reconciliation, host, apiClient, dryrun, rebalanceOptionsBuilder, null);
+                                                          boolean dryrun, RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder,
+                                                          KafkaRebalance kafkaRebalance) {
+        return requestRebalance(reconciliation, host, apiClient, dryrun, rebalanceOptionsBuilder, null, kafkaRebalance);
     }
 
     private Future<KafkaRebalanceStatus> requestRebalance(Reconciliation reconciliation, String host, CruiseControlApi apiClient,
-                                                          boolean dryrun, RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder, String userTaskID) {
+                                                          boolean dryrun, RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder, String userTaskID, KafkaRebalance kafkaRebalance) {
 
         log.info("{}: Requesting Cruise Control rebalance [dryrun={}]", reconciliation, dryrun);
         if (!dryrun) {
@@ -830,22 +848,22 @@ public class KafkaRebalanceAssemblyOperator
                         if (response.isNotEnoughDataForProposal()) {
                             // If there is not enough data for a rebalance, it's an error at the Cruise Control level
                             // Need to re-request the proposal at a later time so move to the PendingProposal State.
-                            return buildRebalanceStatus(null, KafkaRebalanceState.PendingProposal);
+                            return buildRebalanceStatus(null, KafkaRebalanceState.PendingProposal, validate(kafkaRebalance));
                         } else if (response.isProposalStillCalaculating()) {
                             // If rebalance proposal is still being processed, we need to re-request the proposal at a later time
                             // with the corresponding session-id so we move to the PendingProposal State.
-                            return buildRebalanceStatus(response.getUserTaskId(), KafkaRebalanceState.PendingProposal);
+                            return buildRebalanceStatus(response.getUserTaskId(), KafkaRebalanceState.PendingProposal, validate(kafkaRebalance));
                         }
                     } else {
                         if (response.isNotEnoughDataForProposal()) {
                             // We do not include a session id with this status as we do not want to retrieve the state of
                             // this failed tasks (COMPLETED_WITH_ERROR)
-                            return buildRebalanceStatus(null, KafkaRebalanceState.PendingProposal);
+                            return buildRebalanceStatus(null, KafkaRebalanceState.PendingProposal, validate(kafkaRebalance));
                         } else if (response.isProposalStillCalaculating()) {
                             // If dryrun=false and the proposal is not ready we are going to be in a rebalancing state as
                             // soon as it is ready, so set the state to rebalancing.
                             // In the onRebalancing method the optimization proposal will be added when it is ready.
-                            return buildRebalanceStatus(response.getUserTaskId(), KafkaRebalanceState.Rebalancing);
+                            return buildRebalanceStatus(response.getUserTaskId(), KafkaRebalanceState.Rebalancing, validate(kafkaRebalance));
                         }
                     }
 
@@ -856,7 +874,7 @@ public class KafkaRebalanceAssemblyOperator
 
                     // Transition to ProposalReady for a dry run or to the Rebalancing state for a full run
                     KafkaRebalanceState newState = dryrun ? KafkaRebalanceState.ProposalReady : KafkaRebalanceState.Rebalancing;
-                    return buildRebalanceStatus(response.getUserTaskId(), newState, response.getJson().getJsonObject(CC_REST_API_SUMMARY).getMap());
+                    return buildRebalanceStatus(response.getUserTaskId(), newState, response.getJson().getJsonObject(CC_REST_API_SUMMARY).getMap(), validate(kafkaRebalance));
                 });
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -50,6 +50,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -270,7 +271,10 @@ public class KafkaRebalanceAssemblyOperator
 
             Condition cond = rebalanceStateCondition(desiredStatus);
 
-            List<Condition> previous = desiredStatus.getConditions().stream().filter(condition -> condition != cond).collect(Collectors.toList());
+            List<Condition> previous = Collections.emptyList();
+            if (desiredStatus.getConditions() != null) {
+                previous = desiredStatus.getConditions().stream().filter(condition -> condition != cond).collect(Collectors.toList());
+            }
             String rebalanceType = rebalanceStateConditionType(desiredStatus);
 
             // If a throwable is supplied, it is set in the status with priority

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -386,7 +386,7 @@ public class KafkaRebalanceAssemblyOperator
                                                                         KafkaRebalanceAnnotation rebalanceAnnotation, RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder) {
         switch (currentState) {
             case New:
-                return onNew(reconciliation, host, apiClient, rebalanceOptionsBuilder, kafkaRebalance);
+                return onNew(reconciliation, host, apiClient, kafkaRebalance, rebalanceOptionsBuilder);
             case PendingProposal:
                 return onPendingProposal(reconciliation, host, apiClient, kafkaRebalance, rebalanceAnnotation, rebalanceOptionsBuilder);
             case ProposalReady:
@@ -394,7 +394,7 @@ public class KafkaRebalanceAssemblyOperator
             case Rebalancing:
                 return onRebalancing(reconciliation, host, apiClient, kafkaRebalance, rebalanceAnnotation);
             case Stopped:
-                return onStop(reconciliation, host, apiClient, rebalanceAnnotation, rebalanceOptionsBuilder, kafkaRebalance);
+                return onStop(reconciliation, host, apiClient, kafkaRebalance, rebalanceAnnotation, rebalanceOptionsBuilder);
             case Ready:
                 // Rebalance Complete
                 return Future.succeededFuture(buildRebalanceStatusFromPreviousStatus(kafkaRebalance.getStatus(), validate(kafkaRebalance)));
@@ -455,7 +455,7 @@ public class KafkaRebalanceAssemblyOperator
      */
     private Future<KafkaRebalanceStatus> onNew(Reconciliation reconciliation,
                                                String host, CruiseControlApi apiClient,
-                                               RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder, KafkaRebalance kafkaRebalance) {
+                                               KafkaRebalance kafkaRebalance, RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder) {
         return requestRebalance(reconciliation, host, apiClient, true, rebalanceOptionsBuilder, kafkaRebalance);
     }
 
@@ -480,7 +480,7 @@ public class KafkaRebalanceAssemblyOperator
         if (rebalanceAnnotation == KafkaRebalanceAnnotation.refresh) {
             // The user has fixed the error on the resource and want to 'refresh'
             // This actually requests a new rebalance proposal
-            return onNew(reconciliation, host, apiClient, rebalanceOptionsBuilder, kafkaRebalance);
+            return onNew(reconciliation, host, apiClient, kafkaRebalance, rebalanceOptionsBuilder);
         } else {
             // Stay in the current NotReady state, returning null as next state
             return Future.succeededFuture();
@@ -752,8 +752,8 @@ public class KafkaRebalanceAssemblyOperator
      */
     private Future<KafkaRebalanceStatus> onStop(Reconciliation reconciliation,
                                                 String host, CruiseControlApi apiClient,
-                                                KafkaRebalanceAnnotation rebalanceAnnotation,
-                                                RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder, KafkaRebalance kafkaRebalance) {
+                                                KafkaRebalance kafkaRebalance, KafkaRebalanceAnnotation rebalanceAnnotation,
+                                                RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder) {
         if (rebalanceAnnotation == KafkaRebalanceAnnotation.refresh) {
             return requestRebalance(reconciliation, host, apiClient, true, rebalanceOptionsBuilder, kafkaRebalance);
         } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -593,7 +593,6 @@ public class KafkaRebalanceAssemblyOperator
         switch (rebalanceAnnotation) {
             case none:
                 log.debug("{}: No {} annotation set", reconciliation, ANNO_STRIMZI_IO_REBALANCE);
-                KafkaRebalanceStatus stat = buildRebalanceStatusFromPreviousStatus(kafkaRebalance.getStatus(), validate(kafkaRebalance));
                 return Future.succeededFuture(buildRebalanceStatusFromPreviousStatus(kafkaRebalance.getStatus(), validate(kafkaRebalance)));
             case approve:
                 log.debug("{}: Annotation {}={}", reconciliation, ANNO_STRIMZI_IO_REBALANCE, KafkaRebalanceAnnotation.approve);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -54,6 +54,7 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.net.URISyntaxException;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Map;
 
 import static java.util.Collections.singleton;
@@ -61,6 +62,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -472,6 +474,48 @@ public class KafkaRebalanceAssemblyOperatorTest {
                                 "Add skip_hard_goal_check=true parameter to ignore this sanity check.'."));
                 checkpoint.flag();
             })));
+    }
+
+    @Test
+    public void testUnknownPropertyInSpec(VertxTestContext context) throws IOException, URISyntaxException {
+        MockCruiseControl.setupCCRebalanceResponse(ccServer, 2);
+
+        String yaml = "apiVersion: kafka.strimzi.io/v1alpha1\n" +
+                "kind: KafkaRebalance\n" +
+                "metadata:\n" +
+                "  name: " + RESOURCE_NAME + "\n" +
+                "  namespace: " + CLUSTER_NAMESPACE + "\n" +
+                "  labels:\n" +
+                "    strimzi.io/cluster: " + CLUSTER_NAME + "\n" +
+                "spec:\n" +
+                "  unknown: \"property\"\n" +
+                "  goals:\n" +
+                "    - CpuCapacityGoal\n" +
+                "    - NetworkInboundCapacityGoal\n" +
+                "    - DiskCapacityGoal\n" +
+                "    - RackAwareGoal\n" +
+                "    - NetworkOutboundCapacityGoal\n" +
+                "    - ReplicaCapacityGoal\n";
+        KafkaRebalance kr = TestUtils.fromYamlString(yaml, KafkaRebalance.class);
+
+        Crds.kafkaRebalanceOperation(kubernetesClient).inNamespace(CLUSTER_NAMESPACE).create(kr);
+
+        // the Kafka cluster isn't deployed in the namespace
+        when(mockKafkaOps.getAsync(CLUSTER_NAMESPACE, CLUSTER_NAME)).thenReturn(Future.succeededFuture(kafka));
+        mockRebalanceOperator(mockRebalanceOps, CLUSTER_NAMESPACE, RESOURCE_NAME, kubernetesClient);
+
+        Checkpoint checkpoint = context.checkpoint();
+        kcrao.reconcileRebalance(new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME), kr)
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    KafkaRebalance kr1 = Crds.kafkaRebalanceOperation(kubernetesClient).inNamespace(CLUSTER_NAMESPACE).withName(RESOURCE_NAME).get();
+                    assertThat(kr1, StateMatchers.hasState());
+                    Optional<Condition> condition = kr1.getStatus().getConditions().stream().filter(cond -> "UnknownFields".equals(cond.getReason())).findFirst();
+                    assertTrue(condition.isPresent());
+                    assertThat(condition.get().getStatus(), is("True"));
+                    assertThat(condition.get().getMessage(), is("Contains object at path spec with an unknown property: unknown"));
+                    assertThat(condition.get().getType(), is("Warning"));
+                    checkpoint.flag();
+                })));
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -100,26 +100,8 @@ public class StatusUtils {
         if (resource.getMetadata().getGeneration() != null)    {
             status.setObservedGeneration(resource.getMetadata().getGeneration());
         }
-        // condition contains a timestamp so using a set does not help
-        List<Condition> conditionList = new ArrayList<>();
         Condition condition = StatusUtils.buildCondition(type, conditionStatus, null);
-        conditionList.add(condition);
-
-        if (status.getConditions() != null) {
-            status.getConditions().forEach(cond -> {
-                if ("UnknownFields".equals(cond.getReason()) || "DeprecatedFields".equals(cond.getReason()) || "DeprecatedObjects".equals(cond.getReason())) {
-                    if (!conditionAlreadyPresent(conditionList, cond)) {
-                        cond.setLastTransitionTime(iso8601Now());
-                        conditionList.add(cond);
-                    }
-                }
-            });
-        }
-        status.setConditions(new ArrayList<>(conditionList));
-    }
-
-    private static boolean conditionAlreadyPresent(List<Condition> conditions, Condition condition) {
-        return conditions.stream().filter(cond -> condition.getReason().equals(cond.getReason())).findAny().isPresent();
+        status.setConditions(Collections.singletonList(condition));
     }
 
     public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, String type) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -15,9 +15,7 @@ import io.vertx.core.AsyncResult;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 
 public class StatusUtils {
     private static final String V1ALPHA1 = Constants.RESOURCE_GROUP_NAME + "/" + Constants.V1ALPHA1;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -105,25 +105,19 @@ public class StatusUtils {
         Condition condition = StatusUtils.buildCondition(type, conditionStatus, null);
         conditionList.add(condition);
 
-        if (status.getConditions() != null) {
-            status.getConditions().forEach(cond -> {
-                if ("UnknownFields".equals(cond.getReason()) || "DeprecatedFields".equals(cond.getReason())) {
-                    if (!conditionAlreadyPresent(conditionList, cond)) {
-                        conditionList.add(cond);
-                    }
+        status.getConditions().forEach(cond -> {
+            if ("UnknownFields".equals(cond.getReason()) || "DeprecatedFields".equals(cond.getReason())) {
+                if (!conditionAlreadyPresent(conditionList, cond)) {
+                    cond.setLastTransitionTime(iso8601Now());
+                    conditionList.add(cond);
                 }
-            });
-        }
+            }
+        });
         status.setConditions(new ArrayList<>(conditionList));
     }
 
     private static boolean conditionAlreadyPresent(List<Condition> conditions, Condition condition) {
-        return conditions.stream().filter(cond -> {
-            return condition.getReason().equals(cond.getReason()) &&
-                    condition.getType().equals(cond.getType()) &&
-                    condition.getStatus().equals(cond.getStatus()) &&
-                    condition.getMessage().equals(cond.getMessage());
-        }).findAny().isPresent();
+        return conditions.stream().filter(cond -> condition.getReason().equals(cond.getReason())).findAny().isPresent();
     }
 
     public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, String type) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -105,14 +105,16 @@ public class StatusUtils {
         Condition condition = StatusUtils.buildCondition(type, conditionStatus, null);
         conditionList.add(condition);
 
-        status.getConditions().forEach(cond -> {
-            if ("UnknownFields".equals(cond.getReason()) || "DeprecatedFields".equals(cond.getReason())) {
-                if (!conditionAlreadyPresent(conditionList, cond)) {
-                    cond.setLastTransitionTime(iso8601Now());
-                    conditionList.add(cond);
+        if (status.getConditions() != null) {
+            status.getConditions().forEach(cond -> {
+                if ("UnknownFields".equals(cond.getReason()) || "DeprecatedFields".equals(cond.getReason()) || "DeprecatedObjects".equals(cond.getReason())) {
+                    if (!conditionAlreadyPresent(conditionList, cond)) {
+                        cond.setLastTransitionTime(iso8601Now());
+                        conditionList.add(cond);
+                    }
                 }
-            }
-        });
+            });
+        }
         status.setConditions(new ArrayList<>(conditionList));
     }
 


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
KafkaRebalanceAbstractOperator in difference to other operators does not create a new status for each reconciliation. Instead of that, it reuses the previous one. In this PR, new status is built but data from the old one is used. 
Status like bellow does not appear anymore. Also removing non-valid conditions work now (e.g. unknown property is removed)

```
  - lastTransitionTime: 2021-02-02T11:34:16.034937Z
    message: 'Contains object at path spec with an unknown property: asd'
    reason: UnknownFields
    status: "True"
    type: Warning
  - lastTransitionTime: 2021-02-02T11:34:16.052363Z
    message: 'Contains object at path spec with an unknown property: asd'
    reason: UnknownFields
    status: "True"
    type: Warning
```

### Checklist
- [x] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

