### PR TITLE
[DOC] Fix prerequisites in Configuring Kafka chapter

### DIFF
--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -30,7 +30,7 @@ For more information, see link:{BookURLDeploying}#assembly-upgrading-kafka-versi
 
 .Prerequisites
 
-* An OpenShift cluster
+* A Kubernetes cluster
 * A running Cluster Operator
 
 See the _Deploying and Upgrading Strimzi_ guide for instructions on deploying a:


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The prerequisites in the [_Configuring Kafka_ chapter](https://strimzi.io/docs/operators/master/full/using.html#proc-config-kafka-str) in our docs currently list _OpenShfit cluster_ as prerequisite. Since this chapter is not supposed to be OpenShift specific covering any features available only on OpenShift, this should be changed to _Kubernetes cluster_.