### PR TITLE
[DOC] Edit the doc for disabling `OwnerReference` in Cluster and Clients Secrets

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/CertificateAuthority.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CertificateAuthority.java
@@ -60,11 +60,11 @@ public class CertificateAuthority implements UnknownPropertyPreserving, Serializ
         this.generateCertificateAuthority = generateCertificateAuthority;
     }
 
-    @Description("If true, then the Cluster and Client CA Secrets are configured with the `ownerReference` set to the `Kafka` resource. " +
-            "If the Kafka resource is deleted, then the CA Secrets are also deleted. " +
-            "If false, the `ownerReference` is disabled. " +
-            "If the `Kafka` resource is deleted, then the CA Secrets are retained and available for reuse. " +
-            "Default is true.")
+    @Description("If `true`, the Cluster and Client CA Secrets are configured with the `ownerReference` set to the `Kafka` resource. " +
+            "If the `Kafka` resource is deleted when `true`, the CA Secrets are also deleted. " +
+            "If `false`, the `ownerReference` is disabled. " +
+            "If the `Kafka` resource is deleted when `false`, the CA Secrets are retained and available for reuse. " +
+            "Default is `true`.")
     public boolean isGenerateSecretOwnerReference() {
         return generateSecretOwnerReference;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/CertificateAuthority.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CertificateAuthority.java
@@ -60,8 +60,10 @@ public class CertificateAuthority implements UnknownPropertyPreserving, Serializ
         this.generateCertificateAuthority = generateCertificateAuthority;
     }
 
-    @Description("If true then the Certificate Authority certificates secrets owner reference is set to the Kafka object. " +
-            "Otherwise no owner reference is set so deleting the Kafka object won't delete the secrets. " +
+    @Description("If true, then the Cluster and Client CA Secrets are configured with the `ownerReference` set to the `Kafka` resource. " +
+            "If the Kafka resource is deleted, then the CA Secrets are also deleted. " +
+            "If false, the `ownerReference` is disabled. " +
+            "If the `Kafka` resource is deleted, then the CA Secrets are retained and available for reuse. " +
             "Default is true.")
     public boolean isGenerateSecretOwnerReference() {
         return generateSecretOwnerReference;

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
@@ -3961,10 +3961,12 @@ spec:
                       provide a Secret with the CA certificate. Default is true.
                   generateSecretOwnerReference:
                     type: boolean
-                    description: If true then the Certificate Authority certificates
-                      secrets owner reference is set to the Kafka object. Otherwise
-                      no owner reference is set so deleting the Kafka object won't
-                      delete the secrets. Default is true.
+                    description: If true, then the Cluster and Client CA Secrets are
+                      configured with the `ownerReference` set to the `Kafka` resource.
+                      If the Kafka resource is deleted, then the CA Secrets are also
+                      deleted. If false, the `ownerReference` is disabled. If the
+                      `Kafka` resource is deleted, then the CA Secrets are retained
+                      and available for reuse. Default is true.
                   validityDays:
                     type: integer
                     minimum: 1
@@ -4000,10 +4002,12 @@ spec:
                       provide a Secret with the CA certificate. Default is true.
                   generateSecretOwnerReference:
                     type: boolean
-                    description: If true then the Certificate Authority certificates
-                      secrets owner reference is set to the Kafka object. Otherwise
-                      no owner reference is set so deleting the Kafka object won't
-                      delete the secrets. Default is true.
+                    description: If true, then the Cluster and Client CA Secrets are
+                      configured with the `ownerReference` set to the `Kafka` resource.
+                      If the Kafka resource is deleted, then the CA Secrets are also
+                      deleted. If false, the `ownerReference` is disabled. If the
+                      `Kafka` resource is deleted, then the CA Secrets are retained
+                      and available for reuse. Default is true.
                   validityDays:
                     type: integer
                     minimum: 1

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
@@ -3961,12 +3961,12 @@ spec:
                       provide a Secret with the CA certificate. Default is true.
                   generateSecretOwnerReference:
                     type: boolean
-                    description: If true, then the Cluster and Client CA Secrets are
+                    description: If `true`, the Cluster and Client CA Secrets are
                       configured with the `ownerReference` set to the `Kafka` resource.
-                      If the Kafka resource is deleted, then the CA Secrets are also
-                      deleted. If false, the `ownerReference` is disabled. If the
-                      `Kafka` resource is deleted, then the CA Secrets are retained
-                      and available for reuse. Default is true.
+                      If the `Kafka` resource is deleted when `true`, the CA Secrets
+                      are also deleted. If `false`, the `ownerReference` is disabled.
+                      If the `Kafka` resource is deleted when `false`, the CA Secrets
+                      are retained and available for reuse. Default is `true`.
                   validityDays:
                     type: integer
                     minimum: 1
@@ -4002,12 +4002,12 @@ spec:
                       provide a Secret with the CA certificate. Default is true.
                   generateSecretOwnerReference:
                     type: boolean
-                    description: If true, then the Cluster and Client CA Secrets are
+                    description: If `true`, the Cluster and Client CA Secrets are
                       configured with the `ownerReference` set to the `Kafka` resource.
-                      If the Kafka resource is deleted, then the CA Secrets are also
-                      deleted. If false, the `ownerReference` is disabled. If the
-                      `Kafka` resource is deleted, then the CA Secrets are retained
-                      and available for reuse. Default is true.
+                      If the `Kafka` resource is deleted when `true`, the CA Secrets
+                      are also deleted. If `false`, the `ownerReference` is disabled.
+                      If the `Kafka` resource is deleted when `false`, the CA Secrets
+                      are retained and available for reuse. Default is `true`.
                   validityDays:
                     type: integer
                     minimum: 1

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
@@ -3873,12 +3873,12 @@ spec:
                       provide a Secret with the CA certificate. Default is true.
                   generateSecretOwnerReference:
                     type: boolean
-                    description: If true, then the Cluster and Client CA Secrets are
+                    description: If `true`, the Cluster and Client CA Secrets are
                       configured with the `ownerReference` set to the `Kafka` resource.
-                      If the Kafka resource is deleted, then the CA Secrets are also
-                      deleted. If false, the `ownerReference` is disabled. If the
-                      `Kafka` resource is deleted, then the CA Secrets are retained
-                      and available for reuse. Default is true.
+                      If the `Kafka` resource is deleted when `true`, the CA Secrets
+                      are also deleted. If `false`, the `ownerReference` is disabled.
+                      If the `Kafka` resource is deleted when `false`, the CA Secrets
+                      are retained and available for reuse. Default is `true`.
                   validityDays:
                     type: integer
                     minimum: 1
@@ -3914,12 +3914,12 @@ spec:
                       provide a Secret with the CA certificate. Default is true.
                   generateSecretOwnerReference:
                     type: boolean
-                    description: If true, then the Cluster and Client CA Secrets are
+                    description: If `true`, the Cluster and Client CA Secrets are
                       configured with the `ownerReference` set to the `Kafka` resource.
-                      If the Kafka resource is deleted, then the CA Secrets are also
-                      deleted. If false, the `ownerReference` is disabled. If the
-                      `Kafka` resource is deleted, then the CA Secrets are retained
-                      and available for reuse. Default is true.
+                      If the `Kafka` resource is deleted when `true`, the CA Secrets
+                      are also deleted. If `false`, the `ownerReference` is disabled.
+                      If the `Kafka` resource is deleted when `false`, the CA Secrets
+                      are retained and available for reuse. Default is `true`.
                   validityDays:
                     type: integer
                     minimum: 1
@@ -12083,12 +12083,12 @@ spec:
                       provide a Secret with the CA certificate. Default is true.
                   generateSecretOwnerReference:
                     type: boolean
-                    description: If true, then the Cluster and Client CA Secrets are
+                    description: If `true`, the Cluster and Client CA Secrets are
                       configured with the `ownerReference` set to the `Kafka` resource.
-                      If the Kafka resource is deleted, then the CA Secrets are also
-                      deleted. If false, the `ownerReference` is disabled. If the
-                      `Kafka` resource is deleted, then the CA Secrets are retained
-                      and available for reuse. Default is true.
+                      If the `Kafka` resource is deleted when `true`, the CA Secrets
+                      are also deleted. If `false`, the `ownerReference` is disabled.
+                      If the `Kafka` resource is deleted when `false`, the CA Secrets
+                      are retained and available for reuse. Default is `true`.
                   validityDays:
                     type: integer
                     minimum: 1
@@ -12124,12 +12124,12 @@ spec:
                       provide a Secret with the CA certificate. Default is true.
                   generateSecretOwnerReference:
                     type: boolean
-                    description: If true, then the Cluster and Client CA Secrets are
+                    description: If `true`, the Cluster and Client CA Secrets are
                       configured with the `ownerReference` set to the `Kafka` resource.
-                      If the Kafka resource is deleted, then the CA Secrets are also
-                      deleted. If false, the `ownerReference` is disabled. If the
-                      `Kafka` resource is deleted, then the CA Secrets are retained
-                      and available for reuse. Default is true.
+                      If the `Kafka` resource is deleted when `true`, the CA Secrets
+                      are also deleted. If `false`, the `ownerReference` is disabled.
+                      If the `Kafka` resource is deleted when `false`, the CA Secrets
+                      are retained and available for reuse. Default is `true`.
                   validityDays:
                     type: integer
                     minimum: 1
@@ -20301,12 +20301,12 @@ spec:
                       provide a Secret with the CA certificate. Default is true.
                   generateSecretOwnerReference:
                     type: boolean
-                    description: If true, then the Cluster and Client CA Secrets are
+                    description: If `true`, the Cluster and Client CA Secrets are
                       configured with the `ownerReference` set to the `Kafka` resource.
-                      If the Kafka resource is deleted, then the CA Secrets are also
-                      deleted. If false, the `ownerReference` is disabled. If the
-                      `Kafka` resource is deleted, then the CA Secrets are retained
-                      and available for reuse. Default is true.
+                      If the `Kafka` resource is deleted when `true`, the CA Secrets
+                      are also deleted. If `false`, the `ownerReference` is disabled.
+                      If the `Kafka` resource is deleted when `false`, the CA Secrets
+                      are retained and available for reuse. Default is `true`.
                   validityDays:
                     type: integer
                     minimum: 1
@@ -20342,12 +20342,12 @@ spec:
                       provide a Secret with the CA certificate. Default is true.
                   generateSecretOwnerReference:
                     type: boolean
-                    description: If true, then the Cluster and Client CA Secrets are
+                    description: If `true`, the Cluster and Client CA Secrets are
                       configured with the `ownerReference` set to the `Kafka` resource.
-                      If the Kafka resource is deleted, then the CA Secrets are also
-                      deleted. If false, the `ownerReference` is disabled. If the
-                      `Kafka` resource is deleted, then the CA Secrets are retained
-                      and available for reuse. Default is true.
+                      If the `Kafka` resource is deleted when `true`, the CA Secrets
+                      are also deleted. If `false`, the `ownerReference` is disabled.
+                      If the `Kafka` resource is deleted when `false`, the CA Secrets
+                      are retained and available for reuse. Default is `true`.
                   validityDays:
                     type: integer
                     minimum: 1

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
@@ -3873,10 +3873,12 @@ spec:
                       provide a Secret with the CA certificate. Default is true.
                   generateSecretOwnerReference:
                     type: boolean
-                    description: If true then the Certificate Authority certificates
-                      secrets owner reference is set to the Kafka object. Otherwise
-                      no owner reference is set so deleting the Kafka object won't
-                      delete the secrets. Default is true.
+                    description: If true, then the Cluster and Client CA Secrets are
+                      configured with the `ownerReference` set to the `Kafka` resource.
+                      If the Kafka resource is deleted, then the CA Secrets are also
+                      deleted. If false, the `ownerReference` is disabled. If the
+                      `Kafka` resource is deleted, then the CA Secrets are retained
+                      and available for reuse. Default is true.
                   validityDays:
                     type: integer
                     minimum: 1
@@ -3912,10 +3914,12 @@ spec:
                       provide a Secret with the CA certificate. Default is true.
                   generateSecretOwnerReference:
                     type: boolean
-                    description: If true then the Certificate Authority certificates
-                      secrets owner reference is set to the Kafka object. Otherwise
-                      no owner reference is set so deleting the Kafka object won't
-                      delete the secrets. Default is true.
+                    description: If true, then the Cluster and Client CA Secrets are
+                      configured with the `ownerReference` set to the `Kafka` resource.
+                      If the Kafka resource is deleted, then the CA Secrets are also
+                      deleted. If false, the `ownerReference` is disabled. If the
+                      `Kafka` resource is deleted, then the CA Secrets are retained
+                      and available for reuse. Default is true.
                   validityDays:
                     type: integer
                     minimum: 1
@@ -12079,10 +12083,12 @@ spec:
                       provide a Secret with the CA certificate. Default is true.
                   generateSecretOwnerReference:
                     type: boolean
-                    description: If true then the Certificate Authority certificates
-                      secrets owner reference is set to the Kafka object. Otherwise
-                      no owner reference is set so deleting the Kafka object won't
-                      delete the secrets. Default is true.
+                    description: If true, then the Cluster and Client CA Secrets are
+                      configured with the `ownerReference` set to the `Kafka` resource.
+                      If the Kafka resource is deleted, then the CA Secrets are also
+                      deleted. If false, the `ownerReference` is disabled. If the
+                      `Kafka` resource is deleted, then the CA Secrets are retained
+                      and available for reuse. Default is true.
                   validityDays:
                     type: integer
                     minimum: 1
@@ -12118,10 +12124,12 @@ spec:
                       provide a Secret with the CA certificate. Default is true.
                   generateSecretOwnerReference:
                     type: boolean
-                    description: If true then the Certificate Authority certificates
-                      secrets owner reference is set to the Kafka object. Otherwise
-                      no owner reference is set so deleting the Kafka object won't
-                      delete the secrets. Default is true.
+                    description: If true, then the Cluster and Client CA Secrets are
+                      configured with the `ownerReference` set to the `Kafka` resource.
+                      If the Kafka resource is deleted, then the CA Secrets are also
+                      deleted. If false, the `ownerReference` is disabled. If the
+                      `Kafka` resource is deleted, then the CA Secrets are retained
+                      and available for reuse. Default is true.
                   validityDays:
                     type: integer
                     minimum: 1
@@ -20293,10 +20301,12 @@ spec:
                       provide a Secret with the CA certificate. Default is true.
                   generateSecretOwnerReference:
                     type: boolean
-                    description: If true then the Certificate Authority certificates
-                      secrets owner reference is set to the Kafka object. Otherwise
-                      no owner reference is set so deleting the Kafka object won't
-                      delete the secrets. Default is true.
+                    description: If true, then the Cluster and Client CA Secrets are
+                      configured with the `ownerReference` set to the `Kafka` resource.
+                      If the Kafka resource is deleted, then the CA Secrets are also
+                      deleted. If false, the `ownerReference` is disabled. If the
+                      `Kafka` resource is deleted, then the CA Secrets are retained
+                      and available for reuse. Default is true.
                   validityDays:
                     type: integer
                     minimum: 1
@@ -20332,10 +20342,12 @@ spec:
                       provide a Secret with the CA certificate. Default is true.
                   generateSecretOwnerReference:
                     type: boolean
-                    description: If true then the Certificate Authority certificates
-                      secrets owner reference is set to the Kafka object. Otherwise
-                      no owner reference is set so deleting the Kafka object won't
-                      delete the secrets. Default is true.
+                    description: If true, then the Cluster and Client CA Secrets are
+                      configured with the `ownerReference` set to the `Kafka` resource.
+                      If the Kafka resource is deleted, then the CA Secrets are also
+                      deleted. If false, the `ownerReference` is disabled. If the
+                      `Kafka` resource is deleted, then the CA Secrets are retained
+                      and available for reuse. Default is true.
                   validityDays:
                     type: integer
                     minimum: 1

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1669,7 +1669,7 @@ Configuration of how TLS certificates are used within the cluster. This applies 
 |Property                             |Description
 |generateCertificateAuthority  1.2+<.<|If true then Certificate Authority certificates will be generated automatically. Otherwise the user will need to provide a Secret with the CA certificate. Default is true.
 |boolean
-|generateSecretOwnerReference  1.2+<.<|If true then the Certificate Authority certificates secrets owner reference is set to the Kafka object. Otherwise no owner reference is set so deleting the Kafka object won't delete the secrets. Default is true.
+|generateSecretOwnerReference  1.2+<.<|If true, then the Cluster and Client CA Secrets are configured with the `ownerReference` set to the `Kafka` resource. If the Kafka resource is deleted, then the CA Secrets are also deleted. If false, the `ownerReference` is disabled. If the `Kafka` resource is deleted, then the CA Secrets are retained and available for reuse. Default is true.
 |boolean
 |validityDays                  1.2+<.<|The number of days generated certificates should be valid for. The default is 365.
 |integer

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1669,7 +1669,7 @@ Configuration of how TLS certificates are used within the cluster. This applies 
 |Property                             |Description
 |generateCertificateAuthority  1.2+<.<|If true then Certificate Authority certificates will be generated automatically. Otherwise the user will need to provide a Secret with the CA certificate. Default is true.
 |boolean
-|generateSecretOwnerReference  1.2+<.<|If true, then the Cluster and Client CA Secrets are configured with the `ownerReference` set to the `Kafka` resource. If the Kafka resource is deleted, then the CA Secrets are also deleted. If false, the `ownerReference` is disabled. If the `Kafka` resource is deleted, then the CA Secrets are retained and available for reuse. Default is true.
+|generateSecretOwnerReference  1.2+<.<|If `true`, the Cluster and Client CA Secrets are configured with the `ownerReference` set to the `Kafka` resource. If the `Kafka` resource is deleted when `true`, the CA Secrets are also deleted. If `false`, the `ownerReference` is disabled. If the `Kafka` resource is deleted when `false`, the CA Secrets are retained and available for reuse. Default is `true`.
 |boolean
 |validityDays                  1.2+<.<|The number of days generated certificates should be valid for. The default is 365.
 |integer

--- a/documentation/modules/security/ref-certificates-and-secrets.adoc
+++ b/documentation/modules/security/ref-certificates-and-secrets.adoc
@@ -168,7 +168,7 @@ By default, the Cluster and Client CA Secrets are created with an `ownerReferenc
 This means that, when the `Kafka` custom resource is deleted, the CA secrets are also deleted (garbage collected) by Kubernetes.
 
 If you want to reuse the CA for a new cluster, you can disable the `ownerReference` by setting the `generateSecretOwnerReference` property for the Cluster and Client CA Secrets to `false` in the `Kafka` configuration.
-When the `ownerReference` is disabled, CA secrets are not deleted by Kubernetes when the corresponding `Kafka` custom resource is deleted.
+When the `ownerReference` is disabled, CA Secrets are not deleted by Kubernetes when the corresponding `Kafka` custom resource is deleted.
 
 .Example Kafka configuration with disabled `ownerReference` for Cluster and Client CAs
 [source,shell,subs="+quotes"]

--- a/documentation/modules/security/ref-certificates-and-secrets.adoc
+++ b/documentation/modules/security/ref-certificates-and-secrets.adoc
@@ -164,13 +164,13 @@ You can enforce this using Kubernetes role-based access controls if necessary.
 
 == Disabling `ownerReference` in the CA Secrets
 
-By default, the CA secrets created by Strimzi have an `ownerReference` property set to the `Kafka` custom resource.
-This means that when the `Kafka` custom resource is deleted, the CA secrets are garbage collected (deleted) by Kubernetes as well.
+By default, the Cluster and Client CA Secrets are created with an `ownerReference` property that is set to the `Kafka` custom resource.
+This means that, when the `Kafka` custom resource is deleted, the CA secrets are also deleted (garbage collected) by Kubernetes.
 
-If you want to reuse the CA for a new cluster, you can disable the `ownerReference` by setting the `generateSecretOwnerReference` property for the cluster and client CAs to `false` in the `Kafka` configuration.
-When disabled, CA secrets are not deleted by Kubernetes when the corresponding `Kafka` custom resource is deleted.
+If you want to reuse the CA for a new cluster, you can disable the `ownerReference` by setting the `generateSecretOwnerReference` property for the Cluster and Client CA Secrets to `false` in the `Kafka` configuration.
+When the `ownerReference` is disabled, CA secrets are not deleted by Kubernetes when the corresponding `Kafka` custom resource is deleted.
 
-.Example Kafka configuration with disabled `ownerReference` for cluster and client CAs
+.Example Kafka configuration with disabled `ownerReference` for Cluster and Client CAs
 [source,shell,subs="+quotes"]
 ----
 apiVersion: kafka.strimzi.io/v1beta1
@@ -184,6 +184,10 @@ spec:
     generateSecretOwnerReference: false
 # ...
 ----
+
+.Additional resources
+
+* xref:type-CertificateAuthority-reference[`CertificateAuthority` schema reference]
 
 == User Secrets
 

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -5102,7 +5102,7 @@ spec:
                   description: If true then Certificate Authority certificates will be generated automatically. Otherwise the user will need to provide a Secret with the CA certificate. Default is true.
                 generateSecretOwnerReference:
                   type: boolean
-                  description: If true, then the Cluster and Client CA Secrets are configured with the `ownerReference` set to the `Kafka` resource. If the Kafka resource is deleted, then the CA Secrets are also deleted. If false, the `ownerReference` is disabled. If the `Kafka` resource is deleted, then the CA Secrets are retained and available for reuse. Default is true.
+                  description: If `true`, the Cluster and Client CA Secrets are configured with the `ownerReference` set to the `Kafka` resource. If the `Kafka` resource is deleted when `true`, the CA Secrets are also deleted. If `false`, the `ownerReference` is disabled. If the `Kafka` resource is deleted when `false`, the CA Secrets are retained and available for reuse. Default is `true`.
                 validityDays:
                   type: integer
                   minimum: 1
@@ -5126,7 +5126,7 @@ spec:
                   description: If true then Certificate Authority certificates will be generated automatically. Otherwise the user will need to provide a Secret with the CA certificate. Default is true.
                 generateSecretOwnerReference:
                   type: boolean
-                  description: If true, then the Cluster and Client CA Secrets are configured with the `ownerReference` set to the `Kafka` resource. If the Kafka resource is deleted, then the CA Secrets are also deleted. If false, the `ownerReference` is disabled. If the `Kafka` resource is deleted, then the CA Secrets are retained and available for reuse. Default is true.
+                  description: If `true`, the Cluster and Client CA Secrets are configured with the `ownerReference` set to the `Kafka` resource. If the `Kafka` resource is deleted when `true`, the CA Secrets are also deleted. If `false`, the `ownerReference` is disabled. If the `Kafka` resource is deleted when `false`, the CA Secrets are retained and available for reuse. Default is `true`.
                 validityDays:
                   type: integer
                   minimum: 1

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -5102,7 +5102,7 @@ spec:
                   description: If true then Certificate Authority certificates will be generated automatically. Otherwise the user will need to provide a Secret with the CA certificate. Default is true.
                 generateSecretOwnerReference:
                   type: boolean
-                  description: If true then the Certificate Authority certificates secrets owner reference is set to the Kafka object. Otherwise no owner reference is set so deleting the Kafka object won't delete the secrets. Default is true.
+                  description: If true, then the Cluster and Client CA Secrets are configured with the `ownerReference` set to the `Kafka` resource. If the Kafka resource is deleted, then the CA Secrets are also deleted. If false, the `ownerReference` is disabled. If the `Kafka` resource is deleted, then the CA Secrets are retained and available for reuse. Default is true.
                 validityDays:
                   type: integer
                   minimum: 1
@@ -5126,7 +5126,7 @@ spec:
                   description: If true then Certificate Authority certificates will be generated automatically. Otherwise the user will need to provide a Secret with the CA certificate. Default is true.
                 generateSecretOwnerReference:
                   type: boolean
-                  description: If true then the Certificate Authority certificates secrets owner reference is set to the Kafka object. Otherwise no owner reference is set so deleting the Kafka object won't delete the secrets. Default is true.
+                  description: If true, then the Cluster and Client CA Secrets are configured with the `ownerReference` set to the `Kafka` resource. If the Kafka resource is deleted, then the CA Secrets are also deleted. If false, the `ownerReference` is disabled. If the `Kafka` resource is deleted, then the CA Secrets are retained and available for reuse. Default is true.
                 validityDays:
                   type: integer
                   minimum: 1

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -6009,12 +6009,12 @@ spec:
                     a Secret with the CA certificate. Default is true.
                 generateSecretOwnerReference:
                   type: boolean
-                  description: If true, then the Cluster and Client CA Secrets are
-                    configured with the `ownerReference` set to the `Kafka` resource.
-                    If the Kafka resource is deleted, then the CA Secrets are also
-                    deleted. If false, the `ownerReference` is disabled. If the `Kafka`
-                    resource is deleted, then the CA Secrets are retained and available
-                    for reuse. Default is true.
+                  description: If `true`, the Cluster and Client CA Secrets are configured
+                    with the `ownerReference` set to the `Kafka` resource. If the
+                    `Kafka` resource is deleted when `true`, the CA Secrets are also
+                    deleted. If `false`, the `ownerReference` is disabled. If the
+                    `Kafka` resource is deleted when `false`, the CA Secrets are retained
+                    and available for reuse. Default is `true`.
                 validityDays:
                   type: integer
                   minimum: 1
@@ -6049,12 +6049,12 @@ spec:
                     a Secret with the CA certificate. Default is true.
                 generateSecretOwnerReference:
                   type: boolean
-                  description: If true, then the Cluster and Client CA Secrets are
-                    configured with the `ownerReference` set to the `Kafka` resource.
-                    If the Kafka resource is deleted, then the CA Secrets are also
-                    deleted. If false, the `ownerReference` is disabled. If the `Kafka`
-                    resource is deleted, then the CA Secrets are retained and available
-                    for reuse. Default is true.
+                  description: If `true`, the Cluster and Client CA Secrets are configured
+                    with the `ownerReference` set to the `Kafka` resource. If the
+                    `Kafka` resource is deleted when `true`, the CA Secrets are also
+                    deleted. If `false`, the `ownerReference` is disabled. If the
+                    `Kafka` resource is deleted when `false`, the CA Secrets are retained
+                    and available for reuse. Default is `true`.
                 validityDays:
                   type: integer
                   minimum: 1

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -6009,10 +6009,12 @@ spec:
                     a Secret with the CA certificate. Default is true.
                 generateSecretOwnerReference:
                   type: boolean
-                  description: If true then the Certificate Authority certificates
-                    secrets owner reference is set to the Kafka object. Otherwise
-                    no owner reference is set so deleting the Kafka object won't delete
-                    the secrets. Default is true.
+                  description: If true, then the Cluster and Client CA Secrets are
+                    configured with the `ownerReference` set to the `Kafka` resource.
+                    If the Kafka resource is deleted, then the CA Secrets are also
+                    deleted. If false, the `ownerReference` is disabled. If the `Kafka`
+                    resource is deleted, then the CA Secrets are retained and available
+                    for reuse. Default is true.
                 validityDays:
                   type: integer
                   minimum: 1
@@ -6047,10 +6049,12 @@ spec:
                     a Secret with the CA certificate. Default is true.
                 generateSecretOwnerReference:
                   type: boolean
-                  description: If true then the Certificate Authority certificates
-                    secrets owner reference is set to the Kafka object. Otherwise
-                    no owner reference is set so deleting the Kafka object won't delete
-                    the secrets. Default is true.
+                  description: If true, then the Cluster and Client CA Secrets are
+                    configured with the `ownerReference` set to the `Kafka` resource.
+                    If the Kafka resource is deleted, then the CA Secrets are also
+                    deleted. If false, the `ownerReference` is disabled. If the `Kafka`
+                    resource is deleted, then the CA Secrets are retained and available
+                    for reuse. Default is true.
                 validityDays:
                   type: integer
                   minimum: 1


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This pull request makes some text edits to the documentation for "Disabling `ownerReference` in the CA Secrets". It also edits the field descriptions that were added to the Schema Reference.

The related merged PRs are as follows:

- #3453 
- #3933 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

