### PR TITLE
[DOC] Fix wrong Cruise Control label selector

### DIFF
--- a/documentation/modules/cruise-control/proc-deploying-cruise-control.adoc
+++ b/documentation/modules/cruise-control/proc-deploying-cruise-control.adoc
@@ -91,7 +91,7 @@ kubectl apply -f _kafka.yaml_
 +
 [source,shell,subs="+quotes"]
 ----
-kubectl get deployments -l app.kubernetes.io/name=strimzi
+kubectl get deployments -l app.kubernetes.io/name=cruise-control
 ----
 
 [discrete]


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The documentation currently has a wrong label selector for veryfing if Cruise Control has been properly enabled. It should be `app.kubernetes.io/name=cruise-control` instead of `app.kubernetes.io/name=strimzi`.