### PR TITLE
[DOC] Fix links to master branch of our GitHub

### DIFF
--- a/development-docs/RELEASE.md
+++ b/development-docs/RELEASE.md
@@ -37,6 +37,7 @@ The release process should normally look like this:
 10. _(only for GA, not for RCs)_ The maven artifacts (`api` module) will be automatically staged from TravisCI during the tag build. It has to be releases from [Sonatype](https://oss.sonatype.org/#stagingRepositories) to get to the main Maven repositories.
 11. _(only for GA, not for RCs)_ On the `master` git branch of the operators repository:
   * Copy the `helm-charts/index.yaml` from the `release` branch to `master`.
+  * Update the `ProductVersion` variable in `documentation/using/shared/attributes.doc`.
 
 12. _(only for GA, not for RCs)_ Update the Strimzi manifest files in Operate Hub [community operators](https://github.com/operator-framework/community-operators) repository and submit a pull request upstream. *Note*: Instructions for this step need updating.
 13. _(only for GA, not for RCs)_ Add the new version to the `systemtest/src/test/resources/upgrade/StrimziUpgradeST.json` file for the upgrade tests

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -163,7 +163,7 @@
 :ChartRepositoryUrl: https://strimzi.io/charts/
 
 //Latest Strimzi version
-:ProductVersion: 0.21.0
+:ProductVersion: 0.21.1
 
 // Links to other Strimzi documentation books
 :BookURLDeploying: ./deploying.html

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -29,7 +29,7 @@
 :ReleaseDownload: https://github.com/strimzi/strimzi-kafka-operator/releases[GitHub^]
 
 //Monitoring links
-:ExampleMetrics: link:https://github.com/strimzi/strimzi-kafka-operator/tree/master/examples/metrics/
+:ExampleMetrics: link:https://github.com/strimzi/strimzi-kafka-operator/tree/{GithubVersion}/examples/metrics/
 :GrafanaHome: link:https://grafana.com/[Grafana Labs^]
 :JMXExporter: link:https://github.com/prometheus/jmx_exporter[JMX Exporter documentation^]
 :PrometheusHome: link:https://github.com/prometheus[Prometheus^]
@@ -38,13 +38,13 @@
 
 //OAuth attributes and links
 :oauth2-site: link:https://oauth.net/2/[OAuth 2.0 site^]
-:oauth-artifact-version: 0.6.1
+:oauth-version: 0.7.0
 :keycloak-server-doc: link:https://www.keycloak.org/documentation.html[Keycloak documentation^]
 :keycloak-authorization-services: link:https://www.keycloak.org/docs/latest/authorization_services/index.html[Authorization Services^]
 :oauth-blog: link:https://strimzi.io/2019/10/25/kafka-authentication-using-oauth-2.0.html[Kafka authentication using OAuth 2.0^]
-:oauth-demo-keycloak: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/master/examples[Using Keycloak as the OAuth 2.0 authorization server^]
-:oauth-demo-hydra: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/master/examples/docker[Using Hydra as the OAuth 2.0 authorization server^]
-:oauth-kubernetes-examples-link: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/{oauth-artifact-version}/examples/kubernetes[https://github.com/strimzi/strimzi-kafka-oauth/tree/{oauth-artifact-version}/examples/kubernetes]
+:oauth-demo-keycloak: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/{oauth-version}/examples[Using Keycloak as the OAuth 2.0 authorization server^]
+:oauth-demo-hydra: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/{oauth-version}/examples/docker[Using Hydra as the OAuth 2.0 authorization server^]
+:oauth-kubernetes-examples-link: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/{oauth-version}/examples/kubernetes[https://github.com/strimzi/strimzi-kafka-oauth/tree/{oauth-version}/examples/kubernetes]
 
 // External links
 :aws-ebs: link:https://aws.amazon.com/ebs/[Amazon Elastic Block Store (EBS)^]
@@ -163,7 +163,7 @@
 :ChartRepositoryUrl: https://strimzi.io/charts/
 
 //Latest Strimzi version
-:ProductVersion: 0.20.0
+:ProductVersion: 0.21.0
 
 // Links to other Strimzi documentation books
 :BookURLDeploying: ./deploying.html


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Our documentation should not point directly into our master branch for any example files. It needs to use the `{GitHubVersion}` variable which makes it point to master for master builds but into the release tags for release documentation. The same also applies to links to OAuth examples.

In addition, this also updates the versions of OAuth library and Strimzi to make them up-to-date.