### PR TITLE
Fixed wrong ConfigMap apiVersion

### DIFF
--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -354,7 +354,7 @@ When referencing an empty file, all metrics are exposed as long as they have not
 [source,yaml,subs="+attributes"]
 ----
 kind: ConfigMap
-apiVersion: {KafkaApiVersion}
+apiVersion: v1
 metadata:
   name: my-configmap
 data:
@@ -375,7 +375,6 @@ data:
 .Example metrics configuration for Kafka
 [source,yaml,subs="+attributes"]
 ----
-[source,shell,subs="+attributes"]
 apiVersion: {KafkaApiVersion}
 kind: Kafka
 metadata:


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Fixed ConfigMap example for metrics with bad apiVersion, using the Strimzi one and not the right Kubernetes v1 one.
It also removes adoc related information into another example.

### Checklist

- [x] Update documentation
