### PR TITLE
NEW(Tests) OauthPlainST test with audience and/or custom claim check on access token

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -35,6 +35,10 @@ public class OauthAbstractST extends AbstractST {
     protected static final Logger LOGGER = LogManager.getLogger(OauthAbstractST.class);
     protected static final String OAUTH_CLIENT_NAME = "hello-world-producer";
     protected static final String OAUTH_CLIENT_SECRET = "hello-world-producer-secret";
+    protected static final String OAUTH_CLIENT_AUDIENCE_PRODUCER = "kafka-audience-producer";
+    protected static final String OAUTH_CLIENT_AUDIENCE_CONSUMER = "kafka-audience-consumer";
+    protected static final String OAUTH_CLIENT_AUDIENCE_SECRET = "kafka-audience-secret";
+
     protected static final String OAUTH_KAFKA_CLIENT_NAME = "kafka-broker";
     protected static final String OAUTH_PRODUCER_NAME = "oauth-producer";
     protected static final String OAUTH_CONSUMER_NAME = "oauth-consumer";
@@ -101,6 +105,7 @@ public class OauthAbstractST extends AbstractST {
         SecretUtils.createSecret(MIRROR_MAKER_OAUTH_SECRET, OAUTH_KEY, "a2Fma2EtbWlycm9yLW1ha2VyLXNlY3JldA==");
         SecretUtils.createSecret(MIRROR_MAKER_2_OAUTH_SECRET, OAUTH_KEY, "a2Fma2EtbWlycm9yLW1ha2VyLTItc2VjcmV0");
         SecretUtils.createSecret(BRIDGE_OAUTH_SECRET, OAUTH_KEY, "a2Fma2EtYnJpZGdlLXNlY3JldA==");
+        SecretUtils.createSecret(OAUTH_CLIENT_AUDIENCE_SECRET, OAUTH_KEY, "a2Fma2EtYXVkaWVuY2Utc2VjcmV0");
     }
 }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
@@ -162,6 +162,93 @@ public class OauthPlainST extends OauthAbstractST {
         StatefulSetUtils.waitTillSsHasRolled(kafkaStatefulSetName(oauthClusterName), 1, kafkaPods);
     }
 
+    @Test
+    void testAccessTokenClaimCheck() {
+        LOGGER.info("Update Kafka broker configuration to use OAuth2 access token custom claim checks");
+        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(oauthClusterName));
+        KafkaResource.replaceKafkaResource(oauthClusterName, kafka -> {
+            kafka.getSpec().getKafka().setListeners(new ArrayOrObjectKafkaListenersBuilder()
+                .addNewGenericKafkaListener()
+                    .withName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
+                    .withPort(9092)
+                    .withType(KafkaListenerType.INTERNAL)
+                    .withTls(false)
+                    .withNewKafkaListenerAuthenticationOAuth()
+                        .withValidIssuerUri(keycloakInstance.getValidIssuerUri())
+                        .withJwksExpirySeconds(keycloakInstance.getJwksExpireSeconds())
+                        .withJwksRefreshSeconds(keycloakInstance.getJwksRefreshSeconds())
+                        .withJwksEndpointUri(keycloakInstance.getJwksEndpointUri())
+                        .withUserNameClaim(keycloakInstance.getUserNameClaim())
+                        .withEnablePlain(true)
+                        .withCustomClaimCheck("@.clientId && @.clientId =~ /.*hello-world.*/")
+                        .withTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                    .endKafkaListenerAuthenticationOAuth()
+                .endGenericKafkaListener().build());
+        });
+        kafkaPods = StatefulSetUtils.waitTillSsHasRolled(kafkaStatefulSetName(oauthClusterName), 1, kafkaPods);
+
+        LOGGER.info("Use clients with clientId not containing 'hello-world' in access token.");
+        KafkaOauthExampleClients oauthInternalClientProducerJob = new KafkaOauthExampleClients.Builder()
+                .withProducerName(OAUTH_CLIENT_AUDIENCE_PRODUCER)
+                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(oauthClusterName))
+                .withTopicName(TOPIC_NAME)
+                .withMessageCount(MESSAGE_COUNT)
+                .withOAuthClientId(OAUTH_CLIENT_AUDIENCE_PRODUCER)
+                .withOAuthClientSecret(OAUTH_CLIENT_AUDIENCE_SECRET)
+                .withOAuthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                .build();
+
+        KafkaOauthExampleClients oauthInternalClientConsumerJob = new KafkaOauthExampleClients.Builder()
+                .withConsumerName(OAUTH_CLIENT_AUDIENCE_CONSUMER)
+                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(oauthClusterName))
+                .withTopicName(TOPIC_NAME)
+                .withMessageCount(MESSAGE_COUNT)
+                .withOAuthClientId(OAUTH_CLIENT_AUDIENCE_CONSUMER)
+                .withOAuthClientSecret(OAUTH_CLIENT_AUDIENCE_SECRET)
+                .withOAuthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                .build();
+
+        oauthInternalClientProducerJob.createAndWaitForReadiness(oauthInternalClientProducerJob.producerStrimziOauthPlain().build());
+        ClientUtils.waitForClientTimeout(OAUTH_CLIENT_AUDIENCE_PRODUCER, NAMESPACE, MESSAGE_COUNT);
+
+        oauthInternalClientConsumerJob.createAndWaitForReadiness(oauthInternalClientConsumerJob.consumerStrimziOauthPlain().build());
+        ClientUtils.waitForClientTimeout(OAUTH_CLIENT_AUDIENCE_CONSUMER, NAMESPACE, MESSAGE_COUNT);
+
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_CLIENT_AUDIENCE_PRODUCER);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_CLIENT_AUDIENCE_CONSUMER);
+
+        LOGGER.info("Use clients with clientId containing 'hello-world' in access token.");
+        oauthInternalClientJob.createAndWaitForReadiness(oauthInternalClientJob.producerStrimziOauthPlain().build());
+        ClientUtils.waitForClientSuccess(OAUTH_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
+        oauthInternalClientJob.createAndWaitForReadiness(oauthInternalClientJob.consumerStrimziOauthPlain().build());
+        ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
+
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_PRODUCER_NAME);
+        JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_CONSUMER_NAME);
+
+        LOGGER.info("Revert Kafka configuration to original one.");
+        KafkaResource.replaceKafkaResource(oauthClusterName, kafka -> {
+            kafka.getSpec().getKafka().setListeners(new ArrayOrObjectKafkaListenersBuilder()
+                .addNewGenericKafkaListener()
+                    .withName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
+                    .withPort(9092)
+                    .withType(KafkaListenerType.INTERNAL)
+                    .withTls(false)
+                    .withNewKafkaListenerAuthenticationOAuth()
+                        .withValidIssuerUri(keycloakInstance.getValidIssuerUri())
+                        .withJwksExpirySeconds(keycloakInstance.getJwksExpireSeconds())
+                        .withJwksRefreshSeconds(keycloakInstance.getJwksRefreshSeconds())
+                        .withJwksEndpointUri(keycloakInstance.getJwksEndpointUri())
+                        .withUserNameClaim(keycloakInstance.getUserNameClaim())
+                        .withEnablePlain(true)
+                        .withTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                    .endKafkaListenerAuthenticationOAuth()
+                .endGenericKafkaListener()
+                .build());
+        });
+        StatefulSetUtils.waitTillSsHasRolled(kafkaStatefulSetName(oauthClusterName), 1, kafkaPods);
+    }
+
     @Description("As an oauth KafkaConnect, I should be able to sink messages from kafka broker topic.")
     @Test
     @Tag(CONNECT)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
@@ -76,8 +76,9 @@ public class OauthPlainST extends OauthAbstractST {
     @Test
     void testProducerConsumerAudienceTokenChecks() {
         LOGGER.info("Setting producer and consumer properties");
-        oauthInternalClientJob = oauthInternalClientJob.toBuilder().withBootstrapAddress(
-                KafkaResources.bootstrapServiceName(oauthClusterName) + ":" + audienceListenerPort).build();
+        oauthInternalClientJob = oauthInternalClientJob.toBuilder()
+                .withBootstrapAddress(KafkaResources.bootstrapServiceName(oauthClusterName) + ":" + audienceListenerPort)
+                .build();
 
         LOGGER.info("Use clients without access token containing audience token");
         oauthInternalClientJob.createAndWaitForReadiness(oauthInternalClientJob.producerStrimziOauthPlain().build());
@@ -98,17 +99,20 @@ public class OauthPlainST extends OauthAbstractST {
         JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_CLIENT_AUDIENCE_PRODUCER);
         JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_CLIENT_AUDIENCE_CONSUMER);
 
-        oauthInternalClientJob = oauthInternalClientJob.toBuilder().withBootstrapAddress(
-                KafkaResources.plainBootstrapAddress(oauthClusterName)).build();
+        oauthInternalClientJob = oauthInternalClientJob.toBuilder()
+                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(oauthClusterName))
+                .build();
     }
 
     @Test
     void testAccessTokenClaimCheck() {
         LOGGER.info("Use clients with clientId not containing 'hello-world' in access token.");
-        oauthInternalClientProducerJob = oauthInternalClientProducerJob.toBuilder().withBootstrapAddress(
-                KafkaResources.bootstrapServiceName(oauthClusterName) + ":" + customClaimListenerPort).build();
-        oauthInternalClientConsumerJob = oauthInternalClientConsumerJob.toBuilder().withBootstrapAddress(
-                KafkaResources.bootstrapServiceName(oauthClusterName) + ":" + customClaimListenerPort).build();
+        oauthInternalClientProducerJob = oauthInternalClientProducerJob.toBuilder()
+                .withBootstrapAddress(KafkaResources.bootstrapServiceName(oauthClusterName) + ":" + customClaimListenerPort)
+                .build();
+        oauthInternalClientConsumerJob = oauthInternalClientConsumerJob.toBuilder()
+                .withBootstrapAddress(KafkaResources.bootstrapServiceName(oauthClusterName) + ":" + customClaimListenerPort)
+                .build();
 
         oauthInternalClientProducerJob.createAndWaitForReadiness(oauthInternalClientProducerJob.producerStrimziOauthPlain().build());
         ClientUtils.waitForClientTimeout(OAUTH_CLIENT_AUDIENCE_PRODUCER, NAMESPACE, MESSAGE_COUNT);
@@ -131,8 +135,9 @@ public class OauthPlainST extends OauthAbstractST {
         JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_PRODUCER_NAME);
         JobUtils.deleteJobWithWait(NAMESPACE, OAUTH_CONSUMER_NAME);
 
-        oauthInternalClientJob = oauthInternalClientJob.toBuilder().withBootstrapAddress(
-                KafkaResources.plainBootstrapAddress(oauthClusterName)).build();
+        oauthInternalClientJob = oauthInternalClientJob.toBuilder()
+                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(oauthClusterName))
+                .build();
     }
 
     @Description("As an oauth KafkaConnect, I should be able to sink messages from kafka broker topic.")

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
@@ -125,7 +125,7 @@ public class OauthPlainST extends OauthAbstractST {
 
         LOGGER.info("Use clients with clientId containing 'hello-world' in access token.");
         oauthInternalClientJob = oauthInternalClientJob.toBuilder().withBootstrapAddress(
-                KafkaResources.bootstrapServiceName(oauthClusterName) + ":" + audienceListenerPort).build();
+                KafkaResources.bootstrapServiceName(oauthClusterName) + ":" + customClaimListenerPort).build();
 
         oauthInternalClientJob.createAndWaitForReadiness(oauthInternalClientJob.producerStrimziOauthPlain().build());
         ClientUtils.waitForClientSuccess(OAUTH_PRODUCER_NAME, NAMESPACE, MESSAGE_COUNT);
@@ -537,6 +537,7 @@ public class OauthPlainST extends OauthAbstractST {
                                 .withUserNameClaim(keycloakInstance.getUserNameClaim())
                                 .withEnablePlain(true)
                                 .withTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                                .withCustomClaimCheck("@.clientId && @.clientId =~ /.*hello-world.*/")
                             .endKafkaListenerAuthenticationOAuth()
                         .endGenericKafkaListener()
                         .addNewGenericKafkaListener()
@@ -552,6 +553,8 @@ public class OauthPlainST extends OauthAbstractST {
                                 .withUserNameClaim(keycloakInstance.getUserNameClaim())
                                 .withEnablePlain(true)
                                 .withTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                                .withCheckAudience(true)
+                                .withClientId("kafka-component")
                             .endKafkaListenerAuthenticationOAuth()
                         .endGenericKafkaListener()
                     .endListeners()

--- a/systemtest/src/test/resources/oauth2/create_realm.sh
+++ b/systemtest/src/test/resources/oauth2/create_realm.sh
@@ -130,6 +130,18 @@ RESULT=$(curl -v --insecure "https://$URL/auth/admin/realms" \
             "enabled": true,
             "email": "service-account-hello-world-streams@placeholder.org",
             "serviceAccountClientId": "hello-world-streams"
+        },
+        {
+            "username": "service-account-kafka-audience-producer",
+            "enabled": true,
+            "email": "service-account-kafka-audience-producer@placeholder.org",
+            "serviceAccountClientId": "kafka-audience-producer"
+        },
+        {
+            "username": "service-account-kafka-audience-consumer",
+            "enabled": true,
+            "email": "service-account-kafka-audience-consumer@placeholder.org",
+            "serviceAccountClientId": "kafka-audience-consumer"
         }
     ],
     "roles": {
@@ -221,9 +233,22 @@ RESULT=$(curl -v --insecure "https://$URL/auth/admin/realms" \
             "fullScopeAllowed": false,
             "attributes": {
                 "access.token.lifespan": "32140800"
-            }
-        },
-        {
+            },
+            "protocolMappers": [
+              {
+                "name": "audience for kafka-component",
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-audience-mapper",
+                "consentRequired": false,
+                "config": {
+                    "included.client.audience": "kafka-component",
+                    "id.token.claim": "false",
+                    "access.token.claim": "true"
+                }
+              }
+            ]
+          },
+          {
             "clientId": "kafka-producer",
             "enabled": true,
             "clientAuthenticatorType": "client-secret",
@@ -256,6 +281,66 @@ RESULT=$(curl -v --insecure "https://$URL/auth/admin/realms" \
             "attributes": {
                 "access.token.lifespan": "32140800"
             }
+        },
+        {
+            "clientId": "kafka-audience-producer",
+            "enabled": true,
+            "clientAuthenticatorType": "client-secret",
+            "secret": "kafka-audience-secret",
+            "publicClient": false,
+            "bearerOnly": false,
+            "standardFlowEnabled": false,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": true,
+            "serviceAccountsEnabled": true,
+            "consentRequired": false,
+            "fullScopeAllowed": false,
+            "attributes": {
+                "access.token.lifespan": "36000"
+            },
+            "protocolMappers": [
+              {
+                "name": "audience for kafka-component",
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-audience-mapper",
+                "consentRequired": false,
+                "config": {
+                    "included.client.audience": "kafka-component",
+                    "id.token.claim": "false",
+                    "access.token.claim": "true"
+                }
+              }
+            ]
+        },
+        {
+            "clientId": "kafka-audience-consumer",
+            "enabled": true,
+            "clientAuthenticatorType": "client-secret",
+            "secret": "kafka-audience-secret",
+            "publicClient": false,
+            "bearerOnly": false,
+            "standardFlowEnabled": false,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": true,
+            "serviceAccountsEnabled": true,
+            "consentRequired": false,
+            "fullScopeAllowed": false,
+            "attributes": {
+                "access.token.lifespan": "32140800"
+            },
+            "protocolMappers": [
+              {
+                "name": "audience for kafka-component",
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-audience-mapper",
+                "consentRequired": false,
+                "config": {
+                    "included.client.audience": "kafka-component",
+                    "id.token.claim": "false",
+                    "access.token.claim": "true"
+                }
+              }
+            ]
         },
         {
             "clientId": "hello-world-producer",


### PR DESCRIPTION
Signed-off-by: Michal Tóth <mtoth@redhat.com>

Test for access token audience checking for Oauth 2.0.
Related work
strimzi/strimzi-kafka-oauth#78
Audience check #4027


- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
