### PR TITLE
Update Fabric8 Kubernetes Client to 5.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,10 +82,10 @@
         <jacoco.version>0.7.9</jacoco.version>
         <license.maven.version>2.11</license.maven.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
-        <sundrio.version>0.23.1</sundrio.version>
-        <fabric8.kubernetes-client.version>5.0.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>5.0.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>5.0.0</fabric8.kubernetes-model.version>
+        <sundrio.version>0.24.2</sundrio.version>
+        <fabric8.kubernetes-client.version>5.0.2</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>5.0.2</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>5.0.2</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <okhttp.version>3.12.6</okhttp.version>
         <okio.version>1.15.0</okio.version>


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- CVE fix
- Dependency update

### Description

Fabric8 Kubernetes Client 5.0.2 brings following improvements:
* Fixes CVE-2021-20218 (not affecting Strimzi), possibly removes some dependencies (if not used by us)
* Remove javax.annotation-api
* Remove jaxb-api
* Remove jacson-module-jaxb-annotations

### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

