### PR TITLE
CA:true

### DIFF
--- a/.spotbugs/spotbugs-exclude.xml
+++ b/.spotbugs/spotbugs-exclude.xml
@@ -17,4 +17,8 @@
   <Match>
     <Class name="~io\.fabric8\.kubernetes\.api\.model\..+(Builder|FluentImpl)(\$.*)?" />
   </Match>
+  <Match>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+    <Class name="~io\.strimzi\.certs\.OpenSslCertManager" />
+  </Match>
 </FindBugsFilter>

--- a/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
@@ -36,7 +36,8 @@ public interface CertManager {
     /**
      * Renew a new self-signed certificate, keeping the existing private key
      * @param keyFile path to the file containing the existing private key
-     * @param certFile path to the file which will contain the new self signed certificate
+     * @param certFile path to the file which contains the old certificate and
+     *                 will contain the new self signed certificate.
      * @param sbj subject information
      * @param days certificate duration
      * @throws IOException If an input or output file could not be read/written.

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -4,9 +4,6 @@
  */
 package io.strimzi.certs;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
@@ -30,7 +27,9 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import static java.util.Arrays.asList;
 
@@ -283,7 +282,7 @@ public class OpenSslCertManager implements CertManager {
     }
 
     private Path createDefaultConfig() throws IOException {
-        try (InputStream is = Objects.requireNonNull(getClass().getClassLoader().getResourceAsStream("openssl.conf"))) {
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream("openssl.conf")) {
             Path openSslConf = Files.createTempFile("openssl-", ".conf");
             Files.copy(is, openSslConf, StandardCopyOption.REPLACE_EXISTING);
             return openSslConf;

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -56,15 +56,12 @@ public class OpenSslCertManager implements CertManager {
                 "-out", certFile.getAbsolutePath(), "-keyout", keyFile.getAbsolutePath()));
 
         File sna = null;
-        Path openSslConf = null;
         if (sbj != null) {
 
             if (sbj.subjectAltNames() != null && sbj.subjectAltNames().size() > 0) {
 
                 // subject alt names need to be in an openssl configuration file
-                openSslConf = createDefaultConfig();
-
-                sna = addSubjectAltNames(openSslConf, sbj, true);
+                sna = buildConfigFile(sbj, true);
                 cmd.addAll(asList("-config", sna.toPath().toString(), "-extensions", "v3_req"));
             }
 
@@ -77,9 +74,6 @@ public class OpenSslCertManager implements CertManager {
             if (!sna.delete()) {
                 log.warn("{} cannot be deleted", sna.getName());
             }
-        }
-        if (openSslConf != null) {
-            Files.delete(openSslConf);
         }
     }
 
@@ -173,9 +167,7 @@ public class OpenSslCertManager implements CertManager {
                 "-out", certFile.getAbsolutePath()));
 
         // subject alt names need to be in an openssl configuration file
-        Path openSslConf = createDefaultConfig();
-
-        File sna = addSubjectAltNames(openSslConf, sbj, true);
+        File sna = buildConfigFile(sbj, true);
         cmd2.addAll(asList("-extfile", sna.toPath().toString(), "-extensions", "v3_req"));
 
         exec(cmd2);
@@ -183,7 +175,6 @@ public class OpenSslCertManager implements CertManager {
         if (!sna.delete()) {
             log.warn("{} cannot be deleted", sna.getName());
         }
-        Files.delete(openSslConf);
 
         if (!csrFile.delete()) {
             log.warn("{} cannot be deleted", csrFile.getName());
@@ -191,18 +182,14 @@ public class OpenSslCertManager implements CertManager {
     }
 
     /**
-     * Add subject alt names section to the provided openssl configuration file
+     * Add basic constraints and subject alt names section to the provided openssl configuration file
      *
-     * @param opensslConf openssl configuration file
      * @param sbj subject information
      * @return openssl configuration file with subject alt names added
      * @throws IOException
      */
-    private File addSubjectAltNames(Path opensslConf, Subject sbj, boolean isCa) throws IOException {
-
-        File sna = Files.createTempFile("sna-", ".conf").toFile();
-        Files.copy(opensslConf, sna.toPath(), StandardCopyOption.REPLACE_EXISTING);
-
+    private File buildConfigFile(Subject sbj, boolean isCa) throws IOException {
+        File sna = createDefaultConfig().toFile();
         try (BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(sna, true), StandardCharsets.UTF_8))) {
             if (isCa) {
                 out.append("basicConstraints = critical,CA:true,pathlen:1\n");
@@ -234,15 +221,12 @@ public class OpenSslCertManager implements CertManager {
                 "-keyout", keyFile.getAbsolutePath(), "-out", csrFile.getAbsolutePath()));
 
         File sna = null;
-        Path openSslConf = null;
         if (sbj != null) {
 
             if (sbj.subjectAltNames() != null && sbj.subjectAltNames().size() > 0) {
 
                 // subject alt names need to be in an openssl configuration file
-                openSslConf = createDefaultConfig();
-
-                sna = addSubjectAltNames(openSslConf, sbj, false);
+                sna = buildConfigFile(sbj, false);
                 cmd.addAll(asList("-config", sna.toPath().toString(), "-extensions", "v3_req"));
             }
 
@@ -255,9 +239,6 @@ public class OpenSslCertManager implements CertManager {
             if (!sna.delete()) {
                 log.warn("{} cannot be deleted", sna.getName());
             }
-        }
-        if (openSslConf != null) {
-            Files.delete(openSslConf);
         }
     }
 
@@ -279,15 +260,12 @@ public class OpenSslCertManager implements CertManager {
             "-out", crtFile.getAbsolutePath()));
 
         File sna = null;
-        Path openSslConf = null;
         if (sbj != null) {
 
             if (sbj.subjectAltNames() != null && sbj.subjectAltNames().size() > 0) {
 
                 // subject alt names need to be in an openssl configuration file
-                openSslConf = createDefaultConfig();
-
-                sna = addSubjectAltNames(openSslConf, sbj, false);
+                sna = buildConfigFile(sbj, false);
                 cmd.addAll(asList("-extfile", sna.toPath().toString(), "-extensions", "v3_req"));
             }
         }
@@ -298,9 +276,6 @@ public class OpenSslCertManager implements CertManager {
             if (!sna.delete()) {
                 log.warn("{} cannot be deleted", sna.getName());
             }
-        }
-        if (openSslConf != null) {
-            Files.delete(openSslConf);
         }
 
         // We need to remove CA serial file

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -149,11 +149,18 @@ public class OpenSslCertManager implements CertManager {
         //openssl req -new -key root.key -out newcsr.csr
         File csrFile = Files.createTempFile("renewal", ".csr").toFile();
 
-        List<String> cmd = new ArrayList<>(asList("openssl", "x509",
-                "-x509toreq",
-                "-in", certFile.getAbsolutePath(),
-                "-signkey", keyFile.getAbsolutePath(),
-                "-out", csrFile.getAbsolutePath()));
+        List<String> cmd = new ArrayList<>(asList("openssl", "req",
+                "-new",
+                "-batch",
+                "-out", csrFile.getAbsolutePath(),
+                "-key", keyFile.getAbsolutePath()));
+        if (sbj != null) {
+            if (sbj.subjectAltNames() != null && sbj.subjectAltNames().size() > 0) {
+                File sna = buildConfigFile(sbj, true);
+                cmd.addAll(asList("-config", sna.toPath().toString(), "-extensions", "v3_req"));
+            }
+            cmd.addAll(asList("-subj", sbj.toString()));
+        }
 
         exec(cmd);
 

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -145,7 +145,7 @@ public class OpenSslCertManager implements CertManager {
 
     @Override
     public void renewSelfSignedCert(File keyFile, File certFile, Subject sbj, int days) throws IOException {
-        // See https://serverfault.com/questions/306345/certification-authority-root-certificate-expiry-and-renewal
+        // See https://serverfault.com/a/501513
 
         //openssl req -new -key root.key -out newcsr.csr
         File csrFile = Files.createTempFile("renewal", ".csr").toFile();

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -192,7 +192,7 @@ public class OpenSslCertManager implements CertManager {
         File sna = createDefaultConfig().toFile();
         try (BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(sna, true), StandardCharsets.UTF_8))) {
             if (isCa) {
-                out.append("basicConstraints = critical,CA:true,pathlen:1\n");
+                out.append("basicConstraints = critical,CA:true,pathlen:0\n");
             }
             if (sbj != null) {
                 if (sbj.subjectAltNames() != null && sbj.subjectAltNames().size() > 0) {

--- a/certificate-manager/src/main/resources/openssl.conf
+++ b/certificate-manager/src/main/resources/openssl.conf
@@ -5,7 +5,7 @@ req_extensions = v3_req
 [req_distinguished_name]
 
 [v3_req]
-basicConstraints = critical,CA:true,pathlen:1
-# "subjectAltName = @alt_names" added programmatically
+# basicConstraints = critical,CA:true,pathlen:1 may be added programmatically
+# "subjectAltName = @alt_names" may be added programmatically
 
-# [alt_names] section added programmatically
+# [alt_names] section may be added programmatically

--- a/certificate-manager/src/main/resources/openssl.conf
+++ b/certificate-manager/src/main/resources/openssl.conf
@@ -5,8 +5,7 @@ req_extensions = v3_req
 [req_distinguished_name]
 
 [v3_req]
-subjectAltName = @alt_names
 basicConstraints = critical,CA:true,pathlen:1
+# "subjectAltName = @alt_names" added programmatically
 
-[alt_names]
-# added programmatically
+# [alt_names] section added programmatically

--- a/certificate-manager/src/main/resources/openssl.conf
+++ b/certificate-manager/src/main/resources/openssl.conf
@@ -6,6 +6,7 @@ req_extensions = v3_req
 
 [v3_req]
 subjectAltName = @alt_names
+basicConstraints = critical,CA:true,pathlen:1
 
 [alt_names]
 # added programmatically

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -940,7 +940,7 @@ public abstract class Ca {
 
             Base64.Decoder decoder = Base64.getDecoder();
             byte[] keyBytes = decoder.decode(caKeySecret.getData().get(CA_KEY));
-            byte[] certBytes = decoder.decode(caKeySecret.getData().get(CA_CRT));
+            byte[] certBytes = caKeySecret.getData().get(CA_CRT) != null ? decoder.decode(caKeySecret.getData().get(CA_CRT)) : new byte[0];
             File keyFile = File.createTempFile("tls", subject.commonName() + "-key");
             File certFile = File.createTempFile("tls", subject.commonName() + "-crt");
             try {

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -939,13 +939,11 @@ public abstract class Ca {
             log.debug("Renewing CA with subject={}, org={}", subject);
 
             Base64.Decoder decoder = Base64.getDecoder();
-            byte[] keyBytes = decoder.decode(caKeySecret.getData().get(CA_KEY));
-            byte[] certBytes = caKeySecret.getData().get(CA_CRT) != null ? decoder.decode(caKeySecret.getData().get(CA_CRT)) : new byte[0];
+            byte[] bytes = decoder.decode(caKeySecret.getData().get(CA_KEY));
             File keyFile = File.createTempFile("tls", subject.commonName() + "-key");
-            File certFile = File.createTempFile("tls", subject.commonName() + "-crt");
             try {
-                Files.write(keyFile.toPath(), keyBytes);
-                Files.write(certFile.toPath(), certBytes);
+                Files.write(keyFile.toPath(), bytes);
+                File certFile = File.createTempFile("tls", subject.commonName() + "-cert");
                 try {
                     File trustStoreFile = File.createTempFile("tls", subject.commonName() + "-truststore");
                     try {
@@ -953,7 +951,7 @@ public abstract class Ca {
                         certManager.renewSelfSignedCert(keyFile, certFile, subject, validityDays);
                         certManager.addCertToTrustStore(certFile, CA_CRT, trustStoreFile, trustStorePassword);
                         CertAndKey ca = new CertAndKey(
-                                keyBytes,
+                                bytes,
                                 Files.readAllBytes(certFile.toPath()),
                                 Files.readAllBytes(trustStoreFile.toPath()),
                                 null,

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -939,11 +939,13 @@ public abstract class Ca {
             log.debug("Renewing CA with subject={}, org={}", subject);
 
             Base64.Decoder decoder = Base64.getDecoder();
-            byte[] bytes = decoder.decode(caKeySecret.getData().get(CA_KEY));
+            byte[] keyBytes = decoder.decode(caKeySecret.getData().get(CA_KEY));
+            byte[] certBytes = decoder.decode(caKeySecret.getData().get(CA_CRT));
             File keyFile = File.createTempFile("tls", subject.commonName() + "-key");
+            File certFile = File.createTempFile("tls", subject.commonName() + "-crt");
             try {
-                Files.write(keyFile.toPath(), bytes);
-                File certFile = File.createTempFile("tls", subject.commonName() + "-cert");
+                Files.write(keyFile.toPath(), keyBytes);
+                Files.write(certFile.toPath(), certBytes);
                 try {
                     File trustStoreFile = File.createTempFile("tls", subject.commonName() + "-truststore");
                     try {
@@ -951,7 +953,7 @@ public abstract class Ca {
                         certManager.renewSelfSignedCert(keyFile, certFile, subject, validityDays);
                         certManager.addCertToTrustStore(certFile, CA_CRT, trustStoreFile, trustStorePassword);
                         CertAndKey ca = new CertAndKey(
-                                bytes,
+                                keyBytes,
                                 Files.readAllBytes(certFile.toPath()),
                                 Files.readAllBytes(trustStoreFile.toPath()),
                                 null,


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When renewing self-signed certs we weren't generating certs with `CA:true` or the `pathlen` constraint. Doing that requires passing an openssl config file, which previously we only did when the SAN were specified. 

This PR:

* Changes how we construct the renewed certificate using the `openssl` commands described https://serverfault.com/a/501513. Previously we used the accepted answer to that same serverfault question, but it doesn't work for passing the constraints for the new cert.
* Refactors how we build the config file so that we don't always need to have SAN specified in order for the config to be generated.
* Simplifies how the file is constructed to avoid a redundant file copy (we were writing the resource to a file, then copying it and appending the extra bits).
* Generally tries to tidy up the code a bit. 
* Adds a couple of tests and some assertions to the existing tests

Note that it also sets the `pathlen=0` where previously our CA certs got the default pathlen (which meant people could generate intermediate CAs, signed by our root CA). If there are usecases where people in fact use intermediate CAs we should change pathlen.