### PR TITLE
Fix KafkaRebalance status - add the optimization result

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -436,6 +436,7 @@ public class KafkaRebalanceAssemblyOperator
 
         return new KafkaRebalanceStatusBuilder()
                 .withSessionId(currentStatus.getSessionId())
+                .withOptimizationResult(currentStatus.getOptimizationResult())
                 .withConditions(conditions)
                 .build();
     }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes problem with KafkaRebalance, where optimization result was missing inside the status on `ProposalReady` state (and others). Also adding tests for this.

### Checklist

- [x] Write tests
- [ ] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally


