### PR TITLE
[WIP] Avoid openssl for adding key/cert into KeyStore.

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -153,7 +153,7 @@ public class OpenSslCertManager implements CertManager {
 
                     X509Certificate certificate = (X509Certificate) certFactory.generateCertificate(isCertFile);
 
-                    keyStore.setEntry(alias, new KeyStore.TrustedCertificateEntry(certificate),null);
+                    keyStore.setEntry(alias, new KeyStore.TrustedCertificateEntry(certificate), null);
 
                     FileOutputStream osKeyStoreFile = null;
 

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -153,7 +153,7 @@ public class OpenSslCertManager implements CertManager {
 
                     X509Certificate certificate = (X509Certificate) certFactory.generateCertificate(isCertFile);
 
-                    keyStore.setCertificateEntry(alias, certificate);
+                    keyStore.setEntry(alias, new KeyStore.TrustedCertificateEntry(certificate),null);
 
                     FileOutputStream osKeyStoreFile = null;
 

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -7,6 +7,7 @@ package io.strimzi.certs;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import javax.crypto.EncryptedPrivateKeyInfo;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
@@ -26,6 +27,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
@@ -144,7 +146,10 @@ public class OpenSslCertManager implements CertManager {
                 FileInputStream isCertFile = null;
                 KeyStore keyStore = KeyStore.getInstance("PKCS12");
                 keyStore.load(isKeyStoreFile, keyStorePassword.toCharArray());
-                keyStore.setKeyEntry(alias, Files.readAllBytes(keyFile.toPath()), null);
+
+                byte[] key = Base64.getEncoder().encode(Files.readAllBytes(keyFile.toPath()));
+
+                keyStore.setKeyEntry(alias, key, null);
 
                 try {
                     isCertFile = new FileInputStream(certFile);

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -138,8 +138,6 @@ public class OpenSslCertManager implements CertManager {
         try {
             FileInputStream isKeyStoreFile = null;
             try {
-                // check if the truststore file is empty or not, for loading its content eventually
-                // the KeyStore class is able to create an empty store if the input stream is null
                 if (keyStoreFile.length() > 0) {
                     isKeyStoreFile = new FileInputStream(keyStoreFile);
                 }

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -141,11 +141,9 @@ public class OpenSslCertManager implements CertManager {
                 if (keyStoreFile.length() > 0) {
                     isKeyStoreFile = new FileInputStream(keyStoreFile);
                 }
-
                 FileInputStream isCertFile = null;
                 KeyStore keyStore = KeyStore.getInstance("PKCS12");
                 keyStore.load(isKeyStoreFile, keyStorePassword.toCharArray());
-
                 keyStore.setKeyEntry(alias, Files.readAllBytes(keyFile.toPath()), null);
 
                 try {
@@ -162,28 +160,22 @@ public class OpenSslCertManager implements CertManager {
                     try {
                         osKeyStoreFile = new FileOutputStream(keyStoreFile);
                         keyStore.store(osKeyStoreFile, keyStorePassword.toCharArray());
-                    }
-
-                    finally {
-                        if(osKeyStoreFile != null){
+                    } finally {
+                        if (osKeyStoreFile != null) {
                             osKeyStoreFile.close();
                         }
                     }
-                }
-                finally {
-                    if(isCertFile != null){
+                } finally {
+                    if (isCertFile != null) {
                         isCertFile.close();
                     }
                 }
-            }
-            finally {
-                if(isKeyStoreFile != null){
+            } finally {
+                if (isKeyStoreFile != null) {
                     isKeyStoreFile.close();
                 }
             }
-        }
-
-        catch (IOException | CertificateException | KeyStoreException | NoSuchAlgorithmException e) {
+        } catch (IOException | CertificateException | KeyStoreException | NoSuchAlgorithmException e) {
             try {
                 throw e;
             } catch (KeyStoreException keyStoreException) {
@@ -194,7 +186,6 @@ public class OpenSslCertManager implements CertManager {
                 certificateException.printStackTrace();
             }
         }
-
     }
 
     @Override

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -6,8 +6,6 @@ package io.strimzi.certs;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import javax.crypto.EncryptedPrivateKeyInfo;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
@@ -146,9 +144,7 @@ public class OpenSslCertManager implements CertManager {
                 FileInputStream isCertFile = null;
                 KeyStore keyStore = KeyStore.getInstance("PKCS12");
                 keyStore.load(isKeyStoreFile, keyStorePassword.toCharArray());
-
                 byte[] key = Base64.getEncoder().encode(Files.readAllBytes(keyFile.toPath()));
-
                 keyStore.setKeyEntry(alias, key, null);
 
                 try {

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -143,9 +143,6 @@ public class OpenSslCertManager implements CertManager {
                 }
 
                 FileInputStream isCertFile = null;
-
-                isKeyStoreFile = new FileInputStream(keyStoreFile);
-
                 KeyStore keyStore = KeyStore.getInstance("PKCS12");
                 keyStore.load(isKeyStoreFile, keyStorePassword.toCharArray());
 


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <shubhamrwt02@gmail.com>

### Description

Removing openssl command for adding key/cert into KeyStore, now using Keystoreclass  to add key and cert to Keystore.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

