### PR TITLE
[systemtest] Add tests for CR selectors

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
@@ -122,6 +122,9 @@ public class KubernetesResource {
     }
 
     public static List<ClusterRoleBinding> clusterRoleBindingsForAllNamespaces(String namespace) {
+        return clusterRoleBindingsForAllNamespaces(namespace, "strimzi-cluster-operator");
+    }
+    public static List<ClusterRoleBinding> clusterRoleBindingsForAllNamespaces(String namespace, String coName) {
         LOGGER.info("Creating ClusterRoleBinding that grant cluster-wide access to all OpenShift projects");
 
         List<ClusterRoleBinding> kCRBList = new ArrayList<>();
@@ -129,7 +132,7 @@ public class KubernetesResource {
         kCRBList.add(
             new ClusterRoleBindingBuilder()
                 .withNewMetadata()
-                    .withName("strimzi-cluster-operator-namespaced")
+                    .withName(coName + "-namespaced")
                 .endMetadata()
                 .withNewRoleRef()
                     .withApiGroup("rbac.authorization.k8s.io")
@@ -148,7 +151,7 @@ public class KubernetesResource {
         kCRBList.add(
             new ClusterRoleBindingBuilder()
                 .withNewMetadata()
-                    .withName("strimzi-entity-operator")
+                    .withName(coName + "-entity-operator")
                 .endMetadata()
                 .withNewRoleRef()
                     .withApiGroup("rbac.authorization.k8s.io")
@@ -167,7 +170,7 @@ public class KubernetesResource {
         kCRBList.add(
             new ClusterRoleBindingBuilder()
                 .withNewMetadata()
-                    .withName("strimzi-topic-operator")
+                    .withName(coName + "-topic-operator")
                 .endMetadata()
                 .withNewRoleRef()
                     .withApiGroup("rbac.authorization.k8s.io")

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
@@ -55,7 +55,31 @@ public class KafkaRebalanceUtils {
         LOGGER.info("Annotating KafkaRebalance:{} with annotation {}", resourceName, annotation.toString());
         return ResourceManager.cmdKubeClient().namespace(kubeClient().getNamespace())
             .execInCurrentNamespace("annotate", "kafkarebalance", resourceName, Annotations.ANNO_STRIMZI_IO_REBALANCE + "=" + annotation.toString())
-            .out();
+            .out()
+            .trim();
     }
 
+    public static void doRebalancingProcess(String rebalanceName) {
+        LOGGER.info("Verifying that KafkaRebalance resource is in {} state", KafkaRebalanceState.PendingProposal);
+
+        waitForKafkaRebalanceCustomResourceState(rebalanceName, KafkaRebalanceState.PendingProposal);
+
+        LOGGER.info("Verifying that KafkaRebalance resource is in {} state", KafkaRebalanceState.ProposalReady);
+
+        waitForKafkaRebalanceCustomResourceState(rebalanceName, KafkaRebalanceState.ProposalReady);
+
+        LOGGER.info("Triggering the rebalance with annotation {} of KafkaRebalance resource", "strimzi.io/rebalance=approve");
+
+        String response = annotateKafkaRebalanceResource(rebalanceName, KafkaRebalanceAnnotation.approve);
+
+        LOGGER.info("Response from the annotation process {}", response);
+
+        LOGGER.info("Verifying that annotation triggers the {} state", KafkaRebalanceState.Rebalancing);
+
+        waitForKafkaRebalanceCustomResourceState(rebalanceName, KafkaRebalanceState.Rebalancing);
+
+        LOGGER.info("Verifying that KafkaRebalance is in the {} state", KafkaRebalanceState.Ready);
+
+        waitForKafkaRebalanceCustomResourceState(rebalanceName, KafkaRebalanceState.Ready);
+    }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
@@ -60,13 +60,16 @@ public class KafkaRebalanceUtils {
     }
 
     public static void doRebalancingProcess(String rebalanceName) {
-        LOGGER.info("Verifying that KafkaRebalance resource is in {} state", KafkaRebalanceState.PendingProposal);
+        // it can sometimes happen that KafkaRebalance is already in the ProposalReady state -> race condition prevention
+        if (!rebalanceStateCondition(rebalanceName).getType().equals(KafkaRebalanceState.ProposalReady.name())) {
+            LOGGER.info("Verifying that KafkaRebalance resource is in {} state", KafkaRebalanceState.PendingProposal);
 
-        waitForKafkaRebalanceCustomResourceState(rebalanceName, KafkaRebalanceState.PendingProposal);
+            waitForKafkaRebalanceCustomResourceState(rebalanceName, KafkaRebalanceState.PendingProposal);
 
-        LOGGER.info("Verifying that KafkaRebalance resource is in {} state", KafkaRebalanceState.ProposalReady);
+            LOGGER.info("Verifying that KafkaRebalance resource is in {} state", KafkaRebalanceState.ProposalReady);
 
-        waitForKafkaRebalanceCustomResourceState(rebalanceName, KafkaRebalanceState.ProposalReady);
+            waitForKafkaRebalanceCustomResourceState(rebalanceName, KafkaRebalanceState.ProposalReady);
+        }
 
         LOGGER.info("Triggering the rebalance with annotation {} of KafkaRebalance resource", "strimzi.io/rebalance=approve");
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -91,27 +91,7 @@ public class CruiseControlIsolatedST extends AbstractST {
         KafkaResource.createAndWaitForReadiness(KafkaResource.kafkaWithCruiseControl(clusterName, 3, 3).build());
         KafkaRebalanceResource.createAndWaitForReadiness(KafkaRebalanceResource.kafkaRebalance(clusterName).build());
 
-        LOGGER.info("Verifying that KafkaRebalance resource is in {} state", KafkaRebalanceState.PendingProposal);
-
-        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(clusterName, KafkaRebalanceState.PendingProposal);
-
-        LOGGER.info("Verifying that KafkaRebalance resource is in {} state", KafkaRebalanceState.ProposalReady);
-
-        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(clusterName, KafkaRebalanceState.ProposalReady);
-
-        LOGGER.info("Triggering the rebalance with annotation {} of KafkaRebalance resource", "strimzi.io/rebalance=approve");
-
-        String response = KafkaRebalanceUtils.annotateKafkaRebalanceResource(clusterName, KafkaRebalanceAnnotation.approve);
-
-        LOGGER.info("Response from the annotation process {}", response);
-
-        LOGGER.info("Verifying that annotation triggers the {} state", KafkaRebalanceState.Rebalancing);
-
-        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(clusterName, KafkaRebalanceState.Rebalancing);
-
-        LOGGER.info("Verifying that KafkaRebalance is in the {} state", KafkaRebalanceState.Ready);
-
-        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(clusterName, KafkaRebalanceState.Ready);
+        KafkaRebalanceUtils.doRebalancingProcess(clusterName);
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
@@ -29,6 +29,7 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaRebalanceUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import static org.hamcrest.CoreMatchers.is;
@@ -88,7 +89,8 @@ public class MultipleClusterOperatorsST extends AbstractST {
         LOGGER.info("Deploying Kafka with CR selector pointing at first CO");
         KafkaResource.kafkaWithoutWait(KafkaResource.kafkaEphemeral(clusterName, 3, 3).build());
 
-        KafkaUtils.waitForClusterStability(clusterName);
+        PodUtils.waitUntilPodStabilityReplicasCount(clusterName, 0);
+
         LOGGER.info("Add selector for {} into Kafka CR", FIRST_CO_NAME);
         KafkaResource.replaceKafkaResource(clusterName, kafka -> kafka.getMetadata().setLabels(FIRST_CO_SELECTOR));
         KafkaUtils.waitForKafkaReady(clusterName);

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.operators;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.resources.KubernetesResource;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
+import io.strimzi.systemtest.resources.crd.KafkaConnectorResource;
+import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
+import io.strimzi.systemtest.resources.crd.kafkaclients.KafkaBasicExampleClients;
+import io.strimzi.systemtest.resources.operator.BundleResource;
+import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaRebalanceUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import static org.hamcrest.CoreMatchers.is;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@Tag(REGRESSION)
+public class MultipleClusterOperatorsST extends AbstractST {
+
+    private static final Logger LOGGER = LogManager.getLogger(MultipleClusterOperatorsST.class);
+
+    public static final String DEFAULT_NAMESPACE = "multiple-co-cluster-test";
+    public static final String FIRST_NAMESPACE = "first-co-namespace";
+    public static final String SECOND_NAMESPACE = "second-co-namespace";
+
+    public static final String FIRST_CO_NAME = "first-" + Constants.STRIMZI_DEPLOYMENT_NAME;
+    public static final String SECOND_CO_NAME = "second-" + Constants.STRIMZI_DEPLOYMENT_NAME;
+
+    public static final EnvVar FIRST_CO_SELECTOR_ENV = new EnvVar("STRIMZI_CUSTOM_RESOURCE_SELECTOR", "co-name=" + FIRST_CO_NAME, null);
+    public static final EnvVar SECOND_CO_SELECTOR_ENV = new EnvVar("STRIMZI_CUSTOM_RESOURCE_SELECTOR", "co-name=" + SECOND_CO_NAME, null);
+
+    public static final Map<String, String> FIRST_CO_SELECTOR = Collections.singletonMap("co-name", FIRST_CO_NAME);
+    public static final Map<String, String> SECOND_CO_SELECTOR = Collections.singletonMap("co-name", SECOND_CO_NAME);
+
+    @Test
+    void testMultipleCOsWithDifferentCustomResourceSelector() {
+        deployCOInNamespace(FIRST_CO_NAME, DEFAULT_NAMESPACE, FIRST_CO_SELECTOR_ENV, false);
+        deployCOInNamespace(SECOND_CO_NAME, DEFAULT_NAMESPACE, SECOND_CO_SELECTOR_ENV, false);
+
+        testMultipleCOsWithDifferentCRSelectors();
+    }
+
+    @Test
+    void testMultipleCOsInDifferentNamespaces() {
+        deployCOInNamespace(FIRST_CO_NAME, FIRST_NAMESPACE, FIRST_CO_SELECTOR_ENV, true);
+        deployCOInNamespace(SECOND_CO_NAME, SECOND_NAMESPACE, SECOND_CO_SELECTOR_ENV, true);
+
+        cluster.setNamespace(DEFAULT_NAMESPACE);
+
+        testMultipleCOsWithDifferentCRSelectors();
+    }
+
+    void testMultipleCOsWithDifferentCRSelectors() {
+        String producerName = "hello-world-producer";
+        String consumerName = "hello-world-consumer";
+
+        LOGGER.info("Deploying Kafka with CR selector pointing at first CO");
+        KafkaResource.kafkaWithoutWait(KafkaResource.kafkaEphemeral(clusterName, 3, 3).build());
+
+        KafkaUtils.waitForClusterStability(clusterName);
+        LOGGER.info("Add selector for {} into Kafka CR", FIRST_CO_NAME);
+        KafkaResource.replaceKafkaResource(clusterName, kafka -> kafka.getMetadata().setLabels(FIRST_CO_SELECTOR));
+        KafkaUtils.waitForKafkaReady(clusterName);
+
+        LOGGER.info("Deploying topic with different CR selector than Kafka has");
+        KafkaTopicResource.createAndWaitForReadiness(KafkaTopicResource.topic(clusterName, TOPIC_NAME)
+            .editOrNewMetadata()
+                .addToLabels(SECOND_CO_SELECTOR)
+            .endMetadata()
+            .build());
+
+        KafkaConnectResource.createAndWaitForReadiness(KafkaConnectResource.kafkaConnect(clusterName, 1)
+            .editOrNewMetadata()
+                .addToLabels(FIRST_CO_SELECTOR)
+                .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+            .endMetadata()
+            .build(), false);
+
+        String kafkaConnectPodName = kubeClient().listPods(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
+
+        LOGGER.info("Deploying KafkaConnector with file sink and different CR selector than Kafka");
+        KafkaConnectorResource.createAndWaitForReadiness(KafkaConnectorResource.kafkaConnector(clusterName)
+            .editOrNewMetadata()
+                .addToLabels(SECOND_CO_SELECTOR)
+            .endMetadata()
+            .editSpec()
+                .withClassName("org.apache.kafka.connect.file.FileStreamSinkConnector")
+                .addToConfig("file", Constants.DEFAULT_SINK_FILE_PATH)
+                .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
+                .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
+                .addToConfig("topics", TOPIC_NAME)
+            .endSpec()
+            .build());
+
+        KafkaBasicExampleClients basicClients = new KafkaBasicExampleClients.Builder()
+            .withProducerName(producerName)
+            .withConsumerName(consumerName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))
+            .withTopicName(TOPIC_NAME)
+            .withMessageCount(MESSAGE_COUNT)
+            .build();
+
+        basicClients.createAndWaitForReadiness(basicClients.producerStrimzi().build());
+        ClientUtils.waitForClientSuccess(producerName, DEFAULT_NAMESPACE, MESSAGE_COUNT);
+
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "Hello-world - 99");
+    }
+
+    @Test
+    void testLabelingAndUnlabelingOfResource() {
+        int scaleTo = 4;
+        deployCOInNamespace(FIRST_CO_NAME, DEFAULT_NAMESPACE, FIRST_CO_SELECTOR_ENV, false);
+        deployCOInNamespace(SECOND_CO_NAME, DEFAULT_NAMESPACE, SECOND_CO_SELECTOR_ENV, false);
+
+        LOGGER.info("Deploying Kafka with CR selector of first CO");
+        KafkaResource.createAndWaitForReadiness(KafkaResource.kafkaEphemeral(clusterName, 3)
+            .editOrNewMetadata()
+                .addToLabels(FIRST_CO_SELECTOR)
+            .endMetadata()
+            .build());
+
+        LOGGER.info("Removing CR selector from Kafka and increasing number of replicas to 4, new pod should not appear");
+        KafkaResource.replaceKafkaResource(clusterName, kafka -> {
+            kafka.getMetadata().getLabels().clear();
+            kafka.getSpec().getKafka().setReplicas(scaleTo);
+        });
+        KafkaUtils.waitForClusterStability(clusterName);
+
+        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(clusterName));
+        Map<String, String> zkPods = StatefulSetUtils.ssSnapshot(KafkaResources.zookeeperStatefulSetName(clusterName));
+        Map<String, String> eoPods = DeploymentUtils.depSnapshot(KafkaResources.entityOperatorDeploymentName(clusterName));
+
+        LOGGER.info("Adding CR selector of second CO to Kafka");
+        KafkaResource.replaceKafkaResource(clusterName, kafka -> kafka.getMetadata().setLabels(SECOND_CO_SELECTOR));
+
+        LOGGER.info("Waiting for rolling update because of new label, also Kafka should scale to {}", scaleTo);
+        StatefulSetUtils.waitTillSsHasRolled(KafkaResources.zookeeperStatefulSetName(clusterName), 3, zkPods);
+        StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(clusterName), scaleTo, kafkaPods);
+        DeploymentUtils.waitTillDepHasRolled(KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoPods);
+
+        Kafka kafka = KafkaResource.kafkaClient().inNamespace(DEFAULT_NAMESPACE).withName(clusterName).get();
+        assertThat(kafka.getSpec().getKafka().getReplicas(), is(scaleTo));
+        assertThat(StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(clusterName)).size(), is(scaleTo));
+    }
+
+    @Test
+    void testKafkaCCAndRebalanceWithDifferentCRSelectors() {
+        deployCOInNamespace(FIRST_CO_NAME, DEFAULT_NAMESPACE, FIRST_CO_SELECTOR_ENV, false);
+        deployCOInNamespace(SECOND_CO_NAME, DEFAULT_NAMESPACE, SECOND_CO_SELECTOR_ENV, false);
+
+        LOGGER.info("Deploying Kafka with CruiseControl and CR selector of first CO");
+        KafkaResource.createAndWaitForReadiness(KafkaResource.kafkaWithCruiseControl(clusterName, 3, 3)
+            .editOrNewMetadata()
+                .addToLabels(FIRST_CO_SELECTOR)
+            .endMetadata()
+            .build());
+
+        LOGGER.info("Creating KafkaRebalance with different CR selector than CC");
+        KafkaRebalanceResource.createAndWaitForReadiness(KafkaRebalanceResource.kafkaRebalance(clusterName)
+            .editOrNewMetadata()
+                .addToLabels(SECOND_CO_SELECTOR)
+            .endMetadata()
+            .build());
+
+        KafkaRebalanceUtils.doRebalancingProcess(clusterName);
+    }
+
+    void deployCOInNamespace(String coName, String coNamespace, EnvVar selectorEnv, boolean multipleNamespaces) {
+        String namespace = multipleNamespaces ? "*" : coNamespace;
+
+        if (multipleNamespaces) {
+            prepareEnvForOperator(coNamespace);
+
+            // Apply rolebindings in CO namespace
+            applyBindings(coNamespace);
+
+            // Create ClusterRoleBindings that grant cluster-wide access to all OpenShift projects
+            List<ClusterRoleBinding> clusterRoleBindingList = KubernetesResource.clusterRoleBindingsForAllNamespaces(coNamespace, coName);
+            clusterRoleBindingList.forEach(KubernetesResource::clusterRoleBinding);
+        }
+
+
+        LOGGER.info("Creating {} in {} namespace", coName, coNamespace);
+
+        BundleResource.createAndWaitForReadiness(BundleResource.clusterOperator(namespace)
+            .editOrNewMetadata()
+                .withName(coName)
+            .endMetadata()
+            .editOrNewSpec()
+                .editOrNewSelector()
+                    .addToMatchLabels("co-name", coName)
+                .endSelector()
+                .editOrNewTemplate()
+                    .editOrNewMetadata()
+                        .addToLabels("co-name", coName)
+                    .endMetadata()
+                    .editOrNewSpec()
+                        .editContainer(0)
+                            .addToEnv(selectorEnv)
+                        .endContainer()
+                    .endSpec()
+                .endTemplate()
+            .endSpec()
+            .build());
+    }
+
+    @BeforeAll
+    void setup() {
+        assumeTrue(!Environment.isHelmInstall() && !Environment.isOlmInstall());
+        ResourceManager.setClassResources();
+        prepareEnvForOperator(DEFAULT_NAMESPACE);
+        applyBindings(DEFAULT_NAMESPACE);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New tests

### Description

After #4411 we are able to "create" CR selectors, which CO will contain, label with this selector some resource. CO then operates only with resources with same labels.

For testing this I created 2 COs - in one case in different namespaces than the operated resource, in other test cases I have just one namespace which contains everything - and I tried to - create Kafka without labels, labeling and "unlabeling", create KafkaConnect with different label than KafkaConnector, same for the CC and KR.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass