### PR TITLE
Create kafka-mirror-maker-2-sync-groups.yaml

### DIFF
--- a/examples/mirror-maker/kafka-mirror-maker-2-sync-groups.yaml
+++ b/examples/mirror-maker/kafka-mirror-maker-2-sync-groups.yaml
@@ -1,0 +1,34 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaMirrorMaker2
+metadata:
+  name: my-mirror-maker-2
+spec:
+  version: 2.7.0
+  replicas: 1
+  connectCluster: "my-target-cluster"
+  clusters:
+  - alias: "my-source-cluster"
+    bootstrapServers: my-source-cluster-kafka-bootstrap:9092
+  - alias: "my-target-cluster"
+    bootstrapServers: my-target-cluster-kafka-bootstrap:9092
+    config:
+      config.storage.replication.factor: 1
+      offset.storage.replication.factor: 1
+      status.storage.replication.factor: 1
+  mirrors:
+  - sourceCluster: "my-source-cluster"
+    targetCluster: "my-target-cluster"
+    sourceConnector:
+      config:
+        replication.factor: 1
+        offset-syncs.topic.replication.factor: 1
+        sync.topic.acls.enabled: "false"
+    heartbeatConnector:
+      config:
+        heartbeats.topic.replication.factor: 1
+    checkpointConnector:
+      config:
+        checkpoints.topic.replication.factor: 1
+        sync.group.offsets.enabled: "true"
+    topicsPattern: ".*"
+    groupsPattern: ".*"


### PR DESCRIPTION
https://github.com/strimzi/strimzi-kafka-operator/issues/4514

### Type of change

_Select the type of your PR_


- Documentation

### Description

Example how to configure idle consumer group synchronization with kafka MM2 replication



