### PR TITLE
NEW(Tests) Loggers settings with variables #4340

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -961,8 +961,7 @@ class LoggingChangeST extends AbstractST {
                         "log4j.logger.kafka.log.LogCleaner=INFO\n" +
                         "log4j.logger.state.change.logger=TRACE\n" +
                         "log4j.logger.kafka.authorizer.logger=${kafka.my.level.string}\n" +
-                        "kafka.my.level.string=${infoLevel}\n" +
-                        "infoLevel=INFO"
+                        "kafka.my.level.string=INFO"
                         ))
                 .build();
 
@@ -1002,8 +1001,7 @@ class LoggingChangeST extends AbstractST {
                         "log4j.logger.kafka.log.LogCleaner=ERROR\n" +
                         "log4j.logger.state.change.logger=TRACE\n" +
                         "log4j.logger.kafka.authorizer.logger=${kafka.my.level.string}\n" +
-                        "kafka.my.level.string=${errorLevel}\n" +
-                        "errorLevel=ERROR"
+                        "kafka.my.level.string=ERROR"
                         ))
                 .build();
 
@@ -1037,8 +1035,7 @@ class LoggingChangeST extends AbstractST {
                         "log4j.logger.kafka.log.LogCleaner=ERROR\n" +
                         "log4j.logger.state.change.logger=TRACE\n" +
                         "log4j.logger.kafka.authorizer.logger=${kafka.my.level.string}\n" +
-                        "kafka.my.level.string=${debugLevel}\n" +
-                        "debugLevel=DEBUG"
+                        "kafka.my.level.string=DEBUG}"
                 ))
                 .build();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.BRIDGE;
@@ -961,7 +960,10 @@ class LoggingChangeST extends AbstractST {
                         "log4j.logger.kafka.controller=TRACE\n" +
                         "log4j.logger.kafka.log.LogCleaner=INFO\n" +
                         "log4j.logger.state.change.logger=TRACE\n" +
-                        "log4j.logger.kafka.authorizer.logger=INFO"))
+                        "log4j.logger.kafka.authorizer.logger=${kafka.my.level.string}\n" +
+                        "kafka.my.level.string=${infoLevel}\n" +
+                        "infoLevel=INFO"
+                        ))
                 .build();
 
         kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMap);
@@ -999,7 +1001,10 @@ class LoggingChangeST extends AbstractST {
                         "log4j.logger.kafka.controller=ERROR\n" +
                         "log4j.logger.kafka.log.LogCleaner=ERROR\n" +
                         "log4j.logger.state.change.logger=TRACE\n" +
-                        "log4j.logger.kafka.authorizer.logger=ERROR"))
+                        "log4j.logger.kafka.authorizer.logger=${kafka.my.level.string}\n" +
+                        "kafka.my.level.string=${errorLevel}\n" +
+                        "errorLevel=ERROR"
+                        ))
                 .build();
 
         kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMap);
@@ -1031,7 +1036,10 @@ class LoggingChangeST extends AbstractST {
                         "log4j.logger.kafka.controller=ERROR\n" +
                         "log4j.logger.kafka.log.LogCleaner=ERROR\n" +
                         "log4j.logger.state.change.logger=TRACE\n" +
-                        "log4j.logger.kafka.authorizer.logger=DEBUG"))
+                        "log4j.logger.kafka.authorizer.logger=${kafka.my.level.string}\n" +
+                        "kafka.my.level.string=${debugLevel}\n" +
+                        "debugLevel=DEBUG"
+                ))
                 .build();
 
         kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMap);
@@ -1111,60 +1119,6 @@ class LoggingChangeST extends AbstractST {
         );
 
         assertThat("MirrorMaker2 pod should not roll", DeploymentUtils.depSnapshot(KafkaMirrorMaker2Resources.deploymentName(clusterName)), equalTo(mm2Snapshot));
-    }
-
-    @Test
-    void testUseLoggingVarsBeforeDefinition() {
-        String myCustomLevel = "WARN";
-        Map<String, String> loggersConfigKafka = new LinkedHashMap<>() {
-            {
-                put("log4j.rootLogger", "${kafka.root.logger.level}, CONSOLE");
-                put("log4j.logger.org.apache.kafka", "${kafka.my.level.string}");
-                put("log4j.appender.CONSOLE", "org.apache.log4j.ConsoleAppender");
-                put("log4j.appender.CONSOLE.layout", "net.logstash.log4j.JSONEventLayoutV1");
-
-                put("log4j.logger.org.I0Itec.zkclient.ZkClient", "${kafka.my.level.string}");
-                put("log4j.logger.org.apache.zookeeper", "${kafka.my.level.string}");
-                put("log4j.logger.kafka", "${kafka.my.level.string}");
-                put("log4j.logger.kafka.request.logger", "${kafka.my.level.string}, CONSOLE");
-                put("log4j.logger.kafka.network.Processor", "OFF");
-                put("log4j.logger.kafka.server.KafkaApis", "OFF");
-                put("log4j.logger.kafka.network.RequestChannel$", "WARN");
-                put("log4j.logger.kafka.controller", "${kafka.my.level.string}");
-                put("log4j.logger.kafka.log.LogCleaner", "${kafka.my.level.string}");
-                put("log4j.logger.state.change.logger", "TRACE");
-                put("log4j.logger.kafka.authorizer.logger", "${kafka.my.level.string}");
-
-                put("kafka.root.logger.level", "DEBUG");
-                put("kafka.my.level.string", myCustomLevel);
-            }
-        };
-
-        KafkaResource.createAndWaitForReadiness(KafkaResource.kafkaEphemeral(clusterName, 1, 1)
-                .editSpec()
-                    .editKafka()
-                        .withNewInlineLogging()
-                            .addToLoggers(loggersConfigKafka)
-                        .endInlineLogging()
-                .endKafka()
-                .endSpec()
-                .build());
-
-        // We have to check dynamic kafka logs, and not log4j.properties file(s) to get real logging levels
-        String logConfigOutput =  cmdKubeClient().execInPodContainer(KafkaResources.kafkaPodName(clusterName, 0),
-                        "kafka", "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --entity-type broker-loggers --entity-name 0").out();
-
-        assertThat("Expected kafka root logger is incorrect!!", logConfigOutput.contains("root=DEBUG"));
-
-        String expectedString;
-        for (String key : loggersConfigKafka.keySet()) {
-            if (loggersConfigKafka.get(key).contains("${kafka.my.level.string}")) {
-                LOGGER.info("Checking " + key + " value:" + loggersConfigKafka.get(key));
-                expectedString = key.substring("log4j.logger.".length()) + "=" + myCustomLevel;
-                String msg = String.format("Wrong logging key=value: '%s'", expectedString);
-                assertThat(msg, logConfigOutput.contains(expectedString));
-            }
-        }
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.BRIDGE;
@@ -1110,6 +1111,60 @@ class LoggingChangeST extends AbstractST {
         );
 
         assertThat("MirrorMaker2 pod should not roll", DeploymentUtils.depSnapshot(KafkaMirrorMaker2Resources.deploymentName(clusterName)), equalTo(mm2Snapshot));
+    }
+
+    @Test
+    void testUseLoggingVarsBeforeDefinition() {
+        String myCustomLevel = "WARN";
+        Map<String, String> loggersConfigKafka = new LinkedHashMap<>() {
+            {
+                put("log4j.rootLogger", "${kafka.root.logger.level}, CONSOLE");
+                put("log4j.logger.org.apache.kafka", "${kafka.my.level.string}");
+                put("log4j.appender.CONSOLE", "org.apache.log4j.ConsoleAppender");
+                put("log4j.appender.CONSOLE.layout", "net.logstash.log4j.JSONEventLayoutV1");
+
+                put("log4j.logger.org.I0Itec.zkclient.ZkClient", "${kafka.my.level.string}");
+                put("log4j.logger.org.apache.zookeeper", "${kafka.my.level.string}");
+                put("log4j.logger.kafka", "${kafka.my.level.string}");
+                put("log4j.logger.kafka.request.logger", "${kafka.my.level.string}, CONSOLE");
+                put("log4j.logger.kafka.network.Processor", "OFF");
+                put("log4j.logger.kafka.server.KafkaApis", "OFF");
+                put("log4j.logger.kafka.network.RequestChannel$", "WARN");
+                put("log4j.logger.kafka.controller", "${kafka.my.level.string}");
+                put("log4j.logger.kafka.log.LogCleaner", "${kafka.my.level.string}");
+                put("log4j.logger.state.change.logger", "TRACE");
+                put("log4j.logger.kafka.authorizer.logger", "${kafka.my.level.string}");
+
+                put("kafka.root.logger.level", "DEBUG");
+                put("kafka.my.level.string", myCustomLevel);
+            }
+        };
+
+        KafkaResource.createAndWaitForReadiness(KafkaResource.kafkaEphemeral(clusterName, 1, 1)
+                .editSpec()
+                    .editKafka()
+                        .withNewInlineLogging()
+                            .addToLoggers(loggersConfigKafka)
+                        .endInlineLogging()
+                .endKafka()
+                .endSpec()
+                .build());
+
+        // We have to check dynamic kafka logs, and not log4j.properties file(s) to get real logging levels
+        String logConfigOutput =  cmdKubeClient().execInPodContainer(KafkaResources.kafkaPodName(clusterName, 0),
+                        "kafka", "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --entity-type broker-loggers --entity-name 0").out();
+
+        assertThat("Expected kafka root logger is incorrect!!", logConfigOutput.contains("root=DEBUG"));
+
+        String expectedString;
+        for (String key : loggersConfigKafka.keySet()) {
+            if (loggersConfigKafka.get(key).contains("${kafka.my.level.string}")) {
+                LOGGER.info("Checking " + key + " value:" + loggersConfigKafka.get(key));
+                expectedString = key.substring("log4j.logger.".length()) + "=" + myCustomLevel;
+                String msg = String.format("Wrong logging key=value: '%s'", expectedString);
+                assertThat(msg, logConfigOutput.contains(expectedString));
+            }
+        }
     }
 
     @BeforeAll


### PR DESCRIPTION
LoggingChangeST#testUseLoggingVarsBeforeDefinition

This is a follow-up for PR #4340 which contains SystemTest, with logger variables defined later in file, as used.
See PR for more details.


- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging


UPD: I have removed original - new test, and updated existing one instead.
