### PR TITLE
Make it possible to label individual Ingresses, Routes or services for each listener

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfigurationBootstrap.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfigurationBootstrap.java
@@ -35,6 +35,7 @@ public class GenericKafkaListenerConfigurationBootstrap implements Serializable,
     private List<String> alternativeNames;
     private String host;
     private Map<String, String> annotations = new HashMap<>(0);
+    private Map<String, String> labels = new HashMap<>(0);
     private Integer nodePort;
     private String loadBalancerIP;
 
@@ -63,9 +64,9 @@ public class GenericKafkaListenerConfigurationBootstrap implements Serializable,
         this.host = host;
     }
 
-    @Description("Annotations that will be added to the `Ingress` or `Service` resource. " +
+    @Description("Annotations that will be added to the `Ingress`, `Route`, or `Service` resource. " +
             "You can use this field to configure DNS providers such as External DNS. " +
-            "This field can be used only with `loadbalancer`, `nodeport`, or `ingress` type listeners.")
+            "This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getAnnotations() {
         return annotations;
@@ -73,6 +74,17 @@ public class GenericKafkaListenerConfigurationBootstrap implements Serializable,
 
     public void setAnnotations(Map<String, String> annotations) {
         this.annotations = annotations;
+    }
+
+    @Description("Labels that will be added to the `Ingress`, `Route`, or `Service` resource. " +
+            "This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Map<String, String> labels) {
+        this.labels = labels;
     }
 
     @Description("Node port for the bootstrap service. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfigurationBroker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfigurationBroker.java
@@ -39,6 +39,7 @@ public class GenericKafkaListenerConfigurationBroker implements Serializable, Un
     private Integer advertisedPort;
     private String host;
     private Map<String, String> annotations = new HashMap<>(0);
+    private Map<String, String> labels = new HashMap<>(0);
     private Integer nodePort;
     private String loadBalancerIP;
 
@@ -75,7 +76,6 @@ public class GenericKafkaListenerConfigurationBroker implements Serializable, Un
         this.advertisedPort = advertisedPort;
     }
 
-
     @Description("The broker host. " +
             "This field will be used in the Ingress resource or in the Route resource to specify the desired hostname. " +
             "This field can be used only with `route` (optional) or `ingress` (required) type listeners.")
@@ -98,6 +98,17 @@ public class GenericKafkaListenerConfigurationBroker implements Serializable, Un
 
     public void setAnnotations(Map<String, String> annotations) {
         this.annotations = annotations;
+    }
+
+    @Description("Labels that will be added to the `Ingress`, `Route`, or `Service` resource. " +
+            "This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Map<String, String> labels) {
+        this.labels = labels;
     }
 
     @Description("Node port for the per-broker service. " +

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
@@ -492,10 +492,18 @@ spec:
                                   x-kubernetes-preserve-unknown-fields: true
                                   type: object
                                   description: Annotations that will be added to the
-                                    `Ingress` or `Service` resource. You can use this
-                                    field to configure DNS providers such as External
-                                    DNS. This field can be used only with `loadbalancer`,
-                                    `nodeport`, or `ingress` type listeners.
+                                    `Ingress`, `Route`, or `Service` resource. You
+                                    can use this field to configure DNS providers
+                                    such as External DNS. This field can be used only
+                                    with `loadbalancer`, `nodeport`, `route`, or `ingress`
+                                    type listeners.
+                                labels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: Labels that will be added to the `Ingress`,
+                                    `Route`, or `Service` resource. This field can
+                                    be used only with `loadbalancer`, `nodeport`,
+                                    `route`, or `ingress` type listeners.
                               description: Bootstrap configuration.
                             brokers:
                               type: array
@@ -546,6 +554,13 @@ spec:
                                       as External DNS. This field can be used only
                                       with `loadbalancer`, `nodeport`, or `ingress`
                                       type listeners.
+                                  labels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                    description: Labels that will be added to the
+                                      `Ingress`, `Route`, or `Service` resource. This
+                                      field can be used only with `loadbalancer`,
+                                      `nodeport`, `route`, or `ingress` type listeners.
                                 required:
                                 - broker
                               description: Per-broker configurations.

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
@@ -489,10 +489,17 @@ spec:
                                 annotations:
                                   type: object
                                   description: Annotations that will be added to the
-                                    `Ingress` or `Service` resource. You can use this
-                                    field to configure DNS providers such as External
-                                    DNS. This field can be used only with `loadbalancer`,
-                                    `nodeport`, or `ingress` type listeners.
+                                    `Ingress`, `Route`, or `Service` resource. You
+                                    can use this field to configure DNS providers
+                                    such as External DNS. This field can be used only
+                                    with `loadbalancer`, `nodeport`, `route`, or `ingress`
+                                    type listeners.
+                                labels:
+                                  type: object
+                                  description: Labels that will be added to the `Ingress`,
+                                    `Route`, or `Service` resource. This field can
+                                    be used only with `loadbalancer`, `nodeport`,
+                                    `route`, or `ingress` type listeners.
                               description: Bootstrap configuration.
                             brokers:
                               type: array
@@ -542,6 +549,12 @@ spec:
                                       as External DNS. This field can be used only
                                       with `loadbalancer`, `nodeport`, or `ingress`
                                       type listeners.
+                                  labels:
+                                    type: object
+                                    description: Labels that will be added to the
+                                      `Ingress`, `Route`, or `Service` resource. This
+                                      field can be used only with `loadbalancer`,
+                                      `nodeport`, `route`, or `ingress` type listeners.
                                 required:
                                 - broker
                               description: Per-broker configurations.
@@ -6556,11 +6569,17 @@ spec:
                                   annotations:
                                     type: object
                                     description: Annotations that will be added to
-                                      the `Ingress` or `Service` resource. You can
-                                      use this field to configure DNS providers such
-                                      as External DNS. This field can be used only
-                                      with `loadbalancer`, `nodeport`, or `ingress`
-                                      type listeners.
+                                      the `Ingress`, `Route`, or `Service` resource.
+                                      You can use this field to configure DNS providers
+                                      such as External DNS. This field can be used
+                                      only with `loadbalancer`, `nodeport`, `route`,
+                                      or `ingress` type listeners.
+                                  labels:
+                                    type: object
+                                    description: Labels that will be added to the
+                                      `Ingress`, `Route`, or `Service` resource. This
+                                      field can be used only with `loadbalancer`,
+                                      `nodeport`, `route`, or `ingress` type listeners.
                                 description: Bootstrap configuration.
                               brokers:
                                 type: array
@@ -6610,6 +6629,12 @@ spec:
                                         such as External DNS. This field can be used
                                         only with `loadbalancer`, `nodeport`, or `ingress`
                                         type listeners.
+                                    labels:
+                                      type: object
+                                      description: Labels that will be added to the
+                                        `Ingress`, `Route`, or `Service` resource.
+                                        This field can be used only with `loadbalancer`,
+                                        `nodeport`, `route`, or `ingress` type listeners.
                                   required:
                                   - broker
                                 description: Per-broker configurations.
@@ -14841,11 +14866,17 @@ spec:
                                   annotations:
                                     type: object
                                     description: Annotations that will be added to
-                                      the `Ingress` or `Service` resource. You can
-                                      use this field to configure DNS providers such
-                                      as External DNS. This field can be used only
-                                      with `loadbalancer`, `nodeport`, or `ingress`
-                                      type listeners.
+                                      the `Ingress`, `Route`, or `Service` resource.
+                                      You can use this field to configure DNS providers
+                                      such as External DNS. This field can be used
+                                      only with `loadbalancer`, `nodeport`, `route`,
+                                      or `ingress` type listeners.
+                                  labels:
+                                    type: object
+                                    description: Labels that will be added to the
+                                      `Ingress`, `Route`, or `Service` resource. This
+                                      field can be used only with `loadbalancer`,
+                                      `nodeport`, `route`, or `ingress` type listeners.
                                 description: Bootstrap configuration.
                               brokers:
                                 type: array
@@ -14895,6 +14926,12 @@ spec:
                                         such as External DNS. This field can be used
                                         only with `loadbalancer`, `nodeport`, or `ingress`
                                         type listeners.
+                                    labels:
+                                      type: object
+                                      description: Labels that will be added to the
+                                        `Ingress`, `Route`, or `Service` resource.
+                                        This field can be used only with `loadbalancer`,
+                                        `nodeport`, `route`, or `ingress` type listeners.
                                   required:
                                   - broker
                                 description: Per-broker configurations.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -843,7 +843,7 @@ public class KafkaCluster extends AbstractModel {
                     serviceName,
                     ListenersUtils.serviceType(listener),
                     ports,
-                    getLabelsWithStrimziName(name, templateExternalBootstrapServiceLabels),
+                    getLabelsWithStrimziName(name, Util.mergeLabelsOrAnnotations(templateExternalBootstrapServiceLabels, ListenersUtils.bootstrapLabels(listener))),
                     getSelectorLabels(),
                     Util.mergeLabelsOrAnnotations(ListenersUtils.bootstrapAnnotations(listener), templateExternalBootstrapServiceAnnotations)
             );
@@ -907,7 +907,7 @@ public class KafkaCluster extends AbstractModel {
                     serviceName,
                     ListenersUtils.serviceType(listener),
                     ports,
-                    getLabelsWithStrimziName(name, templatePerPodServiceLabels),
+                    getLabelsWithStrimziName(name, Util.mergeLabelsOrAnnotations(templatePerPodServiceLabels, ListenersUtils.brokerLabels(listener, pod))),
                     selector,
                     Util.mergeLabelsOrAnnotations(ListenersUtils.brokerAnnotations(listener, pod), templatePerPodServiceAnnotations)
             );
@@ -960,8 +960,8 @@ public class KafkaCluster extends AbstractModel {
             Route route = new RouteBuilder()
                     .withNewMetadata()
                         .withName(routeName)
-                        .withLabels(getLabelsWithStrimziName(name, templateExternalBootstrapRouteLabels).toMap())
-                        .withAnnotations(templateExternalBootstrapRouteAnnotations)
+                        .withLabels(Util.mergeLabelsOrAnnotations(getLabelsWithStrimziName(name, templateExternalBootstrapRouteLabels).toMap(), ListenersUtils.bootstrapLabels(listener)))
+                        .withAnnotations(Util.mergeLabelsOrAnnotations(templateExternalBootstrapRouteAnnotations, ListenersUtils.bootstrapAnnotations(listener)))
                         .withNamespace(namespace)
                         .withOwnerReferences(createOwnerReference())
                     .endMetadata()
@@ -1005,8 +1005,8 @@ public class KafkaCluster extends AbstractModel {
             Route route = new RouteBuilder()
                     .withNewMetadata()
                         .withName(routeName)
-                        .withLabels(getLabelsWithStrimziName(name, templatePerPodRouteLabels).toMap())
-                        .withAnnotations(templatePerPodRouteAnnotations)
+                        .withLabels(getLabelsWithStrimziName(name, Util.mergeLabelsOrAnnotations(templatePerPodRouteLabels, ListenersUtils.brokerLabels(listener, pod))).toMap())
+                        .withAnnotations(Util.mergeLabelsOrAnnotations(templatePerPodRouteAnnotations, ListenersUtils.brokerAnnotations(listener, pod)))
                         .withNamespace(namespace)
                         .withOwnerReferences(createOwnerReference())
                     .endMetadata()
@@ -1074,7 +1074,7 @@ public class KafkaCluster extends AbstractModel {
             Ingress ingress = new IngressBuilder()
                     .withNewMetadata()
                         .withName(ingressName)
-                        .withLabels(getLabelsWithStrimziName(name, templateExternalBootstrapIngressLabels).toMap())
+                        .withLabels(getLabelsWithStrimziName(name, Util.mergeLabelsOrAnnotations(templateExternalBootstrapIngressLabels, ListenersUtils.bootstrapLabels(listener))).toMap())
                         .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(ingressClass), templateExternalBootstrapIngressAnnotations, dnsAnnotations))
                         .withNamespace(namespace)
                         .withOwnerReferences(createOwnerReference())
@@ -1129,7 +1129,7 @@ public class KafkaCluster extends AbstractModel {
             Ingress ingress = new IngressBuilder()
                     .withNewMetadata()
                         .withName(ingressName)
-                        .withLabels(getLabelsWithStrimziName(name, templatePerPodIngressLabels).toMap())
+                        .withLabels(getLabelsWithStrimziName(name, Util.mergeLabelsOrAnnotations(templatePerPodIngressLabels, ListenersUtils.brokerLabels(listener, pod))).toMap())
                         .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(ingressClass), templatePerPodIngressAnnotations, dnsAnnotations))
                         .withNamespace(namespace)
                         .withOwnerReferences(createOwnerReference())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -415,6 +415,42 @@ public class ListenersUtils {
     }
 
     /**
+     * Finds bootstrap service labels
+     *
+     * @param listener  Listener for which the load balancer IP should be found
+     * @return          Map with labels or empty map if not specified
+     */
+    public static Map<String, String> bootstrapLabels(GenericKafkaListener listener)    {
+        if (listener.getConfiguration() != null
+                && listener.getConfiguration().getBootstrap() != null
+                && listener.getConfiguration().getBootstrap().getLabels() != null) {
+            return listener.getConfiguration().getBootstrap().getLabels();
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Finds broker service labels
+     *
+     * @param listener  Listener for which the load balancer IP should be found
+     * @param pod       Pod ID for which we should get the configuration option
+     * @return          Map with labels or empty map if not specified
+     */
+    public static Map<String, String> brokerLabels(GenericKafkaListener listener, int pod)    {
+        if (listener.getConfiguration() != null
+                && listener.getConfiguration().getBrokers() != null) {
+            return listener.getConfiguration().getBrokers().stream()
+                    .filter(broker -> broker != null && broker.getBroker() != null && broker.getBroker() == pod && broker.getLabels() != null)
+                    .map(GenericKafkaListenerConfigurationBroker::getLabels)
+                    .findAny()
+                    .orElse(Collections.emptyMap());
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
      * Finds bootstrap host
      *
      * @param listener  Listener for which the host should be found

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
@@ -106,6 +106,7 @@ public class ListenersUtilsTest {
                     .withAlternativeNames(asList("my-route-1", "my-route-2"))
                     .withHost("my-route-host")
                     .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                    .withLabels(Collections.singletonMap("label", "label-value"))
                 .endBootstrap()
                 .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder()
                                 .withBroker(0)
@@ -113,6 +114,7 @@ public class ListenersUtilsTest {
                                 .withAdvertisedPort(9092)
                                 .withHost("my-route-host-1")
                                 .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                                .withLabels(Collections.singletonMap("label", "label-value"))
                                 .build(),
                         new GenericKafkaListenerConfigurationBrokerBuilder()
                                 .withBroker(1)
@@ -120,6 +122,7 @@ public class ListenersUtilsTest {
                                 .withAdvertisedPort(9092)
                                 .withHost("my-route-host-2")
                                 .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                                .withLabels(Collections.singletonMap("label", "label-value"))
                                 .build())
             .endConfiguration()
             .build();
@@ -145,6 +148,7 @@ public class ListenersUtilsTest {
                     .withAlternativeNames(asList("my-np-1", "my-np-2"))
                     .withNodePort(32189)
                     .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                    .withLabels(Collections.singletonMap("label", "label-value"))
                 .endBootstrap()
                 .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder()
                                 .withBroker(0)
@@ -152,6 +156,7 @@ public class ListenersUtilsTest {
                                 .withAdvertisedPort(9092)
                                 .withNodePort(32190)
                                 .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                                .withLabels(Collections.singletonMap("label", "label-value"))
                                 .build(),
                         new GenericKafkaListenerConfigurationBrokerBuilder()
                                 .withBroker(1)
@@ -159,6 +164,7 @@ public class ListenersUtilsTest {
                                 .withAdvertisedPort(9092)
                                 .withNodePort(32191)
                                 .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                                .withLabels(Collections.singletonMap("label", "label-value"))
                                 .build())
             .endConfiguration()
             .build();
@@ -189,6 +195,7 @@ public class ListenersUtilsTest {
                     .withAlternativeNames(asList("my-lb-1", "my-lb-2"))
                     .withLoadBalancerIP("130.211.204.1")
                     .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                    .withLabels(Collections.singletonMap("label", "label-value"))
                 .endBootstrap()
                 .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder()
                                 .withBroker(0)
@@ -196,6 +203,7 @@ public class ListenersUtilsTest {
                                 .withAdvertisedPort(19092)
                                 .withLoadBalancerIP("130.211.204.1")
                                 .withAnnotations(Collections.singletonMap("dns-anno-1", "dns-value"))
+                                .withLabels(Collections.singletonMap("label-1", "label-value"))
                                 .build(),
                         new GenericKafkaListenerConfigurationBrokerBuilder()
                                 .withBroker(1)
@@ -203,6 +211,7 @@ public class ListenersUtilsTest {
                                 .withAdvertisedPort(29092)
                                 .withLoadBalancerIP("130.211.204.1")
                                 .withAnnotations(Collections.singletonMap("dns-anno-2", "dns-value"))
+                                .withLabels(Collections.singletonMap("label-2", "label-value"))
                                 .build())
             .endConfiguration()
             .build();
@@ -238,6 +247,7 @@ public class ListenersUtilsTest {
                     .withAlternativeNames(asList("my-ing-1", "my-ing-2"))
                     .withHost("my-ing-host")
                     .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                    .withLabels(Collections.singletonMap("label", "label-value"))
                 .endBootstrap()
                 .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder()
                                 .withBroker(0)
@@ -245,6 +255,7 @@ public class ListenersUtilsTest {
                                 .withAdvertisedPort(9092)
                                 .withHost("my-host")
                                 .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                                .withLabels(Collections.singletonMap("label", "label-value"))
                                 .build(),
                         new GenericKafkaListenerConfigurationBrokerBuilder()
                                 .withBroker(1)
@@ -252,6 +263,7 @@ public class ListenersUtilsTest {
                                 .withAdvertisedPort(9092)
                                 .withHost("my-host")
                                 .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                                .withLabels(Collections.singletonMap("label", "label-value"))
                                 .build())
             .endConfiguration()
             .build();
@@ -451,17 +463,24 @@ public class ListenersUtilsTest {
     }
 
     @Test
-    public void testBootstrapDnsAnnotations() {
+    public void testBootstrapLabelsAndAnnotations() {
         assertThat(ListenersUtils.bootstrapAnnotations(newLoadBalancer), is(emptyMap()));
         assertThat(ListenersUtils.bootstrapAnnotations(newLoadBalancer2), is(Collections.singletonMap("dns-anno", "dns-value")));
         assertThat(ListenersUtils.bootstrapAnnotations(oldPlain), is(emptyMap()));
         assertThat(ListenersUtils.bootstrapAnnotations(newTls), is(emptyMap()));
         assertThat(ListenersUtils.bootstrapAnnotations(newNodePort), is(emptyMap()));
         assertThat(ListenersUtils.bootstrapAnnotations(newNodePort3), is(emptyMap()));
+
+        assertThat(ListenersUtils.bootstrapLabels(newLoadBalancer), is(emptyMap()));
+        assertThat(ListenersUtils.bootstrapLabels(newLoadBalancer2), is(Collections.singletonMap("label", "label-value")));
+        assertThat(ListenersUtils.bootstrapLabels(oldPlain), is(emptyMap()));
+        assertThat(ListenersUtils.bootstrapLabels(newTls), is(emptyMap()));
+        assertThat(ListenersUtils.bootstrapLabels(newNodePort), is(emptyMap()));
+        assertThat(ListenersUtils.bootstrapLabels(newNodePort3), is(emptyMap()));
     }
 
     @Test
-    public void testBrokerDnsAnnotations() {
+    public void testBrokerLabelsAndAnnotations() {
         assertThat(ListenersUtils.brokerAnnotations(newLoadBalancer, 1), is(emptyMap()));
         assertThat(ListenersUtils.brokerAnnotations(newLoadBalancer2, 0), is(Collections.singletonMap("dns-anno-1", "dns-value")));
         assertThat(ListenersUtils.brokerAnnotations(newLoadBalancer2, 1), is(Collections.singletonMap("dns-anno-2", "dns-value")));
@@ -470,6 +489,15 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.brokerAnnotations(newTls, 1), is(emptyMap()));
         assertThat(ListenersUtils.brokerAnnotations(newNodePort, 1), is(emptyMap()));
         assertThat(ListenersUtils.brokerAnnotations(newNodePort3, 1), is(emptyMap()));
+
+        assertThat(ListenersUtils.brokerLabels(newLoadBalancer, 1), is(emptyMap()));
+        assertThat(ListenersUtils.brokerLabels(newLoadBalancer2, 0), is(Collections.singletonMap("label-1", "label-value")));
+        assertThat(ListenersUtils.brokerLabels(newLoadBalancer2, 1), is(Collections.singletonMap("label-2", "label-value")));
+        assertThat(ListenersUtils.brokerLabels(newLoadBalancer2, 2), is(emptyMap()));
+        assertThat(ListenersUtils.brokerLabels(oldPlain, 1), is(emptyMap()));
+        assertThat(ListenersUtils.brokerLabels(newTls, 1), is(emptyMap()));
+        assertThat(ListenersUtils.brokerLabels(newNodePort, 1), is(emptyMap()));
+        assertThat(ListenersUtils.brokerLabels(newNodePort3, 1), is(emptyMap()));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -241,6 +241,7 @@ public class ListenersValidatorTest {
                         .withNodePort(32189)
                         .withHost("my-host")
                         .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                        .withLabels(Collections.singletonMap("label", "label-value"))
                     .endBootstrap()
                     .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder()
                                     .withBroker(0)
@@ -250,6 +251,7 @@ public class ListenersValidatorTest {
                                     .withNodePort(32189)
                                     .withHost("my-host")
                                     .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                                    .withLabels(Collections.singletonMap("label", "label-value"))
                                     .build(),
                             new GenericKafkaListenerConfigurationBrokerBuilder()
                                     .withBroker(1)
@@ -259,6 +261,7 @@ public class ListenersValidatorTest {
                                     .withNodePort(32189)
                                     .withHost("my-host")
                                     .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                                    .withLabels(Collections.singletonMap("label", "label-value"))
                                     .build())
                 .endConfiguration()
                 .build();
@@ -273,11 +276,13 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure bootstrap.host because it is not Route ot Ingress based listener",
                 "listener " + name + " cannot configure bootstrap.loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure bootstrap.nodePort because it is not NodePort based listener",
-                "listener " + name + " cannot configure bootstrap.dnsAnnotations because it is not LoadBalancer, NodePort or Ingress based listener",
+                "listener " + name + " cannot configure bootstrap.annotations because it is not LoadBalancer, NodePort, Route, or Ingress based listener",
+                "listener " + name + " cannot configure bootstrap.labels because it is not LoadBalancer, NodePort, Route, or Ingress based listener",
                 "listener " + name + " cannot configure brokers[].host because it is not Route ot Ingress based listener",
                 "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener",
-                "listener " + name + " cannot configure brokers[].dnsAnnotations because it is not LoadBalancer, NodePort or Ingress based listener"
+                "listener " + name + " cannot configure brokers[].annotations because it is not LoadBalancer, NodePort, Route, or Ingress based listener",
+                "listener " + name + " cannot configure brokers[].labels because it is not LoadBalancer, NodePort, Route, or Ingress based listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(expectedErrors.toArray()));
@@ -438,6 +443,7 @@ public class ListenersValidatorTest {
                         .withNodePort(32189)
                         .withHost("my-host")
                         .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                        .withLabels(Collections.singletonMap("label", "label-value"))
                     .endBootstrap()
                     .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder()
                                     .withBroker(0)
@@ -447,6 +453,7 @@ public class ListenersValidatorTest {
                                     .withNodePort(32189)
                                     .withHost("my-host")
                                     .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                                    .withLabels(Collections.singletonMap("label", "label-value"))
                                     .build(),
                             new GenericKafkaListenerConfigurationBrokerBuilder()
                                     .withBroker(1)
@@ -456,6 +463,7 @@ public class ListenersValidatorTest {
                                     .withNodePort(32189)
                                     .withHost("my-host")
                                     .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                                    .withLabels(Collections.singletonMap("label", "label-value"))
                                     .build())
                 .endConfiguration()
                 .build();
@@ -470,10 +478,8 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure preferredAddressType because it is not NodePort based listener",
                 "listener " + name + " cannot configure bootstrap.loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure bootstrap.nodePort because it is not NodePort based listener",
-                "listener " + name + " cannot configure bootstrap.dnsAnnotations because it is not LoadBalancer, NodePort or Ingress based listener",
                 "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener",
-                "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener",
-                "listener " + name + " cannot configure brokers[].dnsAnnotations because it is not LoadBalancer, NodePort or Ingress based listener"
+                "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(expectedErrors.toArray()));

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -433,7 +433,9 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |integer
 |loadBalancerIP    1.2+<.<|The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This field is ignored if the cloud provider does not support the feature.This field can be used only with `loadbalancer` type listener.
 |string
-|annotations       1.2+<.<|Annotations that will be added to the `Ingress` or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, or `ingress` type listeners.
+|annotations       1.2+<.<|Annotations that will be added to the `Ingress`, `Route`, or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
+|map
+|labels            1.2+<.<|Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
 |map
 |====
 
@@ -466,6 +468,8 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |loadBalancerIP  1.2+<.<|The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This field is ignored if the cloud provider does not support the feature.This field can be used only with `loadbalancer` type listener.
 |string
 |annotations     1.2+<.<|Annotations that will be added to the `Ingress` or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, or `ingress` type listeners.
+|map
+|labels          1.2+<.<|Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
 |map
 |====
 

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -338,7 +338,10 @@ spec:
                                     description: The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This field is ignored if the cloud provider does not support the feature.This field can be used only with `loadbalancer` type listener.
                                   annotations:
                                     type: object
-                                    description: Annotations that will be added to the `Ingress` or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, or `ingress` type listeners.
+                                    description: Annotations that will be added to the `Ingress`, `Route`, or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
+                                  labels:
+                                    type: object
+                                    description: Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
                                 description: Bootstrap configuration.
                               brokers:
                                 type: array
@@ -366,6 +369,9 @@ spec:
                                     annotations:
                                       type: object
                                       description: Annotations that will be added to the `Ingress` or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, or `ingress` type listeners.
+                                    labels:
+                                      type: object
+                                      description: Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
                                   required:
                                     - broker
                                 description: Per-broker configurations.

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -492,10 +492,17 @@ spec:
                                 annotations:
                                   type: object
                                   description: Annotations that will be added to the
-                                    `Ingress` or `Service` resource. You can use this
-                                    field to configure DNS providers such as External
-                                    DNS. This field can be used only with `loadbalancer`,
-                                    `nodeport`, or `ingress` type listeners.
+                                    `Ingress`, `Route`, or `Service` resource. You
+                                    can use this field to configure DNS providers
+                                    such as External DNS. This field can be used only
+                                    with `loadbalancer`, `nodeport`, `route`, or `ingress`
+                                    type listeners.
+                                labels:
+                                  type: object
+                                  description: Labels that will be added to the `Ingress`,
+                                    `Route`, or `Service` resource. This field can
+                                    be used only with `loadbalancer`, `nodeport`,
+                                    `route`, or `ingress` type listeners.
                               description: Bootstrap configuration.
                             brokers:
                               type: array
@@ -545,6 +552,12 @@ spec:
                                       as External DNS. This field can be used only
                                       with `loadbalancer`, `nodeport`, or `ingress`
                                       type listeners.
+                                  labels:
+                                    type: object
+                                    description: Labels that will be added to the
+                                      `Ingress`, `Route`, or `Service` resource. This
+                                      field can be used only with `loadbalancer`,
+                                      `nodeport`, `route`, or `ingress` type listeners.
                                 required:
                                 - broker
                               description: Per-broker configurations.


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In some cases, it is useful to be ale to label individual services, ingresses or routes belonging to a particular listener. For example when using dedicated Ingress controller for each of them to optimize network flows etc. 

Right now, we can specify additional annotations for external services and ingresses. This PR extends the annotations also to OpenShift Routes. Additionally, it also adds new field labels to make it possible to specify the labels for all of these as well. 

This PR also fixes some texts and method names where we still talk about the `dnsAnnotations` (old name used in old object-style listeners) which the field is now called just `annotations`.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally