### PR TITLE
The 'com.jayway.jsonpath:json-path' dependency must not be 'test' scoped

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -647,12 +647,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.jayway.jsonpath</groupId>
-                <artifactId>json-path</artifactId>
-                <version>${jayway-jsonpath.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${gson.version}</version>
@@ -723,6 +717,11 @@
                 <groupId>io.strimzi</groupId>
                 <artifactId>kafka-oauth-keycloak-authorizer</artifactId>
                 <version>${strimzi-oauth.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.jayway.jsonpath</groupId>
+                <artifactId>json-path</artifactId>
+                <version>${jayway-jsonpath.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.micrometer</groupId>


### PR DESCRIPTION
Test scoped dependency is not included in the Operator image

Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>

### Type of change
- Bugfix

### Description

Fix a missing depencency issue that causes ClassNotFoundException at runtime when authentication of type 'oauth' is used with 'customClaimCheck'.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

