### PR TITLE
Add support for Ingress V1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@
 * Updated Cruise Control to version 2.5.32
 * Fix Cruise Control crash loop when updating container configurations
 * Configure extenal logging `ConfigMap` name and key.
+* Add support for Ingress v1 in Kubernetes 1.19 and newer
 
-### Deprecations and removals
+### Changes, deprecations and removals
 
+* In the past, when no Ingress class was specified in the Ingress-type listener in the Kafka custom resource, the 
+  `kubernetes.io/ingress.class` annotation was automatically set to `nginx`. Because of the support for the new 
+  IngressClass resource and the new `ingressClassName` field in the Ingress resource, the default value will not be set 
+  anymore. Please use the `class` field in `.spec.kafka.listeners[].configuration` to specify the class name. 
 * The `KafkaConnectS2I` custom resource is deprecated and will be removed in the future. You can use the new [`KafkaConnect` build feature](https://strimzi.io/docs/operators/latest/full/deploying.html#creating-new-image-using-kafka-connect-build-str) instead.
 * Removed support for Helm2 charts as that version is now unsupported. There is no longer the need for separate `helm2` and `helm3` binaries, only `helm` (version 3) is required.
 * The following annotations are deprecated for a long time and will be removed in 0.23.0:

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalIngress.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalIngress.java
@@ -80,8 +80,7 @@ public class KafkaListenerExternalIngress extends KafkaListenerExternal {
         this.configuration = configuration;
     }
 
-    @Description("Configures the `Ingress` class that defines which `Ingress` controller will be used. " +
-            "If not set, the `Ingress` class is set to `nginx`.")
+    @Description("Configures the `Ingress` class that defines which `Ingress` controller will be used.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("class")
     public String getIngressClass() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
@@ -62,7 +62,6 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
     }
 
     @Description("Configures the `Ingress` class that defines which `Ingress` controller will be used. " +
-            "If not set, the `Ingress` class is set to `nginx`. " +
             "This field can be used only with `ingress` type listener.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("class")

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
@@ -62,7 +62,8 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
     }
 
     @Description("Configures the `Ingress` class that defines which `Ingress` controller will be used. " +
-            "This field can be used only with `ingress` type listener.")
+            "This field can be used only with `ingress` type listener. " +
+            "If not specified, the default Ingress controller will be used.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("class")
     public String getIngressClass() {

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
@@ -568,7 +568,9 @@ spec:
                               type: string
                               description: Configures the `Ingress` class that defines
                                 which `Ingress` controller will be used. This field
-                                can be used only with `ingress` type listener.
+                                can be used only with `ingress` type listener. If
+                                not specified, the default Ingress controller will
+                                be used.
                             preferredNodePortAddressType:
                               type: string
                               enum:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
@@ -567,8 +567,7 @@ spec:
                             class:
                               type: string
                               description: Configures the `Ingress` class that defines
-                                which `Ingress` controller will be used. If not set,
-                                the `Ingress` class is set to `nginx`. This field
+                                which `Ingress` controller will be used. This field
                                 can be used only with `ingress` type listener.
                             preferredNodePortAddressType:
                               type: string

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
@@ -561,8 +561,7 @@ spec:
                             class:
                               type: string
                               description: Configures the `Ingress` class that defines
-                                which `Ingress` controller will be used. If not set,
-                                the `Ingress` class is set to `nginx`. This field
+                                which `Ingress` controller will be used. This field
                                 can be used only with `ingress` type listener.
                             preferredNodePortAddressType:
                               type: string
@@ -6641,9 +6640,8 @@ spec:
                               class:
                                 type: string
                                 description: Configures the `Ingress` class that defines
-                                  which `Ingress` controller will be used. If not
-                                  set, the `Ingress` class is set to `nginx`. This
-                                  field can be used only with `ingress` type listener.
+                                  which `Ingress` controller will be used. This field
+                                  can be used only with `ingress` type listener.
                               preferredNodePortAddressType:
                                 type: string
                                 enum:
@@ -7436,8 +7434,7 @@ spec:
                             class:
                               type: string
                               description: Configures the `Ingress` class that defines
-                                which `Ingress` controller will be used. If not set,
-                                the `Ingress` class is set to `nginx`.
+                                which `Ingress` controller will be used.
                             configuration:
                               type: object
                               properties:
@@ -14938,9 +14935,8 @@ spec:
                               class:
                                 type: string
                                 description: Configures the `Ingress` class that defines
-                                  which `Ingress` controller will be used. If not
-                                  set, the `Ingress` class is set to `nginx`. This
-                                  field can be used only with `ingress` type listener.
+                                  which `Ingress` controller will be used. This field
+                                  can be used only with `ingress` type listener.
                               preferredNodePortAddressType:
                                 type: string
                                 enum:
@@ -15733,8 +15729,7 @@ spec:
                             class:
                               type: string
                               description: Configures the `Ingress` class that defines
-                                which `Ingress` controller will be used. If not set,
-                                the `Ingress` class is set to `nginx`.
+                                which `Ingress` controller will be used.
                             configuration:
                               type: object
                               properties:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
@@ -562,7 +562,9 @@ spec:
                               type: string
                               description: Configures the `Ingress` class that defines
                                 which `Ingress` controller will be used. This field
-                                can be used only with `ingress` type listener.
+                                can be used only with `ingress` type listener. If
+                                not specified, the default Ingress controller will
+                                be used.
                             preferredNodePortAddressType:
                               type: string
                               enum:
@@ -6641,7 +6643,9 @@ spec:
                                 type: string
                                 description: Configures the `Ingress` class that defines
                                   which `Ingress` controller will be used. This field
-                                  can be used only with `ingress` type listener.
+                                  can be used only with `ingress` type listener. If
+                                  not specified, the default Ingress controller will
+                                  be used.
                               preferredNodePortAddressType:
                                 type: string
                                 enum:
@@ -14936,7 +14940,9 @@ spec:
                                 type: string
                                 description: Configures the `Ingress` class that defines
                                   which `Ingress` controller will be used. This field
-                                  can be used only with `ingress` type listener.
+                                  can be used only with `ingress` type listener. If
+                                  not specified, the default Ingress controller will
+                                  be used.
                               preferredNodePortAddressType:
                                 type: string
                                 enum:

--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -43,10 +43,6 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model-extensions</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-model-apiextensions</artifactId>
         </dependency>
         <dependency>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1049,7 +1049,6 @@ public class KafkaCluster extends AbstractModel {
             String serviceName = ListenersUtils.backwardsCompatibleBootstrapServiceName(cluster, listener);
 
             String host = ListenersUtils.bootstrapHost(listener);
-            Map<String, String> dnsAnnotations = ListenersUtils.bootstrapAnnotations(listener);
             String ingressClass = ListenersUtils.ingressClass(listener);
 
             HTTPIngressPath path = new HTTPIngressPathBuilder()
@@ -1080,7 +1079,7 @@ public class KafkaCluster extends AbstractModel {
                     .withNewMetadata()
                         .withName(ingressName)
                         .withLabels(getLabelsWithStrimziName(name, Util.mergeLabelsOrAnnotations(templateExternalBootstrapIngressLabels, ListenersUtils.bootstrapLabels(listener))).toMap())
-                        .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(ingressClass), templateExternalBootstrapIngressAnnotations, dnsAnnotations))
+                        .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(ingressClass), templateExternalBootstrapIngressAnnotations, ListenersUtils.bootstrapAnnotations(listener)))
                         .withNamespace(namespace)
                         .withOwnerReferences(createOwnerReference())
                     .endMetadata()
@@ -1111,7 +1110,6 @@ public class KafkaCluster extends AbstractModel {
             String serviceName = ListenersUtils.backwardsCompatibleBootstrapServiceName(cluster, listener);
 
             String host = ListenersUtils.bootstrapHost(listener);
-            Map<String, String> dnsAnnotations = ListenersUtils.bootstrapAnnotations(listener);
             String ingressClass = ListenersUtils.ingressClass(listener);
 
             io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPath path = new io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPathBuilder()
@@ -1136,8 +1134,8 @@ public class KafkaCluster extends AbstractModel {
             io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingress = new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressBuilder()
                     .withNewMetadata()
                         .withName(ingressName)
-                        .withLabels(getLabelsWithStrimziName(name, templateExternalBootstrapIngressLabels).toMap())
-                        .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(ingressClass), templateExternalBootstrapIngressAnnotations, dnsAnnotations))
+                        .withLabels(getLabelsWithStrimziName(name, Util.mergeLabelsOrAnnotations(templateExternalBootstrapIngressLabels, ListenersUtils.bootstrapLabels(listener))).toMap())
+                        .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(ingressClass), templateExternalBootstrapIngressAnnotations, ListenersUtils.bootstrapAnnotations(listener)))
                         .withNamespace(namespace)
                         .withOwnerReferences(createOwnerReference())
                     .endMetadata()
@@ -1167,7 +1165,6 @@ public class KafkaCluster extends AbstractModel {
         for (GenericKafkaListener listener : ingressListeners)   {
             String ingressName = ListenersUtils.backwardsCompatibleBrokerServiceName(cluster, pod, listener);
             String host = ListenersUtils.brokerHost(listener, pod);
-            Map<String, String> dnsAnnotations = ListenersUtils.brokerAnnotations(listener, pod);
             String ingressClass = ListenersUtils.ingressClass(listener);
 
             HTTPIngressPath path = new HTTPIngressPathBuilder()
@@ -1198,7 +1195,7 @@ public class KafkaCluster extends AbstractModel {
                     .withNewMetadata()
                         .withName(ingressName)
                         .withLabels(getLabelsWithStrimziName(name, Util.mergeLabelsOrAnnotations(templatePerPodIngressLabels, ListenersUtils.brokerLabels(listener, pod))).toMap())
-                        .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(ingressClass), templatePerPodIngressAnnotations, dnsAnnotations))
+                        .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(ingressClass), templatePerPodIngressAnnotations, ListenersUtils.brokerAnnotations(listener, pod)))
                         .withNamespace(namespace)
                         .withOwnerReferences(createOwnerReference())
                     .endMetadata()
@@ -1228,7 +1225,6 @@ public class KafkaCluster extends AbstractModel {
         for (GenericKafkaListener listener : ingressListeners)   {
             String ingressName = ListenersUtils.backwardsCompatibleBrokerServiceName(cluster, pod, listener);
             String host = ListenersUtils.brokerHost(listener, pod);
-            Map<String, String> dnsAnnotations = ListenersUtils.brokerAnnotations(listener, pod);
             String ingressClass = ListenersUtils.ingressClass(listener);
 
             io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPath path = new io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPathBuilder()
@@ -1253,8 +1249,8 @@ public class KafkaCluster extends AbstractModel {
             io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingress = new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressBuilder()
                     .withNewMetadata()
                         .withName(ingressName)
-                        .withLabels(getLabelsWithStrimziName(name, templatePerPodIngressLabels).toMap())
-                        .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(ingressClass), templatePerPodIngressAnnotations, dnsAnnotations))
+                        .withLabels(getLabelsWithStrimziName(name, Util.mergeLabelsOrAnnotations(templatePerPodIngressLabels, ListenersUtils.brokerLabels(listener, pod))).toMap())
+                        .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(ingressClass), templatePerPodIngressAnnotations, ListenersUtils.brokerAnnotations(listener, pod)))
                         .withNamespace(namespace)
                         .withOwnerReferences(createOwnerReference())
                     .endMetadata()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -27,14 +27,14 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
-import io.fabric8.kubernetes.api.model.extensions.HTTPIngressPath;
-import io.fabric8.kubernetes.api.model.extensions.HTTPIngressPathBuilder;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
-import io.fabric8.kubernetes.api.model.extensions.IngressBuilder;
-import io.fabric8.kubernetes.api.model.extensions.IngressRule;
-import io.fabric8.kubernetes.api.model.extensions.IngressRuleBuilder;
-import io.fabric8.kubernetes.api.model.extensions.IngressTLS;
-import io.fabric8.kubernetes.api.model.extensions.IngressTLSBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.HTTPIngressPath;
+import io.fabric8.kubernetes.api.model.networking.v1.HTTPIngressPathBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressRule;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressRuleBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressTLS;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressTLSBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRule;
@@ -1054,9 +1054,14 @@ public class KafkaCluster extends AbstractModel {
 
             HTTPIngressPath path = new HTTPIngressPathBuilder()
                     .withPath("/")
+                    .withNewPathType("Prefix")
                     .withNewBackend()
-                        .withNewServicePort(listener.getPort())
-                        .withServiceName(serviceName)
+                        .withNewService()
+                            .withNewName(serviceName)
+                            .withNewPort()
+                                .withNumber(listener.getPort())
+                            .endPort()
+                        .endService()
                     .endBackend()
                     .build();
 
@@ -1080,6 +1085,64 @@ public class KafkaCluster extends AbstractModel {
                         .withOwnerReferences(createOwnerReference())
                     .endMetadata()
                     .withNewSpec()
+                        .withIngressClassName(ingressClass)
+                        .withRules(rule)
+                        .withTls(tls)
+                    .endSpec()
+                    .build();
+
+            ingresses.add(ingress);
+        }
+
+        return ingresses;
+    }
+
+    /**
+     * Generates a list of bootstrap ingress which can be used to bootstrap clients outside of Kubernetes.
+     *
+     * @return The list of generated Ingresses
+     */
+    public List<io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress> generateExternalBootstrapIngressesV1Beta1() {
+        List<GenericKafkaListener> ingressListeners = ListenersUtils.ingressListeners(listeners);
+        List<io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress> ingresses = new ArrayList<>(ingressListeners.size());
+
+        for (GenericKafkaListener listener : ingressListeners)   {
+            String ingressName = ListenersUtils.backwardsCompatibleBootstrapRouteOrIngressName(cluster, listener);
+            String serviceName = ListenersUtils.backwardsCompatibleBootstrapServiceName(cluster, listener);
+
+            String host = ListenersUtils.bootstrapHost(listener);
+            Map<String, String> dnsAnnotations = ListenersUtils.bootstrapAnnotations(listener);
+            String ingressClass = ListenersUtils.ingressClass(listener);
+
+            io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPath path = new io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPathBuilder()
+                    .withPath("/")
+                    .withNewBackend()
+                        .withNewServicePort(listener.getPort())
+                        .withServiceName(serviceName)
+                    .endBackend()
+                    .build();
+
+            io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRule rule = new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRuleBuilder()
+                    .withHost(host)
+                    .withNewHttp()
+                        .withPaths(path)
+                    .endHttp()
+                    .build();
+
+            io.fabric8.kubernetes.api.model.networking.v1beta1.IngressTLS tls = new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressTLSBuilder()
+                    .withHosts(host)
+                    .build();
+
+            io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingress = new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressBuilder()
+                    .withNewMetadata()
+                        .withName(ingressName)
+                        .withLabels(getLabelsWithStrimziName(name, templateExternalBootstrapIngressLabels).toMap())
+                        .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(ingressClass), templateExternalBootstrapIngressAnnotations, dnsAnnotations))
+                        .withNamespace(namespace)
+                        .withOwnerReferences(createOwnerReference())
+                    .endMetadata()
+                    .withNewSpec()
+                        .withIngressClassName(ingressClass)
                         .withRules(rule)
                         .withTls(tls)
                     .endSpec()
@@ -1109,9 +1172,14 @@ public class KafkaCluster extends AbstractModel {
 
             HTTPIngressPath path = new HTTPIngressPathBuilder()
                     .withPath("/")
+                    .withNewPathType("Prefix")
                     .withNewBackend()
-                        .withNewServicePort(listener.getPort())
-                        .withServiceName(ingressName)
+                        .withNewService()
+                            .withNewName(ingressName)
+                            .withNewPort()
+                                .withNumber(listener.getPort())
+                            .endPort()
+                        .endService()
                     .endBackend()
                     .build();
 
@@ -1135,6 +1203,63 @@ public class KafkaCluster extends AbstractModel {
                         .withOwnerReferences(createOwnerReference())
                     .endMetadata()
                     .withNewSpec()
+                        .withIngressClassName(ingressClass)
+                        .withRules(rule)
+                        .withTls(tls)
+                    .endSpec()
+                    .build();
+
+            ingresses.add(ingress);
+        }
+
+        return ingresses;
+    }
+
+    /**
+     * Generates list of ingress for pod. This ingress is used for exposing it externally using Nginx Ingress.
+     *
+     * @param pod Number of the pod for which this ingress should be generated
+     * @return The list of generated Ingresses
+     */
+    public List<io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress> generateExternalIngressesV1Beta1(int pod) {
+        List<GenericKafkaListener> ingressListeners = ListenersUtils.ingressListeners(listeners);
+        List<io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress> ingresses = new ArrayList<>(ingressListeners.size());
+
+        for (GenericKafkaListener listener : ingressListeners)   {
+            String ingressName = ListenersUtils.backwardsCompatibleBrokerServiceName(cluster, pod, listener);
+            String host = ListenersUtils.brokerHost(listener, pod);
+            Map<String, String> dnsAnnotations = ListenersUtils.brokerAnnotations(listener, pod);
+            String ingressClass = ListenersUtils.ingressClass(listener);
+
+            io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPath path = new io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPathBuilder()
+                    .withPath("/")
+                    .withNewBackend()
+                        .withNewServicePort(listener.getPort())
+                        .withServiceName(ingressName)
+                    .endBackend()
+                    .build();
+
+            io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRule rule = new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRuleBuilder()
+                    .withHost(host)
+                    .withNewHttp()
+                        .withPaths(path)
+                    .endHttp()
+                    .build();
+
+            io.fabric8.kubernetes.api.model.networking.v1beta1.IngressTLS tls = new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressTLSBuilder()
+                    .withHosts(host)
+                    .build();
+
+            io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingress = new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressBuilder()
+                    .withNewMetadata()
+                        .withName(ingressName)
+                        .withLabels(getLabelsWithStrimziName(name, templatePerPodIngressLabels).toMap())
+                        .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(ingressClass), templatePerPodIngressAnnotations, dnsAnnotations))
+                        .withNamespace(namespace)
+                        .withOwnerReferences(createOwnerReference())
+                    .endMetadata()
+                    .withNewSpec()
+                        .withIngressClassName(ingressClass)
                         .withRules(rule)
                         .withTls(tls)
                     .endSpec()
@@ -1155,7 +1280,9 @@ public class KafkaCluster extends AbstractModel {
     private Map<String, String> generateInternalIngressAnnotations(String ingressClass) {
         Map<String, String> internalAnnotations = new HashMap<>(4);
 
-        internalAnnotations.put("kubernetes.io/ingress.class", ingressClass != null ? ingressClass : "nginx");
+        if (ingressClass != null) {
+            internalAnnotations.put("kubernetes.io/ingress.class", ingressClass);
+        }
 
         internalAnnotations.put("ingress.kubernetes.io/ssl-passthrough", "true");
         internalAnnotations.put("nginx.ingress.kubernetes.io/ssl-passthrough", "true");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -37,6 +37,7 @@ import io.strimzi.operator.common.operator.resource.DeploymentConfigOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.ImageStreamOperator;
 import io.strimzi.operator.common.operator.resource.IngressOperator;
+import io.strimzi.operator.common.operator.resource.IngressV1Beta1Operator;
 import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.NodeOperator;
 import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
@@ -80,6 +81,7 @@ public class ResourceOperatorSupplier {
     public final PodDisruptionBudgetOperator podDisruptionBudgetOperator;
     public final PodOperator podOperations;
     public final IngressOperator ingressOperations;
+    public final IngressV1Beta1Operator ingressV1Beta1Operations;
     public final ImageStreamOperator imagesStreamOperations;
     public final BuildConfigOperator buildConfigOperations;
     public final BuildOperator buildOperations;
@@ -120,6 +122,7 @@ public class ResourceOperatorSupplier {
                 new PodDisruptionBudgetOperator(vertx, client),
                 new PodOperator(vertx, client),
                 new IngressOperator(vertx, client),
+                new IngressV1Beta1Operator(vertx, client),
                 pfa.hasImages() ? new ImageStreamOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
                 pfa.hasBuilds() ? new BuildConfigOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
                 pfa.hasBuilds() ? new BuildOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
@@ -155,6 +158,7 @@ public class ResourceOperatorSupplier {
                                     PodDisruptionBudgetOperator podDisruptionBudgetOperator,
                                     PodOperator podOperations,
                                     IngressOperator ingressOperations,
+                                    IngressV1Beta1Operator ingressV1Beta1Operations,
                                     ImageStreamOperator imagesStreamOperations,
                                     BuildConfigOperator buildConfigOperations,
                                     BuildOperator buildOperations,
@@ -189,6 +193,7 @@ public class ResourceOperatorSupplier {
         this.kafkaOperator = kafkaOperator;
         this.podOperations = podOperations;
         this.ingressOperations = ingressOperations;
+        this.ingressV1Beta1Operations = ingressV1Beta1Operations;
         this.imagesStreamOperations = imagesStreamOperations;
         this.buildConfigOperations = buildConfigOperations;
         this.buildOperations = buildOperations;

--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -190,6 +190,8 @@ rules:
     resources:
       # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
       - networkpolicies
+      # The cluster operator needs to access and manage ingresses which allow external access to the services in a cluster
+      - ingresses
     verbs:
       - get
       - list

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -80,6 +80,7 @@ import io.strimzi.operator.common.operator.resource.DeploymentConfigOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.ImageStreamOperator;
 import io.strimzi.operator.common.operator.resource.IngressOperator;
+import io.strimzi.operator.common.operator.resource.IngressV1Beta1Operator;
 import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.NodeOperator;
 import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
@@ -751,6 +752,7 @@ public class ResourceUtils {
                 mock(PodDisruptionBudgetOperator.class),
                 mock(PodOperator.class),
                 mock(IngressOperator.class),
+                mock(IngressV1Beta1Operator.class),
                 mock(ImageStreamOperator.class),
                 mock(BuildConfigOperator.class),
                 mock(BuildOperator.class),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -31,7 +31,7 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.WeightedPodAffinityTerm;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRule;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
@@ -2861,7 +2861,8 @@ public class KafkaClusterTest {
         // Check bootstrap ingress
         Ingress bing = kc.generateExternalBootstrapIngresses().get(0);
         assertThat(bing.getMetadata().getName(), is(KafkaCluster.serviceName(cluster)));
-        assertThat(bing.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is("nginx"));
+        assertThat(bing.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is(nullValue()));
+        assertThat(bing.getSpec().getIngressClassName(), is(nullValue()));
         assertThat(bing.getMetadata().getAnnotations().get("dns-annotation"), is("my-kafka-bootstrap.com"));
         assertThat(bing.getMetadata().getLabels().get("label"), is("label-value"));
         assertThat(bing.getSpec().getTls().size(), is(1));
@@ -2871,15 +2872,33 @@ public class KafkaClusterTest {
         assertThat(bing.getSpec().getRules().get(0).getHost(), is("my-kafka-bootstrap.com"));
         assertThat(bing.getSpec().getRules().get(0).getHttp().getPaths().size(), is(1));
         assertThat(bing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath(), is("/"));
-        assertThat(bing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServiceName(), is(KafkaCluster.externalBootstrapServiceName(cluster)));
-        assertThat(bing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServicePort(), is(new IntOrString(9094)));
+        assertThat(bing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getService().getName(), is(KafkaCluster.externalBootstrapServiceName(cluster)));
+        assertThat(bing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getService().getPort().getNumber(), is(9094));
         checkOwnerReference(kc.createOwnerReference(), bing);
+
+        io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress bingV1Beta1 = kc.generateExternalBootstrapIngressesV1Beta1().get(0);
+        assertThat(bingV1Beta1.getMetadata().getName(), is(KafkaCluster.serviceName(cluster)));
+        assertThat(bingV1Beta1.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is(nullValue()));
+        assertThat(bingV1Beta1.getSpec().getIngressClassName(), is(nullValue()));
+        assertThat(bingV1Beta1.getMetadata().getAnnotations().get("dns-annotation"), is("my-kafka-bootstrap.com"));
+        assertThat(bingV1Beta1.getMetadata().getLabels().get("label"), is("label-value"));
+        assertThat(bingV1Beta1.getSpec().getTls().size(), is(1));
+        assertThat(bingV1Beta1.getSpec().getTls().get(0).getHosts().size(), is(1));
+        assertThat(bingV1Beta1.getSpec().getTls().get(0).getHosts().get(0), is("my-kafka-bootstrap.com"));
+        assertThat(bingV1Beta1.getSpec().getRules().size(), is(1));
+        assertThat(bingV1Beta1.getSpec().getRules().get(0).getHost(), is("my-kafka-bootstrap.com"));
+        assertThat(bingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().size(), is(1));
+        assertThat(bingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath(), is("/"));
+        assertThat(bingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServiceName(), is(KafkaCluster.externalBootstrapServiceName(cluster)));
+        assertThat(bingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServicePort(), is(new IntOrString(9094)));
+        checkOwnerReference(kc.createOwnerReference(), bingV1Beta1);
 
         // Check per pod ingress
         for (int i = 0; i < replicas; i++)  {
             Ingress ing = kc.generateExternalIngresses(i).get(0);
             assertThat(ing.getMetadata().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
-            assertThat(ing.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is("nginx"));
+            assertThat(ing.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is(nullValue()));
+            assertThat(ing.getSpec().getIngressClassName(), is(nullValue()));
             assertThat(ing.getMetadata().getAnnotations().get("dns-annotation"), is("my-kafka-broker.com"));
             assertThat(ing.getMetadata().getLabels().get("label"), is("label-value"));
             assertThat(ing.getSpec().getTls().size(), is(1));
@@ -2889,9 +2908,26 @@ public class KafkaClusterTest {
             assertThat(ing.getSpec().getRules().get(0).getHost(), is(String.format("my-broker-kafka-%d.com", i)));
             assertThat(ing.getSpec().getRules().get(0).getHttp().getPaths().size(), is(1));
             assertThat(ing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath(), is("/"));
-            assertThat(ing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServiceName(), is(KafkaCluster.externalServiceName(cluster, i)));
-            assertThat(ing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServicePort(), is(new IntOrString(9094)));
+            assertThat(ing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getService().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
+            assertThat(ing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getService().getPort().getNumber(), is(9094));
             checkOwnerReference(kc.createOwnerReference(), ing);
+
+            io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingV1Beta1 = kc.generateExternalIngressesV1Beta1(i).get(0);
+            assertThat(ingV1Beta1.getMetadata().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
+            assertThat(ingV1Beta1.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is(nullValue()));
+            assertThat(ingV1Beta1.getSpec().getIngressClassName(), is(nullValue()));
+            assertThat(ingV1Beta1.getMetadata().getAnnotations().get("dns-annotation"), is("my-kafka-broker.com"));
+            assertThat(ingV1Beta1.getMetadata().getLabels().get("label"), is("label-value"));
+            assertThat(ingV1Beta1.getSpec().getTls().size(), is(1));
+            assertThat(ingV1Beta1.getSpec().getTls().get(0).getHosts().size(), is(1));
+            assertThat(ingV1Beta1.getSpec().getTls().get(0).getHosts().get(0), is(String.format("my-broker-kafka-%d.com", i)));
+            assertThat(ingV1Beta1.getSpec().getRules().size(), is(1));
+            assertThat(ingV1Beta1.getSpec().getRules().get(0).getHost(), is(String.format("my-broker-kafka-%d.com", i)));
+            assertThat(ingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().size(), is(1));
+            assertThat(ingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath(), is("/"));
+            assertThat(ingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServiceName(), is(KafkaCluster.externalServiceName(cluster, i)));
+            assertThat(ingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServicePort(), is(new IntOrString(9094)));
+            checkOwnerReference(kc.createOwnerReference(), ingV1Beta1);
         }
     }
 
@@ -2941,11 +2977,21 @@ public class KafkaClusterTest {
          // Check bootstrap ingress
         Ingress bing = kc.generateExternalBootstrapIngresses().get(0);
         assertThat(bing.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is("nginx-internal"));
+        assertThat(bing.getSpec().getIngressClassName(), is("nginx-internal"));
+
+        io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress bingV1Beta1 = kc.generateExternalBootstrapIngressesV1Beta1().get(0);
+        assertThat(bingV1Beta1.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is("nginx-internal"));
+        assertThat(bingV1Beta1.getSpec().getIngressClassName(), is("nginx-internal"));
 
         // Check per pod ingress
         for (int i = 0; i < replicas; i++)  {
             Ingress ing = kc.generateExternalIngresses(i).get(0);
             assertThat(ing.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is("nginx-internal"));
+            assertThat(ing.getSpec().getIngressClassName(), is("nginx-internal"));
+
+            io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingV1Beta1 = kc.generateExternalIngressesV1Beta1(i).get(0);
+            assertThat(ingV1Beta1.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is("nginx-internal"));
+            assertThat(ingV1Beta1.getSpec().getIngressClassName(), is("nginx-internal"));
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
@@ -7,21 +7,33 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.strimzi.api.kafka.model.CertificateAuthority;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBrokerBuilder;
+import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.certs.CertManager;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaCluster;
+import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
+import io.strimzi.operator.common.operator.resource.CrdOperator;
+import io.strimzi.operator.common.operator.resource.IngressOperator;
+import io.strimzi.operator.common.operator.resource.IngressV1Beta1Operator;
+import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.vertx.core.Future;
@@ -40,15 +52,20 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.not;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
@@ -328,5 +345,214 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
 
                     async.flag();
                 })));
+    }
+
+    @Test
+    public void testIngressV1Beta1(VertxTestContext context) {
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                    .withName(NAME)
+                    .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewKafka()
+                        .withReplicas(3)
+                        .withNewListeners()
+                            .addNewGenericKafkaListener()
+                                .withName("ingress")
+                                .withPort(9094)
+                                .withTls(true)
+                                .withType(KafkaListenerType.INGRESS)
+                                .withNewConfiguration()
+                                    .withNewBootstrap()
+                                        .withHost("bootstrap.mydomain.tld")
+                                    .endBootstrap()
+                                    .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder().withBroker(0).withHost("broker-0.mydomain.tld").build(),
+                                            new GenericKafkaListenerConfigurationBrokerBuilder().withBroker(1).withHost("broker-1.mydomain.tld").build(),
+                                            new GenericKafkaListenerConfigurationBrokerBuilder().withBroker(2).withHost("broker-2.mydomain.tld").build())
+                                .endConfiguration()
+                            .endGenericKafkaListener()
+                        .endListeners()
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endKafka()
+                    .withNewZookeeper()
+                        .withReplicas(3)
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endZookeeper()
+                    .withNewEntityOperator()
+                        .withNewUserOperator()
+                        .endUserOperator()
+                        .withNewTopicOperator()
+                        .endTopicOperator()
+                    .endEntityOperator()
+                .endSpec()
+                .build();
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the CRD Operator for Kafka resources
+        CrdOperator mockKafkaOps = supplier.kafkaOperator;
+        when(mockKafkaOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(kafka));
+        when(mockKafkaOps.get(eq(NAMESPACE), eq(NAME))).thenReturn(kafka);
+        when(mockKafkaOps.updateStatusAsync(any(Kafka.class))).thenReturn(Future.succeededFuture());
+
+        // Mock the KafkaSet operations
+        KafkaSetOperator mockKafkaSetOps = supplier.kafkaSetOperations;
+        when(mockKafkaSetOps.getAsync(eq(NAMESPACE), eq(KafkaCluster.kafkaClusterName(NAME)))).thenReturn(Future.succeededFuture());
+
+        // Mock the Pod operations
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(emptyList()));
+
+        // Mock ingress v1beta1 ops
+        IngressV1Beta1Operator mockIngressV1Beta1ops = supplier.ingressV1Beta1Operations;
+        ArgumentCaptor<io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress> ingressV1Beta1Captor = ArgumentCaptor.forClass(io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress.class);
+        when(mockIngressV1Beta1ops.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockIngressV1Beta1ops.reconcile(anyString(), anyString(), ingressV1Beta1Captor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(new io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress())));
+        when(mockIngressV1Beta1ops.hasIngressAddress(eq(NAMESPACE), any(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        // Mock ingress v1 ops
+        IngressOperator mockIngressOps = supplier.ingressOperations;
+        ArgumentCaptor<Ingress> ingressCaptor = ArgumentCaptor.forClass(Ingress.class);
+        when(mockIngressOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockIngressOps.reconcile(anyString(), anyString(), ingressCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(new Ingress())));
+        when(mockIngressOps.hasIngressAddress(eq(NAMESPACE), any(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        KafkaAssemblyOperator op = new MockKafkaAssemblyOperatorForIngressTests(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16), certManager, passwordGenerator,
+                supplier, ResourceUtils.dummyClusterOperatorConfig(KafkaVersionTestUtils.getKafkaVersionLookup()));
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+
+        Checkpoint async = context.checkpoint();
+        op.reconcile(reconciliation)
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    assertThat(ingressCaptor.getAllValues().size(), is(0));
+                    assertThat(ingressV1Beta1Captor.getAllValues().size(), is(4));
+
+                    verify(mockIngressOps, never()).list(any(), any());
+                    verify(mockIngressOps, never()).reconcile(any(), any(), any());
+                    verify(mockIngressOps, never()).hasIngressAddress(any(), any(), anyLong(), anyLong());
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testIngressV1(VertxTestContext context) {
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                    .withName(NAME)
+                    .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewKafka()
+                        .withReplicas(3)
+                        .withNewListeners()
+                            .addNewGenericKafkaListener()
+                                .withName("ingress")
+                                .withPort(9094)
+                                .withTls(true)
+                                .withType(KafkaListenerType.INGRESS)
+                                .withNewConfiguration()
+                                    .withNewBootstrap()
+                                        .withHost("bootstrap.mydomain.tld")
+                                    .endBootstrap()
+                                    .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder().withBroker(0).withHost("broker-0.mydomain.tld").build(),
+                                            new GenericKafkaListenerConfigurationBrokerBuilder().withBroker(1).withHost("broker-1.mydomain.tld").build(),
+                                            new GenericKafkaListenerConfigurationBrokerBuilder().withBroker(2).withHost("broker-2.mydomain.tld").build())
+                                .endConfiguration()
+                            .endGenericKafkaListener()
+                        .endListeners()
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endKafka()
+                    .withNewZookeeper()
+                        .withReplicas(3)
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endZookeeper()
+                    .withNewEntityOperator()
+                        .withNewUserOperator()
+                        .endUserOperator()
+                        .withNewTopicOperator()
+                        .endTopicOperator()
+                    .endEntityOperator()
+                .endSpec()
+                .build();
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the CRD Operator for Kafka resources
+        CrdOperator mockKafkaOps = supplier.kafkaOperator;
+        when(mockKafkaOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(kafka));
+        when(mockKafkaOps.get(eq(NAMESPACE), eq(NAME))).thenReturn(kafka);
+        when(mockKafkaOps.updateStatusAsync(any(Kafka.class))).thenReturn(Future.succeededFuture());
+
+        // Mock the KafkaSet operations
+        KafkaSetOperator mockKafkaSetOps = supplier.kafkaSetOperations;
+        when(mockKafkaSetOps.getAsync(eq(NAMESPACE), eq(KafkaCluster.kafkaClusterName(NAME)))).thenReturn(Future.succeededFuture());
+
+        // Mock the Pod operations
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(emptyList()));
+
+        // Mock ingress v1beta1 ops
+        IngressV1Beta1Operator mockIngressV1Beta1ops = supplier.ingressV1Beta1Operations;
+        ArgumentCaptor<io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress> ingressV1Beta1Captor = ArgumentCaptor.forClass(io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress.class);
+        when(mockIngressV1Beta1ops.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockIngressV1Beta1ops.reconcile(anyString(), anyString(), ingressV1Beta1Captor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(new io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress())));
+        when(mockIngressV1Beta1ops.hasIngressAddress(eq(NAMESPACE), any(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        // Mock ingress v1 ops
+        IngressOperator mockIngressOps = supplier.ingressOperations;
+        ArgumentCaptor<Ingress> ingressCaptor = ArgumentCaptor.forClass(Ingress.class);
+        when(mockIngressOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockIngressOps.reconcile(anyString(), anyString(), ingressCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(new Ingress())));
+        when(mockIngressOps.hasIngressAddress(eq(NAMESPACE), any(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        KafkaAssemblyOperator op = new MockKafkaAssemblyOperatorForIngressTests(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_19), certManager, passwordGenerator,
+                supplier, ResourceUtils.dummyClusterOperatorConfig(KafkaVersionTestUtils.getKafkaVersionLookup()));
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+
+        Checkpoint async = context.checkpoint();
+        op.reconcile(reconciliation)
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    assertThat(ingressCaptor.getAllValues().size(), is(4));
+                    assertThat(ingressV1Beta1Captor.getAllValues().size(), is(0));
+
+                    verify(mockIngressV1Beta1ops, never()).list(any(), any());
+                    verify(mockIngressV1Beta1ops, never()).reconcile(any(), any(), any());
+                    verify(mockIngressV1Beta1ops, never()).hasIngressAddress(any(), any(), anyLong(), anyLong());
+
+                    async.flag();
+                })));
+    }
+
+    /**
+     * Override KafkaAssemblyOperator to only run reconciliation steps that concern the Ingress resources feature
+     */
+    class MockKafkaAssemblyOperatorForIngressTests extends KafkaAssemblyOperator {
+        public MockKafkaAssemblyOperatorForIngressTests(
+                Vertx vertx,
+                PlatformFeaturesAvailability pfa,
+                CertManager certManager,
+                PasswordGenerator passwordGenerator,
+                ResourceOperatorSupplier supplier,
+                ClusterOperatorConfig config
+        ) {
+            super(vertx, pfa, certManager, passwordGenerator, supplier, config);
+        }
+
+        @Override
+        Future<Void> reconcile(ReconciliationState reconcileState)  {
+            return reconcileState.getKafkaClusterDescription()
+                    .compose(state -> state.kafkaIngresses())
+                    .compose(state -> state.kafkaIngressesV1Beta1())
+                    .compose(state -> state.kafkaIngressesReady())
+                    .compose(state -> state.kafkaIngressesV1Beta1Ready())
+                    .map((Void) null);
+        }
+
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -157,7 +157,7 @@ public class KafkaAssemblyOperatorTest {
     private final String differentMetricsCMName = "metrics-cm-2";
     private final ConfigMap metricsCM = io.strimzi.operator.cluster.TestUtils.getJmxMetricsCm(metricsCmJson, metricsCMName);
 
-    private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_16;
+    private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_20;
 
     private static boolean openShift;
     private static boolean metrics;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -164,7 +164,7 @@ public class KafkaConnectorIT {
 
         KafkaConnectAssemblyOperator operator = new KafkaConnectAssemblyOperator(vertx, pfa,
                 new ResourceOperatorSupplier(
-                        null, null, null, null, null, null, null, null, null, null, null,
+                        null, null, null, null, null, null, null, null, null, null, null, null,
                         null, null, null, null, null, null, null, null, null, null, null, null,
                         null, null, connectCrdOperator, null, null, null, null, null, metrics, null),
                 ClusterOperatorConfig.fromMap(Collections.emptyMap(), KafkaVersionTestUtils.getKafkaVersionLookup()),

--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration.adoc
@@ -61,9 +61,7 @@ listeners:
 === `class`
 
 The `class` property is only used with `ingress` listeners.
-
-By default, the `Ingress` class is set to `nginx`.
-You can change the `Ingress` class using the `class` property.
+You can configure the `Ingress` class using the `class` property.
 
 .Example of an external listener of type `ingress` using `Ingress` class `nginx-internal`
 [source,yaml,subs="attributes+"]

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -377,7 +377,7 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |xref:type-GenericKafkaListenerConfigurationBootstrap-{context}[`GenericKafkaListenerConfigurationBootstrap`]
 |brokers                       1.2+<.<|Per-broker configurations.
 |xref:type-GenericKafkaListenerConfigurationBroker-{context}[`GenericKafkaListenerConfigurationBroker`] array
-|class                         1.2+<.<|Configures the `Ingress` class that defines which `Ingress` controller will be used. If not set, the `Ingress` class is set to `nginx`. This field can be used only with `ingress` type listener.
+|class                         1.2+<.<|Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener.
 |string
 |preferredNodePortAddressType  1.2+<.<|Defines which address type should be used as the node address. Available types are: `ExternalDNS`, `ExternalIP`, `InternalDNS`, `InternalIP` and `Hostname`. By default, the addresses will be used in the following order (the first one found will be used):
 * `ExternalDNS`
@@ -827,7 +827,7 @@ It must have the value `ingress` for the type `KafkaListenerExternalIngress`.
 |string
 |authentication      1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, oauth].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`]
-|class               1.2+<.<|Configures the `Ingress` class that defines which `Ingress` controller will be used. If not set, the `Ingress` class is set to `nginx`.
+|class               1.2+<.<|Configures the `Ingress` class that defines which `Ingress` controller will be used.
 |string
 |configuration       1.2+<.<|External listener configuration.
 |xref:type-IngressListenerConfiguration-{context}[`IngressListenerConfiguration`]

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -377,7 +377,7 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |xref:type-GenericKafkaListenerConfigurationBootstrap-{context}[`GenericKafkaListenerConfigurationBootstrap`]
 |brokers                       1.2+<.<|Per-broker configurations.
 |xref:type-GenericKafkaListenerConfigurationBroker-{context}[`GenericKafkaListenerConfigurationBroker`] array
-|class                         1.2+<.<|Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener.
+|class                         1.2+<.<|Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener. If not specified, the default Ingress controller will be used.
 |string
 |preferredNodePortAddressType  1.2+<.<|Defines which address type should be used as the node address. Available types are: `ExternalDNS`, `ExternalIP`, `InternalDNS`, `InternalIP` and `Hostname`. By default, the addresses will be used in the following order (the first one found will be used):
 * `ExternalDNS`

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -377,7 +377,7 @@ spec:
                                 description: Per-broker configurations.
                               class:
                                 type: string
-                                description: Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener.
+                                description: Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener. If not specified, the default Ingress controller will be used.
                               preferredNodePortAddressType:
                                 type: string
                                 enum:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -377,7 +377,7 @@ spec:
                                 description: Per-broker configurations.
                               class:
                                 type: string
-                                description: Configures the `Ingress` class that defines which `Ingress` controller will be used. If not set, the `Ingress` class is set to `nginx`. This field can be used only with `ingress` type listener.
+                                description: Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener.
                               preferredNodePortAddressType:
                                 type: string
                                 enum:
@@ -914,7 +914,7 @@ spec:
                               description: Authentication configuration for Kafka brokers.
                             class:
                               type: string
-                              description: Configures the `Ingress` class that defines which `Ingress` controller will be used. If not set, the `Ingress` class is set to `nginx`.
+                              description: Configures the `Ingress` class that defines which `Ingress` controller will be used.
                             configuration:
                               type: object
                               properties:

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -195,6 +195,8 @@ rules:
   resources:
     # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
   - networkpolicies
+    # The cluster operator needs to access and manage ingresses which allow external access to the services in a cluster
+  - ingresses
   verbs:
   - get
   - list

--- a/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -190,6 +190,8 @@ rules:
     resources:
       # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
       - networkpolicies
+      # The cluster operator needs to access and manage ingresses which allow external access to the services in a cluster
+      - ingresses
     verbs:
       - get
       - list

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -565,7 +565,9 @@ spec:
                               type: string
                               description: Configures the `Ingress` class that defines
                                 which `Ingress` controller will be used. This field
-                                can be used only with `ingress` type listener.
+                                can be used only with `ingress` type listener. If
+                                not specified, the default Ingress controller will
+                                be used.
                             preferredNodePortAddressType:
                               type: string
                               enum:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -564,8 +564,7 @@ spec:
                             class:
                               type: string
                               description: Configures the `Ingress` class that defines
-                                which `Ingress` controller will be used. If not set,
-                                the `Ingress` class is set to `nginx`. This field
+                                which `Ingress` controller will be used. This field
                                 can be used only with `ingress` type listener.
                             preferredNodePortAddressType:
                               type: string
@@ -1342,8 +1341,7 @@ spec:
                           class:
                             type: string
                             description: Configures the `Ingress` class that defines
-                              which `Ingress` controller will be used. If not set,
-                              the `Ingress` class is set to `nginx`.
+                              which `Ingress` controller will be used.
                           configuration:
                             type: object
                             properties:

--- a/mockkube/pom.xml
+++ b/mockkube/pom.xml
@@ -35,10 +35,6 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model-extensions</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-model-apps</artifactId>
         </dependency>
         <dependency>

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
@@ -42,6 +42,7 @@ import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.V1NetworkAPIGroupDSL;
 import io.fabric8.kubernetes.client.V1beta1ApiextensionAPIGroupDSL;
+import io.fabric8.kubernetes.client.V1beta1NetworkAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.ApiextensionsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.CreateOrReplaceable;
@@ -99,6 +100,7 @@ public class MockKube {
     private final Map<String, Role> roleDb = db(emptySet());
     private final Map<String, ClusterRoleBinding> pdbCrb = db(emptySet());
     private final Map<String, Ingress> ingressDb = db(emptySet());
+    private final Map<String, io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress> ingressV1Beta1Db = db(emptySet());
 
     private Map<String, CreateOrReplaceable> crdMixedOps = new HashMap<>();
     private MockBuilder<ConfigMap, ConfigMapList, Resource<ConfigMap>> configMapMockBuilder;
@@ -116,6 +118,7 @@ public class MockKube {
     private MockBuilder<Pod, PodList, PodResource<Pod>> podMockBuilder;
     private MockBuilder<PersistentVolumeClaim, PersistentVolumeClaimList, Resource<PersistentVolumeClaim>> persistentVolumeClaimMockBuilder;
     private MockBuilder<Ingress, IngressList, Resource<Ingress>> ingressMockBuilder;
+    private MockBuilder<io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress, io.fabric8.kubernetes.api.model.networking.v1beta1.IngressList, Resource<io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress>> ingressV1Beta1MockBuilder;
     private DeploymentMockBuilder deploymentMockBuilder;
     private KubernetesClient mockClient;
 
@@ -257,6 +260,7 @@ public class MockKube {
         clusterRoleBindingMockBuilder = addMockBuilder("clusterrolebindings", new MockBuilder<>(ClusterRoleBinding.class, ClusterRoleBindingList.class, MockBuilder.castClass(Resource.class), pdbCrb));
         networkPolicyMockBuilder = addMockBuilder("networkpolicies", new MockBuilder<>(NetworkPolicy.class, NetworkPolicyList.class, MockBuilder.castClass(Resource.class), policyDb));
         ingressMockBuilder = addMockBuilder("ingresses",  new MockBuilder<>(Ingress.class, IngressList.class, MockBuilder.castClass(Resource.class), ingressDb));
+        ingressV1Beta1MockBuilder = addMockBuilder("ingresses",  new MockBuilder<>(io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress.class, io.fabric8.kubernetes.api.model.networking.v1beta1.IngressList.class, MockBuilder.castClass(Resource.class), ingressV1Beta1Db));
 
         podMockBuilder = addMockBuilder("pods", new MockBuilder<>(Pod.class, PodList.class, MockBuilder.castClass(PodResource.class), podDb));
         MixedOperation<Pod, PodList, PodResource<Pod>> mockPods = podMockBuilder.build();
@@ -317,10 +321,13 @@ public class MockKube {
         // Network group
         NetworkAPIGroupDSL network = mock(NetworkAPIGroupDSL.class);
         V1NetworkAPIGroupDSL networkV1 = mock(V1NetworkAPIGroupDSL.class);
+        V1beta1NetworkAPIGroupDSL networkV1beta1 = mock(V1beta1NetworkAPIGroupDSL.class);
         when(mockClient.network()).thenReturn(network);
         when(network.v1()).thenReturn(networkV1);
+        when(network.v1beta1()).thenReturn(networkV1beta1);
         networkPolicyMockBuilder.build2(network::networkPolicies);
         ingressMockBuilder.build2(networkV1::ingresses);
+        ingressV1Beta1MockBuilder.build2(networkV1beta1::ingresses);
 
         // Policy group
         PolicyAPIGroupDSL policy = mock(PolicyAPIGroupDSL.class);

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefin
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetList;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
-import io.fabric8.kubernetes.api.model.extensions.IngressList;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressList;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyList;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
@@ -40,11 +40,11 @@ import io.fabric8.kubernetes.api.model.rbac.RoleBindingList;
 import io.fabric8.kubernetes.api.model.rbac.RoleList;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.V1NetworkAPIGroupDSL;
 import io.fabric8.kubernetes.client.V1beta1ApiextensionAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.ApiextensionsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.CreateOrReplaceable;
-import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NetworkAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
@@ -314,15 +314,13 @@ public class MockKube {
             mockCrs(mockClient);
         }
 
-        // Extensions group
-        ExtensionsAPIGroupDSL extensions = mock(ExtensionsAPIGroupDSL.class);
-        when(mockClient.extensions()).thenReturn(extensions);
-        ingressMockBuilder.build2(extensions::ingresses);
-
         // Network group
         NetworkAPIGroupDSL network = mock(NetworkAPIGroupDSL.class);
+        V1NetworkAPIGroupDSL networkV1 = mock(V1NetworkAPIGroupDSL.class);
         when(mockClient.network()).thenReturn(network);
+        when(network.v1()).thenReturn(networkV1);
         networkPolicyMockBuilder.build2(network::networkPolicies);
+        ingressMockBuilder.build2(networkV1::ingresses);
 
         // Policy group
         PolicyAPIGroupDSL policy = mock(PolicyAPIGroupDSL.class);

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -39,10 +39,6 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model-extensions</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-model-apps</artifactId>
         </dependency>
         <dependency>

--- a/operator-common/src/main/java/io/strimzi/operator/PlatformFeaturesAvailability.java
+++ b/operator-common/src/main/java/io/strimzi/operator/PlatformFeaturesAvailability.java
@@ -248,6 +248,15 @@ public class PlatformFeaturesAvailability {
         return hasBuilds() && hasApps() && hasImages();
     }
 
+    /**
+     * Returns true when the Kubernetes cluster has V1 version of the Ingress resource (Kubernetes 1.19 and newer)
+     *
+     * @return True when Ingress V1 is supported. False otherwise.
+     */
+    public boolean hasIngressV1() {
+        return this.kubernetesVersion.compareTo(KubernetesVersion.V1_19) >= 0;
+    }
+
     @Override
     public String toString() {
         return "ClusterOperatorConfig(" +

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/IngressV1Beta1Operator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/IngressV1Beta1Operator.java
@@ -4,8 +4,8 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
-import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
-import io.fabric8.kubernetes.api.model.networking.v1.IngressList;
+import io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1beta1.IngressList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -15,20 +15,20 @@ import io.vertx.core.Vertx;
 /**
  * Operations for {@code Ingress}es.
  */
-public class IngressOperator extends AbstractResourceOperator<KubernetesClient, Ingress, IngressList, Resource<Ingress>> {
+public class IngressV1Beta1Operator extends AbstractResourceOperator<KubernetesClient, Ingress, IngressList, Resource<Ingress>> {
 
     /**
      * Constructor
      * @param vertx The Vertx instance
      * @param client The Kubernetes client
      */
-    public IngressOperator(Vertx vertx, KubernetesClient client) {
-        super(vertx, client, "Ingress");
+    public IngressV1Beta1Operator(Vertx vertx, KubernetesClient client) {
+        super(vertx, client, "v1beta1.Ingress");
     }
 
     @Override
     protected MixedOperation<Ingress, IngressList, Resource<Ingress>> operation() {
-        return client.network().v1().ingresses();
+        return client.network().v1beta1().ingresses();
     }
 
     /**

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/IngressV1Beta1OperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/IngressV1Beta1OperatorTest.java
@@ -4,11 +4,11 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
-import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
-import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder;
-import io.fabric8.kubernetes.api.model.networking.v1.IngressList;
+import io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1beta1.IngressBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1beta1.IngressList;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.V1NetworkAPIGroupDSL;
+import io.fabric8.kubernetes.client.V1beta1NetworkAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NetworkAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -18,7 +18,7 @@ import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class IngressOperatorTest extends AbstractResourceOperatorTest<KubernetesClient, Ingress, IngressList, Resource<Ingress>> {
+public class IngressV1Beta1OperatorTest extends AbstractResourceOperatorTest<KubernetesClient, Ingress, IngressList, Resource<Ingress>> {
     @Override
     protected Class<KubernetesClient> clientType() {
         return KubernetesClient.class;
@@ -43,14 +43,14 @@ public class IngressOperatorTest extends AbstractResourceOperatorTest<Kubernetes
     @Override
     protected void mocker(KubernetesClient mockClient, MixedOperation op) {
         NetworkAPIGroupDSL network = mock(NetworkAPIGroupDSL.class);
-        V1NetworkAPIGroupDSL v1 = mock(V1NetworkAPIGroupDSL.class);
-        when(network.v1()).thenReturn(v1);
-        when(v1.ingresses()).thenReturn(op);
+        V1beta1NetworkAPIGroupDSL v1beta1 = mock(V1beta1NetworkAPIGroupDSL.class);
+        when(network.v1beta1()).thenReturn(v1beta1);
+        when(v1beta1.ingresses()).thenReturn(op);
         when(mockClient.network()).thenReturn(network);
     }
 
     @Override
     protected AbstractResourceOperator<KubernetesClient, Ingress, IngressList, Resource<Ingress>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
-        return new IngressOperator(vertx, mockClient);
+        return new IngressV1Beta1Operator(vertx, mockClient);
     }
 }

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -54,10 +54,6 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model-extensions</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-model-apps</artifactId>
         </dependency>
         <dependency>

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -9,7 +9,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodCondition;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model-extensions</artifactId>
+            <artifactId>kubernetes-model-networking</artifactId>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -23,7 +23,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.batch.Job;
 import io.fabric8.kubernetes.api.model.batch.JobList;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.Role;
@@ -492,11 +492,11 @@ public class KubeClient {
     // =============================
 
     public Ingress createIngress(Ingress ingress) {
-        return client.extensions().ingresses().inNamespace(getNamespace()).createOrReplace(ingress);
+        return client.network().v1().ingresses().inNamespace(getNamespace()).createOrReplace(ingress);
     }
 
     public Boolean deleteIngress(Ingress ingress) {
-        return client.extensions().ingresses().inNamespace(getNamespace()).delete(ingress);
+        return client.network().v1().ingresses().inNamespace(getNamespace()).delete(ingress);
     }
 
     // =============================


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Kubernetes 1.19 introduced `v1` of the Ingress resource. The previous versions (`extension/v1beta1` and `networking/v1beta1`) will be removed in Kubernetes 1.22. This is relatively short time. This PR adds support for v1 Ingress but keeps the `networking/v1beta1` support present to keep it working on Kubernetes 1.16-1.18. The way it is designed makes it easy to remove the v1beta1 part in the future.

Kubernetes now also have new resource IngressClass which has the concept of default Ingress class. To make this work for the v1 Ingress in Strimzi, this also changes the default `nginx` class which was always set in the previous Strimzi versions.

This has been tested manually against Kube 1.20 and 1.16 to test both v1 and v1beta1 variants.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md