### PR TITLE
Configure labels and annotations for ClusterRoleBindings for Kafka and Kafka Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 * Add support for JMX options configuration of all Kafka Connect (KC, KC2SI, MM2)
 * Updated Cruise Control to version 2.5.32
 * Fix Cruise Control crash loop when updating container configurations
-* Configure extenal logging `ConfigMap` name and key.
+* Configure external logging `ConfigMap` name and key.
+* Add support for configuring labels and annotations in ClusterRoleBindings created as part of Kafka and Kafka Connect clusters
 
 ### Deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
@@ -50,6 +50,7 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
     private ContainerTemplate kafkaContainer;
     private ContainerTemplate tlsSidecarContainer;
     private ContainerTemplate initContainer;
+    private ResourceTemplate clusterRoleBinding;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for Kafka `StatefulSet`.")
@@ -210,8 +211,19 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
     public ResourceTemplate getClusterCaCert() {
         return clusterCaCert;
     }
+
     public void setClusterCaCert(ResourceTemplate clusterCaCert) {
         this.clusterCaCert = clusterCaCert;
+    }
+
+    @Description("Template for the Kafka ClusterRoleBinding.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getClusterRoleBinding() {
+        return clusterRoleBinding;
+    }
+
+    public void setClusterRoleBinding(ResourceTemplate clusterRoleBinding) {
+        this.clusterRoleBinding = clusterRoleBinding;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
@@ -39,6 +39,7 @@ public class KafkaConnectTemplate implements Serializable, UnknownPropertyPreser
     private ContainerTemplate initContainer;
     private ContainerTemplate buildContainer;
     private ResourceTemplate buildConfig;
+    private ResourceTemplate clusterRoleBinding;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for Kafka Connect `Deployment`.")
@@ -132,6 +133,16 @@ public class KafkaConnectTemplate implements Serializable, UnknownPropertyPreser
 
     public void setBuildConfig(ResourceTemplate buildConfig) {
         this.buildConfig = buildConfig;
+    }
+
+    @Description("Template for the Kafka Connect ClusterRoleBinding.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getClusterRoleBinding() {
+        return clusterRoleBinding;
+    }
+
+    public void setClusterRoleBinding(ResourceTemplate clusterRoleBinding) {
+        this.clusterRoleBinding = clusterRoleBinding;
     }
 
     @Override

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1.yaml
@@ -1833,6 +1833,26 @@ spec:
                             description: Metadata applied to the resource.
                         description: Template for Secret with Kafka Cluster certificate
                           public key.
+                      clusterRoleBinding:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: Labels added to the resource template.
+                                  Can be applied to different resources such as `StatefulSets`,
+                                  `Deployments`, `Pods`, and `Services`.
+                              annotations:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: Annotations added to the resource template.
+                                  Can be applied to different resources such as `StatefulSets`,
+                                  `Deployments`, `Pods`, and `Services`.
+                            description: Metadata applied to the resource.
+                        description: Template for the Kafka ClusterRoleBinding.
                     description: Template for Kafka cluster resources. The template
                       allows users to specify how are the `StatefulSet`, `Pods` and
                       `Services` generated.

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka-crdApi-v1beta1.yaml
@@ -1789,6 +1789,24 @@ spec:
                             description: Metadata applied to the resource.
                         description: Template for Secret with Kafka Cluster certificate
                           public key.
+                      clusterRoleBinding:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                type: object
+                                description: Labels added to the resource template.
+                                  Can be applied to different resources such as `StatefulSets`,
+                                  `Deployments`, `Pods`, and `Services`.
+                              annotations:
+                                type: object
+                                description: Annotations added to the resource template.
+                                  Can be applied to different resources such as `StatefulSets`,
+                                  `Deployments`, `Pods`, and `Services`.
+                            description: Metadata applied to the resource.
+                        description: Template for the Kafka ClusterRoleBinding.
                     description: Template for Kafka cluster resources. The template
                       allows users to specify how are the `StatefulSet`, `Pods` and
                       `Services` generated.
@@ -9214,6 +9232,24 @@ spec:
                             description: Metadata applied to the resource.
                         description: Template for Secret with Kafka Cluster certificate
                           public key.
+                      clusterRoleBinding:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                type: object
+                                description: Labels added to the resource template.
+                                  Can be applied to different resources such as `StatefulSets`,
+                                  `Deployments`, `Pods`, and `Services`.
+                              annotations:
+                                type: object
+                                description: Annotations added to the resource template.
+                                  Can be applied to different resources such as `StatefulSets`,
+                                  `Deployments`, `Pods`, and `Services`.
+                            description: Metadata applied to the resource.
+                        description: Template for the Kafka ClusterRoleBinding.
                     description: Template for Kafka cluster resources. The template
                       allows users to specify how are the `StatefulSet`, `Pods` and
                       `Services` generated.
@@ -17547,6 +17583,24 @@ spec:
                             description: Metadata applied to the resource.
                         description: Template for Secret with Kafka Cluster certificate
                           public key.
+                      clusterRoleBinding:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                type: object
+                                description: Labels added to the resource template.
+                                  Can be applied to different resources such as `StatefulSets`,
+                                  `Deployments`, `Pods`, and `Services`.
+                              annotations:
+                                type: object
+                                description: Annotations added to the resource template.
+                                  Can be applied to different resources such as `StatefulSets`,
+                                  `Deployments`, `Pods`, and `Services`.
+                            description: Metadata applied to the resource.
+                        description: Template for the Kafka ClusterRoleBinding.
                     description: Template for Kafka cluster resources. The template
                       allows users to specify how are the `StatefulSet`, `Pods` and
                       `Services` generated.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -280,6 +280,8 @@ public abstract class AbstractModel {
     protected List<HostAlias> templatePodHostAliases;
     protected List<TopologySpreadConstraint> templatePodTopologySpreadConstraints;
     protected PodManagementPolicy templatePodManagementPolicy = PodManagementPolicy.PARALLEL;
+    protected Map<String, String> templateClusterRoleBindingLabels;
+    protected Map<String, String> templateClusterRoleBindingAnnotations;
 
     protected List<Condition> warningConditions = new ArrayList<>(0);
 
@@ -1523,7 +1525,8 @@ public abstract class AbstractModel {
         return new ClusterRoleBindingBuilder()
                 .withNewMetadata()
                     .withName(name)
-                    .withLabels(labels.toMap())
+                    .withLabels(getLabelsWithStrimziName(name, templateClusterRoleBindingLabels).toMap())
+                    .withAnnotations(templateClusterRoleBindingAnnotations)
                 .endMetadata()
                 .withSubjects(subject)
                 .withRoleRef(roleRef)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1525,7 +1525,7 @@ public abstract class AbstractModel {
         return new ClusterRoleBindingBuilder()
                 .withNewMetadata()
                     .withName(name)
-                    .withLabels(getLabelsWithStrimziName(name, templateClusterRoleBindingLabels).toMap())
+                    .withLabels(labels.withAdditionalLabels(templateClusterRoleBindingLabels).toMap())
                     .withAnnotations(templateClusterRoleBindingAnnotations)
                 .endMetadata()
                 .withSubjects(subject)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -572,6 +572,11 @@ public class KafkaCluster extends AbstractModel {
                 result.templatePerPodIngressAnnotations = template.getPerPodIngress().getMetadata().getAnnotations();
             }
 
+            if (template.getClusterRoleBinding() != null && template.getClusterRoleBinding().getMetadata() != null) {
+                result.templateClusterRoleBindingLabels = template.getClusterRoleBinding().getMetadata().getLabels();
+                result.templateClusterRoleBindingAnnotations = template.getClusterRoleBinding().getMetadata().getAnnotations();
+            }
+
             if (template.getPersistentVolumeClaim() != null && template.getPersistentVolumeClaim().getMetadata() != null) {
                 result.templatePersistentVolumeClaimLabels = Util.mergeLabelsOrAnnotations(template.getPersistentVolumeClaim().getMetadata().getLabels(),
                         result.templateStatefulSetLabels);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -263,6 +263,11 @@ public class KafkaConnectCluster extends AbstractModel {
                 kafkaConnect.templateServiceAnnotations = template.getApiService().getMetadata().getAnnotations();
             }
 
+            if (template.getClusterRoleBinding() != null && template.getClusterRoleBinding().getMetadata() != null) {
+                kafkaConnect.templateClusterRoleBindingLabels = template.getClusterRoleBinding().getMetadata().getLabels();
+                kafkaConnect.templateClusterRoleBindingAnnotations = template.getClusterRoleBinding().getMetadata().getAnnotations();
+            }
+
             if (template.getConnectContainer() != null && template.getConnectContainer().getEnv() != null) {
                 kafkaConnect.templateContainerEnvVars = template.getConnectContainer().getEnv();
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -1687,6 +1687,9 @@ public class KafkaClusterTest {
         Map<String, String> pdbLabels = TestUtils.map("l17", "v17", "l18", "v18");
         Map<String, String> pdbAnots = TestUtils.map("a17", "v17", "a18", "v18");
 
+        Map<String, String> crbLabels = TestUtils.map("l19", "v19", "l20", "v20");
+        Map<String, String> crbAnots = TestUtils.map("a19", "v19", "a20", "v20");
+
         HostAlias hostAlias1 = new HostAliasBuilder()
                         .withHostnames("my-host-1", "my-host-2")
                         .withIp("192.168.1.86")
@@ -1719,6 +1722,12 @@ public class KafkaClusterTest {
                                 .withName("external")
                                 .withPort(9094)
                                 .withType(KafkaListenerType.ROUTE)
+                                .withTls(true)
+                            .endGenericKafkaListener()
+                            .addNewGenericKafkaListener()
+                                .withName("external2")
+                                .withPort(9095)
+                                .withType(KafkaListenerType.NODEPORT)
                                 .withTls(true)
                             .endGenericKafkaListener()
                         .endListeners()
@@ -1781,6 +1790,12 @@ public class KafkaClusterTest {
                                     .withAnnotations(pdbAnots)
                                 .endMetadata()
                             .endPodDisruptionBudget()
+                            .withNewClusterRoleBinding()
+                                .withNewMetadata()
+                                    .withLabels(crbLabels)
+                                    .withAnnotations(crbAnots)
+                                .endMetadata()
+                            .endClusterRoleBinding()
                         .endTemplate()
                     .endKafka()
                 .endSpec()
@@ -1834,6 +1849,11 @@ public class KafkaClusterTest {
         PodDisruptionBudget pdb = kc.generatePodDisruptionBudget();
         assertThat(pdb.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
         assertThat(pdb.getMetadata().getAnnotations().entrySet().containsAll(pdbAnots.entrySet()), is(true));
+
+        // Check ClusterRoleBinding
+        ClusterRoleBinding crb = kc.generateClusterRoleBinding("namespace");
+        assertThat(crb.getMetadata().getLabels().entrySet().containsAll(crbLabels.entrySet()), is(true));
+        assertThat(crb.getMetadata().getAnnotations().entrySet().containsAll(crbAnots.entrySet()), is(true));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -565,6 +565,9 @@ public class KafkaConnectClusterTest {
         Map<String, String> pdbLabels = TestUtils.map("l7", "v7", "l8", "v8");
         Map<String, String> pdbAnots = TestUtils.map("a7", "v7", "a8", "v8");
 
+        Map<String, String> crbLabels = TestUtils.map("l9", "v9", "l10", "v10");
+        Map<String, String> crbAnots = TestUtils.map("a9", "v9", "a10", "v10");
+
         HostAlias hostAlias1 = new HostAliasBuilder()
                 .withHostnames("my-host-1", "my-host-2")
                 .withIp("192.168.1.86")
@@ -590,6 +593,7 @@ public class KafkaConnectClusterTest {
 
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .editSpec()
+                    .withNewRack("my-topology-key")
                     .withNewTemplate()
                         .withNewDeployment()
                             .withNewMetadata()
@@ -620,6 +624,12 @@ public class KafkaConnectClusterTest {
                                 .withAnnotations(pdbAnots)
                             .endMetadata()
                         .endPodDisruptionBudget()
+                        .withNewClusterRoleBinding()
+                            .withNewMetadata()
+                                .withLabels(crbLabels)
+                                .withAnnotations(crbAnots)
+                            .endMetadata()
+                        .endClusterRoleBinding()
                     .endTemplate()
                 .endSpec()
                 .build();
@@ -649,6 +659,11 @@ public class KafkaConnectClusterTest {
         PodDisruptionBudget pdb = kc.generatePodDisruptionBudget();
         assertThat(pdb.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
         assertThat(pdb.getMetadata().getAnnotations().entrySet().containsAll(pdbAnots.entrySet()), is(true));
+
+        // Check ClusterRoleBinding
+        ClusterRoleBinding crb = kc.generateClusterRoleBinding();
+        assertThat(crb.getMetadata().getLabels().entrySet().containsAll(crbLabels.entrySet()), is(true));
+        assertThat(crb.getMetadata().getAnnotations().entrySet().containsAll(crbAnots.entrySet()), is(true));
     }
 
     @Test

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1234,6 +1234,8 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |clusterCaCert             1.2+<.<|Template for Secret with Kafka Cluster certificate public key.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|clusterRoleBinding        1.2+<.<|Template for the Kafka ClusterRoleBinding.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |====
 
 [id='type-StatefulSetTemplate-{context}']
@@ -2255,6 +2257,8 @@ Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:ty
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |buildPod             1.2+<.<|Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
+|clusterRoleBinding   1.2+<.<|Template for the Kafka Connect ClusterRoleBinding.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |connectContainer     1.2+<.<|Template for the Kafka Connect container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |initContainer        1.2+<.<|Template for the Kafka init container.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -2408,6 +2408,20 @@ spec:
                               description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
                       description: Template for Secret with Kafka Cluster certificate public key.
+                    clusterRoleBinding:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for the Kafka ClusterRoleBinding.
                   description: Template for Kafka cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
                 version:
                   type: string

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1403,6 +1403,20 @@ spec:
                             type: string
                       description: The pod's topology spread constraints.
                   description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
+                clusterRoleBinding:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                  description: Template for the Kafka Connect ClusterRoleBinding.
                 connectContainer:
                   type: object
                   properties:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -1229,6 +1229,20 @@ spec:
                             type: string
                       description: The pod's topology spread constraints.
                   description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
+                clusterRoleBinding:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                  description: Template for the Kafka Connect ClusterRoleBinding.
                 connectContainer:
                   type: object
                   properties:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -1485,6 +1485,20 @@ spec:
                             type: string
                       description: The pod's topology spread constraints.
                   description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
+                clusterRoleBinding:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                  description: Template for the Kafka Connect ClusterRoleBinding.
                 connectContainer:
                   type: object
                   properties:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -3104,6 +3104,24 @@ spec:
                           description: Metadata applied to the resource.
                       description: Template for Secret with Kafka Cluster certificate
                         public key.
+                    clusterRoleBinding:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for the Kafka ClusterRoleBinding.
                   description: Template for Kafka cluster resources. The template
                     allows users to specify how are the `StatefulSet`, `Pods` and
                     `Services` generated.

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1529,6 +1529,24 @@ spec:
                       description: The pod's topology spread constraints.
                   description: Template for Kafka Connect Build `Pods`. The build
                     pod is used only on Kubernetes.
+                clusterRoleBinding:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                  description: Template for the Kafka Connect ClusterRoleBinding.
                 connectContainer:
                   type: object
                   properties:

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -1317,6 +1317,24 @@ spec:
                       description: The pod's topology spread constraints.
                   description: Template for Kafka Connect Build `Pods`. The build
                     pod is used only on Kubernetes.
+                clusterRoleBinding:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                  description: Template for the Kafka Connect ClusterRoleBinding.
                 connectContainer:
                   type: object
                   properties:

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1635,6 +1635,24 @@ spec:
                       description: The pod's topology spread constraints.
                   description: Template for Kafka Connect Build `Pods`. The build
                     pod is used only on Kubernetes.
+                clusterRoleBinding:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                  description: Template for the Kafka Connect ClusterRoleBinding.
                 connectContainer:
                   type: object
                   properties:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds possibility to configure labels and annotations  for the ClusterRoleBindings created as part of Kafka or Kafka Connect clusters. This can be useful for example to make them work with different GitOps tools etc.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md