### PR TITLE
Try to remove verify when pushing to Nexus to safe some time

### DIFF
--- a/.azure/scripts/build.sh
+++ b/.azure/scripts/build.sh
@@ -59,11 +59,9 @@ fi
 
 # Push artifatcs (Docker containers, JARs, docs)
 if [ "$BUILD_REASON" == "PullRequest" ] ; then
-    #echo "Building Pull Request - nothing to push"
-    make pushtonexus
+    echo "Building Pull Request - nothing to push"
 elif [[ "$BRANCH" != "refs/tags/"* ]] && [ "$BRANCH" != "refs/heads/master" ]; then
-    #echo "Not in master branch and not in release tag - nothing to push"
-    make pushtonexus
+    echo "Not in master branch and not in release tag - nothing to push"
 else
     if [ "${MAIN_BUILD}" == "TRUE" ] ; then
         echo "Main build on master branch or release tag - going to push to Docker Hub, Nexus and website"

--- a/.azure/scripts/build.sh
+++ b/.azure/scripts/build.sh
@@ -59,9 +59,11 @@ fi
 
 # Push artifatcs (Docker containers, JARs, docs)
 if [ "$BUILD_REASON" == "PullRequest" ] ; then
-    echo "Building Pull Request - nothing to push"
+    #echo "Building Pull Request - nothing to push"
+    make pushtonexus
 elif [[ "$BRANCH" != "refs/tags/"* ]] && [ "$BRANCH" != "refs/heads/master" ]; then
-    echo "Not in master branch and not in release tag - nothing to push"
+    #echo "Not in master branch and not in release tag - nothing to push"
+    make pushtonexus
 else
     if [ "${MAIN_BUILD}" == "TRUE" ] ; then
         echo "Main build on master branch or release tag - going to push to Docker Hub, Nexus and website"

--- a/.azure/scripts/push-to-nexus.sh
+++ b/.azure/scripts/push-to-nexus.sh
@@ -5,7 +5,7 @@ export GPG_TTY=$(tty)
 echo $GPG_SIGNING_KEY | base64 -d > signing.gpg
 gpg --batch --import signing.gpg
 
-GPG_EXECUTABLE=gpg mvn -B $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml  -pl ./,crd-generator,api,api-conversion,test-container -P ossrh verify deploy
+GPG_EXECUTABLE=gpg mvn -B $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -pl ./,crd-generator,api,api-conversion,test-container -P ossrh deploy
 
 rm -rf signing.gpg
 gpg --delete-keys


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When pushing to Nexus, we seem to do `mvn verify deploy` => that seems to run the Maven build twice. This PR tries to test if we can remove it and still have properly signed artifacts.