### PR TITLE
Bump Strimzi Kafka OAuth dependency to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Add annotations that enable the operator to restart Kafka Connect connectors or tasks. The annotations can be applied to the KafkaConnector and the KafkaMirrorMaker2 custom resources.
 * Add additional configuration options for the Kaniko executor used by the Kafka Connect Build on Kubernetes
 * Add support for JMX options configuration of all Kafka Connect (KC, KC2SI, MM2)
-* Update Strimzi Kafka OAuth to version 0.7.0 and add support for new features:
+* Update Strimzi Kafka OAuth to version 0.7 and add support for new features:
   * OAuth authentication over SASL PLAIN mechanism
   * Checking token audience
   * Validating tokens using JSONPath filter queries to perform custom checks

--- a/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.5.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.7.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.7.1</strimzi-oauth.version>
         <cruise-control.version>2.5.37</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
     </properties>
@@ -25,6 +25,10 @@
         <repository>
             <id>jcenter</id>
             <url>https://jcenter.bintray.com/</url>
+        </repository>
+        <repository>
+            <id>strimzi-oauth-0.7.1</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1092/</url>
         </repository>
     </repositories>
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.7.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.7.1</strimzi-oauth.version>
         <cruise-control.version>2.5.37</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
     </properties>
@@ -25,6 +25,10 @@
         <repository>
             <id>jcenter</id>
             <url>https://jcenter.bintray.com/</url>
+        </repository>
+        <repository>
+            <id>strimzi-oauth-0.7.1</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1092/</url>
         </repository>
     </repositories>
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.7.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.7.1</strimzi-oauth.version>
         <cruise-control.version>2.5.37</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
     </properties>
@@ -25,6 +25,10 @@
         <repository>
             <id>jcenter</id>
             <url>https://jcenter.bintray.com/</url>
+        </repository>
+        <repository>
+            <id>strimzi-oauth-0.7.1</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1092/</url>
         </repository>
     </repositories>
 

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -44,7 +44,7 @@
 
 //OAuth attributes and links
 :oauth2-site: link:https://oauth.net/2/[OAuth 2.0 site^]
-:oauth-version: 0.7.0
+:oauth-version: 0.7.1
 :keycloak-server-doc: link:https://www.keycloak.org/documentation.html[Keycloak documentation^]
 :keycloak-authorization-services: link:https://www.keycloak.org/docs/latest/authorization_services/index.html[Authorization Services^]
 :oauth-blog: link:https://strimzi.io/2019/10/25/kafka-authentication-using-oauth-2.0.html[Kafka authentication using OAuth 2.0^]

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <jaeger.version>1.3.2</jaeger.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
-        <strimzi-oauth.version>0.7.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.7.1</strimzi-oauth.version>
         <commons-codec.version>1.13</commons-codec.version>
         <registry.version>1.3.0.Final</registry.version>
         <kafka.streams.version>2.6.0</kafka.streams.version>
@@ -152,6 +152,13 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>strimzi-oauth-0.7.1</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1092/</url>
+        </repository>
+    </repositories>
 
     <modules>
         <module>kafka-agent</module>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR bumps the Strimzi OAuth library to 0.7.1 which has some bugfixes compared to 0.7.0.
