### PR TITLE
 OpenSslCertManager.generateCert can delete CA certificate file

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -285,7 +285,10 @@ public class OpenSslCertManager implements CertManager {
         }
 
         // We need to remove CA serial file
-        Files.deleteIfExists(Paths.get(caCert.getPath().replace(".crt", ".srl")));
+        Path path = Paths.get(caCert.getPath().replaceAll(".[a-zA-Z0-9]+$", ".srl"));
+        if (Files.exists(path)) {
+            Files.delete(path);
+        }
     }
 
     private Path createDefaultConfig() throws IOException {


### PR DESCRIPTION
### Type of change

- Bugfix (fixes #3681)

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

