### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,8 +119,8 @@
         <test-containers.version>1.14.0</test-containers.version>
         <javax.json-api.version>1.1.4</javax.json-api.version>
         <javax.json.version>1.1.4</javax.json.version>
-        <rest-assured.version>4.1.1</rest-assured.version>
-        <json-path.version>4.1.1</json-path.version>
+        <rest-assured.version>4.3.3</rest-assured.version>
+        <json-path.version>4.3.3</json-path.version>
         <jupiter.version>5.7.0</jupiter.version>
         <junit.platform.version>1.7.0</junit.platform.version>
         <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement

### Description
`io.rest-assured:rest-assured:4.1.1` and `io.rest-assured:json-path:4.1.1` outdated dependencies contain a CVE-2020-17521. That is removed by using a newer version 4.3.3.
This dependency uses newer groovy 3.0.7
```
[INFO] +- io.rest-assured:rest-assured:jar:4.1.1:compile
[INFO] |  +- org.codehaus.groovy:groovy:jar:2.5.6:compile
[INFO] |  +- org.codehaus.groovy:groovy-xml:jar:2.5.6:compile
```
```
[INFO] +- io.rest-assured:rest-assured:jar:4.3.3:compile
[INFO] |  +- org.codehaus.groovy:groovy:jar:3.0.7:compile
[INFO] |  +- org.codehaus.groovy:groovy-xml:jar:3.0.7:compile
```
The dependency is used since 0.15.0 release.
This CVE *does not* affect strimzi in production since the dependencies are used in systemtest module only.


### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

