### PR TITLE
Add reconcile state metric to Topic Operator class

### DIFF
--- a/examples/topic/kafka-topic.yaml
+++ b/examples/topic/kafka-topic.yaml
@@ -1,7 +1,7 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: my-topic
+  name: my-topic1
   labels:
     strimzi.io/cluster: my-cluster
 spec:
@@ -10,3 +10,4 @@ spec:
   config:
     retention.ms: 7200000
     segment.bytes: 1073741824
+  topicName: my-topic3

--- a/examples/topic/kafka-topic.yaml
+++ b/examples/topic/kafka-topic.yaml
@@ -10,4 +10,3 @@ spec:
   config:
     retention.ms: 7200000
     segment.bytes: 1073741824
-

--- a/examples/topic/kafka-topic.yaml
+++ b/examples/topic/kafka-topic.yaml
@@ -1,7 +1,7 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: my-topic1
+  name: my-topic
   labels:
     strimzi.io/cluster: my-cluster
 spec:
@@ -10,4 +10,4 @@ spec:
   config:
     retention.ms: 7200000
     segment.bytes: 1073741824
-  topicName: my-topic3
+

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -475,13 +475,12 @@ class TopicOperator {
                 action.execute().onComplete(actionResult -> {
                     LOGGER.debug("{}: Executing handler for action {} on topic {}", logContext, action, lockName);
                     action.result = actionResult;
-
                     String keytag = namespace + ":" + "KafkaTopic" + "/" + key.asKubeName().toString();
                     Optional<Meter> metric = metrics.meterRegistry().getMeters()
                             .stream()
                             .filter(meter -> meter.getId().getName().equals(METRICS_PREFIX + "resource.state") &&
                                     meter.getId().getTags().contains(Tag.of("kind", "KafkaTopic")) &&
-                                    meter.getId().getTags().contains(Tag.of("name", action.topic.getMetadata().getName())) &&
+                                    meter.getId().getTags().contains(Tag.of("name",  action.topic == null ? key.asKubeName().toString() : action.topic.getMetadata().getName())) &&
                                     meter.getId().getTags().contains(Tag.of("resource-namespace", namespace))
                             ).findFirst();
                     if (metric.isPresent()) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -481,13 +481,13 @@ class TopicOperator {
                             .stream()
                             .filter(meter -> meter.getId().getName().equals(METRICS_PREFIX + "resource.state") &&
                                     meter.getId().getTags().contains(Tag.of("kind", "KafkaTopic")) &&
-                                    meter.getId().getTags().contains(Tag.of("name", key.asKubeName().toString())) &&
+                                    meter.getId().getTags().contains(Tag.of("name", action.topic.getMetadata().getName())) &&
                                     meter.getId().getTags().contains(Tag.of("resource-namespace", namespace))
                             ).findFirst();
                     if (metric.isPresent()) {
                         // remove metric so it can be re-added with new tags
                         metrics.meterRegistry().remove(metric.get().getId());
-                        LOGGER.debug("Removed metric " + METRICS_PREFIX + "resource.state{}", keytag);
+                        LOGGER.debug("Removed metric {}.resource.state{{}}", METRICS_PREFIX, keytag);
                     }
 
                     if (action.topic != null) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -12,6 +12,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.Meter;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import io.strimzi.api.kafka.model.status.KafkaTopicStatus;
@@ -39,6 +40,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -473,6 +475,33 @@ class TopicOperator {
                 action.execute().onComplete(actionResult -> {
                     LOGGER.debug("{}: Executing handler for action {} on topic {}", logContext, action, lockName);
                     action.result = actionResult;
+
+                    String keytag = namespace + ":" + "KafkaTopic" + "/" + key.asKubeName().toString();
+                    Optional<Meter> metric = metrics.meterRegistry().getMeters()
+                            .stream()
+                            .filter(meter -> meter.getId().getName().equals(METRICS_PREFIX + "resource.state") &&
+                                    meter.getId().getTags().contains(Tag.of("kind", "KafkaTopic")) &&
+                                    meter.getId().getTags().contains(Tag.of("name", key.asKubeName().toString())) &&
+                                    meter.getId().getTags().contains(Tag.of("resource-namespace", namespace))
+                            ).findFirst();
+                    if (metric.isPresent()) {
+                        // remove metric so it can be re-added with new tags
+                        metrics.meterRegistry().remove(metric.get().getId());
+                        LOGGER.debug("Removed metric " + METRICS_PREFIX + "resource.state{}", keytag);
+                    }
+
+                    if (action.topic != null) {
+                        boolean succeeded = actionResult.succeeded();
+                        Tags metricTags;
+                        metricTags = Tags.of(
+                                Tag.of("kind", action.topic.getKind()),
+                                Tag.of("name", action.topic.getMetadata().getName()),
+                                Tag.of("resource-namespace", namespace),
+                                Tag.of("reason", succeeded ? "none" : actionResult.cause().getMessage() == null ? "unknown error" : actionResult.cause().getMessage()));
+
+                        metrics.gauge(METRICS_PREFIX + "resource.state", "Current state of the resource: 1 ready, 0 fail", metricTags).set(actionResult.succeeded() ? 1 : 0);
+                        LOGGER.debug("Updated metric " + METRICS_PREFIX + "resource.state{} = {}", metricTags, succeeded ? 1 : 0);
+                    }
                     // Update status with lock held so that event is ignored via statusUpdateGeneration
                     action.updateStatus(logContext).onComplete(statusResult -> {
                         if (statusResult.failed()) {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR gives the fix for issue #3661 . 

This adds the following metric.

strimzi_resource_state{kind="KafkaTopic", name="my-topic", resource-namespace="my-topic-namespace"}

providing the information on the latest reconcile state of a KafkaTopic resource and if it was created and/or updated successfully at the end of reconciling or something failed (more info to check in the status of the custom resource). The possible values are just 1.0 and 0.0.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

