### PR TITLE
Fix generation of kafka-versions file

### DIFF
--- a/test-container/pom.xml
+++ b/test-container/pom.xml
@@ -76,7 +76,7 @@
                     <executable>yq</executable>
                     <arguments>
                         <argument>eval</argument>
-                        <argument>.[].version</argument>
+                        <argument>.[] | select(.supported == true) | .version</argument>
                         <argument>../kafka-versions.yaml</argument>
                     </arguments>
                     <outputFile>./src/main/resources/kafka-versions.txt</outputFile>


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
The file was generated with no respect to un/supported property.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

