### PR TITLE
[DOC] config for log message and inter-broker protocol versions

### DIFF
--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -24,7 +24,7 @@ This procedure shows only some of the possible configuration options, but those 
 .Kafka versions
 
 The `log.message.format.version` and `inter.broker.protocol.version` properties for the Kafka `config` must be the versions supported by the specified Kafka version (`spec.kafka.version`).
-The properties represent the log format version appended to messages and the version of protocol used in a Kafka cluster.
+The properties represent the log format version appended to messages and the version of Kafka protocol used in a Kafka cluster.
 Updates to these properties are required when upgrading your Kafka version.
 For more information, see link:{BookURLDeploying}#assembly-upgrading-kafka-versions-str[Upgrading Kafka] in the _Deploying and Upgrading Strimzi_ guide.
 

--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -23,7 +23,7 @@ This procedure shows only some of the possible configuration options, but those 
 
 .Kafka versions
 
-The `log.message.format.version` and `inter.broker.protocol.version` properties for the Kafka `config` must be the versions supported by the specified Kafka version (`spec-kafka.version`).
+The `log.message.format.version` and `inter.broker.protocol.version` properties for the Kafka `config` must be the versions supported by the specified Kafka version (`spec.kafka.version`).
 The properties represent the log format version appended to messages and the version of protocol used in a Kafka cluster.
 Updates to these properties are required when upgrading your Kafka version.
 For more information, see link:{BookURLDeploying}#assembly-upgrading-kafka-versions-str[Upgrading Kafka] in the _Deploying and Upgrading Strimzi_ guide.

--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -21,6 +21,13 @@ This procedure shows only some of the possible configuration options, but those 
 * Metrics
 * Cruise Control for cluster rebalancing
 
+.Kafka versions
+
+The `log.message.format.version` and `inter.broker.protocol.version` properties for the Kafka `config` must be the versions supported by the specified Kafka version (`spec-kafka.version`).
+The properties represent the log format version appended to messages and the version of protocol used in a Kafka cluster.
+Updates to these properties are required when upgrading your Kafka version.
+For more information, see link:{BookURLDeploying}#assembly-upgrading-kafka-versions-str[Upgrading Kafka] in the _Deploying and Upgrading Strimzi_ guide.
+
 .Prerequisites
 
 * An OpenShift cluster
@@ -46,7 +53,7 @@ metadata:
 spec:
   kafka:
     replicas: 3 <1>
-    version: {ProductVersion} <2>
+    version: {DefaultKafkaVersion} <2>
     logging: <3>
       type: inline
       loggers:
@@ -97,6 +104,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
+      log.message.format.version: {LogMsgVersHigher}
+      inter.broker.protocol.version: {LogMsgVersHigher}
       ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <19>
       ssl.enabled.protocols: "TLSv1.2"
       ssl.protocol: "TLSv1.2"

--- a/documentation/modules/deploying/proc-deploy-kafka-cluster.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-cluster.adoc
@@ -25,17 +25,29 @@ acquired using a `PersistentVolumeClaim` to make it independent of the actual ty
 ifdef::Kubernetes[HostPath volumes on Minikube or]
 Amazon EBS volumes in Amazon AWS deployments without any changes in the YAML files. The `PersistentVolumeClaim` can use a `StorageClass` to trigger automatic volume provisioning.
 
+The example YAML files specify the latest supported Kafka version, and configuration for its supported log message format version and inter-broker protocol version.
+Updates to these properties are required when xref:assembly-upgrading-kafka-versions-str[upgrading Kafka].
+
 The example clusters are named `my-cluster` by default.
 The cluster name is defined by the name of the resource and cannot be changed after the cluster has been deployed.
 To change the cluster name before you deploy the cluster, edit the `Kafka.metadata.name` property of the `Kafka` resource in the relevant YAML file.
 
+.Default cluster name and specified Kafka versions
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
 kind: Kafka
 metadata:
   name: my-cluster
-# ...
+spec:
+  kafka:
+    version: {DefaultKafkaVersion}
+    #...
+    config:
+      #...
+      log.message.format.version: {LogMsgVersHigher}
+      inter.broker.protocol.version: {LogMsgVersHigher}
+  # ...
 ----
 
 For more information about configuring the `Kafka` resource, see link:{BookURLUsing}#assembly-config-kafka-str[Kafka cluster configuration^] in the _Using Strimzi_ guide.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Updated the following sections to describe and show `inter.broker.protocol.version` and `log.message.format.version`, which is now included in examples:

*  _Configuring Kafka_ procedure in _Using_ guide
*  _Deploying the Kafka cluster_ in the _Deploying_ guide

Note on their importance in upgrading

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

