### PR TITLE
[setup-kubernetes.sh] Add check when KUBE_VERSION is set to latest

### DIFF
--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -38,6 +38,11 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     else
         TEST_MINIKUBE_URL=https://github.com/kubernetes/minikube/releases/download/${TEST_MINIKUBE_VERSION}/minikube-linux-amd64
     fi
+
+    if [ "$KUBE_VERSION" = "latest" ]; then
+        KUBE_VERSION=$(curl -s https://github.com/kubernetes/kubernetes/releases/latest | grep -o "[0-9].[0-9][0-9].[0-9]")
+    fi
+
     curl -Lo minikube ${TEST_MINIKUBE_URL} && chmod +x minikube
     sudo cp minikube /usr/bin
 

--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -39,8 +39,8 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
         TEST_MINIKUBE_URL=https://github.com/kubernetes/minikube/releases/download/${TEST_MINIKUBE_VERSION}/minikube-linux-amd64
     fi
 
-    if [ "$KUBE_VERSION" = "latest" ]; then
-        KUBE_VERSION=$(curl -s https://github.com/kubernetes/kubernetes/releases/latest | grep -o "[0-9].[0-9][0-9].[0-9]")
+    if [ "$KUBE_VERSION" != "latest" ] && [ "$KUBE_VERSION" != "stable" ]; then
+        KUBE_VERSION="v${KUBE_VERSION}"
     fi
 
     curl -Lo minikube ${TEST_MINIKUBE_URL} && chmod +x minikube
@@ -50,7 +50,7 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     export MINIKUBE_WANTREPORTERRORPROMPT=false
     export MINIKUBE_HOME=$HOME
     export CHANGE_MINIKUBE_NONE_USER=true
-    
+
     mkdir $HOME/.kube || true
     touch $HOME/.kube/config
 
@@ -60,7 +60,7 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     # We can turn on network polices support by adding the following options --network-plugin=cni --cni=calico
     # We have to allow trafic for ITS when NPs are turned on
     # We can allow NP after Strimzi#4092 which should fix some issues on STs side
-    sudo -E minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION} \
+    sudo -E minikube start --vm-driver=none --kubernetes-version=${KUBE_VERSION} \
       --insecure-registry=localhost:5000 --extra-config=apiserver.authorization-mode=Node,RBAC
 
     if [ $? -ne 0 ]
@@ -70,7 +70,7 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     fi
 
     sudo -E minikube addons enable default-storageclass
-	kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
+	  kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
 
 elif [ "$TEST_CLUSTER" = "minishift" ]; then
     #install_kubectl


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

In case when we set the `KUBE_VERSION` env to `latest` (for example we don't know which is the latest released version etc.) we should grab it from GH releases. This PR adds this possibility.

