### PR TITLE
Add CRD upgrade to v1beta2 to the API conversion tool

### DIFF
--- a/api-conversion/README.md
+++ b/api-conversion/README.md
@@ -141,7 +141,7 @@ You can also use the tool to update the Strimzi CRDs to use the new `v1beta2` ve
 This is required before upgrading to Strimzi 0.23 and newer.
 You have to first convert all Strimzi custom resources to `v1beta2` using one of the previous commands.
 Once the custom resources are ready, you can use the `crd-upgrade` subcommand to upgrade the CRDs.
-The following example command show how the tool is used:
+The following example command shows how the tool is used:
 
 ```
 # Upgrade the Strimzi CRDs to v1beta2

--- a/api-conversion/README.md
+++ b/api-conversion/README.md
@@ -7,6 +7,7 @@ To make it as easy as possible to convert existing Strimzi custom resources, a c
 The tool can operate in two modes:
 * Converting YAML files
 * Converting Kubernetes resources
+* Upgrading CRDs to v1beta2
 
 You can list the available features using the `help` command:
 
@@ -17,9 +18,10 @@ Conversion tool for Strimzi Custom Resources
   -h, --help      Show this help message and exit.
   -V, --version   Print version information and exit.
 Commands:
-  help                  Displays help information about the specified command
-  convert-file, cf      Convert custom resources from a YAML file
-  convert-resource, cr  Convert custom resources directly in Kubernetes
+  help                                     Displays help information about the specified command
+  convert-file, cf                         Convert Custom Resources from YAML file
+  convert-resource, cr, convert-resources  Convert Custom Resources directly in Kubernetes
+  crd-upgrade, crd                         Upgrades the Strimzi CRDs and CRs to use v1beta2 version
 ```
 
 ## Converting YAML files with custom resources

--- a/api-conversion/README.md
+++ b/api-conversion/README.md
@@ -66,7 +66,7 @@ Convert Custom Resources from YAML file
                           Creates an output YAML file for the converted custom resource
 ```
 
-**Once you converted the YAML files, apply the changes to Kubernetes using `kubectl apply -f` or `kubectl replace -f`.** 
+**When you have converted the YAML files, apply the changes to Kubernetes using `kubectl apply -f` or `kubectl replace -f`.** 
 
 ## Converting Kubernetes resources
 
@@ -112,24 +112,24 @@ Usage: bin/api-conversion.sh convert-resource [-d] [-ll=<level>]
        [<kinds> [<kinds> [<kinds> [<kinds> [<kinds>]]]]]]]]]]]...
        [-n=<namespace> | [-a]]
 Convert Custom Resources directly in Kubernetes
-  -a, --all-namespaces   Convert resources in all namespaces
-  -d, --debug            Use debug?
+  -a, --all-namespaces   Converts resources in all namespaces
+  -d, --debug            Runs the tool in debug mode
   -k, --kind[=<kinds> [<kinds> [<kinds> [<kinds> [<kinds> [<kinds> [<kinds>
         [<kinds> [<kinds> [<kinds>]]]]]]]]]]
-                         Resource Kind which should be converted (if not
-                           specified, all Strimzi resources will be converted)
+                         Specifies the kinds of custom resources to be
+                           converted, or converts all resources if not specified
       -ll, --log-level=<level>
-                         Set log level to enable logging
+                         Sets the log level to enable logging
   -n, --namespace=<namespace>
-                         Kubernetes namespace / OpenShift project (if not
-                           specified, current namespace will be used)
+                         Specifies a Kubernetes namespace or OpenShift project,
+                           or uses the current namespace if not specified
       --name=<name>      Name of the resource which should be converted (can be
                            used onl with --namespace and single --kind options)
 ```
 
 ### Required access rights
 
-To convert the resources directly in your Kubernetes cluster, you need to run the tool with a user which has the following RBAC rights:
+To convert the resources directly in your Kubernetes cluster, you must run the tool as a user with RBAC permission to:
 
 * Get the Strimzi custom resources you are going to convert (when using the `--name` option)
 * List the Strimzi custom resources you are going to convert (when not using the `--name` option)
@@ -148,11 +148,11 @@ The following example command show how the tool is used:
 > bin/api-conversion.sh crd-upgrade
 ```
 
-**Once you upgrade the CRDs to use `v1beta2` as storage version, you should only use the fields available in `v1beta2` in your custom resources.**
+**After you have upgraded the CRDs to use `v1beta2` as storage version, you must only use the fields available in `v1beta2` in your custom resources.**
 
 ### Required access rights
 
-To upgrade the Strimzi CRDs to `v1beta2`, you need to run the tool with a user which has the following RBAC rights:
+To upgrade the Strimzi CRDs to `v1beta2`, you must run the tool as a user with RBAC permission to:
 
 * List the Strimzi custom resources in all namespaces
 * Replace the Strimzi custom resources in all namespaces

--- a/api-conversion/README.md
+++ b/api-conversion/README.md
@@ -66,6 +66,8 @@ Convert Custom Resources from YAML file
                           Creates an output YAML file for the converted custom resource
 ```
 
+**Once you converted the YAML files, apply the changes to Kubernetes using `kubectl apply -f` or `kubectl replace -f`.** 
+
 ## Converting Kubernetes resources
 
 You can also use the tool to convert Strimzi custom resources directly in your Kubernetes cluster.
@@ -124,3 +126,35 @@ Convert Custom Resources directly in Kubernetes
       --name=<name>      Name of the resource which should be converted (can be
                            used onl with --namespace and single --kind options)
 ```
+
+### Required access rights
+
+To convert the resources directly in your Kubernetes cluster, you need to run the tool with a user which has the following RBAC rights:
+
+* Get the Strimzi custom resources you are going to convert (when using the `--name` option)
+* List the Strimzi custom resources you are going to convert (when not using the `--name` option)
+* Replace the Strimzi custom resources you are going to convert
+
+## Upgrading CRDs to v1beta2
+
+You can also use the tool to update the Strimzi CRDs to use the new `v1eta2` version as a stored version.
+This is required before upgrading to Strimzi 0.23 and newer.
+You have to first convert all Strimzi custom resources to `v1beta2` using one of the previous commands.
+Once the custom resources are ready, you can use the `crd-upgrade` subcommand to upgrade the CRDs.
+The following example command show how the tool is used:
+
+```
+# Upgrade the Strimzi CRDs to v1beta2
+> bin/api-conversion.sh crd-upgrade
+```
+
+**Once you upgrade the CRDs to use `v1beta2` as storage version, you should only use the fields available in `v1beta2` in your custom resources.**
+
+### Required access rights
+
+To upgrade the Strimzi CRDs to `v1beta2`, you need to run the tool with a user which has the following RBAC rights:
+
+* List the Strimzi custom resources in all namespaces
+* Replace the Strimzi custom resources in all namespaces
+* Patch the CRD resources
+* Replace the status of the CRD resources

--- a/api-conversion/README.md
+++ b/api-conversion/README.md
@@ -137,7 +137,7 @@ To convert the resources directly in your Kubernetes cluster, you must run the t
 
 ## Upgrading CRDs to v1beta2
 
-You can also use the tool to update the Strimzi CRDs to use the new `v1eta2` version as a stored version.
+You can also use the tool to update the Strimzi CRDs to use the new `v1beta2` version as a stored version.
 This is required before upgrading to Strimzi 0.23 and newer.
 You have to first convert all Strimzi custom resources to `v1beta2` using one of the previous commands.
 Once the custom resources are ready, you can use the `crd-upgrade` subcommand to upgrade the CRDs.

--- a/api-conversion/bin/api-conversion.sh
+++ b/api-conversion/bin/api-conversion.sh
@@ -4,13 +4,4 @@ set -e
 # Find my path to use when calling scripts
 MYPATH="$(dirname "$0")"
 
-# Configure logging
-#if [ -z "$LOG4J_OPTS" ]
-#then
-#      $LOG4J_OPTS="-Dlog4j2.configurationFile=file:${MYPATH}/../config/log4j2.properties"
-#fi
-
-# Make sure that we use /dev/urandom
-#JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp -Djava.security.egd=file:/dev/./urandom"
-
-exec java $JAVA_OPTS $LOG4J_OPTS -classpath "${MYPATH}/../libs/*" io.strimzi.kafka.api.conversion.cli.EntryCommand "$@"
+exec java -classpath "${MYPATH}/../libs/*" io.strimzi.kafka.api.conversion.cli.EntryCommand "$@"

--- a/api-conversion/pom.xml
+++ b/api-conversion/pom.xml
@@ -57,6 +57,10 @@
             <artifactId>kubernetes-model-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apiextensions</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/cli/AbstractCommand.java
+++ b/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/cli/AbstractCommand.java
@@ -4,13 +4,68 @@
  */
 package io.strimzi.kafka.api.conversion.cli;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.strimzi.api.annotations.ApiVersion;
+import io.strimzi.api.kafka.Crds;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import picocli.CommandLine;
 
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
 public abstract class AbstractCommand implements Runnable {
     protected Logger log = LogManager.getLogger(getClass().getName());
+
+    protected static final ApiVersion TO_API_VERSION = ApiVersion.V1BETA2;
+
+    protected static final String STRIMZI_API = "kafka.strimzi.io";
+    protected static final Set<String> STRIMZI_KINDS = Set.of(
+            "Kafka",
+            "KafkaConnect",
+            "KafkaConnectS2I",
+            "KafkaMirrorMaker",
+            "KafkaBridge",
+            "KafkaMirrorMaker2",
+            "KafkaTopic",
+            "KafkaUser",
+            "KafkaConnector",
+            "KafkaRebalance"
+    );
+
+    // Versioned operations are used to write the converted resource using the target API
+    @SuppressWarnings({"rawtypes"})
+    protected final static Map<String, BiFunction<KubernetesClient, String, MixedOperation>> VERSIONED_OPERATIONS = Map.of(
+            "Kafka", Crds::kafkaOperation,
+            "KafkaConnect", Crds::kafkaConnectOperation,
+            "KafkaConnectS2I", Crds::kafkaConnectS2iOperation,
+            "KafkaMirrorMaker", Crds::mirrorMakerOperation,
+            "KafkaBridge", Crds::kafkaBridgeOperation,
+            "KafkaMirrorMaker2", Crds::kafkaMirrorMaker2Operation,
+            "KafkaTopic", Crds::topicOperation,
+            "KafkaUser", Crds::kafkaUserOperation,
+            "KafkaConnector", Crds::kafkaConnectorOperation,
+            "KafkaRebalance", Crds::kafkaRebalanceOperation
+    );
+
+    // The operation with the default versions
+    @SuppressWarnings({"rawtypes"})
+    protected final static Map<String, Function<KubernetesClient, MixedOperation>> DEFAULT_OPERATIONS = Map.of(
+            "Kafka", Crds::kafkaOperation,
+            "KafkaConnect", Crds::kafkaConnectOperation,
+            "KafkaConnectS2I", Crds::kafkaConnectS2iOperation,
+            "KafkaMirrorMaker", Crds::mirrorMakerOperation,
+            "KafkaBridge", Crds::kafkaBridgeOperation,
+            "KafkaMirrorMaker2", Crds::kafkaMirrorMaker2Operation,
+            "KafkaTopic", Crds::topicOperation,
+            "KafkaUser", Crds::kafkaUserOperation,
+            "KafkaConnector", Crds::kafkaConnectorOperation,
+            "KafkaRebalance", Crds::kafkaRebalanceOperation
+    );
 
     @CommandLine.Spec
     CommandLine.Model.CommandSpec spec;
@@ -26,6 +81,12 @@ public abstract class AbstractCommand implements Runnable {
             log.log(level, String.valueOf(value));
         } else {
             spec.commandLine().getOut().println(value);
+        }
+    }
+
+    protected void println() {
+        if (level == null) {
+            spec.commandLine().getOut().println();
         }
     }
 }

--- a/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/cli/AbstractCommand.java
+++ b/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/cli/AbstractCommand.java
@@ -76,6 +76,12 @@ public abstract class AbstractCommand implements Runnable {
     @CommandLine.Option(names = {"-ll", "--log-level"}, description = "Sets the log level to enable logging")
     Level level;
 
+    /**
+     * Prints the value to the standard output using PicoCLI. It is important to use this instead of regular
+     * System.out.println to be able to easily capture the output in tests.
+     *
+     * @param value     Object which should be printed
+     */
     protected void println(Object value) {
         if (level != null) {
             log.log(level, String.valueOf(value));
@@ -84,6 +90,10 @@ public abstract class AbstractCommand implements Runnable {
         }
     }
 
+    /**
+     * Prints empty line to the standard output using PicoCLI. It is important to use this instead of regular
+     * System.out.println to be able to easily capture the output in tests.
+     */
     protected void println() {
         if (level == null) {
             spec.commandLine().getOut().println();

--- a/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/cli/AbstractConversionCommand.java
+++ b/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/cli/AbstractConversionCommand.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.kafka.api.conversion.cli;
 
-import io.strimzi.api.annotations.ApiVersion;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaConnect;
@@ -29,26 +28,9 @@ import io.strimzi.kafka.api.conversion.converter.KafkaRebalanceConverter;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 @SuppressWarnings("deprecation")
 public abstract class AbstractConversionCommand extends AbstractCommand {
-    protected static final ApiVersion TO_API_VERSION = ApiVersion.V1BETA2;
-
-    protected static final String STRIMZI_API = "kafka.strimzi.io";
-    protected static final Set<String> STRIMZI_KINDS = Set.of(
-            "Kafka",
-            "KafkaConnect",
-            "KafkaConnectS2I",
-            "KafkaMirrorMaker",
-            "KafkaBridge",
-            "KafkaMirrorMaker2",
-            "KafkaTopic",
-            "KafkaUser",
-            "KafkaConnector",
-            "KafkaRebalance"
-    );
-
     @SuppressWarnings("rawtypes")
     static Map<Object, Converter> converters;
 

--- a/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/cli/ConvertResourceCommand.java
+++ b/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/cli/ConvertResourceCommand.java
@@ -24,17 +24,17 @@ import java.util.List;
 @SuppressWarnings({"rawtypes"})
 @CommandLine.Command(name = "convert-resource", aliases = {"cr", "convert-resources"}, description = "Convert Custom Resources directly in Kubernetes")
 public class ConvertResourceCommand extends AbstractConversionCommand {
-    @CommandLine.Option(names = {"-k", "--kind"}, arity = "0..10", description = "Resource Kind which should be converted (if not specified, all Strimzi resources will be converted)")
+    @CommandLine.Option(names = {"-k", "--kind"}, arity = "0..10", description = "Specifies the kinds of custom resources to be converted, or converts all resources if not specified")
     String[] kinds;
 
     @CommandLine.ArgGroup
     ConvertResourceCommand.Exclusive exclusive;
 
     static class Exclusive {
-        @CommandLine.Option(names = {"-n", "--namespace"}, description = "Kubernetes namespace / OpenShift project (if not specified, current namespace will be used)")
+        @CommandLine.Option(names = {"-n", "--namespace"}, description = "Specifies a Kubernetes namespace or OpenShift project, or uses the current namespace if not specified")
         String namespace;
 
-        @CommandLine.Option(names = {"-a", "--all-namespaces"}, description = "Convert resources in all namespaces", defaultValue = "false")
+        @CommandLine.Option(names = {"-a", "--all-namespaces"}, description = "Converts resources in all namespaces", defaultValue = "false")
         boolean allNamespaces;
     }
 

--- a/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/cli/CrdUpgradeCommand.java
+++ b/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/cli/CrdUpgradeCommand.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.api.conversion.cli;
+
+import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionVersion;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.CustomResourceList;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.strimzi.api.kafka.Crds;
+import picocli.CommandLine;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@SuppressWarnings({"rawtypes"})
+@CommandLine.Command(name = "crd-upgrade", aliases = {"crd"}, description = "Upgrades the Strimzi CRDs and CRs to use v1beta2 version")
+public class CrdUpgradeCommand extends AbstractCommand {
+    final static Map<String, String> CRD_NAMES = Map.of(
+            "Kafka", "kafkas.kafka.strimzi.io",
+            "KafkaConnect", "kafkaconnects.kafka.strimzi.io",
+            "KafkaConnectS2I", "kafkaconnects2is.kafka.strimzi.io",
+            "KafkaMirrorMaker", "kafkatopics.kafka.strimzi.io",
+            "KafkaBridge", "kafkabridges.kafka.strimzi.io",
+            "KafkaMirrorMaker2", "kafkamirrormaker2s.kafka.strimzi.io",
+            "KafkaTopic", "kafkamirrormakers.kafka.strimzi.io",
+            "KafkaUser", "kafkausers.kafka.strimzi.io",
+            "KafkaConnector", "kafkaconnectors.kafka.strimzi.io",
+            "KafkaRebalance", "kafkarebalances.kafka.strimzi.io"
+    );
+
+    private KubernetesClient client;
+
+    static {
+        Crds.registerCustomKinds();
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private <R extends CustomResource, L extends CustomResourceList<R>> void storeCrsUnderNewVersionForKind(String kind) {
+        MixedOperation<R, L, ?> op = VERSIONED_OPERATIONS.get(kind).apply(client, TO_API_VERSION.toString());
+
+        List<R> crs = op.inAnyNamespace().list().getItems();
+
+        for (R cr : crs)    {
+            println("Updating " + kind + " " + cr.getMetadata().getName() + " to be stored as " + TO_API_VERSION.toString());
+            op.inNamespace(cr.getMetadata().getNamespace()).withName(cr.getMetadata().getName()).replace(cr);
+        }
+    }
+
+    private void storeCrsUnderNewVersion()   {
+        for (String kind : STRIMZI_KINDS)  {
+            storeCrsUnderNewVersionForKind(kind);
+        }
+    }
+
+    private void changeStoredVersionInSpecForKind(String kind) {
+        String crdName = CRD_NAMES.get(kind);
+        CustomResourceDefinition crd = client.apiextensions().v1beta1().customResourceDefinitions().withName(crdName).get();
+
+        if (crd != null) {
+            for (CustomResourceDefinitionVersion crdVersion : crd.getSpec().getVersions()) {
+                if (TO_API_VERSION.toString().equals(crdVersion.getName())) {
+                    if (debug)
+                        println("Updating " + crdVersion.getName() + " version of Kind " + kind + " to be served and stored");
+                    crdVersion.setServed(true);
+                    crdVersion.setStorage(true);
+                } else {
+                    if (debug)
+                        println("Updating " + crdVersion.getName() + " version of Kind " + kind + " to be served but not stored");
+                    crdVersion.setServed(true);
+                    crdVersion.setStorage(false);
+                }
+            }
+
+            println("Updating " + kind + " CRD");
+            client.apiextensions().v1beta1().customResourceDefinitions().withName(crdName).patch(crd);
+        } else {
+            throw new RuntimeException("CRD " + kind + " not found. CRD Upgrade cannot be completed.");
+        }
+    }
+
+    private void changeStoredVersionInSpec()   {
+        for (String kind : STRIMZI_KINDS)  {
+            changeStoredVersionInSpecForKind(kind);
+        }
+    }
+
+    private void changeStoredVersionInStatusForKind(String kind) {
+        String crdName = CRD_NAMES.get(kind);
+        CustomResourceDefinition crd = client.apiextensions().v1beta1().customResourceDefinitions().withName(crdName).get();
+
+        if (crd != null)    {
+            List<String> crdVersions = new ArrayList<>(crd.getStatus().getStoredVersions());
+
+            for (String version : crdVersions) {
+                if (!TO_API_VERSION.toString().equals(version)) {
+                    if (debug) println("Removing version " + version + " version of Kind " + kind + " from stored versions in CRD status");
+                    crd.getStatus().getStoredVersions().remove(version);
+                }
+            }
+
+            println("Updating " + kind + " CRD");
+            client.apiextensions().v1beta1().customResourceDefinitions().withName(crdName).updateStatus(crd);
+        } else {
+            throw new RuntimeException("CRD " + kind + " not found. CRD Upgrade cannot be completed.");
+        }
+    }
+
+    private void changeStoredVersionInStatus()   {
+        for (String kind : STRIMZI_KINDS)  {
+            changeStoredVersionInStatusForKind(kind);
+        }
+    }
+
+    /**
+     * Reads the resources from the Kubernetes API and converts them
+     */
+    @Override
+    public void run() {
+        client = new DefaultKubernetesClient();
+
+        // Change the stored version in CRD spec to v1beta2
+        println("Changing stored version in all Strimzi CRDs to " + TO_API_VERSION.toString() + ":");
+        changeStoredVersionInSpec();
+        println();
+
+        // "Touch" all resources to have them stored as v1beta2
+        println("Updating all Strimzi CRs to be stored under " + TO_API_VERSION.toString() + ":");
+        storeCrsUnderNewVersion();
+        println();
+
+        // Change the stored versions in CRDs to v1beta2
+        println("Changing stored version in statuses of all Strimzi CRDs to " + TO_API_VERSION.toString() + ":");
+        changeStoredVersionInStatus();
+    }
+}

--- a/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/cli/EntryCommand.java
+++ b/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/cli/EntryCommand.java
@@ -20,7 +20,8 @@ import picocli.CommandLine;
         subcommands = {
                 CommandLine.HelpCommand.class,
                 ConvertFileCommand.class,
-                ConvertResourceCommand.class
+                ConvertResourceCommand.class,
+                CrdUpgradeCommand.class
         }
 )
 class EntryCommand {

--- a/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/utils/IoUtil.java
+++ b/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/utils/IoUtil.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.kafka.api.conversion.utils;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,18 +35,6 @@ public class IoUtil {
             throw new UncheckedIOException(e);
         } catch (Exception e) {
             throw new IllegalStateException(e);
-        }
-    }
-
-    /**
-     * Close auto-closeable, ignore any exception.
-     *
-     * @param closeable the closeable
-     */
-    public static void closeIgnore(AutoCloseable closeable) {
-        try {
-            close(closeable);
-        } catch (Exception ignored) {
         }
     }
 
@@ -103,20 +90,6 @@ public class IoUtil {
      */
     public static byte[] toBytes(String string) {
         return string == null ? null : string.getBytes(StandardCharsets.UTF_8);
-    }
-
-    /**
-     * Get stream from content.
-     *
-     * @param content the content
-     * @return content as stream
-     */
-    public static InputStream toStream(String content) {
-        return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-    }
-
-    public static InputStream toStream(byte[] content) {
-        return new ByteArrayInputStream(content);
     }
 
     public static long copy(InputStream input, OutputStream output) throws IOException {

--- a/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/CliTestUtils.java
+++ b/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/CliTestUtils.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.api.conversion.cli;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionVersion;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.test.TestUtils;
+import io.strimzi.test.k8s.KubeClusterResource;
+
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.oneOf;
+
+public class CliTestUtils {
+    public static final String USER_PATH = System.getProperty("user.dir");
+    public static final String CRD_V1_TOPIC = USER_PATH + "/../api/src/test/resources/io/strimzi/api/kafka/model/043-Crd-kafkatopic.yaml";
+    public static final String CRD_V1_KAFKA = USER_PATH + "/../api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml";
+    public static final String CRD_V1_KAFKA_CONNECT = USER_PATH + "/../api/src/test/resources/io/strimzi/api/kafka/model/041-Crd-kafkaconnect.yaml";
+    public static final String CRD_V1_KAFKA_CONNECT_S2I = USER_PATH + "/../api/src/test/resources/io/strimzi/api/kafka/model/042-Crd-kafkaconnects2i.yaml";
+    public static final String CRD_V1_KAFKA_USER = USER_PATH + "/../api/src/test/resources/io/strimzi/api/kafka/model/044-Crd-kafkauser.yaml";
+    public static final String CRD_V1_KAFKA_MIRROR_MAKER = USER_PATH + "/../api/src/test/resources/io/strimzi/api/kafka/model/045-Crd-kafkamirrormaker.yaml";
+    public static final String CRD_V1_KAFKA_BRIDGE = USER_PATH + "/../api/src/test/resources/io/strimzi/api/kafka/model/046-Crd-kafkabridge.yaml";
+    public static final String CRD_V1_KAFKA_MIRROR_MAKER_2 = USER_PATH + "/../api/src/test/resources/io/strimzi/api/kafka/model/048-Crd-kafkamirrormaker2.yaml";
+    public static final String CRD_V1_KAFKA_CONNECTOR = USER_PATH + "/../api/src/test/resources/io/strimzi/api/kafka/model//047-Crd-kafkaconnector.yaml";
+    public static final String CRD_V1_KAFKA_REBALANCE = USER_PATH + "/../api/src/test/resources/io/strimzi/api/kafka/model/049-Crd-kafkarebalance.yaml";
+
+    public static void setupAllCrds(KubeClusterResource cluster)  {
+        cluster.createCustomResources(TestUtils.CRD_KAFKA);
+        cluster.createCustomResources(TestUtils.CRD_KAFKA_CONNECT);
+        cluster.createCustomResources(TestUtils.CRD_KAFKA_CONNECT_S2I);
+        cluster.createCustomResources(TestUtils.CRD_KAFKA_MIRROR_MAKER);
+        cluster.createCustomResources(TestUtils.CRD_KAFKA_MIRROR_MAKER_2);
+        cluster.createCustomResources(TestUtils.CRD_KAFKA_BRIDGE);
+        cluster.createCustomResources(TestUtils.CRD_TOPIC);
+        cluster.createCustomResources(TestUtils.CRD_KAFKA_USER);
+        cluster.createCustomResources(TestUtils.CRD_KAFKA_CONNECTOR);
+        cluster.createCustomResources(TestUtils.CRD_KAFKA_REBALANCE);
+
+        waitForCrd(cluster, "kafkas.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkaconnects2is.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkaconnects.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkamirrormaker2s.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkamirrormakers.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkabridges.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkatopics.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkausers.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkaconnectors.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkarebalances.kafka.strimzi.io");
+    }
+
+    private static void waitForCrd(KubeClusterResource cluster, String name) {
+        cluster.cmdClient().waitFor("crd", name, crd -> {
+            JsonNode json = (JsonNode) crd;
+            if (json != null
+                    && json.hasNonNull("status")
+                    && json.get("status").hasNonNull("conditions")) {
+                return true;
+            }
+
+            return false;
+        });
+    }
+
+    public static void deleteAllCrds(KubeClusterResource cluster) {
+        cluster.deleteCustomResources(TestUtils.CRD_KAFKA);
+        cluster.deleteCustomResources(TestUtils.CRD_KAFKA_CONNECT);
+        cluster.deleteCustomResources(TestUtils.CRD_KAFKA_CONNECT_S2I);
+        cluster.deleteCustomResources(TestUtils.CRD_KAFKA_MIRROR_MAKER);
+        cluster.deleteCustomResources(TestUtils.CRD_KAFKA_MIRROR_MAKER_2);
+        cluster.deleteCustomResources(TestUtils.CRD_KAFKA_BRIDGE);
+        cluster.deleteCustomResources(TestUtils.CRD_TOPIC);
+        cluster.deleteCustomResources(TestUtils.CRD_KAFKA_USER);
+        cluster.deleteCustomResources(TestUtils.CRD_KAFKA_CONNECTOR);
+        cluster.deleteCustomResources(TestUtils.CRD_KAFKA_REBALANCE);
+    }
+
+    public static void crdStatusHasUpdatedStorageVersions(KubernetesClient client)    {
+        for (String kind : AbstractCommand.STRIMZI_KINDS)  {
+            String crdName = CrdUpgradeCommand.CRD_NAMES.get(kind);
+            CustomResourceDefinition crd = client.apiextensions().v1beta1().customResourceDefinitions().withName(crdName).get();
+
+            assertThat(crd.getStatus().getStoredVersions(), hasItem("v1beta2"));
+            assertThat(crd.getStatus().getStoredVersions(), hasItem(not("v1beta1")));
+            assertThat(crd.getStatus().getStoredVersions(), hasItem(not("v1alpha1")));
+        }
+    }
+
+    public static void crdStatusHasNotUpdatedStorageVersions(KubernetesClient client)    {
+        for (String kind : AbstractCommand.STRIMZI_KINDS)  {
+            String crdName = CrdUpgradeCommand.CRD_NAMES.get(kind);
+            CustomResourceDefinition crd = client.apiextensions().v1beta1().customResourceDefinitions().withName(crdName).get();
+
+            assertThat(crd.getStatus().getStoredVersions(), hasItem("v1beta2"));
+            assertThat(crd.getStatus().getStoredVersions(), hasItem(oneOf("v1alpha1", "v1beta1")));
+        }
+    }
+
+    public static void crdSpecHasUpdatedStorage(KubernetesClient client)    {
+        for (String kind : AbstractCommand.STRIMZI_KINDS)  {
+            String crdName = CrdUpgradeCommand.CRD_NAMES.get(kind);
+            CustomResourceDefinition crd = client.apiextensions().v1beta1().customResourceDefinitions().withName(crdName).get();
+
+            for (CustomResourceDefinitionVersion crdVersion : crd.getSpec().getVersions()) {
+                if ("v1beta2".equals(crdVersion.getName())) {
+                    assertThat(crdVersion.getStorage(), is(true));
+                    assertThat(crdVersion.getServed(), is(true));
+                } else {
+                    assertThat(crdVersion.getStorage(), is(false));
+                    assertThat(crdVersion.getServed(), is(true));
+                }
+            }
+        }
+    }
+
+    public static void setupV1Crds(KubeClusterResource cluster)  {
+        cluster.replaceCustomResources(CRD_V1_KAFKA);
+        cluster.replaceCustomResources(CRD_V1_KAFKA_CONNECT);
+        cluster.replaceCustomResources(CRD_V1_KAFKA_CONNECT_S2I);
+        cluster.replaceCustomResources(CRD_V1_KAFKA_MIRROR_MAKER);
+        cluster.replaceCustomResources(CRD_V1_KAFKA_MIRROR_MAKER_2);
+        cluster.replaceCustomResources(CRD_V1_KAFKA_BRIDGE);
+        cluster.replaceCustomResources(CRD_V1_TOPIC);
+        cluster.replaceCustomResources(CRD_V1_KAFKA_USER);
+        cluster.replaceCustomResources(CRD_V1_KAFKA_CONNECTOR);
+        cluster.replaceCustomResources(CRD_V1_KAFKA_REBALANCE);
+
+        waitForCrd(cluster, "kafkas.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkaconnects2is.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkaconnects.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkamirrormaker2s.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkamirrormakers.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkabridges.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkatopics.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkausers.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkaconnectors.kafka.strimzi.io");
+        waitForCrd(cluster, "kafkarebalances.kafka.strimzi.io");
+    }
+
+    public static void deleteV1Crds(KubeClusterResource cluster) {
+        cluster.deleteCustomResources(CRD_V1_KAFKA);
+        cluster.deleteCustomResources(CRD_V1_KAFKA_CONNECT);
+        cluster.deleteCustomResources(CRD_V1_KAFKA_CONNECT_S2I);
+        cluster.deleteCustomResources(CRD_V1_KAFKA_MIRROR_MAKER);
+        cluster.deleteCustomResources(CRD_V1_KAFKA_MIRROR_MAKER_2);
+        cluster.deleteCustomResources(CRD_V1_KAFKA_BRIDGE);
+        cluster.deleteCustomResources(CRD_V1_TOPIC);
+        cluster.deleteCustomResources(CRD_V1_KAFKA_USER);
+        cluster.deleteCustomResources(CRD_V1_KAFKA_CONNECTOR);
+        cluster.deleteCustomResources(CRD_V1_KAFKA_REBALANCE);
+    }
+
+    public static void crdHasV1Beta2Only(KubernetesClient client)    {
+        for (String kind : AbstractCommand.STRIMZI_KINDS)  {
+            String crdName = CrdUpgradeCommand.CRD_NAMES.get(kind);
+            CustomResourceDefinition crd = client.apiextensions().v1beta1().customResourceDefinitions().withName(crdName).get();
+
+            assertThat(crd.getSpec().getVersions().size(), is(1));
+            assertThat(crd.getSpec().getVersions().stream().map(CustomResourceDefinitionVersion::getName).collect(toList()), contains("v1beta2"));
+        }
+    }
+}

--- a/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/ConvertResourceCommandIT.java
+++ b/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/ConvertResourceCommandIT.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.kafka.api.conversion.cli;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.AffinityBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMap;
@@ -24,7 +23,6 @@ import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaConnectS2IBuilder;
 import io.strimzi.api.kafka.model.listener.KafkaListenersBuilder;
 import io.strimzi.kafka.api.conversion.converter.MultipartConversions;
-import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeClusterResource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -57,54 +55,13 @@ public class ConvertResourceCommandIT {
     @BeforeAll
     static void setupEnvironment() {
         CLUSTER.createNamespace(NAMESPACE);
-        CLUSTER.createCustomResources(TestUtils.CRD_KAFKA);
-        CLUSTER.createCustomResources(TestUtils.CRD_KAFKA_CONNECT);
-        CLUSTER.createCustomResources(TestUtils.CRD_KAFKA_CONNECT_S2I);
-        CLUSTER.createCustomResources(TestUtils.CRD_KAFKA_MIRROR_MAKER);
-        CLUSTER.createCustomResources(TestUtils.CRD_KAFKA_MIRROR_MAKER_2);
-        CLUSTER.createCustomResources(TestUtils.CRD_KAFKA_BRIDGE);
-        CLUSTER.createCustomResources(TestUtils.CRD_TOPIC);
-        CLUSTER.createCustomResources(TestUtils.CRD_KAFKA_USER);
-        CLUSTER.createCustomResources(TestUtils.CRD_KAFKA_CONNECTOR);
-        CLUSTER.createCustomResources(TestUtils.CRD_KAFKA_REBALANCE);
-        waitForCrd("kafkas.kafka.strimzi.io");
-        waitForCrd("kafkaconnects2is.kafka.strimzi.io");
-        waitForCrd("kafkaconnects.kafka.strimzi.io");
-        waitForCrd("kafkamirrormaker2s.kafka.strimzi.io");
-        waitForCrd("kafkamirrormakers.kafka.strimzi.io");
-        waitForCrd("kafkabridges.kafka.strimzi.io");
-        waitForCrd("kafkatopics.kafka.strimzi.io");
-        waitForCrd("kafkausers.kafka.strimzi.io");
-        waitForCrd("kafkaconnectors.kafka.strimzi.io");
-        waitForCrd("kafkarebalances.kafka.strimzi.io");
+        CliTestUtils.setupAllCrds(CLUSTER);
     }
 
     @AfterAll
     static void teardownEnvironment() {
-        CLUSTER.deleteCustomResources(TestUtils.CRD_KAFKA);
-        CLUSTER.deleteCustomResources(TestUtils.CRD_KAFKA_CONNECT);
-        CLUSTER.deleteCustomResources(TestUtils.CRD_KAFKA_CONNECT_S2I);
-        CLUSTER.deleteCustomResources(TestUtils.CRD_KAFKA_MIRROR_MAKER);
-        CLUSTER.deleteCustomResources(TestUtils.CRD_KAFKA_MIRROR_MAKER_2);
-        CLUSTER.deleteCustomResources(TestUtils.CRD_KAFKA_BRIDGE);
-        CLUSTER.deleteCustomResources(TestUtils.CRD_TOPIC);
-        CLUSTER.deleteCustomResources(TestUtils.CRD_KAFKA_USER);
-        CLUSTER.deleteCustomResources(TestUtils.CRD_KAFKA_CONNECTOR);
-        CLUSTER.deleteCustomResources(TestUtils.CRD_KAFKA_REBALANCE);
+        CliTestUtils.deleteAllCrds(CLUSTER);
         CLUSTER.deleteNamespaces();
-    }
-
-    private static void waitForCrd(String name) {
-        CLUSTER.cmdClient().waitFor("crd", name, crd -> {
-            JsonNode json = (JsonNode) crd;
-            if (json != null
-                    && json.hasNonNull("status")
-                    && json.get("status").hasNonNull("conditions")) {
-                return true;
-            }
-
-            return false;
-        });
     }
 
     @Test

--- a/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/CrdUpgradeCommandIT.java
+++ b/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/CrdUpgradeCommandIT.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.api.conversion.cli;
+
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.strimzi.api.annotations.ApiVersion;
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.KafkaList;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.listener.KafkaListenersBuilder;
+import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
+import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.test.k8s.KubeClusterResource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class CrdUpgradeCommandIT {
+    private static final String NAMESPACE = "api-conversion";
+    private static final KubeClusterResource CLUSTER = KubeClusterResource.getInstance();
+    private final KubernetesClient client = new DefaultKubernetesClient();
+
+    @BeforeEach
+    void setupEnvironment() {
+        CLUSTER.cluster();
+        CLUSTER.createNamespace(NAMESPACE);
+        CliTestUtils.setupAllCrds(CLUSTER);
+    }
+
+    @AfterEach
+    void teardownEnvironment() {
+        CliTestUtils.deleteAllCrds(CLUSTER);
+        CLUSTER.deleteNamespaces();
+    }
+
+    @Test
+    public void testCrdUpgradeWithConvertedResources() {
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = Crds.kafkaOperation(client, ApiVersion.V1BETA2.toString());
+
+        try {
+            Kafka kafka1 = new KafkaBuilder()
+                    .withNewMetadata()
+                        .withName("kafka1")
+                    .endMetadata()
+                    .withNewSpec()
+                        .withNewZookeeper()
+                            .withReplicas(3)
+                            .withNewEphemeralStorage()
+                            .endEphemeralStorage()
+                        .endZookeeper()
+                        .withNewKafka()
+                            .withVersion("2.7.0")
+                            .withReplicas(3)
+                            .withNewListeners()
+                                .withGenericKafkaListeners(
+                                        new GenericKafkaListenerBuilder()
+                                                .withName("plain")
+                                                .withPort(9092)
+                                                .withTls(false)
+                                                .withType(KafkaListenerType.INTERNAL)
+                                                .build(),
+                                        new GenericKafkaListenerBuilder()
+                                                .withName("tls")
+                                                .withPort(9093)
+                                                .withTls(true)
+                                                .withType(KafkaListenerType.INTERNAL)
+                                                .build())
+                            .endListeners()
+                            .withNewEphemeralStorage()
+                            .endEphemeralStorage()
+                        .endKafka()
+                        .withNewEntityOperator()
+                            .withNewUserOperator()
+                            .endUserOperator()
+                            .withNewTopicOperator()
+                            .endTopicOperator()
+                        .endEntityOperator()
+                    .endSpec()
+                    .build();
+
+            op.inNamespace(NAMESPACE).create(kafka1);
+
+            CommandLine cmd = new CommandLine(new EntryCommand());
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            cmd.setOut(pw);
+            cmd.setErr(pw);
+
+            int exitCode = cmd.execute("crd-upgrade");
+            assertThat(exitCode, is(0));
+
+            String commandOutput = sw.toString();
+            assertThat(commandOutput, containsString("Updating all Strimzi CRs to be stored under v1beta2"));
+            assertThat(commandOutput, containsString("Updating Kafka kafka1 to be stored as v1beta2"));
+            assertThat(commandOutput, containsString("Changing stored version in all Strimzi CRDs to v1beta2:"));
+            assertThat(commandOutput, containsString("Changing stored version in statuses of all Strimzi CRDs to v1beta2:"));
+            assertThat(commandOutput, containsString("Updating Kafka CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaMirrorMaker CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaRebalance CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaUser CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaMirrorMaker2 CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaConnect CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaConnectS2I CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaConnector CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaTopic CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaBridge CRD"));
+
+            CliTestUtils.crdSpecHasUpdatedStorage(client);
+            CliTestUtils.crdStatusHasUpdatedStorageVersions(client);
+
+            Kafka actualKafka1 = op.inNamespace(NAMESPACE).withName("kafka1").get();
+            assertThat(actualKafka1, is(notNullValue()));
+            assertThat(actualKafka1.getSpec().getKafka().getListeners().getKafkaListeners(), is(nullValue()));
+            assertThat(actualKafka1.getSpec().getKafka().getListeners().getGenericKafkaListeners(), is(notNullValue()));
+            assertThat(actualKafka1.getSpec().getKafka().getListeners().getGenericKafkaListeners().size(), is(2));
+        } finally {
+            op.inNamespace(NAMESPACE).withName("kafka1").delete();
+        }
+    }
+
+    @Test
+    public void testUpgradeWithUnconvertedResourcesFails() {
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = Crds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
+
+        try {
+            Kafka kafka1 = new KafkaBuilder()
+                    .withNewMetadata()
+                        .withName("kafka1")
+                    .endMetadata()
+                    .withNewSpec()
+                        .withNewZookeeper()
+                            .withReplicas(3)
+                            .withNewEphemeralStorage()
+                            .endEphemeralStorage()
+                        .endZookeeper()
+                        .withNewKafka()
+                            .withVersion("2.7.0")
+                            .withReplicas(3)
+                            .withNewListeners()
+                                .withKafkaListeners(new KafkaListenersBuilder()
+                                        .withNewPlain()
+                                        .endPlain()
+                                        .withNewTls()
+                                        .endTls()
+                                        .withNewKafkaListenerExternalLoadBalancer()
+                                        .endKafkaListenerExternalLoadBalancer()
+                                        .build())
+                            .endListeners()
+                            .withNewEphemeralStorage()
+                            .endEphemeralStorage()
+                        .endKafka()
+                        .withNewEntityOperator()
+                            .withNewUserOperator()
+                            .endUserOperator()
+                            .withNewTopicOperator()
+                            .endTopicOperator()
+                        .endEntityOperator()
+                    .endSpec()
+                    .build();
+
+            op.inNamespace(NAMESPACE).create(kafka1);
+
+            CommandLine cmd = new CommandLine(new EntryCommand());
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            cmd.setOut(pw);
+            cmd.setErr(pw);
+
+            int exitCode = cmd.execute("crd-upgrade");
+            assertThat(exitCode, is(1));
+
+            String commandOutput = sw.toString();
+            assertThat(commandOutput, containsString("Updating all Strimzi CRs to be stored under v1beta2"));
+            assertThat(commandOutput, containsString("Updating Kafka kafka1 to be stored as v1beta2"));
+            assertThat(commandOutput, containsString("Changing stored version in all Strimzi CRDs to v1beta2:"));
+            assertThat(commandOutput, containsString("Updating Kafka CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaMirrorMaker CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaRebalance CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaUser CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaMirrorMaker2 CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaConnect CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaConnectS2I CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaConnector CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaTopic CRD"));
+            assertThat(commandOutput, containsString("Updating KafkaBridge CRD"));
+
+            CliTestUtils.crdSpecHasUpdatedStorage(client);
+            CliTestUtils.crdStatusHasNotUpdatedStorageVersions(client);
+
+            Kafka actualKafka1 = op.inNamespace(NAMESPACE).withName("kafka1").get();
+            assertThat(actualKafka1, is(notNullValue()));
+            assertThat(actualKafka1.getSpec().getKafka().getListeners().getKafkaListeners(), is(notNullValue()));
+        } finally {
+            op.inNamespace(NAMESPACE).withName("kafka1").delete();
+        }
+    }
+}

--- a/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/FullUpgradeLifecycleIT.java
+++ b/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/FullUpgradeLifecycleIT.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.api.conversion.cli;
+
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.strimzi.api.annotations.ApiVersion;
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.KafkaList;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.listener.KafkaListenersBuilder;
+import io.strimzi.test.k8s.KubeClusterResource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class FullUpgradeLifecycleIT {
+    private static final String NAMESPACE = "api-conversion";
+    private static final KubeClusterResource CLUSTER = KubeClusterResource.getInstance();
+    private final KubernetesClient client = new DefaultKubernetesClient();
+
+    @BeforeEach
+    void setupEnvironment() {
+        CLUSTER.cluster();
+        CLUSTER.createNamespace(NAMESPACE);
+        CliTestUtils.setupAllCrds(CLUSTER);
+    }
+
+    @AfterEach
+    void teardownEnvironment() {
+        CliTestUtils.deleteAllCrds(CLUSTER);
+        CLUSTER.deleteNamespaces();
+    }
+
+    @Test
+    public void testFullLifecycleAsExpected() {
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> opV1Beta2 = Crds.kafkaOperation(client, ApiVersion.V1BETA2.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> opV1Beta1 = Crds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
+
+        try {
+            Kafka kafka1 = new KafkaBuilder()
+                    .withNewMetadata()
+                        .withName("kafka1")
+                    .endMetadata()
+                    .withNewSpec()
+                        .withNewZookeeper()
+                            .withReplicas(3)
+                            .withNewEphemeralStorage()
+                            .endEphemeralStorage()
+                        .endZookeeper()
+                        .withNewKafka()
+                            .withVersion("2.7.0")
+                            .withReplicas(3)
+                            .withNewListeners()
+                                .withKafkaListeners(new KafkaListenersBuilder()
+                                        .withNewPlain()
+                                        .endPlain()
+                                        .withNewTls()
+                                        .endTls()
+                                        .withNewKafkaListenerExternalLoadBalancer()
+                                        .endKafkaListenerExternalLoadBalancer()
+                                        .build())
+                            .endListeners()
+                            .withNewEphemeralStorage()
+                            .endEphemeralStorage()
+                        .endKafka()
+                        .withNewEntityOperator()
+                            .withNewUserOperator()
+                            .endUserOperator()
+                            .withNewTopicOperator()
+                            .endTopicOperator()
+                        .endEntityOperator()
+                    .endSpec()
+                    .build();
+
+            opV1Beta1.inNamespace(NAMESPACE).create(kafka1);
+
+            CommandLine cmd = new CommandLine(new EntryCommand());
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            cmd.setOut(pw);
+            cmd.setErr(pw);
+
+            // Convert resources
+            int exitCode = cmd.execute("convert-resources", "--all-namespaces");
+            assertThat(exitCode, is(0));
+
+            // Upgrade CRDs
+            exitCode = cmd.execute("crd-upgrade");
+            assertThat(exitCode, is(0));
+
+            CliTestUtils.crdSpecHasUpdatedStorage(client);
+            CliTestUtils.crdStatusHasUpdatedStorageVersions(client);
+
+            // Install CRD v1 with v1beta2 only
+            CliTestUtils.setupV1Crds(CLUSTER);
+            CliTestUtils.crdHasV1Beta2Only(client);
+
+            Kafka actualKafka1 = opV1Beta2.inNamespace(NAMESPACE).withName("kafka1").get();
+            assertThat(actualKafka1, is(notNullValue()));
+            assertThat(actualKafka1.getSpec().getKafka().getListeners().getKafkaListeners(), is(nullValue()));
+            assertThat(actualKafka1.getSpec().getKafka().getListeners().getGenericKafkaListeners(), is(notNullValue()));
+            assertThat(actualKafka1.getSpec().getKafka().getListeners().getGenericKafkaListeners().size(), is(3));
+        } finally {
+            opV1Beta2.inNamespace(NAMESPACE).withName("kafka1").delete();
+            CliTestUtils.deleteV1Crds(CLUSTER);
+        }
+    }
+
+    @Test
+    public void testFullLifecycleOnSecondTry() {
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> opV1Beta2 = Crds.kafkaOperation(client, ApiVersion.V1BETA2.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> opV1Beta1 = Crds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
+
+        try {
+            Kafka kafka1 = new KafkaBuilder()
+                    .withNewMetadata()
+                        .withName("kafka1")
+                    .endMetadata()
+                    .withNewSpec()
+                        .withNewZookeeper()
+                            .withReplicas(3)
+                            .withNewEphemeralStorage()
+                            .endEphemeralStorage()
+                        .endZookeeper()
+                        .withNewKafka()
+                            .withVersion("2.7.0")
+                            .withReplicas(3)
+                            .withNewListeners()
+                                .withKafkaListeners(new KafkaListenersBuilder()
+                                        .withNewPlain()
+                                        .endPlain()
+                                        .withNewTls()
+                                        .endTls()
+                                        .withNewKafkaListenerExternalLoadBalancer()
+                                        .endKafkaListenerExternalLoadBalancer()
+                                        .build())
+                            .endListeners()
+                            .withNewEphemeralStorage()
+                            .endEphemeralStorage()
+                        .endKafka()
+                        .withNewEntityOperator()
+                            .withNewUserOperator()
+                            .endUserOperator()
+                            .withNewTopicOperator()
+                            .endTopicOperator()
+                        .endEntityOperator()
+                    .endSpec()
+                    .build();
+
+            opV1Beta1.inNamespace(NAMESPACE).create(kafka1);
+
+            // First try with unconverted resources => should fail
+            CommandLine cmd = new CommandLine(new EntryCommand());
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            cmd.setOut(pw);
+            cmd.setErr(pw);
+
+            int exitCode = cmd.execute("crd-upgrade");
+            assertThat(exitCode, is(1));
+
+            CliTestUtils.crdSpecHasUpdatedStorage(client);
+            CliTestUtils.crdStatusHasNotUpdatedStorageVersions(client);
+
+            // Convert resources
+            exitCode = cmd.execute("convert-resources", "--all-namespaces");
+            assertThat(exitCode, is(0));
+
+            // Upgrade CRDs
+            exitCode = cmd.execute("crd-upgrade");
+            assertThat(exitCode, is(0));
+
+            CliTestUtils.crdSpecHasUpdatedStorage(client);
+            CliTestUtils.crdStatusHasUpdatedStorageVersions(client);
+
+            //Install CRDs v1 with v1beta2 only
+            CliTestUtils.setupV1Crds(CLUSTER);
+            CliTestUtils.crdHasV1Beta2Only(client);
+
+            Kafka actualKafka1 = opV1Beta2.inNamespace(NAMESPACE).withName("kafka1").get();
+            assertThat(actualKafka1, is(notNullValue()));
+            assertThat(actualKafka1.getSpec().getKafka().getListeners().getKafkaListeners(), is(nullValue()));
+            assertThat(actualKafka1.getSpec().getKafka().getListeners().getGenericKafkaListeners(), is(notNullValue()));
+            assertThat(actualKafka1.getSpec().getKafka().getListeners().getGenericKafkaListeners().size(), is(3));
+        } finally {
+            opV1Beta2.inNamespace(NAMESPACE).withName("kafka1").delete();
+            CliTestUtils.deleteV1Crds(CLUSTER);
+        }
+    }
+}

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -186,9 +186,22 @@ public class KubeClusterResource {
         setNamespace(testNamespace);
     }
 
+    /**
+     * Replaces custom resources for CO such as templates. Deletion is up to caller and can be managed
+     * by calling {@link #deleteCustomResources()}
+     *
+     * @param resources array of paths to yaml files with resources specifications
+     */
+    public void replaceCustomResources(String... resources) {
+        for (String resource : resources) {
+            LOGGER.info("Replacing resources {} in Namespace {}", resource, getNamespace());
+            deploymentResources.add(resource);
+            cmdKubeClient().namespace(getNamespace()).replace(resource);
+        }
+    }
 
     /**
-     * Apply custom resources for CO such as templates. Deletion is up to caller and can be managed
+     * Creates custom resources for CO such as templates. Deletion is up to caller and can be managed
      * by calling {@link #deleteCustomResources()}
      * @param resources array of paths to yaml files with resources specifications
      */

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
@@ -48,6 +48,10 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
         return create(asList(files).stream().map(File::new).collect(toList()).toArray(new File[0]));
     }
 
+    default K replace(String... files) {
+        return replace(asList(files).stream().map(File::new).collect(toList()).toArray(new File[0]));
+    }
+
     default K apply(String... files) {
         return apply(asList(files).stream().map(File::new).collect(toList()).toArray(new File[0]));
     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The `api-conversion` tool will need to also upgrade the CRDs to use the `v1beta2` as stored version. This PR adds a new command `crd-upgrade` which does this. It:
* First updates v1beta2 to stored version in the CRD spec section
* Updates all CRs (the have to be converted by this point) to have them also stored under v1beta2
* In the CRD status updates the stored versions to have `v1beta2` only

If any resources are not converted yet, users have to convert them and use the tool again.

This PR also adds test coverage including two tests covering the full lifecycle including upgrade to CRD v1 with `v1beta2` only. And updates the README.md file.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally