### PR TITLE
Increase timeout for azure build to 80 minutes

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -24,7 +24,7 @@ jobs:
           jdk_version: '11'
           jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
     # Set timeout for jobs
-    timeoutInMinutes: 70
+    timeoutInMinutes: 80
     # Base system
     pool:
       vmImage: $(image)


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Description

It seems that 70 minutes for the build is not enough atm. This PR extends it for another 10 minutes.



