### PR TITLE
[DOC] Edits to connector/task restart operations doc

### DIFF
--- a/documentation/modules/configuring/proc-manual-restart-connector-task.adoc
+++ b/documentation/modules/configuring/proc-manual-restart-connector-task.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
-//
-//
+// configuring/assembly-config-kafka-connect.adoc
+// deploying/assembly-deploy-kafka-connect.adoc
 
 [id='proc-manual-restart-connector-task-{context}']
 = Performing a restart of a Kafka connector task
@@ -13,21 +13,34 @@ This procedure describes how to manually trigger a restart of a Kafka connector 
 
 .Procedure
 
-. Find the name of the KafkaConnector custom resource that controls the Kafka connector task you want to restart:
-[source,shell,subs=+quotes]
+. Find the name of the `KafkaConnector` custom resource that controls the Kafka connector task you want to restart:
++
+[source,shell,subs="+quotes"]
+----
 kubectl get KafkaConnector
+----
 
-. Find the ID of the task to be restarted from the KafkaConnector custom resource.
-Task IDs are non-negative integers, starting from 0:
-[source,shell,subs=+quotes]
-kubectl describe KafkaConnector _KafkaConnector-name_
+. Find the ID of the task to be restarted from the `KafkaConnector` custom resource.
+Task IDs are non-negative integers, starting from 0.
++
+[source,shell,subs="+quotes"]
+----
+kubectl describe KafkaConnector _KAFKACONNECTOR-NAME_
+----
 
-. To restart the connector task, annotate the KafkaConnector resource in Kubernetes.
+. To restart the connector task, annotate the `KafkaConnector` resource in Kubernetes. 
 For example, using `kubectl annotate` to restart task 0:
-[source,shell,subs=+quotes]
-kubectl annotate KafkaConnector _KafkaConnector-name_ strimzi.io/restart-task=0
-
++
+[source,shell,subs="+quotes"]
+----
+kubectl annotate KafkaConnector _KAFKACONNECTOR-NAME_ strimzi.io/restart-task=0
+----
 
 . Wait for the next reconciliation to occur (every two minutes by default).
-The Kafka connector task is restarted, as long as the annotation was detected by the reconciliation process.
-When Kafka Connect accepts the restart request, the annotation is removed from the KafkaConnector custom resource.
++
+The Kafka connector task is restarted, as long as the annotation was detected by the reconciliation process. 
+When Kafka Connect accepts the restart request, the annotation is removed from the `KafkaConnector` custom resource.
+
+.Additional resources
+
+* link:{BookURLDeploying}#con-creating-managing-connectors-{context}[Creating and managing connectors^] in the _Deploying and Upgrading_ guide.

--- a/documentation/modules/configuring/proc-manual-restart-connector.adoc
+++ b/documentation/modules/configuring/proc-manual-restart-connector.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
-//
-//
+// configuring/assembly-config-kafka-connect.adoc
+// deploying/assembly-deploy-kafka-connect.adoc
 
 [id='proc-manual-restart-connector-{context}']
 = Performing a restart of a Kafka connector
@@ -13,15 +13,26 @@ This procedure describes how to manually trigger a restart of a Kafka connector 
 
 .Procedure
 
-. Find the name of the KafkaConnector custom resource that controls the Kafka connector you want to restart:
-[source,shell,subs=+quotes]
+. Find the name of the `KafkaConnector` custom resource that controls the Kafka connector you want to restart:
++
+[source,shell,subs="+quotes"]
+----
 kubectl get KafkaConnector
+----
 
-. To restart the connector, annotate the KafkaConnector resource in Kubernetes.
+. To restart the connector, annotate the `KafkaConnector` resource in Kubernetes. 
 For example, using `kubectl annotate`:
-[source,shell,subs=+quotes]
-kubectl annotate KafkaConnector _KafkaConnector-name_ strimzi.io/restart=true
++
+[source,shell,subs="+quotes"]
+----
+kubectl annotate KafkaConnector _KAFKACONNECTOR-NAME_ strimzi.io/restart=true
+----
 
 . Wait for the next reconciliation to occur (every two minutes by default).
-The Kafka connector is restarted, as long as the annotation was detected by the reconciliation process.
-When Kafka Connect accepts the restart request, the annotation is removed from the KafkaConnector custom resource.
++
+The Kafka connector is restarted, as long as the annotation was detected by the reconciliation process. 
+When Kafka Connect accepts the restart request, the annotation is removed from the `KafkaConnector` custom resource.
+
+.Additional resources
+
+* link:{BookURLDeploying}#con-creating-managing-connectors-{context}[Creating and managing connectors^] in the _Deploying and Upgrading_ guide.

--- a/documentation/modules/deploying/con-deploy-kafka-connect-managing-connectors.adoc
+++ b/documentation/modules/deploying/con-deploy-kafka-connect-managing-connectors.adoc
@@ -27,7 +27,8 @@ Using the APIs, you can:
 * Check the status of a connector instance
 * Reconfigure a running connector
 * Increase or decrease the number of tasks for a connector instance
-* Restart failed tasks (not supported by KafkaConnector resource)
+* Restart connectors
+* Restart connector tasks, including failed tasks
 * Pause a connector instance
 * Resume a previously paused connector instance
 * Delete a connector instance
@@ -38,7 +39,8 @@ KafkaConnectors allow you to create and manage connector instances for Kafka Con
 Like other Kafka resources, you declare a connector’s desired state in a KafkaConnector YAML file that is deployed to your Kubernetes cluster to create the connector instance.
 KafkaConnector resources must be deployed to the same namespace as the Kafka Connect cluster they link to.
 
-You manage a running connector instance by updating its corresponding KafkaConnector resource, and then applying the updates.
+You manage a running connector instance by updating its corresponding KafkaConnector resource, and then applying the updates. 
+Annotations are used to manually restart connector instances and connector tasks. 
 You remove a connector by deleting its corresponding KafkaConnector.
 
 To ensure compatibility with earlier versions of Strimzi, KafkaConnectors are disabled by default. To enable them for a Kafka Connect cluster, you must use annotations on the `KafkaConnect` resource.
@@ -46,7 +48,7 @@ For instructions, see link:{BookURLUsing}#proc-kafka-connect-config-str[Configur
 
 When KafkaConnectors are enabled, the Cluster Operator begins to watch for them. It updates the configurations of running connector instances to match the configurations defined in their KafkaConnectors.
 
-Strimzi includes an example `KafkaConnector`, named `examples/connect/source-connector.yaml`. You can use this example to create and manage a `FileStreamSourceConnector`.
+Strimzi includes an example `KafkaConnector`, named `examples/connect/source-connector.yaml`. You can use this example to create and manage a `FileStreamSourceConnector` and a `FileStreamSinkConnector` as described in xref:proc-deploying-kafkaconnector-{context}[]. 
 
 == Availability of the Kafka Connect REST API
 

--- a/documentation/modules/deploying/con-deploy-kafka-connect-managing-connectors.adoc
+++ b/documentation/modules/deploying/con-deploy-kafka-connect-managing-connectors.adoc
@@ -26,7 +26,7 @@ Using the APIs, you can:
 
 * Check the status of a connector instance
 * Reconfigure a running connector
-* Increase or decrease the number of tasks for a connector instance
+* Increase or decrease the number of connector tasks for a connector instance
 * Restart connectors
 * Restart connector tasks, including failed tasks
 * Pause a connector instance

--- a/documentation/modules/proc-manual-restart-mirrormaker2-connector-task.adoc
+++ b/documentation/modules/proc-manual-restart-mirrormaker2-connector-task.adoc
@@ -28,7 +28,7 @@ kubectl describe KafkaMirrorMaker2 _KAFKAMIRRORMAKER-2-NAME_
 ----
 
 . To restart the connector task, annotate the `KafkaMirrorMaker2` resource in Kubernetes. 
-For example, using `kubectl annotate` to restart task 0 of the connector named `+my-source->my-target.MirrorSourceConnector+`:
+In this example, `kubectl annotate` restarts task _0_ of a connector named `+my-source->my-target.MirrorSourceConnector+`:
 +
 [source,shell,subs="+quotes"]
 ----

--- a/documentation/modules/proc-manual-restart-mirrormaker2-connector-task.adoc
+++ b/documentation/modules/proc-manual-restart-mirrormaker2-connector-task.adoc
@@ -1,6 +1,5 @@
 // Module included in the following assemblies:
-//
-//
+// configuring/assembly-config-mirrormaker2.adoc
 
 [id='proc-manual-restart-mirrormaker2-connector-task-{context}']
 = Performing a restart of a Kafka MirrorMaker 2.0 connector task
@@ -14,19 +13,33 @@ This procedure describes how to manually trigger a restart of a Kafka MirrorMake
 .Procedure
 
 . Find the name of the `KafkaMirrorMaker2` custom resource that controls the Kafka MirrorMaker 2.0 connector you want to restart:
-[source,shell,subs=+quotes]
++
+[source,shell,subs="+quotes"]
+----
 kubectl get KafkaMirrorMaker2
+----
 
-. Find the name of the Kafka MirrorMaker 2.0 connector and the ID of the task to be restarted from the `KafkaMirrorMaker2` custom resource.
-Task IDs are non-negative integers, starting from 0:
-[source,shell,subs=+quotes]
-kubectl describe KafkaMirrorMaker2 _KafkaMirrorMaker2-name_
+. Find the name of the Kafka MirrorMaker 2.0 connector and the ID of the task to be restarted from the `KafkaMirrorMaker2` custom resource. 
+Task IDs are non-negative integers, starting from 0.
++
+[source,shell,subs="+quotes"]
+----
+kubectl describe KafkaMirrorMaker2 _KAFKAMIRRORMAKER-2-NAME_
+----
 
-. To restart the connector task, annotate the `KafkaMirrorMaker2` resource in Kubernetes.
+. To restart the connector task, annotate the `KafkaMirrorMaker2` resource in Kubernetes. 
 For example, using `kubectl annotate` to restart task 0 of the connector named `my-source->my-target.MirrorSourceConnector`:
-[source,shell,subs=+quotes]
-kubectl annotate KafkaMirrorMaker2 _KafkaMirrorMaker2-name_ "strimzi.io/restart-connector-task=my-source->my-target.MirrorSourceConnector:0"
++
+[source,shell,subs="+quotes"]
+----
+kubectl annotate KafkaMirrorMaker2 _KAFKAMIRRORMAKER-2-NAME_ "strimzi.io/restart-connector-task=my-source->my-target.MirrorSourceConnector:0"
+----
 
 . Wait for the next reconciliation to occur (every two minutes by default).
-The Kafka MirrorMaker 2.0 connector task is restarted, as long as the annotation was detected by the reconciliation process.
++
+The Kafka MirrorMaker 2.0 connector task is restarted, as long as the annotation was detected by the reconciliation process. 
 When the restart task request is accepted, the annotation is removed from the `KafkaMirrorMaker2` custom resource.
+
+.Additional resources
+
+* xref:assembly-mirrormaker-{context}[Kafka MirrorMaker 2.0 cluster configuration].

--- a/documentation/modules/proc-manual-restart-mirrormaker2-connector-task.adoc
+++ b/documentation/modules/proc-manual-restart-mirrormaker2-connector-task.adoc
@@ -28,7 +28,7 @@ kubectl describe KafkaMirrorMaker2 _KAFKAMIRRORMAKER-2-NAME_
 ----
 
 . To restart the connector task, annotate the `KafkaMirrorMaker2` resource in Kubernetes. 
-For example, using `kubectl annotate` to restart task 0 of the connector named `my-source->my-target.MirrorSourceConnector`:
+For example, using `kubectl annotate` to restart task 0 of the connector named `+my-source->my-target.MirrorSourceConnector+`:
 +
 [source,shell,subs="+quotes"]
 ----

--- a/documentation/modules/proc-manual-restart-mirrormaker2-connector.adoc
+++ b/documentation/modules/proc-manual-restart-mirrormaker2-connector.adoc
@@ -1,6 +1,5 @@
 // Module included in the following assemblies:
-//
-//
+// configuring/assembly-config-mirrormaker2.adoc
 
 [id='proc-manual-restart-mirrormaker2-connector-{context}']
 = Performing a restart of a Kafka MirrorMaker 2.0 connector
@@ -14,17 +13,32 @@ This procedure describes how to manually trigger a restart of a Kafka MirrorMake
 .Procedure
 
 . Find the name of the `KafkaMirrorMaker2` custom resource that controls the Kafka MirrorMaker 2.0 connector you want to restart:
-[source,shell,subs=+quotes]
++
+[source,shell,subs="+quotes"]
+----
 kubectl get KafkaMirrorMaker2
+----
 
 . Find the name of the Kafka MirrorMaker 2.0 connector to be restarted from the `KafkaMirrorMaker2` custom resource.
-[source,shell,subs=+quotes]
-kubectl describe KafkaMirrorMaker2 _KafkaMirrorMaker2-name_
++
+[source,shell,subs="+quotes"]
+----
+kubectl describe KafkaMirrorMaker2 _KAFKAMIRRORMAKER-2-NAME_
+----
 
-. To restart the connector, annotate the `KafkaMirrorMaker2` resource in Kubernetes. For example, using `kubectl annotate` to restart the connector named `my-source->my-target.MirrorSourceConnector`:
-[source,shell,subs=+quotes]
-kubectl annotate KafkaMirrorMaker2 _KafkaMirrorMaker2-name_ "strimzi.io/restart-connector=my-source->my-target.MirrorSourceConnector"
+. To restart the connector, annotate the `KafkaMirrorMaker2` resource in Kubernetes. 
+For example, using `kubectl annotate` to restart the connector named `my-source->my-target.MirrorSourceConnector`:
++
+[source,shell,subs="+quotes"]
+----
+kubectl annotate KafkaMirrorMaker2 _KAFKAMIRRORMAKER-2-NAME_ "strimzi.io/restart-connector=my-source->my-target.MirrorSourceConnector"
+----
 
 . Wait for the next reconciliation to occur (every two minutes by default).
-The Kafka MirrorMaker 2.0 connector is restarted, as long as the annotation was detected by the reconciliation process.
++
+The Kafka MirrorMaker 2.0 connector is restarted, as long as the annotation was detected by the reconciliation process. 
 When the restart request is accepted, the annotation is removed from the `KafkaMirrorMaker2` custom resource.
+
+.Additional resources
+
+* xref:assembly-mirrormaker-{context}[Kafka MirrorMaker 2.0 cluster configuration].

--- a/documentation/modules/proc-manual-restart-mirrormaker2-connector.adoc
+++ b/documentation/modules/proc-manual-restart-mirrormaker2-connector.adoc
@@ -27,7 +27,7 @@ kubectl describe KafkaMirrorMaker2 _KAFKAMIRRORMAKER-2-NAME_
 ----
 
 . To restart the connector, annotate the `KafkaMirrorMaker2` resource in Kubernetes. 
-For example, using `kubectl annotate` to restart the connector named `my-source->my-target.MirrorSourceConnector`:
+For example, using `kubectl annotate` to restart the connector named `+my-source->my-target.MirrorSourceConnector+`:
 +
 [source,shell,subs="+quotes"]
 ----

--- a/documentation/modules/proc-manual-restart-mirrormaker2-connector.adoc
+++ b/documentation/modules/proc-manual-restart-mirrormaker2-connector.adoc
@@ -27,7 +27,7 @@ kubectl describe KafkaMirrorMaker2 _KAFKAMIRRORMAKER-2-NAME_
 ----
 
 . To restart the connector, annotate the `KafkaMirrorMaker2` resource in Kubernetes. 
-For example, using `kubectl annotate` to restart the connector named `+my-source->my-target.MirrorSourceConnector+`:
+In this example, `kubectl annotate` restarts a connector named `+my-source->my-target.MirrorSourceConnector+`:
 +
 [source,shell,subs="+quotes"]
 ----


### PR DESCRIPTION
### Type of change

Documentation

### Description

Guide(s) updated:
- *Using Strimzi*
- *Deploying and Upgrading Strimzi*

This pull request makes minor edits to the content that was added in #4114 for restarting Kafka Connect and Mirror Maker 2.0 connectors via annotations.

The changes to the procedures are mainly related to Asciidoc formatting and adding some cross-references.

I also made some changes to the explanations in `con-deploy-kafka-connect-managing-connectors.adoc`. Please check that this make sense.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging - NO ISSUES FOUND
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

