### PR TITLE
[DOC] mm2 topic offset synchronization

### DIFF
--- a/documentation/modules/configuring/con-config-mirrormaker2-acls.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-acls.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// assembly-mirrormaker.adoc
+// assembly-config-mirrormaker2.adoc
 
 [id='con-mirrormaker-acls-{context}']
 = ACL rules synchronization

--- a/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
@@ -15,10 +15,6 @@ MirrorMaker 2.0 uses:
 MirrorMaker 2.0 is based on the Kafka Connect framework, _connectors_ managing the transfer of data between clusters.
 A MirrorMaker 2.0 `MirrorSourceConnector` replicates topics from a source cluster to a target cluster.
 
-By default, a check for new topics in the source cluster is made every 10 minutes.
-You can change the frequency by adding `refresh.topics.interval.seconds` to the source connector configuration of the `KafkaMirrorMaker2` resource.
-However, increasing the frequency of the operation might affect overall performance.
-
 The process of _mirroring_ data from one cluster to another cluster is asynchronous.
 The recommended pattern is for messages to be produced locally alongside the source Kafka cluster, then consumed remotely close to the target Kafka cluster.
 
@@ -26,6 +22,10 @@ MirrorMaker 2.0 can be used with more than one source cluster.
 
 .Replication across two clusters
 image::mirrormaker.png[MirrorMaker 2.0 replication]
+
+By default, a check for new topics in the source cluster is made every 10 minutes.
+You can change the frequency by adding `refresh.topics.interval.seconds` to the source connector configuration of the `KafkaMirrorMaker2` resource.
+However, increasing the frequency of the operation might affect overall performance.
 
 = Cluster configuration
 
@@ -87,25 +87,27 @@ MirrorMaker 2.0 uses its `MirrorCheckpointConnector` to emit _checkpoints_ for o
 
 == Synchronizing consumer group offsets
 
-The `__consumer_offsets` topic stores information on committed offsets, according to consumer group.
+The `__consumer_offsets` topic stores information on committed offsets, for each consumer group.
 Offset synchronization periodically transfers the consumer offsets for the consumer groups of a source cluster into the consumer offsets topic of a target cluster.
 
 Offset synchronization is particularly useful in an _active/passive_ configuration.
-Should the active cluster go down, consumer applications can switch to the passive (standby) cluster and pick up from the last offset position.
+If the active cluster goes down, consumer applications can switch to the passive (standby) cluster and pick up from the last transferred offset position.
 
 To use topic offset synchronization:
 
 * Enable the synchronization by adding `sync.group.offsets.enabled` to the checkpoint connector configuration of the `KafkaMirrorMaker2` resource,
 and setting the property to `true`. Synchronization is disabled by default.
-* Add the `IdentityReplicationPolicy` to the source connector configuration so that topics in the target cluster retain their original names.
+* Add the `IdentityReplicationPolicy` to the source and checkpoint connector configuration so that topics in the target cluster retain their original names.
 
-For topic offset synchronization to work, consumer groups in the source cluster cannot be active in the target cluster.
-Consequently, if you are using an _active/active_ configuration that does not support or require offset synchronization, do not enable topic offset synchronization.
+For topic offset synchronization to work, consumer groups in the target cluster cannot use the same ids as groups in the source cluster.
 
 If enabled, the synchronization of offsets from the source cluster is made periodically.
 You can change the frequency by adding `sync.group.offsets.interval.seconds` and `emit.checkpoints.interval.seconds` to the checkpoint connector configuration.
 The properties specify the frequency in seconds that the consumer group offsets are synchronized, and the frequency of checkpoints emitted for offset tracking.
 The default for both properties is 60 seconds.
+You might also want to change the frequency of checks for new consumer groups using the `refresh.groups.interval.seconds` property, which is performed every 10 minutes by default.
+
+Because the synchronization is time-based, any switchover by consumers to a passive cluster will likely result in some duplication of messages.
 
 == Connectivity checks
 

--- a/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
@@ -105,7 +105,7 @@ If enabled, the synchronization of offsets from the source cluster is made perio
 You can change the frequency by adding `sync.group.offsets.interval.seconds` and `emit.checkpoints.interval.seconds` to the checkpoint connector configuration.
 The properties specify the frequency in seconds that the consumer group offsets are synchronized, and the frequency of checkpoints emitted for offset tracking.
 The default for both properties is 60 seconds.
-You might also want to change the frequency of checks for new consumer groups using the `refresh.groups.interval.seconds` property, which is performed every 10 minutes by default.
+You can also change the frequency of checks for new consumer groups using the `refresh.groups.interval.seconds` property, which is performed every 10 minutes by default.
 
 Because the synchronization is time-based, any switchover by consumers to a passive cluster will likely result in some duplication of messages.
 

--- a/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// assembly-mirrormaker.adoc
+// assembly-config-mirrormaker2.adoc
 
 [id='con-mirrormaker-{context}']
 = MirrorMaker 2.0 data replication
@@ -14,6 +14,10 @@ MirrorMaker 2.0 uses:
 
 MirrorMaker 2.0 is based on the Kafka Connect framework, _connectors_ managing the transfer of data between clusters.
 A MirrorMaker 2.0 `MirrorSourceConnector` replicates topics from a source cluster to a target cluster.
+
+By default, a check for new topics in the source cluster is made every 10 minutes.
+You can change the frequency by adding `refresh.topics.interval.seconds` to the source connector configuration of the `KafkaMirrorMaker2` resource.
+However, increasing the frequency of the operation might affect overall performance.
 
 The process of _mirroring_ data from one cluster to another cluster is asynchronous.
 The recommended pattern is for messages to be produced locally alongside the source Kafka cluster, then consumed remotely close to the target Kafka cluster.
@@ -80,6 +84,28 @@ Offsets for the _checkpoint_ topic are tracked at predetermined intervals throug
 Both topics enable replication to be fully restored from the correct offset position on failover.
 
 MirrorMaker 2.0 uses its `MirrorCheckpointConnector` to emit _checkpoints_ for offset tracking.
+
+== Synchronizing consumer group offsets
+
+The `__consumer_offsets` topic stores information on committed offsets, according to consumer group.
+Offset synchronization periodically transfers the consumer offsets for the consumer groups of a source cluster into the consumer offsets topic of a target cluster.
+
+Offset synchronization is particularly useful in an _active/passive_ configuration.
+Should the active cluster go down, consumer applications can switch to the passive (standby) cluster and pick up from the last offset position.
+
+To use topic offset synchronization:
+
+* Enable the synchronization by adding `sync.group.offsets.enabled` to the checkpoint connector configuration of the `KafkaMirrorMaker2` resource,
+and setting the property to `true`. Synchronization is disabled by default.
+* Add the `IdentityReplicationPolicy` to the source connector configuration so that topics in the target cluster retain their original names.
+
+For topic offset synchronization to work, consumer groups in the source cluster cannot be active in the target cluster.
+Consequently, if you are using an _active/active_ configuration that does not support or require offset synchronization, do not enable topic offset synchronization.
+
+If enabled, the synchronization of offsets from the source cluster is made periodically.
+You can change the frequency by adding `sync.group.offsets.interval.seconds` and `emit.checkpoints.interval.seconds` to the checkpoint connector configuration.
+The properties specify the frequency in seconds that the consumer group offsets are synchronized, and the frequency of checkpoints emitted for offset tracking.
+The default for both properties is 60 seconds.
 
 == Connectivity checks
 

--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -112,15 +112,15 @@ spec:
         offset-syncs.topic.replication.factor: 1 <21>
         sync.topic.acls.enabled: "false" <22>
         refresh.topics.interval.seconds: 60 <23>
-        refresh.groups.interval.seconds: 600 <24>
-        replication.policy.separator: "" <25>
-        replication.policy.class: "io.strimzi.kafka.connect.mirror.IdentityReplicationPolicy" <26>
-    heartbeatConnector: <27>
+        replication.policy.separator: "" <24>
+        replication.policy.class: "io.strimzi.kafka.connect.mirror.IdentityReplicationPolicy" <25>
+    heartbeatConnector: <26>
       config:
-        heartbeats.topic.replication.factor: 1 <28>
-    checkpointConnector: <29>
+        heartbeats.topic.replication.factor: 1 <27>
+    checkpointConnector: <28>
       config:
-        checkpoints.topic.replication.factor: 1 <30>
+        checkpoints.topic.replication.factor: 1 <29>
+        refresh.groups.interval.seconds: 600 <30>
         sync.group.offsets.enabled: true <31>
         sync.group.offsets.interval.seconds: 60 <32>
         emit.checkpoints.interval.seconds: 60 <33>
@@ -208,14 +208,14 @@ Standard Apache Kafka configuration may be provided, restricted to those propert
 <21> Replication factor for the `MirrorSourceConnector` `offset-syncs` internal topic that maps the offsets of the source and target clusters.
 <22> When xref:con-mirrormaker-acls-{context}[ACL rules synchronization] is enabled, ACLs are applied to synchronized topics. The default is `true`.
 <23> Optional setting to change the frequency of checks for new topics. The default is for a check every 10 minutes.
-<24> Optional setting to change the frequency of checks for new consumer groups. The default is for a check every 10 minutes.
-<25> Defines the separator used for the renaming of remote topics.
-<26> Adds a policy that overrides the automatic renaming of remote topics. Instead of prepending the name with the name of the source cluster, the topic retains its original name. This optional setting is useful for active/passive backups and data migration.
+<24> Defines the separator used for the renaming of remote topics.
+<25> Adds a policy that overrides the automatic renaming of remote topics. Instead of prepending the name with the name of the source cluster, the topic retains its original name. This optional setting is useful for active/passive backups and data migration.
 To configure topic offset synchronization, this property must also be set for the `checkpointConnector.config`.
-<27> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorHeartbeatConnector`] that performs connectivity checks. The `config` overrides the default configuration options.
-<28> Replication factor for the heartbeat topic created at the target cluster.
-<29> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorCheckpointConnector`] that tracks offsets. The `config` overrides the default configuration options.
-<30> Replication factor for the checkpoints topic created at the target cluster.
+<26> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorHeartbeatConnector`] that performs connectivity checks. The `config` overrides the default configuration options.
+<27> Replication factor for the heartbeat topic created at the target cluster.
+<28> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorCheckpointConnector`] that tracks offsets. The `config` overrides the default configuration options.
+<29> Replication factor for the checkpoints topic created at the target cluster.
+<30> Optional setting to change the frequency of checks for new consumer groups. The default is for a check every 10 minutes.
 <31> Optional setting to synchronize consumer group offsets, which is useful for recovery in an active/passive configuration. Synchronization is not enabled by default.
 <32> If the synchronization of consumer group offsets is enabled, you can adjust the frequency of the synchronization.
 <33> Adjusts the frequency of checks for offset tracking. If you change the frequency of offset synchronization, you might also need to adjust the frequency of these checks.

--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -231,4 +231,4 @@ You can use comma-separated lists.
 . Create or update the resource:
 +
 [source,shell,subs=+quotes]
-kubectl apply -f _MIRRORMAKER-CONFIGURATION_FILE_
+kubectl apply -f _MIRRORMAKER-CONFIGURATION-FILE_

--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -112,41 +112,43 @@ spec:
         offset-syncs.topic.replication.factor: 1 <21>
         sync.topic.acls.enabled: "false" <22>
         refresh.topics.interval.seconds: 60 <23>
-        replication.policy.separator: "" <24>
-        replication.policy.class: "io.strimzi.kafka.connect.mirror.IdentityReplicationPolicy" <25>
-    heartbeatConnector: <26>
+        refresh.groups.interval.seconds: 600 <24>
+        replication.policy.separator: "" <25>
+        replication.policy.class: "io.strimzi.kafka.connect.mirror.IdentityReplicationPolicy" <26>
+    heartbeatConnector: <27>
       config:
-        heartbeats.topic.replication.factor: 1 <27>
-    checkpointConnector: <28>
+        heartbeats.topic.replication.factor: 1 <28>
+    checkpointConnector: <29>
       config:
-        checkpoints.topic.replication.factor: 1 <29>
-        sync.group.offsets.enabled: true <30>
-        sync.group.offsets.interval.seconds: 60 <31>
-        emit.checkpoints.interval.seconds: 60 <32>
-    topicsPattern: ".*" <33>
-    groupsPattern: "group1|group2|group3" <34>
-  resources: <35>
+        checkpoints.topic.replication.factor: 1 <30>
+        sync.group.offsets.enabled: true <31>
+        sync.group.offsets.interval.seconds: 60 <32>
+        emit.checkpoints.interval.seconds: 60 <33>
+        replication.policy.class: "io.strimzi.kafka.connect.mirror.IdentityReplicationPolicy"
+    topicsPattern: ".*" <34>
+    groupsPattern: "group1|group2|group3" <35>
+  resources: <36>
     requests:
       cpu: "1"
       memory: 2Gi
     limits:
       cpu: "2"
       memory: 2Gi
-  logging: <36>
+  logging: <37>
     type: inline
     loggers:
       connect.root.logger.level: "INFO"
-  readinessProbe: <37>
+  readinessProbe: <38>
     initialDelaySeconds: 15
     timeoutSeconds: 5
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5
-  jvmOptions: <38>
+  jvmOptions: <39>
     "-Xmx": "1g"
     "-Xms": "1g"
-  image: my-org/my-image:latest <39>
-  template: <40>
+  image: my-org/my-image:latest <40>
+  template: <41>
     pod:
       affinity:
         podAntiAffinity:
@@ -159,7 +161,7 @@ spec:
                       - postgresql
                       - mongodb
               topologyKey: "kubernetes.io/hostname"
-    connectContainer: <41>
+    connectContainer: <42>
       env:
         - name: JAEGER_SERVICE_NAME
           value: my-jaeger-service
@@ -168,8 +170,8 @@ spec:
         - name: JAEGER_AGENT_PORT
           value: "6831"
   tracing:
-    type: jaeger <42>
-  externalConfiguration: <43>
+    type: jaeger <43>
+  externalConfiguration: <44>
     env:
       - name: AWS_ACCESS_KEY_ID
         valueFrom:
@@ -206,27 +208,29 @@ Standard Apache Kafka configuration may be provided, restricted to those propert
 <21> Replication factor for the `MirrorSourceConnector` `offset-syncs` internal topic that maps the offsets of the source and target clusters.
 <22> When xref:con-mirrormaker-acls-{context}[ACL rules synchronization] is enabled, ACLs are applied to synchronized topics. The default is `true`.
 <23> Optional setting to change the frequency of checks for new topics. The default is for a check every 10 minutes.
-<24> Defines the separator used for the renaming of remote topics.
-<25> Adds a policy that overrides the automatic renaming of remote topics. Instead of prepending the name with the name of the source cluster, the topic retains its original name. This optional setting is useful for active/passive backups and data migration.
-<26> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorHeartbeatConnector`] that performs connectivity checks. The `config` overrides the default configuration options.
-<27> Replication factor for the heartbeat topic created at the target cluster.
-<28> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorCheckpointConnector`] that tracks offsets. The `config` overrides the default configuration options.
-<29> Replication factor for the checkpoints topic created at the target cluster.
-<30> Optional setting to synchronize consumer group offsets, which is useful for recovery in an active/passive configuration. Synchronization is not enabled by default.
-<31> If the synchronization of consumer group offsets is enabled, you can adjust the frequency of the synchronization.
-<32> Adjusts the frequency of checks for offset tracking. If you change the frequency of offset synchronization, you might also need to adjust the frequency of these checks.
-<33> Topic replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request all topics.
-<34> Consumer group replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request three consumer groups by name.
+<24> Optional setting to change the frequency of checks for new consumer groups. The default is for a check every 10 minutes.
+<25> Defines the separator used for the renaming of remote topics.
+<26> Adds a policy that overrides the automatic renaming of remote topics. Instead of prepending the name with the name of the source cluster, the topic retains its original name. This optional setting is useful for active/passive backups and data migration.
+To configure topic offset synchronization, this property must also be set for the `checkpointConnector.config`.
+<27> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorHeartbeatConnector`] that performs connectivity checks. The `config` overrides the default configuration options.
+<28> Replication factor for the heartbeat topic created at the target cluster.
+<29> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorCheckpointConnector`] that tracks offsets. The `config` overrides the default configuration options.
+<30> Replication factor for the checkpoints topic created at the target cluster.
+<31> Optional setting to synchronize consumer group offsets, which is useful for recovery in an active/passive configuration. Synchronization is not enabled by default.
+<32> If the synchronization of consumer group offsets is enabled, you can adjust the frequency of the synchronization.
+<33> Adjusts the frequency of checks for offset tracking. If you change the frequency of offset synchronization, you might also need to adjust the frequency of these checks.
+<34> Topic replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request all topics.
+<35> Consumer group replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request three consumer groups by name.
 You can use comma-separated lists.
-<35> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
-<36> Specified xref:property-kafka-connect-logging-reference[Kafka Connect loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. For the Kafka Connect `log4j.rootLogger` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
-<37> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
-<38> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
-<39> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
-<40> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<41> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
-<42> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
-<43> xref:type-ExternalConfiguration-reference[External configuration] for a Kubernetes Secret mounted to Kafka MirrorMaker as an environment variable.
+<36> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
+<37> Specified xref:property-kafka-connect-logging-reference[Kafka Connect loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. For the Kafka Connect `log4j.rootLogger` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<38> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
+<39> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
+<40> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
+<41> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
+<42> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
+<43> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
+<44> xref:type-ExternalConfiguration-reference[External configuration] for a Kubernetes Secret mounted to Kafka MirrorMaker as an environment variable.
 
 . Create or update the resource:
 +

--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// assembly-mirrormaker.adoc
+// assembly-config-mirrormaker2.adoc
 
 [id='proc-mirrormaker-replication-{context}']
 = Synchronizing data between Kafka clusters using MirrorMaker 2.0
@@ -111,38 +111,42 @@ spec:
         replication.factor: 1 <20>
         offset-syncs.topic.replication.factor: 1 <21>
         sync.topic.acls.enabled: "false" <22>
-        replication.policy.separator: "" <23>
-        replication.policy.class: "io.strimzi.kafka.connect.mirror.IdentityReplicationPolicy" <24>
-    heartbeatConnector: <25>
+        refresh.topics.interval.seconds: 60 <23>
+        replication.policy.separator: "" <24>
+        replication.policy.class: "io.strimzi.kafka.connect.mirror.IdentityReplicationPolicy" <25>
+    heartbeatConnector: <26>
       config:
-        heartbeats.topic.replication.factor: 1 <26>
-    checkpointConnector: <27>
+        heartbeats.topic.replication.factor: 1 <27>
+    checkpointConnector: <28>
       config:
-        checkpoints.topic.replication.factor: 1 <28>
-    topicsPattern: ".*" <29>
-    groupsPattern: "group1|group2|group3" <30>
-  resources: <31>
+        checkpoints.topic.replication.factor: 1 <29>
+        sync.group.offsets.enabled: true <30>
+        sync.group.offsets.interval.seconds: 60 <31>
+        emit.checkpoints.interval.seconds: 60 <32>
+    topicsPattern: ".*" <33>
+    groupsPattern: "group1|group2|group3" <34>
+  resources: <35>
     requests:
       cpu: "1"
       memory: 2Gi
     limits:
       cpu: "2"
       memory: 2Gi
-  logging: <32>
+  logging: <36>
     type: inline
     loggers:
       connect.root.logger.level: "INFO"
-  readinessProbe: <33>
+  readinessProbe: <37>
     initialDelaySeconds: 15
     timeoutSeconds: 5
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5
-  jvmOptions: <34>
+  jvmOptions: <38>
     "-Xmx": "1g"
     "-Xms": "1g"
-  image: my-org/my-image:latest <35>
-  template: <36>
+  image: my-org/my-image:latest <39>
+  template: <40>
     pod:
       affinity:
         podAntiAffinity:
@@ -155,7 +159,7 @@ spec:
                       - postgresql
                       - mongodb
               topologyKey: "kubernetes.io/hostname"
-    connectContainer: <37>
+    connectContainer: <41>
       env:
         - name: JAEGER_SERVICE_NAME
           value: my-jaeger-service
@@ -164,8 +168,8 @@ spec:
         - name: JAEGER_AGENT_PORT
           value: "6831"
   tracing:
-    type: jaeger <38>
-  externalConfiguration: <39>
+    type: jaeger <42>
+  externalConfiguration: <43>
     env:
       - name: AWS_ACCESS_KEY_ID
         valueFrom:
@@ -201,26 +205,30 @@ Standard Apache Kafka configuration may be provided, restricted to those propert
 <20> Replication factor for mirrored topics created at the target cluster.
 <21> Replication factor for the `MirrorSourceConnector` `offset-syncs` internal topic that maps the offsets of the source and target clusters.
 <22> When xref:con-mirrormaker-acls-{context}[ACL rules synchronization] is enabled, ACLs are applied to synchronized topics. The default is `true`.
-<23> Defines the separator used for the renaming of remote topics.
-<24> Adds a policy that overrides the automatic renaming of remote topics. Instead of prepending the name with the name of the source cluster, the topic retains its original name. This optional setting is useful for active/passive backups and data migration.
-<25> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorHeartbeatConnector`] that performs connectivity checks. The `config` overrides the default configuration options.
-<26> Replication factor for the heartbeat topic created at the target cluster.
-<27> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorCheckpointConnector`] that tracks offsets. The `config` overrides the default configuration options.
-<28> Replication factor for the checkpoints topic created at the target cluster.
-<29> Topic replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request all topics.
-<30> Consumer group replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request three consumer groups by name.
+<23> Optional setting to change the frequency of checks for new topics. The default is for a check every 10 minutes.
+<24> Defines the separator used for the renaming of remote topics.
+<25> Adds a policy that overrides the automatic renaming of remote topics. Instead of prepending the name with the name of the source cluster, the topic retains its original name. This optional setting is useful for active/passive backups and data migration.
+<26> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorHeartbeatConnector`] that performs connectivity checks. The `config` overrides the default configuration options.
+<27> Replication factor for the heartbeat topic created at the target cluster.
+<28> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorCheckpointConnector`] that tracks offsets. The `config` overrides the default configuration options.
+<29> Replication factor for the checkpoints topic created at the target cluster.
+<30> Optional setting to synchronize consumer group offsets, which is useful for recovery in an active/passive configuration. Synchronization is not enabled by default.
+<31> If the synchronization of consumer group offsets is enabled, you can adjust the frequency of the synchronization.
+<32> Adjusts the frequency of checks for offset tracking. If you change the frequency of offset synchronization, you might also need to adjust the frequency of these checks.
+<33> Topic replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request all topics.
+<34> Consumer group replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as regular expression patterns]. Here we request three consumer groups by name.
 You can use comma-separated lists.
-<31> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
-<32> Specified xref:property-kafka-connect-logging-reference[Kafka Connect loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. For the Kafka Connect `log4j.rootLogger` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
-<33> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
-<34> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
-<35> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
-<36> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<37> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
-<38> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
-<39> xref:type-ExternalConfiguration-reference[External configuration] for a Kubernetes Secret mounted to Kafka MirrorMaker as an environment variable.
+<35> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
+<36> Specified xref:property-kafka-connect-logging-reference[Kafka Connect loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. For the Kafka Connect `log4j.rootLogger` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<37> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
+<38> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
+<39> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
+<40> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
+<41> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
+<42> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
+<43> xref:type-ExternalConfiguration-reference[External configuration] for a Kubernetes Secret mounted to Kafka MirrorMaker as an environment variable.
 
 . Create or update the resource:
 +
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _MIRRORMAKER-CONFIGURATION_FILE_


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

New section describing _synchronizing consumer group offsets_ added to the MirrorMaker 2.0 _Cluster Configuration_ section
Example config added to the procedure in _Synchronizing data between Kafka clusters using MirrorMaker 2.0_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

