### PR TITLE
Fix JMX configuration issues caused by port already in use

### DIFF
--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -23,8 +23,6 @@ if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
     export KAFKA_OPTS="${KAFKA_OPTS} ${STRIMZI_JAVA_SYSTEM_PROPERTIES}"
 fi
 
-KAFKA_OPTS="${KAFKA_OPTS} ${KAFKA_JMX_OPTS}"
-
 # enabling Prometheus JMX exporter as Java agent
 if [ "$KAFKA_METRICS_ENABLED" = "true" ]; then
   KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$KAFKA_HOME"/libs/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.yml"

--- a/docker-images/kafka/scripts/set_kafka_jmx_options.sh
+++ b/docker-images/kafka/scripts/set_kafka_jmx_options.sh
@@ -9,23 +9,30 @@ if [ "$JMX_ENABLED" = "true" ]; then
   KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote=true -Djava.rmi.server.hostname=$(hostname -i) -Djava.net.preferIPv4Stack=true"
 
   if [ -n "$JMX_USERNAME" ]; then
+    mkdir -p /tmp/jmx/
+
     # Secure JMX port on 9999 with username and password
-    JMX_ACCESS_FILE="/tmp/access.file"
-    JMX_PASSWORD_FILE="/tmp/password.file"
+    JMX_ACCESS_FILE="/tmp/jmx/access.file"
+    rm -f "${JMX_ACCESS_FILE}"
+    JMX_PASSWORD_FILE="/tmp/jmx/password.file"
+    rm -f "${JMX_PASSWORD_FILE}"
 
     cat << EOF > "${JMX_ACCESS_FILE}"
 ${JMX_USERNAME} readonly
 EOF
 
     cat << EOF > "${JMX_PASSWORD_FILE}"
-$JMX_USERNAME $JMX_PASSWORD
+${JMX_USERNAME} ${JMX_PASSWORD}
 EOF
     chmod 400 "${JMX_PASSWORD_FILE}"
     KAFKA_JMX_OPTS="${KAFKA_JMX_OPTS} -Dcom.sun.management.jmxremote.access.file=${JMX_ACCESS_FILE} -Dcom.sun.management.jmxremote.password.file=${JMX_PASSWORD_FILE}  -Dcom.sun.management.jmxremote.authenticate=true"
-    export KAFKA_JMX_OPTS
+
+    KAFKA_OPTS="${KAFKA_OPTS} ${KAFKA_JMX_OPTS}"
+    export KAFKA_OPTS
   else
     # expose the port insecurely
     KAFKA_JMX_OPTS="${KAFKA_JMX_OPTS} -Dcom.sun.management.jmxremote.authenticate=false"
-    export KAFKA_JMX_OPTS
+    KAFKA_OPTS="${KAFKA_OPTS} ${KAFKA_JMX_OPTS}"
+    export KAFKA_OPTS
   fi
 fi


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It looks like the JMX in Kafka and Kafka Connect does not work right now. There are two issues:
* First one is the error from #4467. This is caused by the new volume based `/tmp` => the JMX password file has special permissions and it is not possible to overwrite it when the container restarts (and the file is still there because we use volume for `/tmp` now). This is resolved by deleting the files first which seems to work.
* Second problem seems to be why does the container restart in the first place. I'm not sure this was the same case with #4467 (since in general, any restart would cause this and the issue was reported with 0.21.1 where this should not be an issue). But in master, it ends up with `Port already in use: 9999` error. That seems to be caused by the master using `KAFKA_JMX_OPTS` instead of `KAFKA_OPTS`. That seems to cause this problem. Changing ti back to `KAFKA_OPTS` seems to solve the issue.

This PR also improves the file names etc.

Separate issues opened for adding STs for JMX - #4481.

This should close #4467.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging