### PR TITLE
[systemtest] Add tests for pausing reconciliation feature

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/balancing/KafkaRebalanceState.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/balancing/KafkaRebalanceState.java
@@ -67,5 +67,9 @@ public enum KafkaRebalanceState {
      * The resource is eligible for garbage collection after a configurable delay.
      * There is no transition from this state to a new one.
      */
-    Ready
+    Ready,
+    /**
+     * The user paused reconciliations by setting annotation strimzi.io/pause-reconciliation="true".
+     */
+    ReconciliationPaused
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/enums/CustomResourceStatus.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/enums/CustomResourceStatus.java
@@ -7,5 +7,6 @@ package io.strimzi.systemtest.enums;
 public enum CustomResourceStatus {
     Ready,
     NotReady,
-    Warning
+    Warning,
+    ReconciliationPaused
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectorUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectorUtils.java
@@ -127,7 +127,10 @@ public class KafkaConnectorUtils {
         return getConnectorConfig(podName, connectorName, apiUrl);
     }
 
-    public static void waitForConnectorsSpecStability(String podName, String connectorName, String oldSpec) {
+    /**
+     * Checks stability of Connector's spec on Connect API, which should be same like before changes
+     */
+    public static void waitForConnectorSpecFromConnectAPIStability(String podName, String connectorName, String oldSpec) {
         int[] stableCounter = {0};
 
         TestUtils.waitFor("Connector's spec will be stable", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT, () -> {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
@@ -5,10 +5,10 @@
 package io.strimzi.systemtest.utils.kafkaUtils;
 
 import io.strimzi.api.kafka.model.KafkaRebalance;
-import io.strimzi.api.kafka.model.KafkaRebalanceSpec;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceAnnotation;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
+import io.strimzi.api.kafka.model.status.KafkaRebalanceStatus;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -89,24 +89,24 @@ public class KafkaRebalanceUtils {
         waitForKafkaRebalanceCustomResourceState(rebalanceName, KafkaRebalanceState.Ready);
     }
 
-    public static void waitForRebalanceSpecStability(String resourceName) {
+    public static void waitForRebalanceStatusStability(String resourceName) {
         int[] stableCounter = {0};
 
-        KafkaRebalanceSpec oldSpec = KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get().getSpec();
+        KafkaRebalanceStatus oldStatus = KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get().getStatus();
 
-        TestUtils.waitFor("KafkaRebalance spec will be stable", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
-            if (KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get().getSpec().equals(oldSpec)) {
+        TestUtils.waitFor("KafkaRebalance status will be stable", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
+            if (KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get().getStatus().equals(oldStatus)) {
                 stableCounter[0]++;
                 if (stableCounter[0] == Constants.GLOBAL_STABILITY_OFFSET_COUNT) {
-                    LOGGER.info("KafkaRebalance spec is stable for {} polls intervals", stableCounter[0]);
+                    LOGGER.info("KafkaRebalance status is stable for {} polls intervals", stableCounter[0]);
                     return true;
                 }
             } else {
-                LOGGER.info("KafkaRebalance spec is not stable. Going to set the counter to zero.");
+                LOGGER.info("KafkaRebalance status is not stable. Going to set the counter to zero.");
                 stableCounter[0] = 0;
                 return false;
             }
-            LOGGER.info("KafkaRebalance spec gonna be stable in {} polls", Constants.GLOBAL_STABILITY_OFFSET_COUNT - stableCounter[0]);
+            LOGGER.info("KafkaRebalance status gonna be stable in {} polls", Constants.GLOBAL_STABILITY_OFFSET_COUNT - stableCounter[0]);
             return false;
         });
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -146,7 +146,7 @@ public class KafkaTopicUtils {
         String oldSpec = describeTopicViaKafkaPod(topicName, podName, bootstrapServer);
 
         TestUtils.waitFor("KafkaTopic's spec will be stable", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
-            if (oldSpec == describeTopicViaKafkaPod(topicName, podName, bootstrapServer)) {
+            if (oldSpec.equals(describeTopicViaKafkaPod(topicName, podName, bootstrapServer))) {
                 stableCounter[0]++;
                 if (stableCounter[0] == Constants.GLOBAL_STABILITY_OFFSET_COUNT) {
                     LOGGER.info("KafkaTopic's spec is stable for {} polls intervals", stableCounter[0]);

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/ReconciliationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/ReconciliationST.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.operators;
+
+import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaConnectResources;
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.balancing.KafkaRebalanceAnnotation;
+import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.enums.CustomResourceStatus;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
+import io.strimzi.systemtest.resources.crd.KafkaConnectorResource;
+import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaRebalanceUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.vertx.core.json.JsonObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Tag(REGRESSION)
+public class ReconciliationST extends AbstractST {
+    private static final Logger LOGGER = LogManager.getLogger(ReconciliationST.class);
+    private static final String NAMESPACE = "reconciliation-cluster-test";
+
+    private static final Map<String, String> PAUSE_ANNO = Collections.singletonMap(Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "true");
+    private static final int SCALE_TO = 4;
+
+    @Test
+    void testPauseReconciliationInKafkaAndKafkaConnectWithConnector() {
+        KafkaResource.createAndWaitForReadiness(KafkaResource.kafkaEphemeral(clusterName, 3).build());
+
+        String kafkaSsName = KafkaResources.kafkaStatefulSetName(clusterName);
+
+        LOGGER.info("Adding pause annotation into Kafka resource and also scaling replicas to 4, new pod should not appear");
+        KafkaResource.replaceKafkaResource(clusterName, kafka -> {
+            kafka.getMetadata().setAnnotations(PAUSE_ANNO);
+            kafka.getSpec().getKafka().setReplicas(SCALE_TO);
+        });
+
+        LOGGER.info("Kafka should contain status with {}", CustomResourceStatus.ReconciliationPaused.toString());
+        KafkaUtils.waitForKafkaStatus(clusterName, CustomResourceStatus.ReconciliationPaused);
+        PodUtils.waitUntilPodStabilityReplicasCount(kafkaSsName, 3);
+
+        LOGGER.info("Setting annotation to \"false\", Kafka should be scaled to {}", SCALE_TO);
+        KafkaResource.replaceKafkaResource(clusterName, kafka -> kafka.getMetadata().getAnnotations().replace(Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "true", "false"));
+        StatefulSetUtils.waitForAllStatefulSetPodsReady(kafkaSsName, SCALE_TO);
+
+        LOGGER.info("Deploying KafkaConnect with pause anno from the start, no pods should appear");
+        KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.kafkaConnect(clusterName, 1)
+            .editOrNewMetadata()
+                .addToAnnotations(PAUSE_ANNO)
+                .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+            .endMetadata()
+            .build());
+
+        String connectDepName = KafkaConnectResources.deploymentName(clusterName);
+
+        KafkaConnectUtils.waitForConnectStatus(clusterName, CustomResourceStatus.ReconciliationPaused);
+        PodUtils.waitUntilPodStabilityReplicasCount(connectDepName, 0);
+
+        LOGGER.info("Setting annotation to \"false\" and creating KafkaConnector");
+        KafkaConnectResource.replaceKafkaConnectResource(clusterName,
+            kc -> kc.getMetadata().getAnnotations().replace(Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "true", "false"));
+        DeploymentUtils.waitForDeploymentAndPodsReady(connectDepName, 1);
+
+        KafkaConnectorResource.createAndWaitForReadiness(KafkaConnectorResource.kafkaConnector(clusterName).build());
+
+        String connectPodName = kubeClient().listPods(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
+        String connectorSpec = KafkaConnectorUtils.getConnectorSpecFromConnectAPI(connectPodName, clusterName);
+
+        LOGGER.info("Adding pause annotation into the KafkaConnector and scaling taskMax to 4");
+        KafkaConnectorResource.replaceKafkaConnectorResource(clusterName, connector -> {
+            connector.getMetadata().setAnnotations(PAUSE_ANNO);
+            connector.getSpec().setTasksMax(SCALE_TO);
+        });
+
+        KafkaConnectorUtils.waitForConnectorStatus(clusterName, CustomResourceStatus.ReconciliationPaused);
+        KafkaConnectorUtils.waitForConnectorsSpecStability(connectPodName, clusterName, connectorSpec);
+
+        LOGGER.info("Setting annotation to \"false\", taskMax should be increased to {}", SCALE_TO);
+        KafkaConnectorResource.replaceKafkaConnectorResource(clusterName, connector ->
+            connector.getMetadata().getAnnotations().replace(Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "true", "false"));
+
+        String oldConfig = new JsonObject(connectorSpec).getValue("config").toString();
+        JsonObject newConfig = new JsonObject(KafkaConnectorUtils.waitForConnectorConfigUpdate(connectPodName, clusterName, oldConfig, "localhost"));
+
+        assertThat(newConfig.getValue("tasks.max"), is(Integer.toString(SCALE_TO)));
+    }
+
+    @Test
+    void testPauseReconciliationInKafkaRebalanceAndTopic() {
+        KafkaResource.createAndWaitForReadiness(KafkaResource.kafkaWithCruiseControl(clusterName, 3, 3).build());
+
+        KafkaTopicResource.createAndWaitForReadiness(KafkaTopicResource.topic(clusterName, TOPIC_NAME).build());
+
+        /* TODO: after issue with TO and pausing reconciliations in KafkaTopic will be fixed, uncomment these lines
+        LOGGER.info("Adding pause annotation into KafkaTopic resource and changing replication factor");
+        KafkaTopicResource.replaceTopicResource(TOPIC_NAME, topic -> {
+            topic.getMetadata().setAnnotations(PAUSE_ANNO);
+            topic.getSpec().setPartitions(SCALE_TO);
+        });
+
+        KafkaTopicUtils.waitForKafkaTopicStatus(TOPIC_NAME, CustomResourceStatus.ReconciliationPaused);
+        KafkaTopicUtils.waitForKafkaTopicSpecStability(TOPIC_NAME);
+
+        LOGGER.info("Setting annotation to \"false\", partitions should be scaled to {}", SCALE_TO);
+        KafkaTopicResource.replaceTopicResource(TOPIC_NAME,
+            topic -> topic.getMetadata().getAnnotations().replace(Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "true", "false"));
+        KafkaTopicUtils.waitForKafkaTopicPartitionChange(TOPIC_NAME, SCALE_TO);
+        */
+
+        KafkaRebalanceResource.createAndWaitForReadiness(KafkaRebalanceResource.kafkaRebalance(clusterName).build());
+
+        LOGGER.info("Waiting for {}, then add pause and rebalance annotation, rebalancing should not be triggered", KafkaRebalanceState.ProposalReady);
+
+        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(clusterName, KafkaRebalanceState.ProposalReady);
+
+        KafkaRebalanceResource.replaceKafkaRebalanceResource(clusterName, rebalance -> {
+            rebalance.getMetadata().setAnnotations(PAUSE_ANNO);
+            rebalance.getSpec().setExcludedTopics(TOPIC_NAME);
+        });
+
+        KafkaRebalanceUtils.annotateKafkaRebalanceResource(clusterName, KafkaRebalanceAnnotation.approve);
+
+        // because we don't have any option to check if KR is rebalancing (other than status),
+        // we will check that spec is not changed because of excluded topic
+        KafkaRebalanceUtils.waitForRebalanceSpecStability(clusterName);
+
+        LOGGER.info("Setting annotation to \"false\" and waiting for KafkaRebalance to be in {} state", KafkaRebalanceState.Ready);
+        KafkaRebalanceResource.replaceKafkaRebalanceResource(clusterName,
+            rebalance -> rebalance.getMetadata().getAnnotations().replace(Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "true", "false"));
+        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(clusterName, KafkaRebalanceState.Ready);
+    }
+
+    @BeforeAll
+    void setup() {
+        ResourceManager.setClassResources();
+        installClusterOperator(NAMESPACE);
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/ReconciliationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/ReconciliationST.java
@@ -153,6 +153,8 @@ public class ReconciliationST extends AbstractST {
         KafkaRebalanceResource.replaceKafkaRebalanceResource(clusterName,
             rebalance -> rebalance.getMetadata().getAnnotations().replace(Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "true", "false"));
 
+        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(clusterName, KafkaRebalanceState.ProposalReady);
+
         // because approve annotation wasn't reflected, approving again
         KafkaRebalanceUtils.annotateKafkaRebalanceResource(clusterName, KafkaRebalanceAnnotation.approve);
         KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(clusterName, KafkaRebalanceState.Ready);


### PR DESCRIPTION
### Type of change

- New tests

### Description

After #4399 we are able to add annotation to resources about pausing the reconciliations (`strimzi.io/pause-reconciliation: "true"`), which causes that resource is not created (if the anno is added when we deploying it) or changes are not reflected. This PR adds tests for this new feature.

_**NOTE**: currently KafkaTopic checks are commented because of issues connected to reconciliation feature, after the problems will be fixed, these lines will be uncommented._

### Checklist

- [X] Write tests
- [ ] Make sure all tests pass


