### PR TITLE
[DOC] Use tls: true in Ingress examples

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
@@ -30,7 +30,7 @@ spec:
       - name: external2
         port: 9095
         type: ingress
-        tls: false
+        tls: true
         authentication:
           type: tls
         configuration:
@@ -143,7 +143,7 @@ spec:
       - name: external2
         port: 9095
         type: ingress
-        tls: false
+        tls: true
         authentication:
           type: tls
         configuration:

--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration.adoc
@@ -73,7 +73,7 @@ listeners:
   - name: external
     port: 9094
     type: ingress
-    tls: false
+    tls: true
     configuration:
       class: nginx-internal
     # ...


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Ingress type listeners require TLS to be always enabled because it uses TLS passthrough. So we should use `tls: true` in all the examples.

### Checklist

- [x] Update documentation