### PR TITLE
Remove duplicate dependency on Strimzi API module

### DIFF
--- a/mockkube/pom.xml
+++ b/mockkube/pom.xml
@@ -88,11 +88,6 @@
         </dependency>
         <dependency>
             <groupId>io.strimzi</groupId>
-            <artifactId>api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.strimzi</groupId>
             <artifactId>test</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `mockkube` module seems to have the dependency on the `api` module declared twice. That results in the following warning:

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for io.strimzi:mockkube:jar:0.22.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.strimzi:api:jar -> duplicate declaration of version (?) @ line 98, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```

This PR fixes that and removes the warning.