### PR TITLE
Update Kaniko container builder to 1.5.1

### DIFF
--- a/docker-images/kaniko-executor/Makefile
+++ b/docker-images/kaniko-executor/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := kaniko-executor
-KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.3.0
+KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.5.1
 
 docker_build:
 	# The Kaniko executor image used for building new Kafka Connect images with additional connectors is not build from


### PR DESCRIPTION
### Type of change

- Task

### Description

Currently, we use the Kaniko container builder in version 1.3.0. There is now a new version 1.5.1 available. This PR updates Strimzi to use the new version.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally