### PR TITLE
SystemTests Generate and use Custom Cluster/ClientsCA 

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertAndKeyBuilder.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertAndKeyBuilder.java
@@ -59,7 +59,7 @@ import static org.bouncycastle.jce.provider.BouncyCastleProvider.PROVIDER_NAME;
 public class SystemTestCertAndKeyBuilder {
 
     private static final int KEY_SIZE = 2048;
-    private static final String KEY_PAIR_ALGORITHM = "RSA";
+    protected static final String KEY_PAIR_ALGORITHM = "RSA";
     private static final String SIGNATURE_ALGORITHM = "SHA256WithRSA";
     private static final Duration CERTIFICATE_VALIDITY_PERIOD = Duration.ofDays(30);
 
@@ -102,6 +102,19 @@ public class SystemTestCertAndKeyBuilder {
                 caCert,
                 asList(
                         new Extension(keyUsage, true, keyUsage(keyCertSign)),
+                        new Extension(basicConstraints, true, ca()),
+                        new Extension(subjectKeyIdentifier, false, createSubjectKeyIdentifier(keyPair.getPublic())),
+                        new Extension(authorityKeyIdentifier, false, createAuthorityKeyIdentifier(caCert.getPublicKey()))
+                )
+        );
+    }
+
+    public static SystemTestCertAndKeyBuilder strimziCaCertBuilder(SystemTestCertAndKey caCert) {
+        KeyPair keyPair = generateKeyPair();
+        return new SystemTestCertAndKeyBuilder(
+                keyPair,
+                caCert,
+                asList(
                         new Extension(basicConstraints, true, ca()),
                         new Extension(subjectKeyIdentifier, false, createSubjectKeyIdentifier(keyPair.getPublic())),
                         new Extension(authorityKeyIdentifier, false, createAuthorityKeyIdentifier(caCert.getPublicKey()))

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -80,6 +80,10 @@ public class SecretUtils {
         createSecretFromFile(Collections.singletonMap(key, pathToOrigin), name, namespace, null);
     }
 
+    public static void createSecretFromFile(String pathToOrigin, String key, String name, String namespace, Map<String, String> labels) {
+        createSecretFromFile(Collections.singletonMap(key, pathToOrigin), name, namespace, labels);
+    }
+
     public static void createSecretFromFile(Map<String, String> certFilesPath, String name, String namespace) {
         createSecretFromFile(certFilesPath, name, namespace, null);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -1479,12 +1479,10 @@ class SecurityST extends AbstractST {
             // Deploy ClusterCA secret
             LOGGER.info("Deploy all certificates and keys as secrets.");
             SecretUtils.deleteSecretWithWait(KafkaResources.clusterCaCertificateSecretName(clusterName), NAMESPACE);
-            // kubectl create secret generic CA-CERTIFICATE-SECRET --from-file=ca.crt=CA-CERTIFICATE-FILENAME
             SecretUtils.createCustomSecret(KafkaResources.clusterCaCertificateSecretName(clusterName), clusterName, NAMESPACE, clusterBundle);
 
 
             SecretUtils.deleteSecretWithWait(KafkaResources.clusterCaKeySecretName(clusterName), NAMESPACE);
-            // kubectl create secret generic CA-KEY-SECRET --from-file=ca.key=CA-KEY-SECRET-FILENAME
             File strimziKeyPKCS8 = convertPrivateKeyToPKCS8File(stClusterCA.getPrivateKey());
             SecretUtils.createSecretFromFile(strimziKeyPKCS8.getAbsolutePath(), "ca.key", KafkaResources.clusterCaKeySecretName(clusterName), NAMESPACE, secretLabels);
 


### PR DESCRIPTION
SystemTests Generate and use Custom Cluster/ClientsCA  - `SecurityST#generateAndDeployCustomStrimziCA`

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging


