### PR TITLE
[systemtest] NetworkPoliciesST - enable NP for KafkaExporter

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
@@ -92,6 +92,8 @@ public class NetworkPoliciesST extends AbstractST {
             .endSpec()
             .build());
 
+        KubernetesResource.allowNetworkPolicySettingsForKafkaExporter(clusterName);
+
         String topic0 = "topic-example-0";
         String topic1 = "topic-example-1";
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Test fix

### Description

`testNetworkPoliciesWithPlainListener` was failing because method for obtaining metrics from KE pod was returning empty map. The problem was that our clients pod, from which we are sending requests to `/metrics` endpoint, didn't have "access" for this -> I set network policies for KafkaExporter - that solved the problem.

### Checklist

- [x] Make sure all tests pass

