### PR TITLE
TO is too verbose on debug level

### DIFF
--- a/cluster-operator/src/main/resources/entityTopicOperatorDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/entityTopicOperatorDefaultLoggingProperties
@@ -11,9 +11,9 @@ rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
 
 logger.clients.name = org.apache.kafka.clients
-logger.clients.level = WARN
+logger.clients.level = INFO
 logger.clients.additivity = false
 
 logger.streams.name = org.apache.kafka.streams
-logger.streams.level = WARN
+logger.streams.level = INFO
 logger.streams.additivity = false

--- a/cluster-operator/src/main/resources/entityTopicOperatorDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/entityTopicOperatorDefaultLoggingProperties
@@ -9,3 +9,11 @@ rootLogger.level = INFO
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
+
+logger.clients.name = org.apache.kafka.clients
+logger.clients.level = WARN
+logger.clients.additivity = false
+
+logger.streams.name = org.apache.kafka.streams
+logger.streams.level = WARN
+logger.streams.additivity = false

--- a/cluster-operator/src/main/resources/topicOperatorDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/topicOperatorDefaultLoggingProperties
@@ -13,9 +13,9 @@ rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
 
 logger.clients.name = org.apache.kafka.clients
-logger.clients.level = WARN
+logger.clients.level = INFO
 logger.clients.additivity = false
 
 logger.streams.name = org.apache.kafka.streams
-logger.streams.level = WARN
+logger.streams.level = INFO
 logger.streams.additivity = false

--- a/cluster-operator/src/main/resources/topicOperatorDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/topicOperatorDefaultLoggingProperties
@@ -11,3 +11,11 @@ rootLogger.level = ${topic-operator.root.logger}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
+
+logger.clients.name = org.apache.kafka.clients
+logger.clients.level = WARN
+logger.clients.additivity = false
+
+logger.streams.name = org.apache.kafka.streams
+logger.streams.level = WARN
+logger.streams.additivity = false


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement

### Description
After recent changes in TO (topic store) it became disturbingly noisy. Setting the noisemaker loggers to WARN.

### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

