### PR TITLE
ST: use full path for images during upgrade/downgrade

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/OlmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/OlmResource.java
@@ -69,10 +69,10 @@ public class OlmResource {
         if (fromVersion != null) {
             createAndModifySubscription(namespace, operationTimeout, reconciliationInterval, olmInstallationStrategy, fromVersion);
             // must be strimzi-cluster-operator.v0.18.0
-            csvName = Environment.OLM_APP_BUNDLE_PREFIX + "." + fromVersion;
+            csvName = Environment.OLM_APP_BUNDLE_PREFIX + ".v" + fromVersion;
         } else {
             createAndModifySubscriptionLatestRelease(namespace, operationTimeout, reconciliationInterval, olmInstallationStrategy);
-            csvName = Environment.OLM_APP_BUNDLE_PREFIX + "." + Environment.OLM_OPERATOR_LATEST_RELEASE_VERSION;
+            csvName = Environment.OLM_APP_BUNDLE_PREFIX + ".v" + Environment.OLM_OPERATOR_LATEST_RELEASE_VERSION;
         }
 
         // manual installation needs approval with patch

--- a/systemtest/src/main/resources/olm/subscription.yaml
+++ b/systemtest/src/main/resources/olm/subscription.yaml
@@ -9,7 +9,7 @@ spec:
   name: ${OLM_OPERATOR_NAME}
   source: ${OLM_SOURCE_NAME}
   sourceNamespace: ${OLM_SOURCE_NAMESPACE}
-  startingCSV: ${OLM_APP_BUNDLE_PREFIX}.${OLM_OPERATOR_VERSION}
+  startingCSV: ${OLM_APP_BUNDLE_PREFIX}.v${OLM_OPERATOR_VERSION}
   channel: stable
   installPlanApproval: ${OLM_INSTALL_PLAN_APPROVAL}
   config:

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeST.java
@@ -90,7 +90,7 @@ public class OlmUpgradeST extends AbstractUpgradeST {
         // 2. Approve installation
         //   a) get name of install-plan
         //   b) approve installation
-        OlmResource.clusterOperator(namespace, OlmInstallationStrategy.Manual, "v" + fromVersion);
+        OlmResource.clusterOperator(namespace, OlmInstallationStrategy.Manual, fromVersion);
 
         String url = testParameters.getString("urlFrom");
         File dir = FileUtils.downloadAndUnzip(url);

--- a/systemtest/src/test/resources/upgrade/StrimziDowngradeST.json
+++ b/systemtest/src/test/resources/upgrade/StrimziDowngradeST.json
@@ -52,7 +52,7 @@
       "interBrokerProtocolVersion": "2.6"
     },
     "client": {
-      "beforeKafkaUpgradeDowngrade": "strimzi/test-client:0.21.1-kafka-2.7.0",
+      "beforeKafkaUpgradeDowngrade": "quay.io/strimzi/test-client:0.21.1-kafka-2.7.0",
       "afterKafkaUpgradeDowngrade": "quay.io/strimzi/test-client:0.20.1-kafka-2.6.0",
       "continuousClientsMessages": 500
     },

--- a/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
+++ b/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
@@ -81,7 +81,7 @@
       "userOperator": "strimzi/operator:latest"
     },
     "client": {
-      "beforeKafkaUpgradeDowngrade": "quay.io/strimzi/test-client:0.20.1-kafka-2.6.0",
+      "beforeKafkaUpgradeDowngrade": "quay.io/strimzi/test-client:0.20.0-kafka-2.6.0",
       "afterKafkaUpgradeDowngrade": "quay.io/strimzi/test-client:latest-kafka-2.7.0",
       "continuousClientsMessages": 500
     },

--- a/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
+++ b/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
@@ -19,8 +19,8 @@
       "userOperator": "strimzi/operator:latest"
     },
     "client": {
-      "beforeKafkaUpgradeDowngrade": "strimzi/test-client:0.18.0-kafka-2.5.0",
-      "afterKafkaUpgradeDowngrade": "strimzi/test-client:latest-kafka-2.7.0",
+      "beforeKafkaUpgradeDowngrade": "quay.io/strimzi/test-client:0.18.0-kafka-2.5.0",
+      "afterKafkaUpgradeDowngrade": "quay.io/strimzi/test-client:latest-kafka-2.7.0",
       "continuousClientsMessages": 0
     },
     "environmentInfo": {
@@ -50,8 +50,8 @@
       "userOperator": "strimzi/operator:latest"
     },
     "client": {
-      "beforeKafkaUpgradeDowngrade": "strimzi/test-client:0.19.0-kafka-2.5.0",
-      "afterKafkaUpgradeDowngrade": "strimzi/test-client:latest-kafka-2.7.0",
+      "beforeKafkaUpgradeDowngrade": "quay.io/strimzi/test-client:0.19.0-kafka-2.5.0",
+      "afterKafkaUpgradeDowngrade": "quay.io/strimzi/test-client:latest-kafka-2.7.0",
       "continuousClientsMessages": 500
     },
     "environmentInfo": {
@@ -81,8 +81,8 @@
       "userOperator": "strimzi/operator:latest"
     },
     "client": {
-      "beforeKafkaUpgradeDowngrade": "strimzi/test-client:0.20.1-kafka-2.6.0",
-      "afterKafkaUpgradeDowngrade": "strimzi/test-client:latest-kafka-2.7.0",
+      "beforeKafkaUpgradeDowngrade": "quay.io/strimzi/test-client:0.20.1-kafka-2.6.0",
+      "afterKafkaUpgradeDowngrade": "quay.io/strimzi/test-client:latest-kafka-2.7.0",
       "continuousClientsMessages": 500
     },
     "environmentInfo": {
@@ -113,7 +113,7 @@
     },
     "client": {
       "beforeKafkaUpgradeDowngrade": "quay.io/strimzi/test-client:0.21.1-kafka-2.7.0",
-      "afterKafkaUpgradeDowngrade": "strimzi/test-client:latest-kafka-2.7.0",
+      "afterKafkaUpgradeDowngrade": "quay.io/strimzi/test-client:latest-kafka-2.7.0",
       "continuousClientsMessages": 500
     },
     "environmentInfo": {


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

To avoid the issue with the docker pull limit, we should use a full path for images used during the upgrade and downgrade.
This PR also fixes a little issue with OLM versions passed to subscriptions.

### Checklist

- [x] Make sure all tests pass

