### PR TITLE
Make it possible to generate CRDs without descriptions for some versions

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/ApiEvolutionCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/ApiEvolutionCrdIT.java
@@ -240,7 +240,7 @@ public class ApiEvolutionCrdIT extends AbstractCrdIT {
             new CrdGenerator(KubeVersion.V1_16_PLUS, V1BETA1, CrdGenerator.YAML_MAPPER, emptyMap(),
                     new CrdGenerator.DefaultReporter(), asList(versions), storageVersion,
                     servedVersions,
-                    new CrdGenerator.NoneConversionStrategy(), asList(versions)).generate(Kafka.class, sw);
+                    new CrdGenerator.NoneConversionStrategy(), null).generate(Kafka.class, sw);
             return CrdGenerator.YAML_MAPPER.readValue(sw.toString(), CustomResourceDefinition.class);
         }
 
@@ -264,7 +264,7 @@ public class ApiEvolutionCrdIT extends AbstractCrdIT {
             StringWriter sw = new StringWriter();
             new CrdGenerator(KubeVersion.V1_16_PLUS, V1, CrdGenerator.YAML_MAPPER, emptyMap(),
                     new CrdGenerator.DefaultReporter(), asList(versions), storageVersion, servedVersions,
-                    new CrdGenerator.NoneConversionStrategy(), asList(versions)).generate(Kafka.class, sw);
+                    new CrdGenerator.NoneConversionStrategy(), null).generate(Kafka.class, sw);
             return CrdGenerator.YAML_MAPPER.readValue(sw.toString(), io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition.class);
         }
 

--- a/api/src/test/java/io/strimzi/api/kafka/model/ApiEvolutionCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/ApiEvolutionCrdIT.java
@@ -240,7 +240,7 @@ public class ApiEvolutionCrdIT extends AbstractCrdIT {
             new CrdGenerator(KubeVersion.V1_16_PLUS, V1BETA1, CrdGenerator.YAML_MAPPER, emptyMap(),
                     new CrdGenerator.DefaultReporter(), asList(versions), storageVersion,
                     servedVersions,
-                    new CrdGenerator.NoneConversionStrategy()).generate(Kafka.class, sw);
+                    new CrdGenerator.NoneConversionStrategy(), asList(versions)).generate(Kafka.class, sw);
             return CrdGenerator.YAML_MAPPER.readValue(sw.toString(), CustomResourceDefinition.class);
         }
 
@@ -264,7 +264,7 @@ public class ApiEvolutionCrdIT extends AbstractCrdIT {
             StringWriter sw = new StringWriter();
             new CrdGenerator(KubeVersion.V1_16_PLUS, V1, CrdGenerator.YAML_MAPPER, emptyMap(),
                     new CrdGenerator.DefaultReporter(), asList(versions), storageVersion, servedVersions,
-                    new CrdGenerator.NoneConversionStrategy()).generate(Kafka.class, sw);
+                    new CrdGenerator.NoneConversionStrategy(), asList(versions)).generate(Kafka.class, sw);
             return CrdGenerator.YAML_MAPPER.readValue(sw.toString(), io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition.class);
         }
 

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -172,7 +172,7 @@ public class CrdGenerator {
     private final List<ApiVersion> generateVersions;
     private final ApiVersion storageVersion;
     private final VersionRange<ApiVersion> servedVersion;
-    private final List<ApiVersion> describeVersions;
+    private final VersionRange<ApiVersion> describeVersions;
     // TODO CrdValidator
     // extraProperties
     // @Buildable
@@ -268,7 +268,7 @@ public class CrdGenerator {
 
     public CrdGenerator(VersionRange<KubeVersion> targetKubeVersions, ApiVersion crdApiVersion) {
         this(targetKubeVersions, crdApiVersion, CrdGenerator.YAML_MAPPER, emptyMap(), new DefaultReporter(),
-                emptyList(), null, null, new NoneConversionStrategy(), emptyList());
+                emptyList(), null, null, new NoneConversionStrategy(), null);
     }
 
     /**
@@ -281,7 +281,7 @@ public class CrdGenerator {
      * @param storageVersion If not null, override the storageVersion to the given value.
      * @param servedVersions If not null, override the serverd versions according to the given range.
      * @param conversionStrategy The conversion strategy.
-     * @param describeVersions The API versions to which descriptions should be added
+     * @param describeVersions The range of API versions for which descriptions should be added
      */
     public CrdGenerator(VersionRange<KubeVersion> targetKubeVersions, ApiVersion crdApiVersion,
                  ObjectMapper mapper, Map<String, String> labels, Reporter reporter,
@@ -289,7 +289,7 @@ public class CrdGenerator {
                  ApiVersion storageVersion,
                  VersionRange<ApiVersion> servedVersions,
                  ConversionStrategy conversionStrategy,
-                 List<ApiVersion> describeVersions) {
+                 VersionRange<ApiVersion> describeVersions) {
         this.reporter = reporter;
         if (targetKubeVersions.isEmpty()
             || targetKubeVersions.isAll()) {
@@ -475,6 +475,7 @@ public class CrdGenerator {
     private boolean shouldDescribeVersion(ApiVersion version) {
         return describeVersions == null
                 || describeVersions.isEmpty()
+                || describeVersions.isAll()
                 || describeVersions.contains(version);
     }
 
@@ -1038,7 +1039,7 @@ public class CrdGenerator {
         VersionRange<KubeVersion> targetKubeVersions = null;
         ApiVersion crdApiVersion = null;
         List<ApiVersion> apiVersions = null;
-        List<ApiVersion> describeVersions = null;
+        VersionRange<ApiVersion> describeVersions = null;
         ApiVersion storageVersion = null;
         Map<String, Class<? extends CustomResource>> classes = new HashMap<>();
         private final ConversionStrategy conversionStrategy;
@@ -1099,7 +1100,7 @@ public class CrdGenerator {
                             } else if (i >= arg.length() - 1) {
                                 argParseErr("--describe-api-versions needs an argument");
                             } else {
-                                describeVersions = Arrays.stream(args[++i].split(",")).map(v -> ApiVersion.parse(v)).collect(Collectors.toList());
+                                describeVersions = ApiVersion.parseRange(args[++i]);
                             }
                             break;
                         case "--storage-version":

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -34,7 +33,7 @@ public class CrdGeneratorTest {
     @Test
     public void simpleTestWithoutDescriptions() throws IOException {
         CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_11_PLUS, ApiVersion.V1BETA1, CrdGenerator.YAML_MAPPER, emptyMap(),
-                new CrdGenerator.DefaultReporter(), emptyList(), null, null, new CrdGenerator.NoneConversionStrategy(), List.of(ApiVersion.V1));
+                new CrdGenerator.DefaultReporter(), emptyList(), null, null, new CrdGenerator.NoneConversionStrategy(), ApiVersion.parseRange("v1+"));
         StringWriter w = new StringWriter();
         crdGenerator.generate(ExampleCrd.class, w);
         String s = w.toString();
@@ -60,7 +59,7 @@ public class CrdGeneratorTest {
         labels.put("heritage", "{{ .Release.Service }}");
         CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_11_PLUS, ApiVersion.V1BETA1,
                 CrdGenerator.YAML_MAPPER, labels,
-                new CrdGenerator.DefaultReporter(), emptyList(), null, null, new CrdGenerator.NoneConversionStrategy(), emptyList());
+                new CrdGenerator.DefaultReporter(), emptyList(), null, null, new CrdGenerator.NoneConversionStrategy(), null);
         StringWriter w = new StringWriter();
         crdGenerator.generate(ExampleCrd.class, w);
         String s = w.toString();
@@ -90,7 +89,7 @@ public class CrdGeneratorTest {
                         errors.add(s);
                     }
                 },
-                emptyList(), null, null, new CrdGenerator.NoneConversionStrategy(), emptyList());
+                emptyList(), null, null, new CrdGenerator.NoneConversionStrategy(), null);
         StringWriter w = new StringWriter();
         crdGenerator.generate(VersionedExampleCrd.class, w);
         assertTrue(errors.contains("Multiple scales specified but 1.11 doesn't support schema per version"), errors.toString());

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,6 +32,16 @@ public class CrdGeneratorTest {
     }
 
     @Test
+    public void simpleTestWithoutDescriptions() throws IOException {
+        CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_11_PLUS, ApiVersion.V1BETA1, CrdGenerator.YAML_MAPPER, emptyMap(),
+                new CrdGenerator.DefaultReporter(), emptyList(), null, null, new CrdGenerator.NoneConversionStrategy(), List.of(ApiVersion.V1));
+        StringWriter w = new StringWriter();
+        crdGenerator.generate(ExampleCrd.class, w);
+        String s = w.toString();
+        assertEquals(CrdTestUtils.readResource("simpleTestWithoutDescriptions.yaml"), s);
+    }
+
+    @Test
     public void simpleTestWithSubresources() throws IOException {
         CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_11_PLUS, ApiVersion.V1BETA1);
         StringWriter w = new StringWriter();
@@ -49,7 +60,7 @@ public class CrdGeneratorTest {
         labels.put("heritage", "{{ .Release.Service }}");
         CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_11_PLUS, ApiVersion.V1BETA1,
                 CrdGenerator.YAML_MAPPER, labels,
-                new CrdGenerator.DefaultReporter(), emptyList(), null, null, new CrdGenerator.NoneConversionStrategy());
+                new CrdGenerator.DefaultReporter(), emptyList(), null, null, new CrdGenerator.NoneConversionStrategy(), emptyList());
         StringWriter w = new StringWriter();
         crdGenerator.generate(ExampleCrd.class, w);
         String s = w.toString();
@@ -79,7 +90,7 @@ public class CrdGeneratorTest {
                         errors.add(s);
                     }
                 },
-                emptyList(), null, null, new CrdGenerator.NoneConversionStrategy());
+                emptyList(), null, null, new CrdGenerator.NoneConversionStrategy(), emptyList());
         StringWriter w = new StringWriter();
         crdGenerator.generate(VersionedExampleCrd.class, w);
         assertTrue(errors.contains("Multiple scales specified but 1.11 doesn't support schema per version"), errors.toString());

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/TopicCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/TopicCrd.java
@@ -41,7 +41,7 @@ public class TopicCrd extends CustomResource {
         System.out.println(m.writeValueAsString(x));
 
         new CrdGenerator(KubeVersion.V1_11_PLUS, ApiVersion.V1BETA1, m, emptyMap(), new CrdGenerator.DefaultReporter(),
-                emptyList(), null, null, new CrdGenerator.NoneConversionStrategy(), emptyList())
+                emptyList(), null, null, new CrdGenerator.NoneConversionStrategy(), null)
             .generate(TopicCrd.class, new OutputStreamWriter(System.out));
     }
 }

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/TopicCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/TopicCrd.java
@@ -41,7 +41,7 @@ public class TopicCrd extends CustomResource {
         System.out.println(m.writeValueAsString(x));
 
         new CrdGenerator(KubeVersion.V1_11_PLUS, ApiVersion.V1BETA1, m, emptyMap(), new CrdGenerator.DefaultReporter(),
-                emptyList(), null, null, new CrdGenerator.NoneConversionStrategy())
+                emptyList(), null, null, new CrdGenerator.NoneConversionStrategy(), emptyList())
             .generate(TopicCrd.class, new OutputStreamWriter(System.out));
     }
 }

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
@@ -1,0 +1,457 @@
+apiVersion: "apiextensions.k8s.io/v1beta1"
+kind: "CustomResourceDefinition"
+metadata:
+  name: "examples.crdgenerator.strimzi.io"
+spec:
+  group: "crdgenerator.strimzi.io"
+  names:
+    kind: "Example"
+    listKind: "ExampleList"
+    singular: "example"
+    plural: "examples"
+    categories:
+    - "strimzi"
+  scope: "Namespaced"
+  additionalPrinterColumns:
+  - name: "Foo"
+    description: "The foo"
+    JSONPath: "..."
+    type: "integer"
+  conversion:
+    strategy: "None"
+  versions:
+  - name: "v1alpha1"
+    served: true
+    storage: true
+  - name: "v1beta1"
+    served: true
+    storage: false
+  version: "v1alpha1"
+  validation:
+    openAPIV3Schema:
+      properties:
+        affinity:
+          type: "object"
+          properties:
+            nodeAffinity:
+              type: "object"
+              properties:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  type: "array"
+                  items:
+                    type: "object"
+                    properties:
+                      preference:
+                        type: "object"
+                        properties:
+                          matchExpressions:
+                            type: "array"
+                            items:
+                              type: "object"
+                              properties:
+                                key:
+                                  type: "string"
+                                operator:
+                                  type: "string"
+                                values:
+                                  type: "array"
+                                  items:
+                                    type: "string"
+                          matchFields:
+                            type: "array"
+                            items:
+                              type: "object"
+                              properties:
+                                key:
+                                  type: "string"
+                                operator:
+                                  type: "string"
+                                values:
+                                  type: "array"
+                                  items:
+                                    type: "string"
+                      weight:
+                        type: "integer"
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  type: "object"
+                  properties:
+                    nodeSelectorTerms:
+                      type: "array"
+                      items:
+                        type: "object"
+                        properties:
+                          matchExpressions:
+                            type: "array"
+                            items:
+                              type: "object"
+                              properties:
+                                key:
+                                  type: "string"
+                                operator:
+                                  type: "string"
+                                values:
+                                  type: "array"
+                                  items:
+                                    type: "string"
+                          matchFields:
+                            type: "array"
+                            items:
+                              type: "object"
+                              properties:
+                                key:
+                                  type: "string"
+                                operator:
+                                  type: "string"
+                                values:
+                                  type: "array"
+                                  items:
+                                    type: "string"
+            podAffinity:
+              type: "object"
+              properties:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  type: "array"
+                  items:
+                    type: "object"
+                    properties:
+                      podAffinityTerm:
+                        type: "object"
+                        properties:
+                          labelSelector:
+                            type: "object"
+                            properties:
+                              matchExpressions:
+                                type: "array"
+                                items:
+                                  type: "object"
+                                  properties:
+                                    key:
+                                      type: "string"
+                                    operator:
+                                      type: "string"
+                                    values:
+                                      type: "array"
+                                      items:
+                                        type: "string"
+                              matchLabels:
+                                type: "object"
+                          namespaces:
+                            type: "array"
+                            items:
+                              type: "string"
+                          topologyKey:
+                            type: "string"
+                      weight:
+                        type: "integer"
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  type: "array"
+                  items:
+                    type: "object"
+                    properties:
+                      labelSelector:
+                        type: "object"
+                        properties:
+                          matchExpressions:
+                            type: "array"
+                            items:
+                              type: "object"
+                              properties:
+                                key:
+                                  type: "string"
+                                operator:
+                                  type: "string"
+                                values:
+                                  type: "array"
+                                  items:
+                                    type: "string"
+                          matchLabels:
+                            type: "object"
+                      namespaces:
+                        type: "array"
+                        items:
+                          type: "string"
+                      topologyKey:
+                        type: "string"
+            podAntiAffinity:
+              type: "object"
+              properties:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  type: "array"
+                  items:
+                    type: "object"
+                    properties:
+                      podAffinityTerm:
+                        type: "object"
+                        properties:
+                          labelSelector:
+                            type: "object"
+                            properties:
+                              matchExpressions:
+                                type: "array"
+                                items:
+                                  type: "object"
+                                  properties:
+                                    key:
+                                      type: "string"
+                                    operator:
+                                      type: "string"
+                                    values:
+                                      type: "array"
+                                      items:
+                                        type: "string"
+                              matchLabels:
+                                type: "object"
+                          namespaces:
+                            type: "array"
+                            items:
+                              type: "string"
+                          topologyKey:
+                            type: "string"
+                      weight:
+                        type: "integer"
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  type: "array"
+                  items:
+                    type: "object"
+                    properties:
+                      labelSelector:
+                        type: "object"
+                        properties:
+                          matchExpressions:
+                            type: "array"
+                            items:
+                              type: "object"
+                              properties:
+                                key:
+                                  type: "string"
+                                operator:
+                                  type: "string"
+                                values:
+                                  type: "array"
+                                  items:
+                                    type: "string"
+                          matchLabels:
+                            type: "object"
+                      namespaces:
+                        type: "array"
+                        items:
+                          type: "string"
+                      topologyKey:
+                        type: "string"
+        alternatives:
+          oneOf:
+          - type: "array"
+            items:
+              type: "string"
+          - type: "object"
+        arrayOfBoundTypeVar:
+          type: "array"
+          items:
+            type: "object"
+            properties: {}
+        arrayOfBoundTypeVar2:
+          type: "array"
+          items:
+            type: "object"
+            properties: {}
+        arrayOfList:
+          type: "array"
+          items:
+            type: "array"
+            items:
+              type: "string"
+        arrayOfRawList:
+          type: "array"
+          items:
+            type: "array"
+            items:
+              type: "object"
+              properties: {}
+        arrayOfTypeVar:
+          type: "array"
+          items:
+            type: "object"
+            properties: {}
+        arrayProperty:
+          type: "array"
+          minItems: 1
+          items:
+            type: "string"
+        arrayProperty2:
+          type: "array"
+          items:
+            type: "array"
+            items:
+              type: "string"
+        booleanProperty:
+          type: "boolean"
+        customisedEnum:
+          type: "string"
+          enum:
+          - "one"
+          - "two"
+        fieldProperty:
+          type: "string"
+        intProperty:
+          type: "integer"
+          example: "42"
+          minimum: 42
+        listOfArray:
+          type: "array"
+          items:
+            type: "array"
+            items:
+              type: "string"
+        listOfBoundTypeVar:
+          type: "array"
+          items:
+            type: "object"
+            properties: {}
+        listOfBoundTypeVar2:
+          type: "array"
+          items:
+            type: "object"
+            properties: {}
+        listOfInts:
+          type: "array"
+          items:
+            type: "integer"
+        listOfInts2:
+          type: "array"
+          items:
+            type: "array"
+            items:
+              type: "integer"
+        listOfMaps:
+          type: "array"
+          items:
+            type: "object"
+        listOfObjects:
+          type: "array"
+          items:
+            type: "object"
+            properties:
+              bar:
+                type: "string"
+              foo:
+                type: "string"
+        listOfPolymorphic:
+          type: "array"
+          items:
+            type: "object"
+            properties:
+              commonProperty:
+                type: "string"
+              discrim:
+                type: "string"
+                enum:
+                - "left"
+                - "right"
+              leftProperty:
+                type: "string"
+              rightProperty:
+                type: "string"
+            required:
+            - "discrim"
+        listOfRawList:
+          type: "array"
+          items:
+            type: "array"
+            items:
+              type: "object"
+              properties: {}
+        listOfTypeVar:
+          type: "array"
+          items:
+            type: "object"
+            properties: {}
+        listOfWildcardTypeVar1:
+          type: "array"
+          items:
+            type: "string"
+        listOfWildcardTypeVar2:
+          type: "array"
+          items:
+            type: "object"
+            properties: {}
+        listOfWildcardTypeVar3:
+          type: "array"
+          items:
+            type: "object"
+            properties: {}
+        listOfWildcardTypeVar4:
+          type: "array"
+          items:
+            type: "array"
+            items:
+              type: "object"
+              properties: {}
+        longProperty:
+          type: "integer"
+          example: "42"
+          minimum: 42
+        mapProperty:
+          type: "object"
+        normalEnum:
+          type: "string"
+          enum:
+          - "FOO"
+          - "BAR"
+        objectProperty:
+          type: "object"
+          properties:
+            bar:
+              type: "string"
+            foo:
+              type: "string"
+        polymorphicProperty:
+          type: "object"
+          properties:
+            commonProperty:
+              type: "string"
+            discrim:
+              type: "string"
+              enum:
+              - "left"
+              - "right"
+            leftProperty:
+              type: "string"
+            rightProperty:
+              type: "string"
+          required:
+          - "discrim"
+        rawList:
+          type: "array"
+          items:
+            type: "object"
+            properties: {}
+        spec:
+          type: "object"
+          properties: {}
+        status:
+          type: "object"
+          properties: {}
+        stringProperty:
+          type: "string"
+          pattern: ".*"
+        typedAlternatives:
+          oneOf:
+          - type: "object"
+            properties:
+              key2:
+                type: "string"
+          - type: "object"
+            properties:
+              key1:
+                type: "string"
+      oneOf:
+      - properties:
+          either: {}
+        required:
+        - "either"
+      - properties:
+          or: {}
+        required:
+        - "or"
+      required:
+      - "stringProperty"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In some cases it might be useful to be able to disable generating descriptions for all API versions in the CRDs in order to make the files smaller. This enhancement to the CrdGenerator allows to specify versions for which should the descriptions be generated. This is currently not used for the CRDs in the repo, but it is available when needed for example to generate OLM files etc.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally