### PR TITLE
Bump Cruise Control to v2.5.37 for Kafka 2.7 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,13 @@
   * OAuth authentication over SASL PLAIN mechanism
   * Checking token audience
   * Validating tokens using JSONPath filter queries to perform custom checks
-* Updated Cruise Control to version 2.5.32
 * Fix Cruise Control crash loop when updating container configurations
 * Configure external logging `ConfigMap` name and key.
 * Add support for configuring labels and annotations in ClusterRoleBindings created as part of Kafka and Kafka Connect clusters
 * Add support for Ingress v1 in Kubernetes 1.19 and newer
 * Add support for Kafka 2.6.1
 * List topics used by a Kafka Connect connector in the `.status` section of the `KafkaConnector` custom resource
-* Bump Cruise Control to v2.5.37 for Kafka 2.7 support. Note this new version of Cruise Control uses `log4j2` and is supported by dynamic logging configuration. However, existing `log4j` configurations must be updated to `log4j2` configurations.
+* Bump Cruise Control to v2.5.37 for Kafka 2.7 support. Note this new version of Cruise Control uses `Log4j 2` and is supported by dynamic logging configuration (where logging properties are defined in a ConfigMap). However, existing `Log4j` configurations must be updated to `Log4j 2` configurations.
 
 ### Changes, deprecations and removals
 
@@ -49,9 +48,9 @@
         name: my-config-map
         key: my-key
   ``` 
-* Exisiting Cruise Control logging configurations must be updated from `log4j` syntax to `log4j2` syntax.
+* Existing Cruise Control logging configurations must be updated from `Log4j` syntax to `Log4j 2` syntax.
   * For existing inline configurations, replace the `cruisecontrol.root.logger` property with `rootLogger.level`.
-  * For existing external configurations, replace the existing configuration a new configuration file named `log4j2.properties` using `log4j2` syntax. 
+  * For existing external configurations, replace the existing configuration with a new configuration file named `log4j2.properties` using `log4j 2` syntax.
 
 ## 0.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,7 @@
 * Add support for Ingress v1 in Kubernetes 1.19 and newer
 * Add support for Kafka 2.6.1
 * List topics used by a Kafka Connect connector in the `.status` section of the `KafkaConnector` custom resource
-* Bump Cruise Control to v2.5.37 for Kafka 2.7 support.
-* New Cruise Control supports `log4j2` implementation thus we support dynamic logging changes for it. The logging configuration has to be changed.
+* Bump Cruise Control to v2.5.37 for Kafka 2.7 support. Note this new version of Cruise Control uses `log4j2` and is supported by dynamic logging configuration. However, existing `log4j` configurations must be updated to `log4j2` configurations.
 
 ### Changes, deprecations and removals
 
@@ -50,7 +49,9 @@
         name: my-config-map
         key: my-key
   ``` 
-* Cruise Control logging configuration does not contain `cruisecontrol.root.logger` property anymore. It has been replaced by `rootLogger.level`.
+* Exisiting Cruise Control logging configurations must be updated from `log4j` syntax to `log4j2` syntax.
+  * For existing inline configurations, replace the `cruisecontrol.root.logger` property with `rootLogger.level`.
+  * For existing external configurations, replace the existing configuration a new configuration file named `log4j2.properties` using `log4j2` syntax. 
 
 ## 0.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add support for Ingress v1 in Kubernetes 1.19 and newer
 * Add support for Kafka 2.6.1
 * List topics used by a Kafka Connect connector in the `.status` section of the `KafkaConnector` custom resource
+* Bump Cruise Control to v2.5.37 for Kafka 2.7 support.
 
 ### Changes, deprecations and removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Add support for Kafka 2.6.1
 * List topics used by a Kafka Connect connector in the `.status` section of the `KafkaConnector` custom resource
 * Bump Cruise Control to v2.5.37 for Kafka 2.7 support.
+* New Cruise Control supports `log4j2` implementation thus we support dynamic logging changes for it. The logging configuration has to be changed.
 
 ### Changes, deprecations and removals
 
@@ -49,6 +50,7 @@
         name: my-config-map
         key: my-key
   ``` 
+* Cruise Control logging configuration does not contain `cruisecontrol.root.logger` property anymore. It has been replaced by `rootLogger.level`.
 
 ## 0.21.0
 

--- a/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/converter/KafkaConverter.java
+++ b/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/converter/KafkaConverter.java
@@ -71,7 +71,7 @@ public class KafkaConverter extends Converter<Kafka> {
         Conversion.replaceLogging("/spec/zookeeper/logging", "log4j.properties"),
         Conversion.replaceLogging("/spec/entityOperator/topicOperator/logging", "log4j2.properties"),
         Conversion.replaceLogging("/spec/entityOperator/userOperator/logging", "log4j2.properties"),
-        Conversion.replaceLogging("/spec/cruiseControl/logging", "log4j.properties"),
+        Conversion.replaceLogging("/spec/cruiseControl/logging", "log4j2.properties"),
         new MetricsConversion<>("/spec/kafka", KafkaClusterSpec.class, "kafka"),
         new MetricsConversion<>("/spec/zookeeper", ZookeeperClusterSpec.class, "zookeeper"),
         new MetricsConversion<>("/spec/cruiseControl", CruiseControlSpec.class, "cruise-control")

--- a/api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/cli/kafka-logging.out
+++ b/api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/cli/kafka-logging.out
@@ -65,5 +65,5 @@ spec:
       type: external
       valueFrom:
         configMapKeyRef:
-          key: log4j.properties
+          key: log4j2.properties
           name: my-config-map

--- a/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
@@ -128,7 +128,7 @@ public class CruiseControlSpec implements HasConfigurableMetrics, UnknownPropert
         this.metricsConfig = metricsConfig;
     }
 
-    @Description("Logging configuration (log4j2) for Cruise Control.")
+    @Description("Logging configuration (Log4j 2) for Cruise Control.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public Logging getLogging() {
         return logging;

--- a/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
@@ -128,7 +128,7 @@ public class CruiseControlSpec implements HasConfigurableMetrics, UnknownPropert
         this.metricsConfig = metricsConfig;
     }
 
-    @Description("Logging configuration (log4j1) for Cruise Control.")
+    @Description("Logging configuration (log4j2) for Cruise Control.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public Logging getLogging() {
         return logging;

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
@@ -4058,7 +4058,7 @@ spec:
                           is stored. '
                     required:
                     - type
-                    description: Logging configuration (log4j2) for Cruise Control.
+                    description: Logging configuration (Log4j 2) for Cruise Control.
                   template:
                     type: object
                     properties:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
@@ -4058,7 +4058,7 @@ spec:
                           is stored. '
                     required:
                     - type
-                    description: Logging configuration (log4j1) for Cruise Control.
+                    description: Logging configuration (log4j2) for Cruise Control.
                   template:
                     type: object
                     properties:

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -46,6 +46,7 @@ import io.strimzi.operator.cluster.model.cruisecontrol.Capacity;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.model.OrderedProperties;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -615,5 +616,23 @@ public class CruiseControl extends AbstractModel {
 
         log.trace("Created network policy {}", networkPolicy);
         return networkPolicy;
+    }
+
+    @Override
+    public String getAncillaryConfigMapKeyLogConfig() {
+        return "log4j2.properties";
+    }
+
+    /**
+     * Transforms properties to log4j2 properties file format and adds property for reloading the config
+     * @param properties map with properties
+     * @return modified string with monitorInterval
+     */
+    @Override
+    public String createLog4jProperties(OrderedProperties properties) {
+        if (!properties.asMap().keySet().contains("monitorInterval")) {
+            properties.addPair("monitorInterval", "30");
+        }
+        return super.createLog4jProperties(properties);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
@@ -28,6 +28,7 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
     protected static final List<String> CRUISE_CONTROL_GOALS_LIST = Collections.unmodifiableList(
         Arrays.asList(
                 CruiseControlGoals.RACK_AWARENESS_GOAL.toString(),
+                CruiseControlGoals.MIN_TOPIC_LEADERS_PER_BROKER_GOAL.toString(),
                 CruiseControlGoals.REPLICA_CAPACITY_GOAL.toString(),
                 CruiseControlGoals.DISK_CAPACITY_GOAL.toString(),
                 CruiseControlGoals.NETWORK_INBOUND_CAPACITY_GOAL.toString(),
@@ -68,6 +69,7 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
     protected static final List<String> CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS_LIST = Collections.unmodifiableList(
         Arrays.asList(
                 CruiseControlGoals.RACK_AWARENESS_GOAL.toString(),
+                CruiseControlGoals.MIN_TOPIC_LEADERS_PER_BROKER_GOAL.toString(),
                 CruiseControlGoals.REPLICA_CAPACITY_GOAL.toString(),
                 CruiseControlGoals.DISK_CAPACITY_GOAL.toString()
         )

--- a/cluster-operator/src/main/resources/cruiseControlDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/cruiseControlDefaultLoggingProperties
@@ -1,6 +1,12 @@
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n
-log4j.additivity.kafka.request.logger=false
-cruisecontrol.root.logger=INFO
-log4j.rootLogger=${cruisecontrol.root.logger}, CONSOLE
+name = CCConfig
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+#appender.console.layout.pattern = %d{ISO8601} %p %m (%c) [%t]%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+rootLogger.level = INFO
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.additivity = false

--- a/docker-images/kafka/cruise-control-scripts/cruise_control_run.sh
+++ b/docker-images/kafka/cruise-control-scripts/cruise_control_run.sh
@@ -21,7 +21,7 @@ export STRIMZI_KEYSTORE_LOCATION=/tmp/cruise-control/replication.keystore.p12
 export STRIMZI_KEYSTORE_PASSWORD="$CERTS_STORE_PASSWORD"
 
 if [ -z "$KAFKA_LOG4J_OPTS" ]; then
-  export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$CRUISE_CONTROL_HOME/custom-config/log4j.properties"
+  export KAFKA_LOG4J_OPTS="-Dlog4j.configurationFile=file:$CRUISE_CONTROL_HOME/custom-config/log4j.properties"
 fi
 
 # enabling Prometheus JMX exporter as Java agent

--- a/docker-images/kafka/cruise-control-scripts/cruise_control_run.sh
+++ b/docker-images/kafka/cruise-control-scripts/cruise_control_run.sh
@@ -21,7 +21,7 @@ export STRIMZI_KEYSTORE_LOCATION=/tmp/cruise-control/replication.keystore.p12
 export STRIMZI_KEYSTORE_PASSWORD="$CERTS_STORE_PASSWORD"
 
 if [ -z "$KAFKA_LOG4J_OPTS" ]; then
-  export KAFKA_LOG4J_OPTS="-Dlog4j.configurationFile=file:$CRUISE_CONTROL_HOME/custom-config/log4j.properties"
+  export KAFKA_LOG4J_OPTS="-Dlog4j2.configurationFile=file:$CRUISE_CONTROL_HOME/custom-config/log4j2.properties"
 fi
 
 # enabling Prometheus JMX exporter as Java agent

--- a/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.7.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.32</cruise-control.version>
+        <cruise-control.version>2.5.37</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
     </properties>
 
@@ -241,6 +241,14 @@
                 <exclusion>
                     <groupId>org.apache.kafka</groupId>
                     <artifactId>kafka-clients</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.7.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.32</cruise-control.version>
+        <cruise-control.version>2.5.37</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
     </properties>
 
@@ -241,6 +241,14 @@
                 <exclusion>
                     <groupId>org.apache.kafka</groupId>
                     <artifactId>kafka-clients</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.7.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.32</cruise-control.version>
+        <cruise-control.version>2.5.37</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
     </properties>
 
@@ -241,6 +241,14 @@
                 <exclusion>
                     <groupId>org.apache.kafka</groupId>
                     <artifactId>kafka-clients</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.5.32</cruise-control.version>
+        <cruise-control.version>2.5.37</cruise-control.version>
     </properties>
 
     <repositories>

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1725,7 +1725,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |xref:type-Probe-{context}[`Probe`]
 |jvmOptions      1.2+<.<|JVM Options for the Cruise Control container.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|logging         1.2+<.<|Logging configuration (log4j1) for Cruise Control. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging         1.2+<.<|Logging configuration (log4j2) for Cruise Control. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
 |template        1.2+<.<|Template to specify how Cruise Control resources, `Deployments` and `Pods`, are generated.
 |xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`]

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1725,7 +1725,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |xref:type-Probe-{context}[`Probe`]
 |jvmOptions      1.2+<.<|JVM Options for the Cruise Control container.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|logging         1.2+<.<|Logging configuration (log4j2) for Cruise Control. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging         1.2+<.<|Logging configuration (Log4j 2) for Cruise Control. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
 |template        1.2+<.<|Template to specify how Cruise Control resources, `Deployments` and `Pods`, are generated.
 |xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`]

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -60,7 +60,7 @@ Cruise Control will ignore this goal if doing so enables all the configured hard
 In Cruise Control, the following xref:master-goals[master optimization goals] are preset as hard goals:
 
 [source]
-RackAwareGoal; MinTopicLeadersPerBrokerGoal; MinTopicLeadersPerBrokerGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CpuCapacityGoal
+RackAwareGoal; MinTopicLeadersPerBrokerGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CpuCapacityGoal
 
 You configure hard goals in the Cruise Control deployment configuration, by editing the `hard.goals` property in `Kafka.spec.cruiseControl.config`.
 

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -12,6 +12,7 @@ Strimzi supports most of the optimization goals developed in the Cruise Control 
 The supported goals, in the default descending order of priority, are as follows:
 
 . Rack-awareness
+. Minimum topic leaders per broker
 . Replica capacity
 . _Capacity_: Disk capacity, Network inbound capacity, Network outbound capacity, CPU capacity
 . Replica distribution

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -60,7 +60,7 @@ Cruise Control will ignore this goal if doing so enables all the configured hard
 In Cruise Control, the following xref:master-goals[master optimization goals] are preset as hard goals:
 
 [source]
-RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CpuCapacityGoal
+RackAwareGoal; MinTopicLeadersPerBrokerGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CpuCapacityGoal
 
 You configure hard goals in the Cruise Control deployment configuration, by editing the `hard.goals` property in `Kafka.spec.cruiseControl.config`.
 

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -12,7 +12,7 @@ Strimzi supports most of the optimization goals developed in the Cruise Control 
 The supported goals, in the default descending order of priority, are as follows:
 
 . Rack-awareness
-. Minimum topic leaders per broker
+. Minimum number of leader replicas per broker for a set of topics
 . Replica capacity
 . _Capacity_: Disk capacity, Network inbound capacity, Network outbound capacity, CPU capacity
 . Replica distribution
@@ -60,7 +60,7 @@ Cruise Control will ignore this goal if doing so enables all the configured hard
 In Cruise Control, the following xref:master-goals[master optimization goals] are preset as hard goals:
 
 [source]
-RackAwareGoal; MinTopicLeadersPerBrokerGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CpuCapacityGoal
+RackAwareGoal; MinTopicLeadersPerBrokerGoal; MinTopicLeadersPerBrokerGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CpuCapacityGoal
 
 You configure hard goals in the Cruise Control deployment configuration, by editing the `hard.goals` property in `Kafka.spec.cruiseControl.config`.
 

--- a/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
+++ b/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
@@ -124,7 +124,7 @@ Cruise Control has its own configurable logger:
 
 * `rootLogger.level`
 
-Cruise Control uses the Apache `log4j2` logger implementation.
+Cruise Control uses the Apache `log4j 2` logger implementation.
 
 Use the `logging` property to configure loggers and logger levels.
 

--- a/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
+++ b/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
@@ -122,9 +122,9 @@ For more information, refer to the xref:type-BrokerCapacity-reference[].
 
 Cruise Control has its own configurable logger:
 
-* `cruisecontrol.root.logger`
+* `rootLogger.level`
 
-Cruise Control uses the Apache `log4j` logger implementation.
+Cruise Control uses the Apache `log4j2` logger implementation.
 
 Use the `logging` property to configure loggers and logger levels.
 
@@ -144,7 +144,7 @@ spec:
     logging:
       type: inline
       loggers:
-        cruisecontrol.root.logger: "INFO"
+        rootLogger.level: "INFO"
     # ...
 ----
 

--- a/examples/cruise-control/kafka-rebalance-with-goals.yaml
+++ b/examples/cruise-control/kafka-rebalance-with-goals.yaml
@@ -10,5 +10,6 @@ spec:
     - NetworkInboundCapacityGoal
     - DiskCapacityGoal
     - RackAwareGoal
+    - MinTopicLeadersPerBrokerGoal
     - NetworkOutboundCapacityGoal
     - ReplicaCapacityGoal

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -3316,7 +3316,7 @@ spec:
                           description: '`ConfigMap` entry where the logging configuration is stored. '
                       required:
                         - type
-                      description: Logging configuration (log4j1) for Cruise Control.
+                      description: Logging configuration (log4j2) for Cruise Control.
                     template:
                       type: object
                       properties:
@@ -10409,7 +10409,7 @@ spec:
                           description: '`ConfigMap` entry where the logging configuration is stored. '
                       required:
                         - type
-                      description: Logging configuration (log4j1) for Cruise Control.
+                      description: Logging configuration (log4j2) for Cruise Control.
                     template:
                       type: object
                       properties:
@@ -17505,7 +17505,7 @@ spec:
                           description: '`ConfigMap` entry where the logging configuration is stored. '
                       required:
                         - type
-                      description: Logging configuration (log4j1) for Cruise Control.
+                      description: Logging configuration (log4j2) for Cruise Control.
                     template:
                       type: object
                       properties:

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -3316,7 +3316,7 @@ spec:
                           description: '`ConfigMap` entry where the logging configuration is stored. '
                       required:
                         - type
-                      description: Logging configuration (log4j2) for Cruise Control.
+                      description: Logging configuration (Log4j 2) for Cruise Control.
                     template:
                       type: object
                       properties:
@@ -10409,7 +10409,7 @@ spec:
                           description: '`ConfigMap` entry where the logging configuration is stored. '
                       required:
                         - type
-                      description: Logging configuration (log4j2) for Cruise Control.
+                      description: Logging configuration (Log4j 2) for Cruise Control.
                     template:
                       type: object
                       properties:
@@ -17505,7 +17505,7 @@ spec:
                           description: '`ConfigMap` entry where the logging configuration is stored. '
                       required:
                         - type
-                      description: Logging configuration (log4j2) for Cruise Control.
+                      description: Logging configuration (Log4j 2) for Cruise Control.
                     template:
                       type: object
                       properties:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -3964,7 +3964,7 @@ spec:
                           is stored. '
                     required:
                     - type
-                    description: Logging configuration (log4j2) for Cruise Control.
+                    description: Logging configuration (Log4j 2) for Cruise Control.
                   template:
                     type: object
                     properties:
@@ -12335,7 +12335,7 @@ spec:
                           is stored. '
                     required:
                     - type
-                    description: Logging configuration (log4j2) for Cruise Control.
+                    description: Logging configuration (Log4j 2) for Cruise Control.
                   template:
                     type: object
                     properties:
@@ -20710,7 +20710,7 @@ spec:
                           is stored. '
                     required:
                     - type
-                    description: Logging configuration (log4j2) for Cruise Control.
+                    description: Logging configuration (Log4j 2) for Cruise Control.
                   template:
                     type: object
                     properties:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -3964,7 +3964,7 @@ spec:
                           is stored. '
                     required:
                     - type
-                    description: Logging configuration (log4j1) for Cruise Control.
+                    description: Logging configuration (log4j2) for Cruise Control.
                   template:
                     type: object
                     properties:
@@ -12335,7 +12335,7 @@ spec:
                           is stored. '
                     required:
                     - type
-                    description: Logging configuration (log4j1) for Cruise Control.
+                    description: Logging configuration (log4j2) for Cruise Control.
                   template:
                     type: object
                     properties:
@@ -20710,7 +20710,7 @@ spec:
                           is stored. '
                     required:
                     - type
-                    description: Logging configuration (log4j1) for Cruise Control.
+                    description: Logging configuration (log4j2) for Cruise Control.
                   template:
                     type: object
                     properties:

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlGoals.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlGoals.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 public enum CruiseControlGoals {
 
     RACK_AWARENESS_GOAL("com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal"),
+    MIN_TOPIC_LEADERS_PER_BROKER_GOAL("com.linkedin.kafka.cruisecontrol.analyzer.goals.MinTopicLeadersPerBrokerGoal"),
     REPLICA_CAPACITY_GOAL("com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal"),
     DISK_CAPACITY_GOAL("com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal"),
     NETWORK_INBOUND_CAPACITY_GOAL("com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal"),


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Bump Cruise Control to v2.5.37 for Kafka 2.7 support. The update required some minimal changes for the integration to work correctly:

- Updating the log4j parameter argument from `-Dlog4j.configuration` to `-Dlog4j.configurationFile` in the cruise control run script.
- Adding a new hard goal to the `MinTopicLeadersPerBrokerGoal`[1] to the default and hard goal lists.

[1] https://github.com/linkedin/cruise-control/issues/921

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

