### PR TITLE
Pause reconciliations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add support for Kafka 2.6.1
 * List topics used by a Kafka Connect connector in the `.status` section of the `KafkaConnector` custom resource
 * Bump Cruise Control to v2.5.37 for Kafka 2.7 support. Note this new version of Cruise Control uses `Log4j 2` and is supported by dynamic logging configuration (where logging properties are defined in a ConfigMap). However, existing `Log4j` configurations must be updated to `Log4j 2` configurations.
+* Support pausing reconciliation of CR with annotation `strimzi.io/pause-reconciliation`
 
 ### Changes, deprecations and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -76,10 +76,8 @@ import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -435,10 +433,10 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         connectorsReconciliationsCounter.increment();
         Timer.Sample connectorsReconciliationsTimerSample = Timer.start(metrics.meterRegistry());
 
-        if (hasPauseReconciliationAnnotation(connector)) {
+        if (connector != null && Annotations.isReconciliationPausedWithAnnotation(connector)) {
             Set<Condition> conditions = validate(connector);
             Condition pausedCondition = new ConditionBuilder()
-                    .withLastTransitionTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(new Date()))
+                    .withLastTransitionTime(StatusUtils.iso8601Now())
                     .withType("ReconciliationPaused")
                     .withStatus("True")
                     .build();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -37,7 +37,6 @@ import io.strimzi.api.kafka.model.KafkaConnectorSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.api.kafka.model.status.Condition;
-import io.strimzi.api.kafka.model.status.ConditionBuilder;
 import io.strimzi.api.kafka.model.status.KafkaConnectS2IStatus;
 import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
 import io.strimzi.api.kafka.model.status.KafkaConnectorStatus;
@@ -435,12 +434,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
 
         if (connector != null && Annotations.isReconciliationPausedWithAnnotation(connector)) {
             Set<Condition> conditions = validate(connector);
-            Condition pausedCondition = new ConditionBuilder()
-                    .withLastTransitionTime(StatusUtils.iso8601Now())
-                    .withType("ReconciliationPaused")
-                    .withStatus("True")
-                    .build();
-            conditions.add(pausedCondition);
+            conditions.add(StatusUtils.getPausedCondition());
 
             return maybeUpdateConnectorStatus(reconciliation, connector, new ConnectorStatusAndConditions(emptyMap(), new ArrayList<>(conditions)), null).compose(
                 i -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -37,6 +37,7 @@ import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControl
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.RebalanceOptions;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.AbstractOperator;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
@@ -339,7 +340,7 @@ public class KafkaRebalanceAssemblyOperator
 
         log.info("{}: Rebalance action from state [{}]", reconciliation, currentState);
 
-        if (hasPauseReconciliationAnnotation(kafkaRebalance)) {
+        if (Annotations.isReconciliationPausedWithAnnotation(kafkaRebalance)) {
             // we need to do this check again because it was triggered by a watcher
             KafkaRebalanceStatus status = new KafkaRebalanceStatus();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -341,10 +341,11 @@ public class KafkaRebalanceAssemblyOperator
             // we need to do this check again because it was triggered by a watcher
             KafkaRebalanceStatus status = new KafkaRebalanceStatus();
 
+            Set<Condition> unknownAndDeprecatedConditions = validate(kafkaRebalance);
             unknownAndDeprecatedConditions.add(StatusUtils.getPausedCondition());
             status.setConditions(new ArrayList<>(unknownAndDeprecatedConditions));
 
-            return  updateStatus(kafkaRebalance, status, null).compose(i -> Future.succeededFuture());
+            return updateStatus(kafkaRebalance, status, null).compose(i -> Future.succeededFuture());
         }
 
         RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder = convertRebalanceSpecToRebalanceOptions(kafkaRebalance.getSpec());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -18,7 +18,6 @@ import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.KafkaRebalanceBuilder;
 import io.strimzi.api.kafka.model.KafkaRebalanceSpec;
 import io.strimzi.api.kafka.model.status.Condition;
-import io.strimzi.api.kafka.model.status.ConditionBuilder;
 import io.strimzi.api.kafka.model.status.KafkaRebalanceStatus;
 import io.strimzi.api.kafka.model.status.KafkaRebalanceStatusBuilder;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceAnnotation;
@@ -342,13 +341,7 @@ public class KafkaRebalanceAssemblyOperator
             // we need to do this check again because it was triggered by a watcher
             KafkaRebalanceStatus status = new KafkaRebalanceStatus();
 
-            Condition pauseCondition = new ConditionBuilder()
-                    .withLastTransitionTime(StatusUtils.iso8601Now())
-                    .withType("ReconciliationPaused")
-                    .withStatus("True")
-                    .build();
-
-            unknownAndDeprecatedConditions.add(pauseCondition);
+            unknownAndDeprecatedConditions.add(StatusUtils.getPausedCondition());
             status.setConditions(new ArrayList<>(unknownAndDeprecatedConditions));
 
             return  updateStatus(kafkaRebalance, status, null).compose(i -> Future.succeededFuture());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -27,7 +27,6 @@ import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.model.CruiseControl;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
-import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.NoSuchResourceException;
 import io.strimzi.operator.cluster.model.StatusDiff;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlApi;
@@ -53,7 +52,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -345,7 +343,7 @@ public class KafkaRebalanceAssemblyOperator
             KafkaRebalanceStatus status = new KafkaRebalanceStatus();
 
             Condition pauseCondition = new ConditionBuilder()
-                    .withLastTransitionTime(ModelUtils.formatTimestamp(new Date()))
+                    .withLastTransitionTime(StatusUtils.iso8601Now())
                     .withType("ReconciliationPaused")
                     .withStatus("True")
                     .build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/TestUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/TestUtils.java
@@ -7,11 +7,19 @@ package io.strimzi.operator.cluster;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapKeySelectorBuilder;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.model.JmxPrometheusExporterMetrics;
 import io.strimzi.api.kafka.model.JmxPrometheusExporterMetricsBuilder;
+import io.strimzi.api.kafka.model.status.Status;
 import io.strimzi.operator.cluster.model.AbstractModel;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Predicate;
+
 import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestUtils {
     public static JmxPrometheusExporterMetrics getJmxPrometheusExporterMetrics(String key, String name) {
@@ -35,5 +43,19 @@ public class TestUtils {
                 .withData(singletonMap(AbstractModel.ANCILLARY_CM_KEY_METRICS, data))
                 .build();
         return metricsCM;
+    }
+
+    public static <T extends CustomResource<?, ? extends Status>> void waitForStatus(Resource<T> resource, String resourceName, Predicate<T> predicate) {
+        try {
+            resource.waitUntilCondition(predicate, 10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            if (!(e instanceof TimeoutException)) {
+                throw new RuntimeException(e);
+            }
+            String conditions =
+                    resource.get().getStatus() == null ? "no status" :
+                            String.valueOf(resource.get().getStatus().getConditions());
+            fail(resourceName + " never matched required predicate: " + conditions);
+        }
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -349,6 +349,7 @@ public class KafkaAssemblyOperatorMockTest {
             .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)))
             .onComplete(context.succeeding(v -> async.flag()));
     }
+
     @ParameterizedTest
     @MethodSource("data")
     public void testReconcileReplacesAllDeletedSecrets(Params params, VertxTestContext context) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -25,6 +25,7 @@ import io.strimzi.api.kafka.KafkaList;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.storage.EphemeralStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
@@ -36,6 +37,7 @@ import io.strimzi.operator.cluster.ClusterOperator;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.TestUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.operator.cluster.model.KafkaCluster;
@@ -121,6 +123,7 @@ public class KafkaAssemblyOperatorMockTest {
         private final int kafkaReplicas;
         private final Storage kafkaStorage;
         private ResourceRequirements resources;
+        private boolean pause = false;
 
         public Params(int zkReplicas,
                       SingleVolumeStorage zkStorage,
@@ -234,6 +237,7 @@ public class KafkaAssemblyOperatorMockTest {
                     .withName(CLUSTER_NAME)
                     .withNamespace(NAMESPACE)
                     .withLabels(singletonMap("foo", "bar"))
+                    .withAnnotations(singletonMap("strimzi.io/pause-reconciliation", Boolean.toString(params.pause)))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()
@@ -348,6 +352,47 @@ public class KafkaAssemblyOperatorMockTest {
             .onComplete(context.succeeding())
             .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)))
             .onComplete(context.succeeding(v -> async.flag()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testPauseReconcile(Params params, VertxTestContext context) {
+        params.pause = true;
+
+        init(params);
+
+        cluster.getMetadata().setAnnotations(singletonMap("strimzi.io/pause-reconciliation", "true"));
+        CustomResourceDefinition kafkaAssemblyCrd = Crds.kafka();
+
+        client = new MockKube()
+                .withCustomResourceDefinition(kafkaAssemblyCrd, Kafka.class, KafkaList.class)
+                .withInitialInstances(Collections.singleton(cluster))
+                .end()
+                .build();
+
+        Checkpoint async = context.checkpoint();
+        operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    Resource<Kafka> resource = Crds.kafkaOperation(client).inNamespace(NAMESPACE).withName(CLUSTER_NAME);
+                    TestUtils.waitForStatus(resource, CLUSTER_NAME, s -> {
+                        if (s.getStatus() == null) {
+                            return false;
+                        }
+                        List<Condition> conditions = s.getStatus().getConditions();
+                        boolean conditionFound = false;
+                        if (conditions != null && !conditions.isEmpty()) {
+                            for (Condition condition: conditions) {
+                                if ("ReconciliationPaused".equals(condition.getType())) {
+                                    conditionFound = true;
+                                    break;
+                                }
+                            }
+                        }
+                        return conditionFound;
+                    });
+                    async.flag();
+                    params.pause = false;
+                })));
     }
     
     @ParameterizedTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -349,7 +349,6 @@ public class KafkaAssemblyOperatorMockTest {
             .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)))
             .onComplete(context.succeeding(v -> async.flag()));
     }
-
     @ParameterizedTest
     @MethodSource("data")
     public void testReconcileReplacesAllDeletedSecrets(Params params, VertxTestContext context) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.Crds;
@@ -54,10 +53,15 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
@@ -122,7 +126,6 @@ public class KafkaConnectAssemblyOperatorMockTest {
 
         Promise created = Promise.promise();
 
-        Deployment depBeforeRecon = mockClient.apps().deployments().inNamespace(NAMESPACE).withName(KafkaConnectResources.deploymentName(CLUSTER_NAME)).get();
         LOGGER.info("Reconciling initially -> create");
         kco.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME))
             .onComplete(context.succeeding(v -> context.verify(() -> {
@@ -132,7 +135,8 @@ public class KafkaConnectAssemblyOperatorMockTest {
                     assertThat(mockClient.services().inNamespace(NAMESPACE).withName(KafkaConnectResources.serviceName(CLUSTER_NAME)).get(), is(notNullValue()));
                     assertThat(mockClient.policy().podDisruptionBudget().inNamespace(NAMESPACE).withName(KafkaConnectResources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue()));
                 } else {
-                    assertThat(mockClient.apps().deployments().inNamespace(NAMESPACE).withName(KafkaConnectResources.deploymentName(CLUSTER_NAME)).get(), is(depBeforeRecon));
+                    assertThat(mockClient.apps().deployments().inNamespace(NAMESPACE).withName(KafkaConnectResources.deploymentName(CLUSTER_NAME)).get(), is(nullValue()));
+                    verify(mockClient, never()).customResources(KafkaConnect.class);
                 }
                 created.complete();
             })));
@@ -192,22 +196,21 @@ public class KafkaConnectAssemblyOperatorMockTest {
                 })
                 .onComplete(context.succeeding(v -> context.verify(() -> {
                     Resource<KafkaConnect> resource = Crds.kafkaConnectOperation(mockClient).inNamespace(NAMESPACE).withName(CLUSTER_NAME);
-                    io.strimzi.operator.cluster.TestUtils.waitForStatus(resource, CLUSTER_NAME, s -> {
-                        if (s.getStatus() == null) {
-                            return false;
-                        }
-                        List<Condition> conditions = s.getStatus().getConditions();
-                        boolean conditionFound = false;
-                        if (conditions != null && !conditions.isEmpty()) {
-                            for (Condition condition: conditions) {
-                                if ("ReconciliationPaused".equals(condition.getType())) {
-                                    conditionFound = true;
-                                    break;
-                                }
+                    if (resource.get().getStatus() == null) {
+                        fail();
+                    }
+                    List<Condition> conditions = resource.get().getStatus().getConditions();
+                    boolean conditionFound = false;
+                    if (conditions != null && !conditions.isEmpty()) {
+                        for (Condition condition: conditions) {
+                            if ("ReconciliationPaused".equals(condition.getType())) {
+                                conditionFound = true;
+                                break;
                             }
                         }
-                        return conditionFound;
-                    });
+                    }
+                    assertTrue(conditionFound);
+
                     async.flag();
                 })));
 

--- a/mockkube/pom.xml
+++ b/mockkube/pom.xml
@@ -96,6 +96,10 @@
             <artifactId>test</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
             <scope>compile</scope>

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/CustomResourceMockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/CustomResourceMockBuilder.java
@@ -9,12 +9,13 @@ import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.strimzi.api.kafka.model.status.Status;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.function.Function;
 
-class CustomResourceMockBuilder<T extends CustomResource, L extends KubernetesResource & KubernetesResourceList<T>, S>
+class CustomResourceMockBuilder<T extends CustomResource, L extends KubernetesResource & KubernetesResourceList<T>, S extends Status>
         extends MockBuilder<T, L, Resource<T>> {
 
     private static final Logger LOGGER = LogManager.getLogger(CustomResourceMockBuilder.class);

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
@@ -31,6 +31,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -296,7 +298,7 @@ class MockBuilder<T extends HasMetadata,
         if (Readiness.isReadinessApplicable(resourceTypeClass)) {
             mockIsReady(resourceName, resource);
         }
-        /*try {
+        try {
             when(resource.waitUntilCondition(any(), anyLong(), any())).thenAnswer(i -> {
                 Predicate<T> p = i.getArgument(0);
                 T t = resource.get();
@@ -316,7 +318,7 @@ class MockBuilder<T extends HasMetadata,
             });
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
-        }*/
+        }
     }
 
     protected void checkNotExists(String resourceName) {

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
@@ -31,8 +31,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -298,7 +296,7 @@ class MockBuilder<T extends HasMetadata,
         if (Readiness.isReadinessApplicable(resourceTypeClass)) {
             mockIsReady(resourceName, resource);
         }
-        try {
+        /*try {
             when(resource.waitUntilCondition(any(), anyLong(), any())).thenAnswer(i -> {
                 Predicate<T> p = i.getArgument(0);
                 T t = resource.get();
@@ -318,7 +316,7 @@ class MockBuilder<T extends HasMetadata,
             });
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
-        }
+        }*/
     }
 
     protected void checkNotExists(String resourceName) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -208,12 +208,7 @@ public abstract class AbstractOperator<
                 if (Annotations.isReconciliationPausedWithAnnotation(cr)) {
                     S status = createStatus();
                     Set<Condition> conditions = validate(cr);
-                    Condition pausedCondition = new ConditionBuilder()
-                            .withLastTransitionTime(StatusUtils.iso8601Now())
-                            .withType("ReconciliationPaused")
-                            .withStatus("True")
-                            .build();
-                    conditions.add(pausedCondition);
+                    conditions.add(StatusUtils.getPausedCondition());
                     status.setConditions(new ArrayList<>(conditions));
 
                     updateStatus(reconciliation, status).onComplete(statusResult -> {

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -89,6 +89,9 @@ public class Annotations {
     }
 
     public static boolean booleanAnnotation(HasMetadata resource, String annotation, boolean defaultValue, String... deprecatedAnnotations) {
+        if (resource == null) {
+            return defaultValue;
+        }
         ObjectMeta metadata = resource.getMetadata();
         String str = annotation(annotation, null, metadata, deprecatedAnnotations);
         return str != null ? parseBoolean(str) : defaultValue;

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -34,6 +34,8 @@ public class Annotations {
     public static final String STRIMZI_IO_CONNECT_BUILD_REVISION = STRIMZI_DOMAIN + "connect-build-revision";
     // Use to force rebuild of the container image even if the dockerfile did not changed
     public static final String STRIMZI_IO_CONNECT_FORCE_REBUILD = STRIMZI_DOMAIN + "force-rebuild";
+    // Use to pause resource reconciliation
+    public static final String ANNO_STRIMZI_IO_PAUSE_RECONCILIATION = STRIMZI_DOMAIN + "pause-reconciliation";
     public static final String ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE = STRIMZI_DOMAIN + "manual-rolling-update";
     // This annotation with related possible values (approve, stop, refresh) is set by the user for interacting
     // with the rebalance operator in order to start, stop, or refresh rebalancing proposals and operations.

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -69,10 +69,13 @@ public class Annotations {
     );
 
     private static Map<String, String> annotations(ObjectMeta metadata) {
-        Map<String, String> annotations = metadata.getAnnotations();
-        if (annotations == null) {
-            annotations = new HashMap<>(3);
-            metadata.setAnnotations(annotations);
+        Map<String, String> annotations = new HashMap<>();
+        if (metadata != null) {
+            annotations = metadata.getAnnotations();
+            if (annotations == null) {
+                annotations = new HashMap<>(3);
+                metadata.setAnnotations(annotations);
+            }
         }
         return annotations;
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
@@ -51,6 +51,7 @@ public interface Operator {
      */
     default void reconcileAll(String trigger, String namespace, Handler<AsyncResult<Void>> handler) {
         allResourceNames(namespace).onComplete(ar -> {
+            getPausedResourceCounter().set(0);
             if (ar.succeeded()) {
                 reconcileThese(trigger, ar.result(), handler);
                 getPeriodicReconciliationsCounter().increment();
@@ -96,4 +97,6 @@ public interface Operator {
     Counter getPeriodicReconciliationsCounter();
 
     AtomicInteger getResourceCounter();
+
+    AtomicInteger getPausedResourceCounter();
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -109,7 +109,7 @@ public class CrdOperator<C extends KubernetesClient,
 
             try {
                 T result = operation().inNamespace(namespace).withName(name).updateStatus(resource);
-                log.debug("Status of {} {} in namespace {} has been updated", resourceKind, name, namespace);
+                log.info("Status of {} {} in namespace {} has been updated", resourceKind, name, namespace);
                 future.complete(result);
             } catch (Exception e) {
                 log.debug("Caught exception while updating status of {} {} in namespace {}", resourceKind, name, namespace, e);

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -109,4 +109,13 @@ public class StatusUtils {
     public static <R extends CustomResource> boolean isResourceV1alpha1(R resource) {
         return resource.getApiVersion() != null && resource.getApiVersion().equals(V1ALPHA1);
     }
+
+    public static Condition getPausedCondition() {
+        Condition pausedCondition = new ConditionBuilder()
+                .withLastTransitionTime(StatusUtils.iso8601Now())
+                .withType("ReconciliationPaused")
+                .withStatus("True")
+                .build();
+        return pausedCondition;
+    }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
@@ -374,7 +374,7 @@ public class OperatorMetricsTest {
                 class Foo extends MyResource {
                     @Override
                     public ObjectMeta getMetadata() {
-                        return null;
+                        return new ObjectMeta();
                     }
 
                     @Override

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
@@ -5,11 +5,9 @@
 package io.strimzi.operator.topic;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.WatcherException;
 import io.strimzi.api.kafka.model.KafkaTopic;
-import io.strimzi.operator.common.Annotations;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -18,8 +16,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
 import java.util.Objects;
-
-import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION;
 
 class K8sTopicWatcher implements Watcher<KafkaTopic> {
 
@@ -39,9 +35,6 @@ class K8sTopicWatcher implements Watcher<KafkaTopic> {
     public void eventReceived(Action action, KafkaTopic kafkaTopic) {
         ObjectMeta metadata = kafkaTopic.getMetadata();
         Map<String, String> labels = metadata.getLabels();
-        if (kafkaTopic.getMetadata() != null && kafkaTopic.getMetadata().getAnnotations() != null) {
-            LOGGER.info("k8s mam anotaci {}", hasPauseReconciliationAnnotation(kafkaTopic));
-        }
         if (kafkaTopic.getSpec() != null) {
             LogContext logContext = LogContext.kubeWatch(action, kafkaTopic).withKubeTopic(kafkaTopic);
             String name = metadata.getName();
@@ -79,10 +72,6 @@ class K8sTopicWatcher implements Watcher<KafkaTopic> {
                 }
             }
         }
-    }
-
-    protected boolean hasPauseReconciliationAnnotation(CustomResource resource) {
-        return Annotations.booleanAnnotation(resource, ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, false);
     }
 
     public boolean shouldReconcile(KafkaTopic kafkaTopic, ObjectMeta metadata) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
@@ -5,9 +5,11 @@
 package io.strimzi.operator.topic;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.WatcherException;
 import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.operator.common.Annotations;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -16,6 +18,8 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
 import java.util.Objects;
+
+import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION;
 
 class K8sTopicWatcher implements Watcher<KafkaTopic> {
 
@@ -35,6 +39,9 @@ class K8sTopicWatcher implements Watcher<KafkaTopic> {
     public void eventReceived(Action action, KafkaTopic kafkaTopic) {
         ObjectMeta metadata = kafkaTopic.getMetadata();
         Map<String, String> labels = metadata.getLabels();
+        if (kafkaTopic.getMetadata() != null && kafkaTopic.getMetadata().getAnnotations() != null) {
+            LOGGER.info("k8s mam anotaci {}", hasPauseReconciliationAnnotation(kafkaTopic));
+        }
         if (kafkaTopic.getSpec() != null) {
             LogContext logContext = LogContext.kubeWatch(action, kafkaTopic).withKubeTopic(kafkaTopic);
             String name = metadata.getName();
@@ -72,6 +79,10 @@ class K8sTopicWatcher implements Watcher<KafkaTopic> {
                 }
             }
         }
+    }
+
+    protected boolean hasPauseReconciliationAnnotation(CustomResource resource) {
+        return Annotations.booleanAnnotation(resource, ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, false);
     }
 
     public boolean shouldReconcile(KafkaTopic kafkaTopic, ObjectMeta metadata) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -14,8 +14,6 @@ import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
-import io.strimzi.api.kafka.model.status.Condition;
-import io.strimzi.api.kafka.model.status.ConditionBuilder;
 import io.strimzi.api.kafka.model.status.KafkaTopicStatus;
 import io.strimzi.operator.cluster.model.StatusDiff;
 import io.strimzi.operator.common.Annotations;
@@ -1022,12 +1020,7 @@ class TopicOperator {
                         Promise<Void> promise = Promise.promise();
                         statusFuture = promise.future();
 
-                        Condition pausedCondition = new ConditionBuilder()
-                                .withLastTransitionTime(StatusUtils.iso8601Now())
-                                .withType("ReconciliationPaused")
-                                .withStatus("True")
-                                .build();
-                        kts.setConditions(singletonList(pausedCondition));
+                        kts.setConditions(singletonList(StatusUtils.getPausedCondition()));
 
                         k8s.updateResourceStatus(new KafkaTopicBuilder(topic).withStatus(kts).build()).onComplete(ar -> {
                             if (ar.succeeded() && ar.result() != null) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.topic;
 import io.fabric8.kubernetes.api.model.EventBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.Watcher;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Tag;
@@ -36,11 +35,9 @@ import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -52,7 +49,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
-import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION;
 import static java.util.Collections.disjoint;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -561,11 +557,6 @@ class TopicOperator {
                 }
             } else if (kafkaTopic == null) {
                 // it's been created in k8s => create in Kafka and privateState
-                if (hasPauseReconciliationAnnotation(TopicSerialization.toTopicResource(k8sTopic, new Labels()))) {
-                    reconciliationResultHandler = Future.succeededFuture();
-                    return reconciliationResultHandler;
-                }
-
                 LOGGER.debug("{}: KafkaTopic created in k8s, will create topic in kafka and topicStore", logContext);
                 reconciliationResultHandler = createKafkaTopic(logContext, k8sTopic, involvedObject)
                     .compose(ignore -> createInTopicStore(logContext, k8sTopic, involvedObject))
@@ -847,16 +838,6 @@ class TopicOperator {
     }
 
     /**
-     * Whether the provided resource instance is a KafkaConnector and has the strimzi.io/pause-reconciliation annotation
-     *
-     * @param resource resource instance to check
-     * @return true if the provided resource instance has the strimzi.io/pause-reconciliation annotation; false otherwise
-     */
-    protected boolean hasPauseReconciliationAnnotation(CustomResource resource) {
-        return Annotations.booleanAnnotation(resource, ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, false);
-    }
-
-    /**
      * Called when ZK watch notifies of a change to the topic's partitions
      */
     Future<Void> onTopicPartitionsChanged(LogContext logContext, TopicName topicName) {
@@ -921,7 +902,11 @@ class TopicOperator {
                 return k8s.getFromName(resourceName).compose(topic -> {
                     reconciliation.observedTopicFuture(kafkaTopic != null ? topic : null);
                     Topic k8sTopic = TopicSerialization.fromTopicResource(topic);
-                    return reconcile(reconciliation, logContext.withKubeTopic(topic), topic, k8sTopic, kafkaTopic, storeTopic);
+                    if (topic != null && Annotations.isReconciliationPausedWithAnnotation(topic)) {
+                        return reconcile(reconciliation, logContext.withKubeTopic(topic), topic, k8sTopic, kafkaTopic, storeTopic);
+                    } else {
+                        return Future.succeededFuture();
+                    }
                 });
             });
     }
@@ -1033,10 +1018,17 @@ class TopicOperator {
                     KafkaTopicStatus kts = new KafkaTopicStatus();
                     StatusUtils.setStatusConditionAndObservedGeneration(topic, kts, result);
 
-                    StatusDiff ksDiff = new StatusDiff(topic.getStatus(), kts);
-                    if (!ksDiff.isEmpty()) {
+                    if (Annotations.isReconciliationPausedWithAnnotation(topic)) {
                         Promise<Void> promise = Promise.promise();
                         statusFuture = promise.future();
+
+                        Condition pausedCondition = new ConditionBuilder()
+                                .withLastTransitionTime(StatusUtils.iso8601Now())
+                                .withType("ReconciliationPaused")
+                                .withStatus("True")
+                                .build();
+                        kts.setConditions(singletonList(pausedCondition));
+
                         k8s.updateResourceStatus(new KafkaTopicBuilder(topic).withStatus(kts).build()).onComplete(ar -> {
                             if (ar.succeeded() && ar.result() != null) {
                                 ObjectMeta metadata = ar.result().getMetadata();
@@ -1051,7 +1043,26 @@ class TopicOperator {
                             statusFuture.handle(ar.map((Void) null));
                         });
                     } else {
-                        statusFuture = Future.succeededFuture();
+                        StatusDiff ksDiff = new StatusDiff(topic.getStatus(), kts);
+                        if (!ksDiff.isEmpty()) {
+                            Promise<Void> promise = Promise.promise();
+                            statusFuture = promise.future();
+                            k8s.updateResourceStatus(new KafkaTopicBuilder(topic).withStatus(kts).build()).onComplete(ar -> {
+                                if (ar.succeeded() && ar.result() != null) {
+                                    ObjectMeta metadata = ar.result().getMetadata();
+                                    LOGGER.debug("{}: status was set rv={}, generation={}, observedGeneration={}",
+                                            logContext,
+                                            metadata.getResourceVersion(),
+                                            metadata.getGeneration(),
+                                            ar.result().getStatus().getObservedGeneration());
+                                } else {
+                                    LOGGER.error("{}: Error setting resource status", logContext, ar.cause());
+                                }
+                                statusFuture.handle(ar.map((Void) null));
+                            });
+                        } else {
+                            statusFuture = Future.succeededFuture();
+                        }
                     }
                 } else {
                     LOGGER.debug("{}: No KafkaTopic to set status", logContext);
@@ -1067,23 +1078,6 @@ class TopicOperator {
 
     /** Called when a resource is isModify in k8s */
     Future<Void> onResourceEvent(LogContext logContext, KafkaTopic modifiedTopic, Watcher.Action action) {
-        if (hasPauseReconciliationAnnotation(modifiedTopic)) {
-            Condition pausedCondition = new ConditionBuilder()
-                    .withLastTransitionTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(new Date()))
-                    .withType("ReconciliationPaused")
-                    .withStatus("True")
-                    .build();
-
-            KafkaTopicStatus status = new KafkaTopicStatus();
-            status.setConditions(singletonList(pausedCondition));
-            Promise<Void> promise = Promise.promise();
-            Future<Void> statusFuture = promise.future();
-            k8s.updateResourceStatus(new KafkaTopicBuilder(modifiedTopic).withStatus(status).build()).onComplete(ar -> {
-                statusFuture.handle(ar.map((Void) null));
-            });
-
-            return statusFuture;
-        }
         return executeWithTopicLockHeld(logContext, new TopicName(modifiedTopic),
                 new Reconciliation("onResourceEvent", false) {
                     @Override
@@ -1133,7 +1127,11 @@ class TopicOperator {
                             "Kafka topics cannot be renamed, but KafkaTopic's spec.topicName has changed.",
                             EventType.WARNING, result));
                 } else {
-                    result = reconcile(reconciliation, logContext, topicResource, k8sTopic, kafkaTopic, privateTopic);
+                    if (topicResource != null && Annotations.isReconciliationPausedWithAnnotation(topicResource)) {
+                        result = Future.succeededFuture();
+                    } else {
+                        result = reconcile(reconciliation, logContext, topicResource, k8sTopic, kafkaTopic, privateTopic);
+                    }
                 }
                 return result;
             });
@@ -1484,7 +1482,6 @@ class TopicOperator {
             @Override
             public Future<Void> execute() {
                 Reconciliation self = this;
-                //todo tady taky?
                 return CompositeFuture.all(
                         k8s.getFromName(kubeName).map(kt -> {
                             observedTopicFuture(kt);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -903,9 +903,9 @@ class TopicOperator {
                     reconciliation.observedTopicFuture(kafkaTopic != null ? topic : null);
                     Topic k8sTopic = TopicSerialization.fromTopicResource(topic);
                     if (topic != null && Annotations.isReconciliationPausedWithAnnotation(topic)) {
-                        return reconcile(reconciliation, logContext.withKubeTopic(topic), topic, k8sTopic, kafkaTopic, storeTopic);
-                    } else {
                         return Future.succeededFuture();
+                    } else {
+                        return reconcile(reconciliation, logContext.withKubeTopic(topic), topic, k8sTopic, kafkaTopic, storeTopic);
                     }
                 });
             });


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement / new feature


### Description
`strimzi.io/pause-reconciliation: "true"` annotation allows to pause reconciliations.
That may come useful if we want to create k8s resource but not the `$resource`.

Each operator watches resources of some `Kind`. When some change is done in k8s resource, this change is reflected. If reconciliations are paused, no change is reflected.
The TopicOperator is special because it works bidirectionally. That means if the kafka topic is created in kafka, the k8s resource is still created. (This may be discussed).


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

