### PR TITLE
Add used topics in KafkaConnector status section to the CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add support for configuring labels and annotations in ClusterRoleBindings created as part of Kafka and Kafka Connect clusters
 * Add support for Ingress v1 in Kubernetes 1.19 and newer
 * Add support for Kafka 2.6.1
+* List topics used by a Kafka Connect connector in the `.status` section of the `KafkaConnector` custom resource
 
 ### Changes, deprecations and removals
 


### PR DESCRIPTION
### Type of change

- Task

### Description

#4414 added a list of used topics to the `.status` section of the `KafkaConnector` custom resource. We forgot to list it in the CHANGELOG.md file, but this change seems to be interesting enough to cover it there. This PR tries to fix it.