### PR TITLE
Add cold/offline backup script

### DIFF
--- a/.azure/scripts/install_yq.sh
+++ b/.azure/scripts/install_yq.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-curl -L https://github.com/mikefarah/yq/releases/download/v4.2.1/yq_linux_amd64 > yq && chmod +x yq
+curl -L https://github.com/mikefarah/yq/releases/download/v4.6.3/yq_linux_amd64 > yq && chmod +x yq
 sudo cp yq /usr/bin/

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/ClientArgument.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/ClientArgument.java
@@ -11,6 +11,8 @@ public enum ClientArgument {
     // Common
     TOPIC("--topic"),
     VERBOSE("--verbose"),
+    GROUP("--group"),
+    DESCRIBE("--describe"),
 
     // Consumer
     CONSUMER_CONFIG("--consumer.config"),

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/ClientType.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/ClientType.java
@@ -6,7 +6,8 @@ package io.strimzi.systemtest.kafkaclients.internalClients;
 
 public enum ClientType {
     CLI_KAFKA_VERIFIABLE_PRODUCER,
-    CLI_KAFKA_VERIFIABLE_CONSUMER;
+    CLI_KAFKA_VERIFIABLE_CONSUMER,
+    CLI_KAFKA_CONSUMER_GROUPS;
 
     /**
      * Get bind kafka client type to kafka client executable
@@ -20,6 +21,8 @@ public enum ClientType {
                 return "/opt/kafka/producer.sh";
             case CLI_KAFKA_VERIFIABLE_CONSUMER:
                 return "/opt/kafka/consumer.sh";
+            case CLI_KAFKA_CONSUMER_GROUPS:
+                return "/opt/kafka/bin/kafka-consumer-groups.sh";
             default:
                 throw new IllegalArgumentException("Unexpected client type!");
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -61,17 +61,18 @@ public class KafkaUtils {
 
     private KafkaUtils() {}
 
-    public static boolean waitForKafkaReady(String clusterName) {
-        return waitForKafkaStatus(clusterName, Ready);
+    public static void waitForKafkaReady(String clusterName) {
+        waitForKafkaStatus(clusterName, Ready);
     }
 
     public static void waitForKafkaNotReady(String clusterName) {
         waitForKafkaStatus(clusterName, NotReady);
     }
 
-    public static boolean waitForKafkaStatus(String clusterName, Enum<?>  state) {
-        Kafka kafka = KafkaResource.kafkaClient().inNamespace(kubeClient().getNamespace()).withName(clusterName).get();
-        return ResourceManager.waitForResourceStatus(KafkaResource.kafkaClient(), kafka, state);
+    public static void waitForKafkaStatus(String clusterName, Enum<?>  state) {
+        String namespace = kubeClient().getNamespace();
+        Kafka kafka = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get();
+        ResourceManager.waitForResourceStatus(KafkaResource.kafkaClient(), kafka, state);
     }
 
     /**

--- a/systemtest/src/test/java/io/strimzi/systemtest/backup/ColdBackupScriptST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/backup/ColdBackupScriptST.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.backup;
+
+import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.test.TestUtils.USER_PATH;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.Map;
+
+import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.NamespaceUtils;
+import io.strimzi.test.executor.Exec;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+@Tag(REGRESSION)
+@Tag(INTERNAL_CLIENTS_USED)
+public class ColdBackupScriptST extends AbstractST {
+
+    private static final Logger LOGGER = LogManager.getLogger(ColdBackupScriptST.class);
+    private static final String NAMESPACE = "cold-backup";
+
+    @Test
+    void backupAndRestore(ExtensionContext context) {
+        String clusterName = mapWithClusterNames.get(context.getDisplayName());
+        String groupName = "my-group", newGroupName = "new-group";
+        int firstBatchSize = 100, secondBatchSize = 10;
+        String backupFilePath = USER_PATH + "/target/" + clusterName + ".zip";
+
+        // deploy a test cluster
+        installClusterOperator(context, NAMESPACE);
+        resourceManager.createResource(context, KafkaTemplates.kafkaPersistent(clusterName, 1, 1).build());
+        String clientsPodName = deployAndGetInternalClientsPodName(context);
+        InternalKafkaClient clients = buildInternalClients(context, clientsPodName, groupName, firstBatchSize);
+
+        // send messages and consume them
+        clients.sendMessagesPlain();
+        clients.receiveMessagesPlain();
+
+        // save consumer group offsets
+        Map<String, String> offsetsBeforeBackup = clients.getCurrentOffsets();
+
+        // send additional messages
+        clients.setMessageCount(secondBatchSize);
+        clients.sendMessagesPlain();
+
+        // run backup procedure
+        LOGGER.info("Running backup procedure for {}/{}", NAMESPACE, clusterName);
+        String[] backupCommand = new String[] {
+            USER_PATH + "/../tools/cold-backup/run.sh", "backup", "-n", NAMESPACE, "-c", clusterName, "-t", backupFilePath, "-y"
+        };
+        Exec.exec(true, backupCommand);
+
+        // recreate the namespace and deploy the operator
+        ResourceManager.kubeClient().deleteNamespace(NAMESPACE);
+        NamespaceUtils.waitForNamespaceDeletion(NAMESPACE);
+        installClusterOperator(context, NAMESPACE);
+
+        // run restore procedure and wait for provisioning
+        LOGGER.info("Running restore procedure for {}/{}", NAMESPACE, clusterName);
+        String[] restoreCommand = new String[] {
+            USER_PATH + "/../tools/cold-backup/run.sh", "restore", "-n", NAMESPACE, "-c", clusterName, "-s", backupFilePath, "-y"
+        };
+        Exec.exec(true, restoreCommand);
+
+        // check consumer group offsets
+        KafkaUtils.waitForKafkaReady(clusterName);
+        clientsPodName = deployAndGetInternalClientsPodName(context);
+        clients = buildInternalClients(context, clientsPodName, groupName, secondBatchSize);
+        Map<String, String> offsetsAfterRestore = clients.getCurrentOffsets();
+        assertThat("Current consumer group offsets are not the same as before the backup", offsetsAfterRestore, is(offsetsBeforeBackup));
+
+        // check consumer group recovery
+        assertThat("Consumer group is not able to recover after restore", clients.receiveMessagesPlain(), is(secondBatchSize));
+
+        // check total number of messages
+        int batchSize = firstBatchSize + secondBatchSize;
+        clients = clients.toBuilder()
+            .withConsumerGroupName(newGroupName)
+            .withMessageCount(batchSize)
+            .build();
+        assertThat("A new consumer group is not able to get all messages", clients.receiveMessagesPlain(), is(batchSize));
+    }
+
+    private String deployAndGetInternalClientsPodName(ExtensionContext context) {
+        final String kafkaClientsName = mapWithKafkaClientNames.get(context.getDisplayName());
+        resourceManager.createResource(context, KafkaClientsTemplates.kafkaClients(false, kafkaClientsName).build());
+        return ResourceManager.kubeClient().listPodsByPrefixInName(kafkaClientsName).get(0).getMetadata().getName();
+    }
+
+    private InternalKafkaClient buildInternalClients(ExtensionContext context, String podName, String groupName, int batchSize) {
+        String clusterName = mapWithClusterNames.get(context.getDisplayName());
+        String topicName = mapWithTestTopics.get(context.getDisplayName());
+        InternalKafkaClient clients = new InternalKafkaClient.Builder()
+            .withListenerName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
+            .withNamespaceName(NAMESPACE)
+            .withUsingPodName(podName)
+            .withClusterName(clusterName)
+            .withTopicName(topicName)
+            .withConsumerGroupName(groupName)
+            .withMessageCount(batchSize)
+            .build();
+        return clients;
+    }
+
+}

--- a/tools/cold-backup/README.md
+++ b/tools/cold-backup/README.md
@@ -1,0 +1,82 @@
+# Strimzi backup
+Bash script for cold/offline backups of Kafka clusters on Kubernetes/OpenShift.
+
+If you think you do not need a backup strategy for Kafka because of its embedded data replication,
+then consider the impact of a misconfiguration, bug or security breach that deleted all your data.
+For hot/online backups, you can use storage snapshotting or streaming into object storage.
+
+To run the script, the Kubernetes user must have permission to work with PVC and Strimzi custom resources.
+The procedure will stop the Cluster Operator and selected cluster for the duration of the backup. Before
+restoring the Kafka cluster you need to make sure to have the right version of Strimzi CRDs installed.
+If you have a single cluster-wide Cluster Operator, then you need to scale it down manually. You can run
+backup and restore procedures for different Kafka clusters in parallel. Only the local file system is supported.
+Consumer group offsets are included, but not Kafka Connect, MirrorMaker and Kafka Bridge custom resources.
+
+## Requirements
+- bash 5+ (GNU)
+- tar 1.33+ (GNU)
+- kubectl 1.16+ (K8s CLI)
+- yq 4.6+ (YAML processor)
+- zip 3+ (Info-ZIP)
+- unzip 6+ (Info-ZIP)
+- enough disk space
+
+## Test procedure
+```sh
+# deploy a test cluster
+kubectl create namespace myproject
+kubectl config set-context --current --namespace="myproject"
+kubectl create -f ./install/cluster-operator
+kubectl create -f ./examples/kafka/kafka-persistent.yaml
+kubectl create -f ./examples/topic/kafka-topic.yaml
+
+# send 100000 messages and consume them
+kubectl run kafka-producer-perf-test -it \
+    --image="quay.io/strimzi/kafka:latest-kafka-2.6.0" \
+    --rm="true" --restart="Never" -- bin/kafka-producer-perf-test.sh \
+    --topic my-topic --record-size 1000 --num-records 100000 --throughput -1 \
+    --producer-props acks=1 bootstrap.servers=my-cluster-kafka-bootstrap:9092
+
+kubectl exec -it my-cluster-kafka-0 -c kafka -- \
+    bin/kafka-console-consumer.sh --bootstrap-server :9092 \
+    --topic my-topic --group my-group --from-beginning --timeout-ms 15000
+
+# save consumer group offsets
+kubectl exec -it my-cluster-kafka-0 -c kafka -- \
+    bin/kafka-consumer-groups.sh --bootstrap-server :9092 \
+    --group my-group --describe > /tmp/offsets.txt
+
+# send additional 12345 messages
+kubectl run kafka-producer-perf-test -it \
+    --image="quay.io/strimzi/kafka:latest-kafka-2.6.0" \
+    --rm="true" --restart="Never" -- bin/kafka-producer-perf-test.sh \
+    --topic my-topic --record-size 1000 --num-records 12345 --throughput -1 \
+    --producer-props acks=1 bootstrap.servers=my-cluster-kafka-bootstrap:9092
+
+# run backup procedure
+./tools/cold-backup/run.sh backup -n myproject -c my-cluster -t /tmp/my-cluster.zip
+
+# recreate the namespace and deploy the operator
+kubectl delete ns myproject
+kubectl create ns myproject
+kubectl create -f ./install/cluster-operator
+
+# run restore procedure and wait for provisioning
+./tools/cold-backup/run.sh restore -n myproject -c my-cluster -s /tmp/my-cluster.zip
+
+# check consumer group offsets (expected: current-offset match)
+cat /tmp/offsets.txt
+kubectl exec -it my-cluster-kafka-0 -c kafka -- \
+    bin/kafka-consumer-groups.sh --bootstrap-server :9092 \
+    --group my-group --describe
+
+# check consumer group recovery (expected: 12345)
+kubectl exec -it my-cluster-kafka-0 -c kafka -- \
+    bin/kafka-console-consumer.sh --bootstrap-server :9092 \
+    --topic my-topic --group my-group --from-beginning --timeout-ms 15000
+
+# check total number of messages (expected: 112345)
+kubectl exec -it my-cluster-kafka-0 -c kafka -- \
+    bin/kafka-console-consumer.sh --bootstrap-server :9092 \
+    --topic my-topic --group new-group --from-beginning --timeout-ms 15000
+```

--- a/tools/cold-backup/run.sh
+++ b/tools/cold-backup/run.sh
@@ -1,0 +1,455 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+if [[ $(uname -s) == "Darwin" ]]; then
+    shopt -s expand_aliases
+    alias rm="grm"
+    alias echo="gecho"
+    alias dirname="gdirname"
+    alias grep="ggrep"
+    alias readlink="greadlink"
+    alias tar="gtar"
+    alias sed="gsed"
+fi
+__TMP="/tmp/cold-backup" && readonly __TMP && mkdir -p $__TMP
+__HOME="" && pushd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" >/dev/null \
+    && { __HOME=$PWD; popd >/dev/null; } && readonly __HOME
+trap __cleanup EXIT
+
+RSYNC_POD_NAME=""
+WAIT_TIMEOUT_SEC=300
+ZK_REPLICAS=0
+ZK_PVC=()
+ZK_PVC_SIZE=""
+ZK_PVC_CLASS=""
+KAFKA_REPLICAS=0
+KAFKA_PVC=()
+KAFKA_PVC_SIZE=""
+KAFKA_PVC_CLASS=""
+COMMAND=""
+INCREMENTAL=false
+CONFIRM=true
+NAMESPACE=""
+CLUSTER_NAME=""
+TARGET_FILE=""
+SOURCE_FILE=""
+CUSTOM_CM=""
+CUSTOM_SE=""
+
+__start_cluster() {
+    if [[ -n $NAMESPACE && -n $CLUSTER_NAME ]]; then
+        echo "Starting cluster $CLUSTER_NAME"
+        if [[ $COMMAND == "backup" && -n $ZK_REPLICAS && -n $KAFKA_REPLICAS ]]; then
+            local zoo_ss="$(kubectl -n $NAMESPACE get statefulset $CLUSTER_NAME-zookeeper -o name --ignore-not-found)"
+            if [[ -n $zoo_ss ]]; then
+                kubectl -n $NAMESPACE scale $zoo_ss --replicas $ZK_REPLICAS
+                __wait_for condition=ready pod strimzi.io/name=$CLUSTER_NAME-zookeeper
+            fi
+            local kafka_ss="$(kubectl -n $NAMESPACE get statefulset $CLUSTER_NAME-kafka -o name --ignore-not-found)"
+            if [[ -n $kafka_ss ]]; then
+                kubectl -n $NAMESPACE scale $kafka_ss --replicas $KAFKA_REPLICAS
+                __wait_for condition=ready pod strimzi.io/name=$CLUSTER_NAME-kafka
+            fi
+            local eo_deploy="$(kubectl -n $NAMESPACE get deploy $CLUSTER_NAME-entity-operator -o name --ignore-not-found)"
+            if [[ -n $eo_deploy ]]; then
+                kubectl -n $NAMESPACE scale $eo_deploy --replicas 1
+                __wait_for condition=ready pod strimzi.io/name=$CLUSTER_NAME-entity-operator
+            fi
+            local ke_deploy="$(kubectl -n $NAMESPACE get deploy $CLUSTER_NAME-kafka-exporter -o name --ignore-not-found)"
+            if [[ -n $ke_deploy ]]; then
+                kubectl -n $NAMESPACE scale $ke_deploy --replicas 1
+                __wait_for condition=ready pod strimzi.io/name=$CLUSTER_NAME-kafka-exporter
+            fi
+        fi
+        if [[ $COMMAND == "backup" || $COMMAND == "restore" ]]; then
+            local co_deploy="$(kubectl -n $NAMESPACE get deploy strimzi-cluster-operator -o name --ignore-not-found)"
+            if [[ -n $co_deploy ]]; then
+                kubectl -n $NAMESPACE scale $co_deploy --replicas 1
+                __wait_for condition=ready pod strimzi.io/kind=cluster-operator
+            fi
+            if [[ $COMMAND == "restore" ]]; then
+                local i=0
+                local wait_cmd="__wait_for condition=ready pod strimzi.io/name=$CLUSTER_NAME-kafka"
+                echo "Waiting for Kafka to be ready"
+                while [[ ! $($wait_cmd) && $i -lt $WAIT_TIMEOUT_SEC ]]; do
+                    i=$((i+1))
+                    sleep 1
+                done
+                $wait_cmd
+            fi
+        fi
+    fi
+}
+
+__stop_cluster() {
+    if [[ -n $NAMESPACE && -n $CLUSTER_NAME ]]; then
+        echo "Stopping cluster $CLUSTER_NAME"
+        local co_deploy="$(kubectl -n $NAMESPACE get deploy strimzi-cluster-operator -o name --ignore-not-found)"
+        if [[ -n $co_deploy ]]; then
+            kubectl -n $NAMESPACE scale $co_deploy --replicas 0
+            __wait_for delete pod strimzi.io/kind=cluster-operator
+        else
+            echo "No local operator found, make sure no cluster-wide operator is watching this namespace"
+            __confirm
+        fi
+        local eo_deploy="$(kubectl -n $NAMESPACE get deploy $CLUSTER_NAME-entity-operator -o name --ignore-not-found)"
+        if [[ -n $eo_deploy ]]; then
+            kubectl -n $NAMESPACE scale $eo_deploy --replicas 0
+            __wait_for delete pod strimzi.io/name=$CLUSTER_NAME-entity-operator
+        fi
+        local ke_deploy="$(kubectl -n $NAMESPACE get deploy $CLUSTER_NAME-kafka-exporter -o name --ignore-not-found)"
+        if [[ -n $ke_deploy ]]; then
+            kubectl -n $NAMESPACE scale $ke_deploy --replicas 0
+            __wait_for delete pod strimzi.io/name=$CLUSTER_NAME-kafka-exporter
+        fi
+        local kafka_ss="$(kubectl -n $NAMESPACE get statefulset $CLUSTER_NAME-kafka -o name --ignore-not-found)"
+        if [[ -n $kafka_ss ]]; then
+            kubectl -n $NAMESPACE scale $kafka_ss --replicas 0
+            __wait_for delete pod strimzi.io/name=$CLUSTER_NAME-kafka
+        fi
+        local zoo_ss="$(kubectl -n $NAMESPACE get statefulset $CLUSTER_NAME-zookeeper -o name --ignore-not-found)"
+        if [[ -n $zoo_ss ]]; then
+            kubectl -n $NAMESPACE scale $zoo_ss --replicas 0
+            __wait_for delete pod strimzi.io/name=$CLUSTER_NAME-zookeeper
+        fi
+    fi
+}
+
+__cleanup() {
+    if [[ $INCREMENTAL == false ]]; then
+        rm -rf $__TMP/$NAMESPACE/$CLUSTER_NAME
+    fi
+    kubectl -n $NAMESPACE delete pod $RSYNC_POD_NAME 2>/dev/null ||true
+    __start_cluster
+}
+
+__error() {
+    echo "$@" 1>&2
+    exit 1
+}
+
+__confirm() {
+    read -p "Please confirm (y/n) " reply
+    if [[ ! $reply =~ ^[Yy]$ ]]; then
+        exit 0
+    fi
+}
+
+__wait_for() {
+    local condition="$1"
+    local type="$2"
+    local label="$3"
+    if [[ -n $condition && -n $type && -n $label ]]; then
+        local resource=$(kubectl -n $NAMESPACE get $type -l $label -o name --ignore-not-found)
+        if [[ -n $resource ]]; then
+            echo "Waiting for $condition of $type with label $label"
+            kubectl -n $NAMESPACE wait $type -l $label --for="$condition" --timeout="${WAIT_TIMEOUT_SEC}s"
+        fi
+    else
+        __error "Missing required parameters"
+    fi
+}
+
+__export_env() {
+    local dest_path="$1"
+    if [[ -n $dest_path ]]; then
+        echo "Exporting environment"
+        local zk_label="strimzi.io/name=$CLUSTER_NAME-zookeeper"
+        ZK_REPLICAS=$(kubectl -n $NAMESPACE get kafka $CLUSTER_NAME -o yaml | yq eval ".spec.zookeeper.replicas" -)
+        mapfile -t ZK_PVC < <(kubectl -n $NAMESPACE get pvc -l $zk_label -o yaml | yq eval ".items[].metadata.name" -)
+        ZK_PVC_SIZE=$(kubectl -n $NAMESPACE get pvc -l $zk_label -o yaml | yq eval ".items[0].spec.resources.requests.storage" -)
+        ZK_PVC_CLASS=$(kubectl -n $NAMESPACE get pvc -l $zk_label -o yaml | yq eval ".items[0].spec.storageClassName" -)
+        local kafka_label="strimzi.io/name=$CLUSTER_NAME-kafka"
+        KAFKA_REPLICAS=$(kubectl -n $NAMESPACE get kafka $CLUSTER_NAME -o yaml | yq eval ".spec.kafka.replicas" -)
+        mapfile -t KAFKA_PVC < <(kubectl -n $NAMESPACE get pvc -l $kafka_label -o yaml | yq eval ".items[].metadata.name" -)
+        KAFKA_PVC_SIZE=$(kubectl -n $NAMESPACE get pvc -l $kafka_label -o yaml | yq eval ".items[0].spec.resources.requests.storage" -)
+        KAFKA_PVC_CLASS=$(kubectl -n $NAMESPACE get pvc -l $kafka_label -o yaml | yq eval ".items[0].spec.storageClassName" -)
+        declare -px ZK_REPLICAS ZK_PVC ZK_PVC_SIZE ZK_PVC_CLASS KAFKA_REPLICAS KAFKA_PVC KAFKA_PVC_SIZE KAFKA_PVC_CLASS > "$dest_path"
+    else
+        __error "Missing required parameters"
+    fi
+}
+
+__export_res() {
+    local res_type="$1"
+    local res_id="$2"
+    local dest_path="$3"
+    if [[ -n $res_type && -n $res_id && -n $dest_path ]]; then
+        local resources=$(kubectl -n $NAMESPACE get $res_type -l $res_id -o name --ignore-not-found ||true)
+        if [[ -z $resources ]]; then
+            resources=$(kubectl -n $NAMESPACE get $res_type $res_id -o name --ignore-not-found 2>/dev/null ||true)
+        fi
+        if [[ -n $resources ]]; then
+            echo "Exporting $res_type $res_id"
+            # delete runtime metadata expression
+            local exp="del(.metadata.namespace, .items[].metadata.namespace, \
+                .metadata.resourceVersion, .items[].metadata.resourceVersion, \
+                .metadata.selfLink, .items[].metadata.selfLink, \
+                .metadata.uid, .items[].metadata.uid, \
+                .status, .items[].status)"
+            local file_name=$(printf $res_type-$res_id | sed 's/\//-/g;s/ //g')
+            kubectl -n $NAMESPACE get $resources -o yaml | yq eval "$exp" - > $dest_path/$file_name.yaml
+        fi
+    else
+        __error "Missing required parameters"
+    fi
+}
+
+__rsync() {
+    local source="$1"
+    local target="$2"
+    if [[ -n $source && -n $target ]]; then
+        echo "Rsync from $source to $target"
+        local flags="--no-check-device --no-acls --no-xattrs --no-same-owner"
+        if [[ $source != "/tmp/"* ]]; then
+            # download from pod to local (backup)
+            flags="$flags --listed-incremental /data/backup.snar \
+                --exclude=backup.snar --exclude=data/version-2/{currentEpoch,acceptedEpoch}"
+            if [[ $INCREMENTAL == false ]]; then
+                flags="$flags --level=0"
+            fi
+            local patch=$(sed "s/\$name/$source/g" $__HOME/templates/patch.json)
+            kubectl -n $NAMESPACE run $RSYNC_POD_NAME --image="dummy" --restart="Never" --overrides="$patch"
+            __wait_for condition=ready pod run="$RSYNC_POD_NAME"
+            kubectl -n $NAMESPACE exec -i $RSYNC_POD_NAME -- sh -c "tar $flags -C /data -c ." | tar $flags -C $target -xv -f -
+            kubectl -n $NAMESPACE delete pod $RSYNC_POD_NAME
+        else
+            # upload from local to pod (restore)
+            local patch=$(sed "s/\$name/$target/g" $__HOME/templates/patch.json)
+            kubectl -n $NAMESPACE run $RSYNC_POD_NAME --image="dummy" --restart="Never" --overrides="$patch"
+            __wait_for condition=ready pod run="$RSYNC_POD_NAME"
+            tar $flags -C $source -c . | kubectl -n $NAMESPACE exec -i $RSYNC_POD_NAME -- sh -c "tar $flags -C /data -xv -f -"
+            kubectl -n $NAMESPACE delete pod $RSYNC_POD_NAME
+        fi
+    else
+        __error "Missing required parameters"
+    fi
+}
+
+__create_pvc() {
+    local name="$1"
+    local size="$2"
+    local class="${3-}"
+    if [[ -n $name && -n $size ]]; then
+        local exp="s/\$name/$name/g; s/\$size/$size/g; /storageClassName/d"
+        if [[ $class != "null" ]]; then
+            exp="s/\$name/$name/g; s/\$size/$size/g; s/\$class/$class/g"
+        fi
+        echo "Creating pvc $name of size $size"
+        sed "$exp" $__HOME/templates/pvc.yaml | kubectl -n $NAMESPACE create -f -
+    else
+        __error "Missing required parameters"
+    fi
+}
+
+__compress() {
+    local source_dir="$1"
+    local target_file="$2"
+    if [[ -n $source_dir && -n $target_file ]]; then
+        local current_dir=$(pwd)
+        local target_path=$(readlink -f $target_file)
+        local target_name=$(basename "$target_file")
+        cd $source_dir
+        echo "Compressing $source_dir to $target_file"
+        zip -FSqr $target_name *
+        mv $target_name $target_path
+        cd $current_dir
+    else
+        __error "Missing required parameters"
+    fi
+}
+
+__uncompress() {
+    local source_file="$1"
+    local readonly target_dir="$2"
+    if [[ -n $source_file && -n $target_dir ]]; then
+        echo "Uncompressing $source_file to $target_dir"
+        rm -rf $target_dir
+        mkdir -p $target_dir
+        unzip -qo $source_file -d $target_dir
+        chmod -R ugo+rwx $target_dir
+    else
+        __error "Missing required parameters"
+    fi
+}
+
+backup() {
+    # init context
+    local readonly tmp="$__TMP/$NAMESPACE/$CLUSTER_NAME"
+    if [[ $CONFIRM == true ]]; then
+        echo "Backup of cluster $NAMESPACE/$CLUSTER_NAME"
+        echo "The cluster won't be available for the entire duration of the process"
+        __confirm
+    fi
+    if [[ $INCREMENTAL == true ]]; then
+        echo "Starting incremental backup"
+    else
+        echo "Starting full backup"
+        rm -rf $tmp
+    fi
+    mkdir -p $tmp/resources $tmp/data
+    __export_env $tmp/env
+    __stop_cluster
+
+    # export resources
+    __export_res kafka $CLUSTER_NAME $tmp/resources
+    __export_res kafkatopics strimzi.io/cluster=$CLUSTER_NAME $tmp/resources
+    __export_res kafkausers strimzi.io/cluster=$CLUSTER_NAME $tmp/resources
+    __export_res kafkarebalances strimzi.io/cluster=$CLUSTER_NAME $tmp/resources
+    # cluster configmap and secrets
+    __export_res configmaps app.kubernetes.io/instance=$CLUSTER_NAME $tmp/resources
+    __export_res secrets app.kubernetes.io/instance=$CLUSTER_NAME $tmp/resources
+    # custom configmap and secrets
+    if [[ -n $CUSTOM_CM ]]; then
+        for name in $(printf $CUSTOM_CM | sed "s/,/ /g"); do
+            __export_res configmap $name $tmp/resources
+        done
+    fi
+    if [[ -n $CUSTOM_SE ]]; then
+        for name in $(printf $CUSTOM_SE | sed "s/,/ /g"); do
+            __export_res secret $name $tmp/resources
+        done
+    fi
+
+    # for each PVC, rsync data from PV to backup
+    for name in "${ZK_PVC[@]}"; do
+        local path="$tmp/data/$name"
+        mkdir -p $path
+        __rsync $name $path
+    done
+    for name in "${KAFKA_PVC[@]}"; do
+        local path="$tmp/data/$name"
+        mkdir -p $path
+        __rsync $name $path
+    done
+
+    # create the archive
+    __compress $tmp $TARGET_FILE
+}
+
+restore() {
+    # init context
+    local readonly tmp="$__TMP/$NAMESPACE/$CLUSTER_NAME"
+    if [[ $CONFIRM == true ]]; then
+        echo "Restore of cluster $NAMESPACE/$CLUSTER_NAME"
+        __confirm
+    fi
+    __uncompress $SOURCE_FILE $tmp
+    source $tmp/env
+    __stop_cluster
+
+    # for each PVC, create it and rsync data from backup to PV
+    for name in "${ZK_PVC[@]}"; do
+        __create_pvc $name $ZK_PVC_SIZE $ZK_PVC_CLASS
+        __rsync $tmp/data/$name/. $name
+    done
+    for name in "${KAFKA_PVC[@]}"; do
+        __create_pvc $name $KAFKA_PVC_SIZE $KAFKA_PVC_CLASS
+        __rsync $tmp/data/$name/. $name
+    done
+
+    # import resources
+    # KafkaTopic resources must be created *before*
+    # deploying the Topic Operator or it will delete them
+    kubectl -n $NAMESPACE apply -f $tmp/resources
+}
+
+readonly USAGE="Usage: $0 [commands] [options]
+
+Commands:
+  backup   Cluster backup
+  restore  Cluster restore
+
+Options:
+  -i  Enable incremental backup
+  -y  Skip confirmation step
+  -n  Cluster namespace
+  -c  Cluster name
+  -t  Target file path
+  -s  Source file path
+  -m  Custom config maps (-m cm0,cm1,cm2)
+  -x  Custom secrets (-x se0,se1,se2)
+
+Examples:
+  # Full backup with custom cm and secrets
+  $0 backup -n test -c my-cluster \\
+    -t /tmp/my-cluster.zip \\
+    -m kafka-metrics,log4j-properties \\
+    -x ext-listener-crt
+
+  # Restore to a new namespace
+  $0 restore -n test-new -c my-cluster \\
+    -s /tmp/my-cluster.zip"
+
+COMMAND="${1-}"
+readonly COMMAND
+if [[ $COMMAND != "backup" && $COMMAND != "restore" ]]; then
+    __error "$USAGE"
+else
+    shift
+fi
+while getopts ":iyn:c:t:s:m:x:" opt; do
+    case "${opt-}" in
+        i)
+            INCREMENTAL=true
+            readonly INCREMENTAL
+            ;;
+        y)
+            CONFIRM=false
+            readonly CONFIRM
+            ;;
+        n)
+            NAMESPACE=${OPTARG-}
+            readonly NAMESPACE
+            ;;
+        c)
+            CLUSTER_NAME=${OPTARG-}
+            readonly CLUSTER_NAME
+            ;;
+        t)
+            TARGET_FILE=${OPTARG-}
+            readonly TARGET_FILE
+            ;;
+        s)
+            SOURCE_FILE=${OPTARG-}
+            readonly SOURCE_FILE
+            ;;
+        m)
+            CUSTOM_CM=${OPTARG-}
+            readonly CUSTOM_CM
+            ;;
+        x)
+            CUSTOM_SE=${OPTARG-}
+            readonly CUSTOM_SE
+            ;;
+        *)
+            __error "$USAGE"
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [[ $COMMAND == "backup" ]]; then
+    if [[ -n $NAMESPACE && -n $CLUSTER_NAME && -n $TARGET_FILE ]]; then
+        if [[ -d "$(dirname $TARGET_FILE)" ]]; then
+            readonly RSYNC_POD_NAME="$CLUSTER_NAME-backup"
+            backup
+        else
+            __error "$(dirname $TARGET_FILE) not found"
+        fi
+    else
+        __error "Specify namespace, cluster name and target file to backup"
+    fi
+fi
+
+if [[ $COMMAND == "restore" ]]; then
+    if  [[ -n $NAMESPACE && -n $CLUSTER_NAME && -f $SOURCE_FILE ]]; then
+        if [[ -f $SOURCE_FILE ]]; then
+            readonly RSYNC_POD_NAME="$CLUSTER_NAME-restore"
+            restore
+        else
+            __error "$SOURCE_FILE file not found"
+        fi
+    else
+        __error "Specify namespace, cluster name and source file to restore"
+    fi
+fi

--- a/tools/cold-backup/templates/patch.json
+++ b/tools/cold-backup/templates/patch.json
@@ -1,0 +1,29 @@
+{
+    "spec": {
+        "containers": [
+            {
+                "name": "dummy",
+                "image": "centos:7",
+                "command": [
+                    "/bin/bash",
+                    "-c",
+                    "trap : TERM INT; sleep infinity & wait"
+                ],
+                "volumeMounts": [
+                    {
+                        "name": "data",
+                        "mountPath": "/data"
+                    }
+                ]
+            }
+        ],
+        "volumes": [
+            {
+                "name": "data",
+                "persistentVolumeClaim": {
+                    "claimName": "$name"
+                }
+            }
+        ]
+    }
+}

--- a/tools/cold-backup/templates/pvc.yaml
+++ b/tools/cold-backup/templates/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: $name
+spec:
+  storageClassName: $class
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: $size


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description
Bash script for cold/offline backups of Kafka clusters on Kubernetes/OpenShift.

If you think you do not need a backup strategy for Kafka because of its embedded data replication,
then consider the impact of a misconfiguration, bug or security breach that deleted all your data.
For hot/online backups, you can use storage snapshotting or streaming into object storage.

To run the script, the Kubernetes user must have permission to work with PVC and Strimzi custom resources.
The procedure will stop the Cluster Operator and selected cluster for the duration of the backup. Before
restoring the Kafka cluster you need to make sure to have the right version of Strimzi CRDs installed.
If you have a single cluster-wide Cluster Operator, then you need to scale it down manually. You can run
backup and restore procedures for different Kafka clusters in parallel. Only the local file system is supported.
Consumer group offsets are included, but not Kafka Connect, MirrorMaker and Kafka Bridge custom resources.

### Requirements
- bash 5+ (GNU
- tar 1.33+ (GNU)
- kubectl 1.16+ (K8s CLI)
- yq 4.6+ (YAML processor)
- zip 3+ (Info-ZIP)
- unzip 6+ (Info-ZIP)
- enough disk space


