### PR TITLE
Replication policy should be configured in both the source connector and checkpoint connector

### DIFF
--- a/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
+++ b/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
@@ -31,5 +31,7 @@ spec:
     checkpointConnector:
       config:
         checkpoints.topic.replication.factor: 1
+        replication.policy.separator: ""
+        replication.policy.class: "io.strimzi.kafka.connect.mirror.IdentityReplicationPolicy"
     topicsPattern: ".*"
     groupsPattern: ".*"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Out Mirror Maker 2 example with the `IndentityReplicationPolicy` currently has it configured only for the `sourceConnector` that is sufficient to replicate the topics. But when using it with enabled `checkpointConnector` to replicate offsets, it needs to be configured there as well to synchronise the offsets for the right topics and not for the topics with completely different name.

This Pr updates the example to configure it in both places and make this work better out of the box.