### PR TITLE
Rename confusing json-path variables in Maven poms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <scala-library.version>2.12.12</scala-library.version>
         <zookeeper.version>3.5.8</zookeeper.version>
         <mockito.version>2.28.2</mockito.version>
-        <jsonpath.version>2.5.0</jsonpath.version>
+        <jayway-jsonpath.version>2.5.0</jayway-jsonpath.version>
         <slf4j.version>1.7.25</slf4j.version>
         <quartz.version>2.3.2</quartz.version>
         <debezium.version>1.3.1.Final</debezium.version>
@@ -120,7 +120,7 @@
         <javax.json-api.version>1.1.4</javax.json-api.version>
         <javax.json.version>1.1.4</javax.json.version>
         <rest-assured.version>4.3.3</rest-assured.version>
-        <json-path.version>4.3.3</json-path.version>
+        <rest-assured-json-path.version>4.3.3</rest-assured-json-path.version>
         <jupiter.version>5.7.0</jupiter.version>
         <junit.platform.version>1.7.0</junit.platform.version>
         <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
@@ -625,7 +625,7 @@
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
-                <version>${jsonpath.version}</version>
+                <version>${jayway-jsonpath.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -157,7 +157,7 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>json-path</artifactId>
-            <version>${json-path.version}</version>
+            <version>${rest-assured-json-path.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>${jsonpath.version}</version>
+            <version>${jayway-jsonpath.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Right now we have in our pom files two variables:
* `jsonpath.version`
* `json-path.version`

This is confusing since it is not clear which is which. This Pr renames them to make it more clear which dpeendency they refer to.