### PR TITLE
Add OAuth 0.7.0 to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Update Strimzi Kafka OAuth to version 0.7.0 and add support for new features:
   * OAuth authentication over SASL PLAIN mechanism
   * Checking token audience
-  * Validating token claims
+  * Validating tokens using JSONPath filter queries to perform custom checks
 * Updated Cruise Control to version 2.5.32
 * Fix Cruise Control crash loop when updating container configurations
 * Configure extenal logging `ConfigMap` name and key.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * Add annotations that enable the operator to restart Kafka Connect connectors or tasks. The annotations can be applied to the KafkaConnector and the KafkaMirrorMaker2 custom resources.
 * Add additional configuration options for the Kaniko executor used by the Kafka Connect Build on Kubernetes
 * Add support for JMX options configuration of all Kafka Connect (KC, KC2SI, MM2)
+* Update Strimzi Kafka OAuth to version 0.7.0 and add support for new features:
+  * OAuth authentication over SASL PLAIN mechanism
+  * Checking token audience
+  * Validating token claims
 * Updated Cruise Control to version 2.5.32
 * Fix Cruise Control crash loop when updating container configurations
 * Configure extenal logging `ConfigMap` name and key.


### PR DESCRIPTION
### Type of change

- Task

### Description

We added lot of OAuth improvements to Strimzi as part of the Strimzi Kafka OAuth 0.7.0 library but we did not convered them in the CHANGELOG.md. This PR adds them there.