### PR TITLE
[DOC] Upgrades from older Strimzi versions

### DIFF
--- a/documentation/assemblies/upgrading/assembly-upgrade-kafka-cluster-operator.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-kafka-cluster-operator.adoc
@@ -7,7 +7,7 @@
 
 The steps to upgrade your Cluster Operator deployment to use Strimzi {ProductVersion} are described in this section.
 
-Follow this procedure if you deployed the Cluster Operator using the installation YAML files.
+Follow this procedure if you deployed the Cluster Operator using the installation YAML files rather than {OperatorHub}.
 
 The availability of Kafka clusters managed by the Cluster Operator is not affected by the upgrade operation.
 

--- a/documentation/assemblies/upgrading/assembly-upgrade-kafka-versions.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-kafka-versions.adoc
@@ -6,7 +6,7 @@
 
 = Upgrading Kafka
 
-After you have upgraded your Cluster Operator, the next step is to upgrade all Kafka brokers to a later supported version of Kafka.
+After you have upgraded your Cluster Operator to {ProductVersion}, the next step is to upgrade all Kafka brokers to the latest supported version of Kafka.
 
 Kafka upgrades are performed by the Cluster Operator through rolling updates of the Kafka brokers. 
 
@@ -29,8 +29,10 @@ The Cluster Operator initiates rolling updates based on the Kafka cluster config
 
 |===
 
-Additional rolling updates occur if the new version of Kafka requires a new ZooKeeper version.
-//check the above statement is still accurate
+As part of the Kafka upgrade, the Cluster Operator initiates rolling updates for ZooKeeper.
+
+* A single rolling update occurs even if the ZooKeeper version is unchanged.
+* Additional rolling updates occur if the new version of Kafka requires a new ZooKeeper version.
 
 .Additional resources
 

--- a/documentation/assemblies/upgrading/assembly-upgrade-kafka-versions.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-kafka-versions.adoc
@@ -6,7 +6,7 @@
 
 = Upgrading Kafka
 
-After you have upgraded your Cluster Operator, the next step is to upgrade all Kafka brokers to a higher supported version of Kafka.
+After you have upgraded your Cluster Operator, the next step is to upgrade all Kafka brokers to a later supported version of Kafka.
 
 Kafka upgrades are performed by the Cluster Operator through rolling updates of the Kafka brokers. 
 

--- a/documentation/assemblies/upgrading/assembly-upgrade-kafka-versions.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-kafka-versions.adoc
@@ -6,18 +6,31 @@
 
 = Upgrading Kafka
 
-After you have upgraded your Cluster Operator, you can upgrade all Kafka brokers to a higher supported version of Kafka.
+After you have upgraded your Cluster Operator, the next step is to upgrade all Kafka brokers to a higher supported version of Kafka.
 
-Kafka upgrades are performed using the Cluster Operator. 
-How the Cluster Operator performs an upgrade depends on the differences between the versions of:
+Kafka upgrades are performed by the Cluster Operator through rolling updates of the Kafka brokers. 
 
-* Inter-broker protocol
-* Log message format
-* ZooKeeper
+The Cluster Operator initiates rolling updates based on the Kafka cluster configuration.
 
-When the versions are the same for the current and target Kafka version, as is typically the case for a patch level upgrade, the Cluster Operator can upgrade through a single rolling update of the Kafka brokers.
+[cols="2*",options="header",stripes="none",separator=¦]
+|===
 
-When one or more of these versions differ, the Cluster Operator requires two or three rolling updates of the Kafka brokers to perform the upgrade.
+¦If `Kafka.spec.kafka.config` contains...
+¦The Cluster Operator initiates...
+
+¦Both the `inter.broker.protocol.version` and the `log.message.format.version`.
+¦A single rolling update.
+
+¦Either the `inter.broker.protocol.version` or the `log.message.format.version`.
+¦Two rolling updates.
+
+¦No configuration for the `inter.broker.protocol.version` or the `log.message.format.version`.
+¦Two rolling updates.
+
+|===
+
+Additional rolling updates occur if the new version of Kafka requires a new ZooKeeper version.
+//check the above statement is still accurate
 
 .Additional resources
 

--- a/documentation/assemblies/upgrading/assembly-upgrade-kafka.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-kafka.adoc
@@ -8,13 +8,13 @@
 Upgrading Strimzi is a three-stage process. 
 To upgrade brokers and clients without downtime, you _must_ complete the upgrade procedures in the following order:
 
-. Update your Cluster Operator to a later Strimzi version.
+. Update your Cluster Operator to Strimzi version {ProductVersion}.
 +
 The approach you take depends on how you xref:cluster-operator-{context}[deployed the Cluster Operator].
 +
 * If you deployed the Cluster Operator using the installation YAML files, perform your upgrade by modifying the Operator installation files, as described in xref:assembly-upgrade-cluster-operator-{context}[Upgrading the Cluster Operator]. 
 +
-* If you deployed the Cluster Operator from {OperatorHub}, use the Operator Lifecycle Manager (OLM) to change the update channel for the Strimzi Operators to the new Strimzi version.
+* If you deployed the Cluster Operator from {OperatorHub}, use the Operator Lifecycle Manager (OLM) to change the update channel for the Strimzi Operators to the Strimzi version {ProductVersion}.
 +
 Depending on your chosen upgrade strategy, after updating the channel, either:
 +
@@ -24,7 +24,7 @@ Depending on your chosen upgrade strategy, after updating the channel, either:
 +
 For more information on using {OperatorHub} to upgrade Operators, see the {OLMOperatorDocs}.
 
-. Upgrade all Kafka brokers and client applications to a later supported Kafka version.
+. Upgrade all Kafka brokers and client applications to the latest supported Kafka version.
 +
 * xref:assembly-upgrading-kafka-versions-{context}[]
 * xref:con-strategies-for-upgrading-clients-{context}[] 

--- a/documentation/assemblies/upgrading/assembly-upgrade-kafka.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-kafka.adoc
@@ -5,9 +5,10 @@
 [id='assembly-upgrade-kafka-{context}']
 = Strimzi and Kafka upgrades
 
-Upgrading Strimzi is a three-stage process. To upgrade brokers and clients without downtime, you _must_ complete the upgrade procedures in the following order:
+Upgrading Strimzi is a three-stage process. 
+To upgrade brokers and clients without downtime, you _must_ complete the upgrade procedures in the following order:
 
-. Update your Cluster Operator to the latest Strimzi version.
+. Update your Cluster Operator to a later Strimzi version.
 +
 The approach you take depends on how you xref:cluster-operator-{context}[deployed the Cluster Operator].
 +
@@ -23,7 +24,7 @@ Depending on your chosen upgrade strategy, after updating the channel, either:
 +
 For more information on using {OperatorHub} to upgrade Operators, see the {OLMOperatorDocs}.
 
-. Upgrade all Kafka brokers and client applications to the latest Kafka version.
+. Upgrade all Kafka brokers and client applications to a later supported Kafka version.
 +
 * xref:assembly-upgrading-kafka-versions-{context}[]
 * xref:con-strategies-for-upgrading-clients-{context}[] 

--- a/documentation/assemblies/upgrading/assembly-upgrade-kafka.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-kafka.adoc
@@ -14,7 +14,7 @@ The approach you take depends on how you xref:cluster-operator-{context}[deploye
 +
 * If you deployed the Cluster Operator using the installation YAML files, perform your upgrade by modifying the Operator installation files, as described in xref:assembly-upgrade-cluster-operator-{context}[Upgrading the Cluster Operator]. 
 +
-* If you deployed the Cluster Operator from {OperatorHub}, use the Operator Lifecycle Manager (OLM) to change the update channel for the Strimzi Operators to the Strimzi version {ProductVersion}.
+* If you deployed the Cluster Operator from {OperatorHub}, use the Operator Lifecycle Manager (OLM) to change the update channel for the Strimzi Operators to a new Strimzi version.
 +
 Depending on your chosen upgrade strategy, after updating the channel, either:
 +

--- a/documentation/assemblies/upgrading/assembly-upgrade-kafka.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-kafka.adoc
@@ -8,7 +8,7 @@
 Upgrading Strimzi is a three-stage process. 
 To upgrade brokers and clients without downtime, you _must_ complete the upgrade procedures in the following order:
 
-. Update your Cluster Operator to Strimzi version {ProductVersion}.
+. Update your Cluster Operator to a new Strimzi version.
 +
 The approach you take depends on how you xref:cluster-operator-{context}[deployed the Cluster Operator].
 +

--- a/documentation/assemblies/upgrading/assembly-upgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade.adoc
@@ -9,7 +9,7 @@
 Strimzi can be upgraded from a lower version to a higher version to take advantage of new features and enhancements, performance improvements, and security options.
 
 As part of the upgrade, you upgrade Kafka to a higher supported version. 
-Each Kafka release introduces new features, improvements, and bug fixes.
+Each Kafka release introduces new features, improvements, and bug fixes to your Strimzi deployment.
 
 Strimzi can be xref:assembly-downgrade-{context}[downgraded] to the previous version if you encounter issues with a newer version.
 
@@ -27,7 +27,21 @@ Upgrading Strimzi from the current version to any higher version within a single
 +
 For example, upgrading from Strimzi 0.19.0 directly to Strimzi 0.21.0.
 
-The link:https://strimzi.io/downloads/[Supported versions^] table lists every released version of Strimzi.
+.Kafka version support
+
+You can review supported Kafka versions in the link:https://strimzi.io/downloads/[Supported versions^] table.
+
+* The *Operators* column lists all released Strimzi versions (the Strimzi version is often called the "Operator version"). 
+
+* The *Kafka versions* column lists the set of Kafka versions that are supported by each Strimzi version. 
+
+Additional steps are required when upgrading to an Operator version that drops support for the Kafka version you are upgrading from. 
+In these situations, the upgraded Cluster Operator returns an error message, for example:
+
+[source]
+Version 2.4.0 is not supported. Supported versions are: 2.5.0, 2.5.1, 2.6.0, 2.7.0.
+
+To continue with the upgrade, you would need to change the `spec.Kafka.version` in the Kafka custom resource to a Kafka version that is supported by the new Operator version.
 
 .Downtime and availability
 
@@ -40,7 +54,6 @@ A reduction in cluster availability increases the chance that a broker failure w
 
 .Kafka version compatibility
 
-Each version of Strimzi supports one or more versions of Apache Kafka.
 You can upgrade to a higher Kafka version as long as it is supported by your version of Strimzi.
 In some cases, you can also downgrade to a lower supported Kafka version.
 

--- a/documentation/assemblies/upgrading/assembly-upgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade.adoc
@@ -11,6 +11,24 @@ Strimzi can be upgraded from a lower version to a higher version to take advanta
 As part of the upgrade, you upgrade Kafka to a higher supported version. 
 Each Kafka release introduces new features, improvements, and bug fixes.
 
+Strimzi can be xref:assembly-downgrade-{context}[downgraded] to the previous version if you encounter issues with a newer version.
+
+.Upgrade paths
+
+Two upgrade paths are possible:
+
+Incremental:: 
+Upgrading Strimzi from the current version to the next highest version.
++
+For example, upgrading from Strimzi 0.20.1 to 0.21.0.
+
+Multi-version::
+Upgrading Strimzi from the current version to any higher version within a single upgrade (skipping one or more versions).
++
+For example, upgrading from Strimzi 0.19.0 directly to Strimzi 0.21.0.
+
+The link:https://strimzi.io/downloads/[Supported versions^] table lists every released version of Strimzi.
+
 .Downtime and availability
 
 If topics are configured for high availability, upgrading Strimzi should not cause any downtime for consumers and producers that publish and read data from those topics. 

--- a/documentation/assemblies/upgrading/assembly-upgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade.adoc
@@ -6,9 +6,9 @@
 [id='assembly-upgrade-{context}']
 = Upgrading Strimzi
 
-Strimzi can be upgraded from a lower version to a higher version to take advantage of new features and enhancements, performance improvements, and security options.
+Strimzi can be upgraded from a given version to a later version to take advantage of new features and enhancements, performance improvements, and security options.
 
-As part of the upgrade, you upgrade Kafka to a higher supported version. 
+As part of the upgrade, you upgrade Kafka to a later supported version. 
 Each Kafka release introduces new features, improvements, and bug fixes to your Strimzi deployment.
 
 Strimzi can be xref:assembly-downgrade-{context}[downgraded] to the previous version if you encounter issues with a newer version.
@@ -18,12 +18,12 @@ Strimzi can be xref:assembly-downgrade-{context}[downgraded] to the previous ver
 Two upgrade paths are possible:
 
 Incremental:: 
-Upgrading Strimzi from the current version to the next highest version.
+Upgrading Strimzi from the current version to the next version.
 +
 For example, upgrading from Strimzi 0.20.1 to 0.21.0.
 
 Multi-version::
-Upgrading Strimzi from the current version to any higher version within a single upgrade (skipping one or more versions).
+Upgrading Strimzi from the current version to any later version within a single upgrade (skipping one or more versions).
 +
 For example, upgrading from Strimzi 0.19.0 directly to Strimzi 0.21.0.
 
@@ -33,15 +33,14 @@ You can review supported Kafka versions in the link:https://strimzi.io/downloads
 
 * The *Operators* column lists all released Strimzi versions (the Strimzi version is often called the "Operator version"). 
 
-* The *Kafka versions* column lists the set of Kafka versions that are supported by each Strimzi version. 
+* The *Kafka versions* column lists the Kafka versions that are supported by each Strimzi version. 
 
-Additional steps are required when upgrading to an Operator version that drops support for the Kafka version you are upgrading from. 
-In these situations, the upgraded Cluster Operator returns an error message, for example:
+//When upgrading to an Operator version that drops support for the Kafka version you are upgrading from, the upgraded Cluster Operator returns an error message, for example:
 
-[source]
-Version 2.4.0 is not supported. Supported versions are: 2.5.0, 2.5.1, 2.6.0, 2.7.0.
+//[source]
+//Version 2.4.0 is not supported. Supported versions are: 2.5.0, 2.5.1, 2.6.0, 2.7.0.
 
-To continue with the upgrade, you would need to change the `spec.Kafka.version` in the Kafka custom resource to a Kafka version that is supported by the new Operator version.
+//You can upgrade to a supported Kafka version when upgrading the brokers, you change the `spec.Kafka.version` in the Kafka custom resource to a later Kafka version that is supported by the new Operator version.
 
 .Downtime and availability
 
@@ -54,8 +53,8 @@ A reduction in cluster availability increases the chance that a broker failure w
 
 .Kafka version compatibility
 
-You can upgrade to a higher Kafka version as long as it is supported by your version of Strimzi.
-In some cases, you can also downgrade to a lower supported Kafka version.
+You can upgrade to a later Kafka version as long as it is supported by your version of Strimzi.
+In some cases, you can also downgrade to a previous supported Kafka version.
 
 include::assembly-upgrade-kafka.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/upgrading/assembly-upgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade.adoc
@@ -6,26 +6,24 @@
 [id='assembly-upgrade-{context}']
 = Upgrading Strimzi
 
-Strimzi can be upgraded from a given version to a later version to take advantage of new features and enhancements, performance improvements, and security options.
+Strimzi can be upgraded to version {ProductVersion} to take advantage of new features and enhancements, performance improvements, and security options.
 
-As part of the upgrade, you upgrade Kafka to a later supported version. 
+As part of the upgrade, you upgrade Kafka to the latest supported version.  
 Each Kafka release introduces new features, improvements, and bug fixes to your Strimzi deployment.
 
-Strimzi can be xref:assembly-downgrade-{context}[downgraded] to the previous version if you encounter issues with a newer version.
+Strimzi can be xref:assembly-downgrade-{context}[downgraded] to the previous version if you encounter issues with the newer version.
 
 .Upgrade paths
 
 Two upgrade paths are possible:
 
 Incremental:: 
-Upgrading Strimzi from the current version to the next version.
-+
-For example, upgrading from Strimzi 0.20.1 to 0.21.0.
+Upgrading Strimzi from version 0.21.1 to version {ProductVersion}.
 
 Multi-version::
-Upgrading Strimzi from the current version to any later version within a single upgrade (skipping one or more intermediate versions).
+Upgrading Strimzi from an old version to version {ProductVersion} within a single upgrade (skipping one or more intermediate versions).
 +
-For example, upgrading from Strimzi 0.19.0 directly to Strimzi 0.21.0.
+For example, upgrading from Strimzi 0.20.0 directly to Strimzi {ProductVersion}.
 
 .Kafka version support
 
@@ -39,7 +37,7 @@ Decide which Kafka version to upgrade to before beginning the Strimzi upgrade pr
 
 [NOTE]
 ====
-You can upgrade to a later Kafka version as long as it is supported by your version of Strimzi. 
+You can upgrade to a higher Kafka version as long as it is supported by your version of Strimzi. 
 In some cases, you can also downgrade to a previous supported Kafka version.
 ====
 

--- a/documentation/assemblies/upgrading/assembly-upgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade.adoc
@@ -18,7 +18,7 @@ Strimzi can be xref:assembly-downgrade-{context}[downgraded] to the previous ver
 Two upgrade paths are possible:
 
 Incremental:: 
-Upgrading Strimzi from version 0.21.1 to version {ProductVersion}.
+Upgrading Strimzi from the previous minor version to version {ProductVersion}.
 
 Multi-version::
 Upgrading Strimzi from an old version to version {ProductVersion} within a single upgrade (skipping one or more intermediate versions).

--- a/documentation/assemblies/upgrading/assembly-upgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade.adoc
@@ -26,8 +26,6 @@ Each version of Strimzi supports one or more versions of Apache Kafka.
 You can upgrade to a higher Kafka version as long as it is supported by your version of Strimzi.
 In some cases, you can also downgrade to a lower supported Kafka version.
 
-Newer versions of Strimzi may support newer versions of Kafka, but you need to upgrade Strimzi _before_ you can upgrade to a higher supported Kafka version.
-
 include::assembly-upgrade-kafka.adoc[leveloffset=+1]
 
 include::assembly-upgrade-resources.adoc[leveloffset=+1]

--- a/documentation/assemblies/upgrading/assembly-upgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade.adoc
@@ -23,7 +23,7 @@ Upgrading Strimzi from the current version to the next version.
 For example, upgrading from Strimzi 0.20.1 to 0.21.0.
 
 Multi-version::
-Upgrading Strimzi from the current version to any later version within a single upgrade (skipping one or more versions).
+Upgrading Strimzi from the current version to any later version within a single upgrade (skipping one or more intermediate versions).
 +
 For example, upgrading from Strimzi 0.19.0 directly to Strimzi 0.21.0.
 
@@ -33,14 +33,15 @@ You can review supported Kafka versions in the link:https://strimzi.io/downloads
 
 * The *Operators* column lists all released Strimzi versions (the Strimzi version is often called the "Operator version"). 
 
-* The *Kafka versions* column lists the Kafka versions that are supported by each Strimzi version. 
+* The *Kafka versions* column lists the supported Kafka versions for each Strimzi version.
 
-//When upgrading to an Operator version that drops support for the Kafka version you are upgrading from, the upgraded Cluster Operator returns an error message, for example:
+Decide which Kafka version to upgrade to before beginning the Strimzi upgrade process.
 
-//[source]
-//Version 2.4.0 is not supported. Supported versions are: 2.5.0, 2.5.1, 2.6.0, 2.7.0.
-
-//You can upgrade to a supported Kafka version when upgrading the brokers, you change the `spec.Kafka.version` in the Kafka custom resource to a later Kafka version that is supported by the new Operator version.
+[NOTE]
+====
+You can upgrade to a later Kafka version as long as it is supported by your version of Strimzi. 
+In some cases, you can also downgrade to a previous supported Kafka version.
+====
 
 .Downtime and availability
 
@@ -50,11 +51,6 @@ Highly available topics have a replication factor of at least 3 and partitions d
 Upgrading Strimzi triggers rolling updates, where all brokers are restarted in turn, at different stages of the process. 
 During rolling updates, not all brokers are online, so overall _cluster availability_ is temporarily reduced.  
 A reduction in cluster availability increases the chance that a broker failure will result in lost messages.
-
-.Kafka version compatibility
-
-You can upgrade to a later Kafka version as long as it is supported by your version of Strimzi.
-In some cases, you can also downgrade to a previous supported Kafka version.
 
 include::assembly-upgrade-kafka.adoc[leveloffset=+1]
 

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -83,39 +83,19 @@ See xref:con-versions-and-images-str[Kafka version and image mappings]
 
 . Save and exit the editor, then wait for rolling updates to complete.
 +
-NOTE: Additional rolling updates occur if the new version of Kafka has a new ZooKeeper version.
-+
-Check the update in the logs or by watching the pod state transitions:
-+
-[source,shell,subs=+quotes]
-----
-kubectl logs -f _CLUSTER-OPERATOR-POD-NAME_ | grep -E "Kafka version upgrade from KafkaVersion.*[0-9.]+.* to KafkaVersion.*[0-9.]+.*completed"
-----
+Check the progress of the rolling updates by watching the pod state transitions:
 +
 [source,shell,subs=+quotes]
 ----
 kubectl get pods my-cluster-kafka-0 -o jsonpath='{.spec.containers[0].image}'
 ----
 +
-If the current and new versions of Kafka have different inter-broker protocol versions, check the Cluster Operator logs for an `INFO` level message:
-+
-[source,shell,subs=+quotes]
-----
-Reconciliation #_NUM_(watch) Kafka(_NAMESPACE_/_NAME_): Kafka version upgrade from _FROM-VERSION_ to _TO-VERSION_, phase 2 of 2 completed
-----
-Alternatively, if the current and new versions of Kafka have the same interbroker protocol version, check for:
-+
-[source,shell,subs=+quotes]
-----
-Reconciliation #_NUM_(watch) Kafka(_NAMESPACE_/_NAME_): Kafka version upgrade from _FROM-VERSION_ to _TO-VERSION_, phase 1 of 1 completed
-----
-+
 The rolling updates:
 +
 * Ensure each pod is using the broker binaries for the new version of Kafka
-* Configure the brokers to send messages using the inter-broker protocol of the new version of Kafka
+* Configure the brokers to send messages using the inter-broker protocol version of the new version of Kafka
 +
-NOTE: Clients are still using the old version, so brokers will convert messages to the old version before sending them to the clients. To minimize this additional load, update the clients as quickly as possible.
+IMPORTANT: Clients are still using the old Kafka version, so brokers will convert messages to the old version before sending them to the clients. To minimize this additional load, update all client applications as soon as possible.
 
 . Depending on your chosen xref:con-strategies-for-upgrading-clients-{context}[strategy for upgrading clients], upgrade all client applications to use the new version of the client binaries.
 +

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -6,7 +6,7 @@
 
 = Upgrading Kafka brokers and client applications
 
-This procedure describes how to upgrade a Strimzi Kafka cluster to a higher version of Kafka.
+This procedure describes how to upgrade a Strimzi Kafka cluster to a later version of Kafka.
 
 .Prerequisites
 
@@ -18,7 +18,7 @@ For the `Kafka` resource to be upgraded, check:
 xref:ref-kafka-versions-{context}[Consult the Kafka versions table].
 
 Also, consider the xref:con-strategies-for-upgrading-clients-{context}[strategies for upgrading clients]. 
-Clients are upgraded in step 6 of this procedure according to your chosen strategy.
+Clients are upgraded in step 6 of this procedure, according to your chosen strategy.
 
 .Procedure
 
@@ -52,7 +52,9 @@ If the `log.message.format.version` and `inter.broker.protocol.version` are unse
 +
 NOTE: The value of `log.message.format.version` and `inter.broker.protocol.version` must be strings to prevent them from being interpreted as floating point numbers.
 
-. Change the `Kafka.spec.kafka.version` to specify the new version (leaving the `log.message.format.version` and `inter.broker.protocol.version` at the _current_ versions).
+. Change the `Kafka.spec.kafka.version` to specify the new Kafka version.
++
+*Leave the `log.message.format.version` and `inter.broker.protocol.version` at the _current_ versions.*
 +
 For example, if upgrading from Kafka {KafkaVersionLower} to {KafkaVersionHigher}:
 +
@@ -107,7 +109,7 @@ If required, set the `version` property for Kafka Connect and MirrorMaker as the
 
 . _Optional step to reduce rolling updates_:
 +
-You can now perform one or more further product upgrades, starting with xref:proc-upgrading-the-co-{context}[Upgrading the Cluster Operator to a later version]. 
+You can now perform one or more further product upgrades, starting with xref:proc-upgrading-the-co-{context}[]. 
 After reaching this step for the last upgrade you want to perform, you can complete this procedure.
 +
 Alternatively, skip this step and go to step 8.

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -6,15 +6,15 @@
 
 = Upgrading Kafka brokers and client applications
 
-This procedure describes how to upgrade a Strimzi Kafka cluster to a later version of Kafka.
+This procedure describes how to upgrade a Strimzi Kafka cluster to the latest supported Kafka version.
 
 .Prerequisites
 
 For the `Kafka` resource to be upgraded, check:
 
 * The Cluster Operator, which supports both versions of Kafka, is up and running.
-* The `Kafka.spec.kafka.config` does _not_ contain options that are not supported in the version of Kafka that you are upgrading to.
-* Whether the `log.message.format.version` and `inter.broker.protocol.version` for the current Kafka version need to be updated for the new version.
+* The `Kafka.spec.kafka.config` does _not_ contain options that are not supported in the new Kafka version.
+* Whether the `log.message.format.version` and `inter.broker.protocol.version` for the current Kafka version need to be updated for the new Kafka version.
 xref:ref-kafka-versions-{context}[Consult the Kafka versions table].
 
 Also, consider the xref:con-strategies-for-upgrading-clients-{context}[strategies for upgrading clients]. 

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -8,17 +8,19 @@
 
 This procedure describes how to upgrade a Strimzi Kafka cluster to the latest supported Kafka version.
 
+Compared to your current Kafka version, the new version might support a higher _log message format version_ or _inter-broker protocol version_, or both.
+Follow the steps to upgrade these versions, if required. 
+For more information, see xref:ref-kafka-versions-{context}[].
+
+You should also choose a xref:con-strategies-for-upgrading-clients-{context}[strategy for upgrading clients]. 
+Kafka clients are upgraded in step 6 of this procedure.
+
 .Prerequisites
 
-For the `Kafka` resource to be upgraded, check:
+For the `Kafka` resource to be upgraded, check that:
 
 * The Cluster Operator, which supports both versions of Kafka, is up and running.
 * The `Kafka.spec.kafka.config` does _not_ contain options that are not supported in the new Kafka version.
-* Whether the `log.message.format.version` and `inter.broker.protocol.version` for the current Kafka version need to be updated for the new Kafka version.
-xref:ref-kafka-versions-{context}[Consult the Kafka versions table].
-
-Also, consider the xref:con-strategies-for-upgrading-clients-{context}[strategies for upgrading clients]. 
-Clients are upgraded in step 6 of this procedure, according to your chosen strategy.
 
 .Procedure
 
@@ -33,7 +35,7 @@ kubectl edit kafka _my-cluster_
 +
 Otherwise, ensure that `Kafka.spec.kafka.config` has the `log.message.format.version` and `inter.broker.protocol.version` configured to the defaults for the _current_ Kafka version.
 +
-For example, if upgrading from Kafka {KafkaVersionLower}:
+For example, if upgrading from Kafka version {KafkaVersionLower} to {KafkaVersionHigher}:
 +
 [source,yaml,subs=attributes+]
 ----
@@ -48,17 +50,19 @@ spec:
       # ...
 ----
 +
-If the `log.message.format.version` and `inter.broker.protocol.version` are unset, set them to the defaults for the _current_ Kafka version.
-+
 NOTE: The value of `log.message.format.version` and `inter.broker.protocol.version` must be strings to prevent them from being interpreted as floating point numbers.
 
-. Change the `Kafka.spec.kafka.version` to specify the new Kafka version.
+. Change the `Kafka.spec.kafka.version` to specify the new Kafka version; leave the `log.message.format.version` and `inter.broker.protocol.version` at the defaults for the _current_ Kafka version.
 +
-*Leave the `log.message.format.version` and `inter.broker.protocol.version` at the _current_ versions.*
+[NOTE]
+====
+Changing the `kafka.version` ensures that all brokers in the cluster will be upgraded to start using the new broker binaries. 
+During this process, some brokers are using the old binaries while others have already upgraded to the new ones. 
+Leaving the `inter.broker.protocol.version` unchanged ensures that the brokers can continue to communicate with each other throughout the upgrade. 
+====
 +
 For example, if upgrading from Kafka {KafkaVersionLower} to {KafkaVersionHigher}:
 +
---
 [source,yaml,subs=attributes+]
 ----
 apiVersion: {KafkaApiVersion}
@@ -75,7 +79,6 @@ spec:
 <1> Kafka version is changed to the new version.
 <2> Message format version is unchanged.
 <3> Inter-broker protocol version is unchanged.
---
 +
 WARNING: You cannot downgrade Kafka if the `inter.broker.protocol.version` for the new Kafka version changes. The inter-broker protocol version determines the schemas used for persistent metadata stored by the broker, including messages written to `__consumer_offsets`. The downgraded cluster will not understand the messages.
 
@@ -96,8 +99,6 @@ The rolling updates:
 +
 * Ensure each pod is using the broker binaries for the new version of Kafka
 * Configure the brokers to send messages using the inter-broker protocol version of the new version of Kafka
-+
-IMPORTANT: Clients are still using the old Kafka version, so brokers will convert messages to the old version before sending them to the clients. To minimize this additional load, update all client applications as soon as possible.
 
 . Depending on your chosen xref:con-strategies-for-upgrading-clients-{context}[strategy for upgrading clients], upgrade all client applications to use the new version of the client binaries.
 +
@@ -115,8 +116,8 @@ After reaching this step for the last upgrade you want to perform, you can compl
 Alternatively, skip this step and go to step 8.
 +
 . If the `log.message.format.version` and `inter.broker.protocol.version` of the _new_ Kafka version are _different from_ the old Kafka version, update the Kafka resource to use the new default versions. Otherwise, go to step 9.
-
-.. In `Kafka.spec.kafka.config`, change the `log.message.format.version` and `inter.broker.protocol.version`.
++
+In `Kafka.spec.kafka.config`, change the `log.message.format.version` and `inter.broker.protocol.version`.
 +
 For example, if upgrading to Kafka {KafkaVersionHigher}:
 +

--- a/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
@@ -36,16 +36,21 @@ kubectl apply -f install/cluster-operator
 ----
 +
 Wait for the rolling updates to complete.
+
+. If the new Operator version no longer supports the Kafka version you are upgrading from, an error message is returned by the Cluster Operator. For example:
 +
-The Cluster Operator might return an error message similar to:
-+
-[source,shell,subs="+quotes"]
+[source,shell,subs="+quotes,attributes"]
 ----
 "Version {KafkaVersionLower} is not supported. Supported versions are: #...".
 ----
 +
-This error occurs when upgrading to an Operator version that drops support for the previous Kafka version. 
-You will upgrade to a supported Kafka version in the next procedure, when you upgrade all brokers to a later Kafka version.
+If you see this message, upgrade to a Kafka version that is supported by the new Cluster Operator version:
+
+.. Edit the Kafka custom resource.
+
+.. Change the `spec.Kafka.version` property to a supported Kafka version.
++
+If the "Version not supported" message is _not_ displayed, go to the next step. You will upgrade the Kafka version later.
 
 . Get the image for the Kafka pod to ensure the upgrade was successful:
 +

--- a/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
@@ -48,7 +48,7 @@ If you see this message, upgrade to a Kafka version that is supported by the new
 
 .. Edit the Kafka custom resource.
 
-.. Change the `spec.Kafka.version` property to a supported Kafka version.
+.. Change the `spec.kafka.version` property to a supported Kafka version.
 +
 If the "Version not supported" message is _not_ displayed, go to the next step. You will upgrade the Kafka version later.
 

--- a/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
@@ -37,20 +37,24 @@ kubectl apply -f install/cluster-operator
 +
 Wait for the rolling updates to complete.
 
-. If the new Operator version no longer supports the Kafka version you are upgrading from, an error message is returned by the Cluster Operator. For example:
+. If the new Operator version no longer supports the Kafka version you are upgrading from, the Cluster Operator returns a "Version not found" error message. 
+Otherwise, no error message is returned.
++
+For example:
 +
 [source,shell,subs="+quotes,attributes"]
 ----
 "Version 2.4.0 is not supported. Supported versions are: 2.6.0, 2.6.1, 2.7.0."
 ----
-+
-If you see this message, upgrade to a Kafka version that is supported by the new Cluster Operator version:
 
-.. Edit the Kafka custom resource.
+* If the error message is returned, upgrade to a Kafka version that is supported by the new Cluster Operator version:
+
+.. Edit the `Kafka` custom resource.
 
 .. Change the `spec.kafka.version` property to a supported Kafka version.
-+
-If the "Version not supported" message is _not_ displayed, go to the next step. You will upgrade the Kafka version later.
+
+* If the error message is _not_ returned, go to the next step. 
+You will upgrade the Kafka version later.
 
 . Get the image for the Kafka pod to ensure the upgrade was successful:
 +
@@ -66,6 +70,6 @@ The image tag shows the new Operator version. For example:
 {ExampleImageTagUpgrades}
 ----
 
-Your Cluster Operator was upgraded to version {ProductVersion}, but the version of Kafka running in the cluster it manages is unchanged.
+Your Cluster Operator was upgraded to version {ProductVersion} but the version of Kafka running in the cluster it manages is unchanged.
 
 Following the Cluster Operator upgrade, you must perform a xref:assembly-upgrading-kafka-versions-str[Kafka upgrade].

--- a/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
@@ -10,14 +10,14 @@ This procedure describes how to upgrade a Cluster Operator deployment to use Str
 .Prerequisites
 
 * An existing Cluster Operator deployment is available.
-* You have xref:downloads-{context}[downloaded the installation files for the new version].
+* You have xref:downloads-{context}[downloaded the release artifacts for Strimzi {ProductVersion}].
 
 .Procedure
 
 . Take note of any configuration changes made to the existing Cluster Operator resources (in the `/install/cluster-operator` directory).
 Any changes will be *overwritten* by the new version of the Cluster Operator.
 
-. Update your custom resources to reflect the supported configuration options available for the version of Strimzi you are upgrading to.
+. Update your custom resources to reflect the supported configuration options available for Strimzi version {ProductVersion}.
 
 . Update the Cluster Operator.
 
@@ -41,7 +41,7 @@ Wait for the rolling updates to complete.
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-"Version {KafkaVersionLower} is not supported. Supported versions are: #...".
+"Version 2.4.0 is not supported. Supported versions are: 2.6.0, 2.6.1, 2.7.0."
 ----
 +
 If you see this message, upgrade to a Kafka version that is supported by the new Cluster Operator version:
@@ -66,6 +66,6 @@ The image tag shows the new Operator version. For example:
 {ExampleImageTagUpgrades}
 ----
 
-Your Cluster Operator was upgraded to the later version, but the version of Kafka running in the cluster it manages is unchanged.
+Your Cluster Operator was upgraded to version {ProductVersion}, but the version of Kafka running in the cluster it manages is unchanged.
 
 Following the Cluster Operator upgrade, you must perform a xref:assembly-upgrading-kafka-versions-str[Kafka upgrade].

--- a/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
@@ -3,9 +3,9 @@
 // assembly-upgrade.adoc
 
 [id='proc-upgrading-the-co-{context}']
-= Upgrading the Cluster Operator to a later version
+= Upgrading the Cluster Operator
 
-This procedure describes how to upgrade a Cluster Operator deployment to a later version.
+This procedure describes how to upgrade a Cluster Operator deployment to use Strimzi {ProductVersion}.
 
 .Prerequisites
 
@@ -36,6 +36,16 @@ kubectl apply -f install/cluster-operator
 ----
 +
 Wait for the rolling updates to complete.
++
+The Cluster Operator might return an error message similar to:
++
+[source,shell,subs="+quotes"]
+----
+"Version {KafkaVersionLower} is not supported. Supported versions are: #...".
+----
++
+This error occurs when upgrading to an Operator version that drops support for the previous Kafka version. 
+You will upgrade to a supported Kafka version in the next procedure, when you upgrade all brokers to a later Kafka version.
 
 . Get the image for the Kafka pod to ensure the upgrade was successful:
 +
@@ -44,7 +54,7 @@ Wait for the rolling updates to complete.
 kubectl get pods my-cluster-kafka-0 -o jsonpath='{.spec.containers[0].image}'
 ----
 +
-The image tag shows the new Strimzi version and the new Kafka version. For example: 
+The image tag shows the new Operator version. For example: 
 +
 [source,shell,subs="+quotes,attributes"]
 ----

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -13,7 +13,7 @@
 :toclevels: 3
 
 //Latest Strimzi version
-:ProductVersion: 0.21.1
+:ProductVersion: 0.22.0
 
 // Kubernetes and OpenShift versions
 :OpenShiftVersion: 4.3 and later
@@ -21,8 +21,6 @@
 
 // Kafka upgrade attributes used in kafka upgrades section
 :DefaultKafkaVersion: 2.7.0
-:KafkaVersionLower: 2.6.0
-:KafkaVersionHigher: 2.7.0
 :ExampleImageTagUpgrades: quay.io/strimzi/kafka:{ProductVersion}-kafka-{KafkaVersionHigher}
 
 //log message format version and inter-broker protocol version

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -21,6 +21,8 @@
 
 // Kafka upgrade attributes used in kafka upgrades section
 :DefaultKafkaVersion: 2.7.0
+:KafkaVersionLower: 2.6.1
+:KafkaVersionHigher: 2.7.0
 :ExampleImageTagUpgrades: quay.io/strimzi/kafka:{ProductVersion}-kafka-{KafkaVersionHigher}
 
 //log message format version and inter-broker protocol version


### PR DESCRIPTION
Signed-off-by: Daniel Laing <dlaing@redhat.com>

### Type of change
- Documentation

### Description

Guide(s) updated: _Deploying and Upgrading Strimzi_

This pull request makes further updates to the "Upgrading Strimzi" chapter based the redesigned Kafka upgrade process completed in PR #4314 .

Outstanding to do / discuss
- Add a new procedure for "Upgrading from an older Strimzi version". Older = older than `Strimzi latest - 1`.
- Is adding a new procedure the best approach or should we modify the existing procedures?

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging
 - RELATED TO ISSUE **#1160** - Use Info level k8s `Event` to tell user about phases of Kafka upgrade
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

