### PR TITLE
Update template with smaller volume size

### DIFF
--- a/examples/kafka/kafka-persistent-single.yaml
+++ b/examples/kafka/kafka-persistent-single.yaml
@@ -26,13 +26,13 @@ spec:
       volumes:
       - id: 0
         type: persistent-claim
-        size: 100Gi
+        size: 2Gi
         deleteClaim: false
   zookeeper:
     replicas: 1
     storage:
       type: persistent-claim
-      size: 100Gi
+      size: 2Gi
       deleteClaim: false
   entityOperator:
     topicOperator: {}


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix


### Description

This template is used in Quicstart document, it requires 100GB volume in local environment. This is often impractical and leads local creation of cluster to fail. Therefore, a smaller volume would be better for local environment.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

