### PR TITLE
Fix azure pipelines for upgrade and fix also the tests

### DIFF
--- a/.azure/upgrade-pipeline.yaml
+++ b/.azure/upgrade-pipeline.yaml
@@ -12,7 +12,7 @@ jobs:
     parameters:
       name: 'strimzi_upgrade'
       display_name: 'strimzi-upgrade-bundle'
-      test_case: 'StrimziUpgradeST,StrimziDowngradeST'
+      test_case: 'upgrade/**/*ST,!KafkaUpgradeDowngradeST'
       groups: 'upgrade'
       cluster_operator_install_type: 'bundle'
       timeout: 360

--- a/.azure/upgrade-pipeline.yaml
+++ b/.azure/upgrade-pipeline.yaml
@@ -12,7 +12,7 @@ jobs:
     parameters:
       name: 'strimzi_upgrade'
       display_name: 'strimzi-upgrade-bundle'
-      test_case: '.StrimziUpgradeST'
+      test_case: 'StrimziUpgradeST,StrimziDowngradeST'
       groups: 'upgrade'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -21,7 +21,7 @@ jobs:
     parameters:
       name: 'kafka_upgrade_downgrade'
       display_name: 'kafka-upgrade-downgrade-bundle'
-      test_case: '.KafkaUpgradeDowngradeST'
+      test_case: 'KafkaUpgradeDowngradeST'
       groups: 'upgrade'
       cluster_operator_install_type: 'bundle'
       timeout: 360

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziDowngradeST.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.upgrade;
 
 import io.strimzi.systemtest.utils.StUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -61,6 +62,8 @@ public class StrimziDowngradeST extends AbstractUpgradeST {
         // Wait for Kafka cluster rolling update
         waitForKafkaClusterRollingUpdate();
         logPodImages(clusterName);
+        // Verify that pods are stable
+        PodUtils.verifyThatRunningPodsAreStable(clusterName);
         checkAllImages(testParameters.getJsonObject("imagesAfterOperatorDowngrade"));
         // Verify upgrade
         verifyProcedure(testParameters, producerName, consumerName, NAMESPACE);


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

We never really ran `StrimziDowngradeST` in azure and after the merge of registry changes for minikube we kinda broke the upgrade tests as well. This PR address the issues.

### Checklist


- [x] Make sure all tests pass

