### PR TITLE
Make it possible to use a Label selector to operate only some CRs

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -345,8 +345,7 @@ public class ClusterOperatorConfig {
     }
 
     /**
-     * Parse labels from String into the Labels format. This is used to parse the custom resource labels and the
-     * namespace labels.
+     * Parse labels from String into the Labels format.
      *
      * @param vars              Map with configuration variables
      * @param configurationKey  Key containing the string with labels

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -131,14 +131,14 @@ public class Main {
                 new KafkaBridgeAssemblyOperator(vertx, pfa, certManager, passwordGenerator, resourceOperatorSupplier, config);
 
         KafkaRebalanceAssemblyOperator kafkaRebalanceAssemblyOperator =
-                new KafkaRebalanceAssemblyOperator(vertx, pfa, resourceOperatorSupplier);
+                new KafkaRebalanceAssemblyOperator(vertx, pfa, resourceOperatorSupplier, config);
 
         List<Future> futures = new ArrayList<>(config.getNamespaces().size());
         for (String namespace : config.getNamespaces()) {
             Promise<String> prom = Promise.promise();
             futures.add(prom.future());
             ClusterOperator operator = new ClusterOperator(namespace,
-                    config.getReconciliationIntervalMs(),
+                    config,
                     client,
                     kafkaClusterOperations,
                     kafkaConnectClusterOperations,
@@ -151,7 +151,7 @@ public class Main {
             vertx.deployVerticle(operator,
                 res -> {
                     if (res.succeeded()) {
-                        log.info("Cluster Operator verticle started in namespace {}", namespace);
+                        log.info("Cluster Operator verticle started in namespace {} with label selector {}", namespace, config.getCustomResourceSelector());
                     } else {
                         log.error("Cluster Operator verticle in namespace {} failed to start", namespace, res.cause());
                         System.exit(1);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -75,7 +75,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
                                        AbstractWatchableStatusedResourceOperator<C, T, L, R> resourceOperator,
                                        ResourceOperatorSupplier supplier,
                                        ClusterOperatorConfig config) {
-        super(vertx, kind, resourceOperator, supplier.metricsProvider);
+        super(vertx, kind, resourceOperator, supplier.metricsProvider, config.getCustomResourceSelector());
         this.pfa = pfa;
         this.certManager = certManager;
         this.passwordGenerator = passwordGenerator;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -819,7 +819,8 @@ public class ResourceUtils {
                 null,
                 null,
                 null,
-                ClusterOperatorConfig.RbacScope.CLUSTER);
+                ClusterOperatorConfig.RbacScope.CLUSTER,
+                null);
     }
 
     public static ClusterOperatorConfig dummyClusterOperatorConfigRolesOnly(KafkaVersion.Lookup versions, long operationTimeoutMs) {
@@ -834,7 +835,8 @@ public class ResourceUtils {
                 null,
                 null,
                 null,
-                ClusterOperatorConfig.RbacScope.NAMESPACE);
+                ClusterOperatorConfig.RbacScope.NAMESPACE,
+                null);
     }
 
     public static ClusterOperatorConfig dummyClusterOperatorConfig(KafkaVersion.Lookup versions) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -182,7 +182,7 @@ public class ConnectorMockTest {
                 return kafkaConnectS2iOperator.createWatch(NAMESPACE, e -> testContext.failNow(e));
             })
             .onComplete(testContext.succeeding())
-            .compose(watch -> AbstractConnectOperator.createConnectorWatch(kafkaConnectOperator, kafkaConnectS2iOperator, NAMESPACE))
+            .compose(watch -> AbstractConnectOperator.createConnectorWatch(kafkaConnectOperator, kafkaConnectS2iOperator, NAMESPACE, null))
             .onComplete(testContext.succeeding(v -> async.flag()));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
@@ -24,7 +24,6 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaCluster;
-import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
@@ -24,6 +24,7 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaCluster;
+import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -795,11 +795,11 @@ public class KafkaRebalanceAssemblyOperatorTest {
         kcrao.reconcileRebalance(
                 new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
                 kr).onComplete(context.succeeding(v -> context.verify(() -> {
-            // The labels of the Kafka resource do not match the => the KafkaRebalance should not be reconciled and the
-            // rebalance ops should have no interactions.
-            verifyZeroInteractions(mockRebalanceOps);
-            checkpoint.flag();
-        })));
+                    // The labels of the Kafka resource do not match the => the KafkaRebalance should not be reconciled and the
+                    // rebalance ops should have no interactions.
+                    verifyZeroInteractions(mockRebalanceOps);
+                    checkpoint.flag();
+                })));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -41,8 +41,6 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -72,8 +70,6 @@ public class KafkaRebalanceAssemblyOperatorTest {
     private static final String CLUSTER_NAME = "kafka-cruise-control-test-cluster";
 
     private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_18;
-
-    private static final Logger log = LogManager.getLogger(KafkaRebalanceAssemblyOperatorTest.class.getName());
 
     private static ClientAndServer ccServer;
     private KubernetesClient kubernetesClient;
@@ -125,7 +121,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
 
         // Override to inject mocked cruise control address so real cruise control not required
-        kcrao = new KafkaRebalanceAssemblyOperator(vertx, pfa, supplier) {
+        kcrao = new KafkaRebalanceAssemblyOperator(vertx, pfa, supplier, ResourceUtils.dummyClusterOperatorConfig()) {
             @Override
             public String cruiseControlHost(String clusterName, String clusterNamespace) {
                 return HOST;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -33,8 +33,6 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,8 +60,6 @@ public class KafkaRebalanceStateMachineTest {
     private static final String CLUSTER_NAME = "kafka-cruise-control-test-cluster";
 
     private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_18;
-
-    private static final Logger log = LogManager.getLogger(KafkaRebalanceStateMachineTest.class.getName());
 
     private static ClientAndServer ccServer;
 
@@ -141,7 +137,7 @@ public class KafkaRebalanceStateMachineTest {
         CruiseControlApi client = new CruiseControlApiImpl(vertx);
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
-        KafkaRebalanceAssemblyOperator kcrao = new KafkaRebalanceAssemblyOperator(vertx, pfa, supplier) {
+        KafkaRebalanceAssemblyOperator kcrao = new KafkaRebalanceAssemblyOperator(vertx, pfa, supplier, ResourceUtils.dummyClusterOperatorConfig()) {
             @Override
             public String cruiseControlHost(String clusterName, String clusterNamespace) {
                 return HOST;

--- a/documentation/modules/ref-operator-cluster.adoc
+++ b/documentation/modules/ref-operator-cluster.adoc
@@ -45,6 +45,27 @@ env:
 The labels of the namespace where the Strimzi Cluster Operator is running.
 Namespace labels are used to configure the namespace selector in network policies to allow the Strimzi Cluster Operator to only have access to the operands from the namespace with these labels.
 When not set, the namespace selector in network policies is configured to allow access to the Strimzi Cluster Operator from any namespace in the Kubernetes cluster.
++
+[source,yaml,options="nowrap"]
+----
+env:
+  - name: STRIMZI_OPERATOR_NAMESPACE_LABELS
+    value: label1=value1,label2=value2
+----
+
+`STRIMZI_CUSTOM_RESOURCE_SELECTOR`:: Optional.
+Specifies label selector used to filter the custom resources handled by the operator.
+The operator will operate only the custom resource which will have the labels set.
+Resources without these labels will not be seen by the operator.
+The label selector applies to `Kafka`, `KafkaConnect`, `KafkaConnectS2I`, `KafkaBridge`, `KafkaMirrorMaker`, and `KafkaMirrorMaker2` resources.
+`KafkaRebalance` and `KafkaConnector` resources will be operated only when their corresponding Kafka and Kafka Connect clusters have the matching labels.
++
+[source,yaml,options="nowrap"]
+----
+env:
+  - name: STRIMZI_CUSTOM_RESOURCE_SELECTOR
+    value: label1=value1,label2=value2
+----
 
 `STRIMZI_KAFKA_IMAGES`:: Required.
 This provides a mapping from Kafka version to the corresponding Docker image containing a Kafka broker of that version.

--- a/documentation/modules/ref-operator-cluster.adoc
+++ b/documentation/modules/ref-operator-cluster.adoc
@@ -55,7 +55,7 @@ env:
 
 `STRIMZI_CUSTOM_RESOURCE_SELECTOR`:: Optional.
 Specifies label selector used to filter the custom resources handled by the operator.
-The operator will operate only the custom resource which will have the labels set.
+The operator will operate only on those custom resources which will have the specified labels set.
 Resources without these labels will not be seen by the operator.
 The label selector applies to `Kafka`, `KafkaConnect`, `KafkaConnectS2I`, `KafkaBridge`, `KafkaMirrorMaker`, and `KafkaMirrorMaker2` resources.
 `KafkaRebalance` and `KafkaConnector` resources will be operated only when their corresponding Kafka and Kafka Connect clusters have the matching labels.

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -193,6 +193,13 @@ public abstract class AbstractOperator<
             T cr = resourceOperator.get(namespace, name);
 
             if (cr != null) {
+                if (!Util.matchesSelector(selector(), cr))  {
+                    // The the labels matching the selector are removed, the DELETED event is triggered. We have to
+                    // filter these situations out and ignore the reconciliation.
+                    log.debug("{}: {} {} in namespace {} does not match label selector {} and will be ignored", reconciliation, kind(), name, namespace, selector().get().getMatchLabels());
+                    return Future.succeededFuture();
+                }
+
                 Promise<Void> createOrUpdate = Promise.promise();
 
                 if (cr.getSpec() == null)   {

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -194,8 +194,11 @@ public abstract class AbstractOperator<
 
             if (cr != null) {
                 if (!Util.matchesSelector(selector(), cr))  {
-                    // The the labels matching the selector are removed, the DELETED event is triggered. We have to
-                    // filter these situations out and ignore the reconciliation.
+                    // When the labels matching the selector are removed from the custom resource, a DELETE event is
+                    // triggered by the watch even through the custom resource might not match the watch labels anymore
+                    // and might not be really deleted. We have to filter these situations out and ignore the
+                    // reconciliation because such resource might be already operated by another instance (where the
+                    // same change triggered ADDED event).
                     log.debug("{}: {} {} in namespace {} does not match label selector {} and will be ignored", reconciliation, kind(), name, namespace, selector().get().getMatchLabels());
                     return Future.succeededFuture();
                 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -20,6 +20,7 @@ import io.strimzi.api.kafka.model.status.ConditionBuilder;
 import io.strimzi.api.kafka.model.status.Status;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.cluster.model.StatusDiff;
+import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.NamespaceAndName;
 import io.strimzi.operator.common.model.ResourceVisitor;
 import io.strimzi.operator.common.model.ValidationVisitor;
@@ -80,6 +81,8 @@ public abstract class AbstractOperator<
     protected final O resourceOperator;
     private final String kind;
 
+    private final Optional<LabelSelector> selector;
+
     protected final MetricsProvider metrics;
     private final Counter periodicReconciliationsCounter;
     private final Counter reconciliationsCounter;
@@ -90,10 +93,11 @@ public abstract class AbstractOperator<
     private final Timer reconciliationsTimer;
     private final Map<Tags, AtomicInteger> resourcesStateCounter;
 
-    public AbstractOperator(Vertx vertx, String kind, O resourceOperator, MetricsProvider metrics) {
+    public AbstractOperator(Vertx vertx, String kind, O resourceOperator, MetricsProvider metrics, Labels selectorLabels) {
         this.vertx = vertx;
         this.kind = kind;
         this.resourceOperator = resourceOperator;
+        this.selector = (selectorLabels == null || selectorLabels.toMap().isEmpty()) ? Optional.empty() : Optional.of(new LabelSelector(null, selectorLabels.toMap()));
         this.metrics = metrics;
 
         // Setup metrics
@@ -416,7 +420,7 @@ public abstract class AbstractOperator<
      * @return A selector.
      */
     public Optional<LabelSelector> selector() {
-        return Optional.empty();
+        return selector;
     }
 
     /**

--- a/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
@@ -67,7 +67,7 @@ public class OperatorMetricsTest {
 
         AbstractWatchableStatusedResourceOperator resourceOperator = resourceOperatorWithExistingResource();
 
-        AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metrics) {
+        AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metrics, null) {
             @Override
             protected Future createOrUpdate(Reconciliation reconciliation, CustomResource resource) {
                 return Future.succeededFuture();
@@ -117,7 +117,7 @@ public class OperatorMetricsTest {
 
         AbstractWatchableStatusedResourceOperator resourceOperator = resourceOperatorWithExistingResource();
 
-        AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metrics) {
+        AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metrics, null) {
             @Override
             protected Future createOrUpdate(Reconciliation reconciliation, CustomResource resource) {
                 return Future.failedFuture(new RuntimeException("Test error"));
@@ -167,7 +167,7 @@ public class OperatorMetricsTest {
 
         AbstractWatchableStatusedResourceOperator resourceOperator = resourceOperatorWithExistingResource();
 
-        AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metrics) {
+        AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metrics, null) {
             @Override
             protected Future createOrUpdate(Reconciliation reconciliation, CustomResource resource) {
                 return Future.failedFuture(new UnableToAcquireLockException());
@@ -226,7 +226,7 @@ public class OperatorMetricsTest {
             }
         };
 
-        AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metrics) {
+        AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metrics, null) {
             @Override
             protected Future createOrUpdate(Reconciliation reconciliation, CustomResource resource) {
                 return null;
@@ -283,7 +283,7 @@ public class OperatorMetricsTest {
 
         AbstractWatchableStatusedResourceOperator resourceOperator = resourceOperatorWithExistingResource();
 
-        AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metrics) {
+        AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metrics, null) {
             @Override
             protected Future createOrUpdate(Reconciliation reconciliation, CustomResource resource) {
                 return Future.succeededFuture();


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Sometimes, it could be handy to be able to specify a selector which will be used by the operator and make it see only some resources. This can be used for example for A-B testing, blue-green deployments etc. This PR adds support for such selector for all cluster based resources (Kafka, KafkaConnect, KafkaConnectS2I, KafkaMirrorMaker, KafkaMirrorMaker2, KafkaBridge). The KafkaConnector and KafkaRebalance resources will be operated by the operator which also operates the main resource they belong to.

Right now, the labels used by the selector propagate into the operand resources. That means that while handing over between operator instances, the operands will be always rolled. We should figure out how to avoid this, but that should be done in a separate PR - perhaps while addressing #4394.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally