### PR TITLE
Try to speed up downloads of Kafka binaries - Attempt No 2

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -24,7 +24,7 @@ jobs:
           jdk_version: '11'
           jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
     # Set timeout for jobs
-    timeoutInMinutes: 80
+    timeoutInMinutes: 120
     # Base system
     pool:
       vmImage: $(image)

--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -41,6 +41,12 @@ jobs:
           path: "$(MVN_CACHE_FOLDER)"
         displayName: Maven cache
 
+      - task: Cache@2
+        inputs:
+          key: 'kafka-binaries | version-1'
+          path: "docker-images/kafka/tmp/kafka_*.tgz"
+        displayName: Kafka Binaries cache
+
       - bash: ".azure/scripts/build.sh"
         env:
           BUILD_REASON: $(Build.Reason)

--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -35,18 +35,6 @@ jobs:
     steps:
       - template: "templates/general_steps.yaml"
 
-      - task: Cache@2
-        inputs:
-          key: 'mvn-m2-cache | $(System.JobName)'
-          path: "$(MVN_CACHE_FOLDER)"
-        displayName: Maven cache
-
-      - task: Cache@2
-        inputs:
-          key: 'kafka-binaries | version-1'
-          path: "docker-images/kafka/tmp/kafka_*.tgz"
-        displayName: Kafka Binaries cache
-
       - bash: ".azure/scripts/build.sh"
         env:
           BUILD_REASON: $(Build.Reason)

--- a/.azure/templates/build_strimzi.yaml
+++ b/.azure/templates/build_strimzi.yaml
@@ -8,7 +8,7 @@ steps:
 - task: Cache@2
   inputs:
     key: 'kafka-binaries | version-1'
-    path: "docker-images/kafka/tmp/kafka_*.tgz"
+    path: docker-images/kafka/tmp/kafka_*.tgz
   displayName: Kafka Binaries cache
 - task: Maven@3
   inputs:

--- a/.azure/templates/build_strimzi.yaml
+++ b/.azure/templates/build_strimzi.yaml
@@ -8,7 +8,7 @@ steps:
 - task: Cache@2
   inputs:
     key: 'kafka-binaries | version-1'
-    path: docker-images/kafka/tmp/kafka_*.tgz
+    path: docker-images/kafka/tmp/archives
   displayName: Kafka Binaries cache
 - task: Maven@3
   inputs:

--- a/.azure/templates/build_strimzi.yaml
+++ b/.azure/templates/build_strimzi.yaml
@@ -1,5 +1,15 @@
 # Step to simple build Strimzi project without tests
 steps:
+- task: Cache@2
+  inputs:
+    key: 'mvn-m2-cache | $(System.JobName)'
+    path: "$(MVN_CACHE_FOLDER)"
+  displayName: Maven cache
+- task: Cache@2
+  inputs:
+    key: 'kafka-binaries | version-1'
+    path: "docker-images/kafka/tmp/kafka_*.tgz"
+  displayName: Kafka Binaries cache
 - task: Maven@3
   inputs:
     mavenPomFile: 'pom.xml'

--- a/docker-images/build.sh
+++ b/docker-images/build.sh
@@ -50,7 +50,7 @@ function fetch_and_unpack_kafka_binaries {
     declare -Ag version_dist_dirs
 
     # Set the cache folder to store the binary files
-    binary_file_dir="$kafka_image/tmp"
+    binary_file_dir="$kafka_image/tmp/archives"
     test -d "$binary_file_dir" || mkdir -p "$binary_file_dir"
 
     for kafka_version in "${!version_checksums[@]}"
@@ -111,7 +111,7 @@ function fetch_and_unpack_kafka_binaries {
         fi
 
         # We now have a verified tar archive for this version of Kafka. Unpack it into the temp dir
-        dist_dir="$binary_file_dir/$kafka_version"
+        dist_dir="$kafka_image/tmp/$kafka_version"
         # If an unpacked directory with the same name exists then delete it
         test -d "$dist_dir" && rm -r "$dist_dir"
         mkdir -p "$dist_dir"
@@ -124,7 +124,7 @@ function fetch_and_unpack_kafka_binaries {
         # create a file listing all the jars with colliding class files in the Kafka dist
         # (on the assumption that this is OK). This file will be used after building the images to detect any collisions
         # added by the third-party jars mechanism.
-        whilelist_file="$binary_file_dir/$kafka_version.whitelist"
+        whilelist_file="$dist_dir.whitelist"
         if [ ! -e $whilelist_file ]
         then
             unzipped_dir=`mktemp -d`

--- a/kafka-versions.yaml
+++ b/kafka-versions.yaml
@@ -105,7 +105,7 @@
 - version: 2.7.0
   format: 2.7
   protocol: 2.7
-  url: https://downloads.apache.org/kafka/2.7.0/kafka_2.12-2.7.0.tgz
+  url: https://archive.apache.org/dist/kafka/2.7.0/kafka_2.12-2.7.0.tgz
   checksum: ADAD48E6D9C9BF6577FC97DB10BFE9EF3755DA7B3060ED633EDB89EB99722DC81B111BAB2C91E7875E0A866A1020C8C31904B088D2A9F9950796EDA8ED789CCD
   zookeeper: 3.5.8
   third-party-libs: 2.7.x


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR tries to use two mechanisms to speed up things:
* It tries to cache the Kafka artifacts
* It tries to use the mirrors for the latest versions available on them

It also increases the maximal build time because we need to finish the build to get the cache first.