### PR TITLE
Use ISO-8601 timestamp in Kafka resource status - 

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -41,12 +41,10 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -90,10 +88,6 @@ public class ModelUtils {
         }
 
         return renewalDays;
-    }
-
-    public static String formatTimestamp(Date date) {
-        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(date);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -230,7 +230,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
             if (reconcileResult.succeeded())    {
                 condition = new ConditionBuilder()
-                        .withLastTransitionTime(ModelUtils.formatTimestamp(dateSupplier()))
+                        .withLastTransitionTime(StatusUtils.iso8601(dateSupplier()))
                         .withType("Ready")
                         .withStatus("True")
                         .build();
@@ -239,7 +239,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 createOrUpdatePromise.complete(status);
             } else {
                 condition = new ConditionBuilder()
-                        .withLastTransitionTime(ModelUtils.formatTimestamp(dateSupplier()))
+                        .withLastTransitionTime(StatusUtils.iso8601(dateSupplier()))
                         .withType("NotReady")
                         .withStatus("True")
                         .withReason(reconcileResult.cause().getClass().getSimpleName())
@@ -518,7 +518,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         log.debug("{}: Setting the initial status for a new resource", reconciliation);
 
                         Condition deployingCondition = new ConditionBuilder()
-                                .withLastTransitionTime(ModelUtils.formatTimestamp(dateSupplier()))
+                                .withLastTransitionTime(StatusUtils.iso8601(dateSupplier()))
                                 .withType("NotReady")
                                 .withStatus("True")
                                 .withReason("Creating")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StatusDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StatusDiffTest.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.status.KafkaStatus;
 import io.strimzi.api.kafka.model.status.ListenerAddressBuilder;
 import io.strimzi.api.kafka.model.status.ListenerStatus;
 import io.strimzi.api.kafka.model.status.ListenerStatusBuilder;
+import io.strimzi.operator.common.operator.resource.StatusUtils;
 import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
@@ -48,13 +49,13 @@ public class StatusDiffTest {
                 .build();
 
         Condition condition1 = new ConditionBuilder()
-                .withNewLastTransitionTime(ModelUtils.formatTimestamp(new Date()))
+                .withNewLastTransitionTime(StatusUtils.iso8601(new Date()))
                 .withNewType("Ready")
                 .withNewStatus("True")
                 .build();
 
         Condition condition2 = new ConditionBuilder()
-                .withNewLastTransitionTime(ModelUtils.formatTimestamp(new Date()))
+                .withNewLastTransitionTime(StatusUtils.iso8601(new Date()))
                 .withNewType("Ready2")
                 .withNewStatus("True")
                 .build();
@@ -127,13 +128,13 @@ public class StatusDiffTest {
                 .build();
 
         Condition condition1 = new ConditionBuilder()
-                .withNewLastTransitionTime(ModelUtils.formatTimestamp(new Date()))
+                .withNewLastTransitionTime(StatusUtils.iso8601(new Date()))
                 .withNewType("Ready")
                 .withNewStatus("True")
                 .build();
 
         Condition condition2 = new ConditionBuilder()
-                .withNewLastTransitionTime(ModelUtils.formatTimestamp(new SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse("2011-01-01 00:00:00")))
+                .withNewLastTransitionTime(StatusUtils.iso8601(new SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse("2011-01-01 00:00:00")))
                 .withNewType("Ready")
                 .withNewStatus("True")
                 .build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -32,7 +32,6 @@ import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.KubernetesVersion;
-import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.MetricsAndLogging;
@@ -45,6 +44,7 @@ import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.NodeOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.strimzi.operator.common.operator.resource.StatusUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -124,7 +124,7 @@ public class KafkaStatusTest {
                 .withNewStatus()
                     .withObservedGeneration(1L)
                     .withConditions(new ConditionBuilder()
-                            .withNewLastTransitionTime(ModelUtils.formatTimestamp(new SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse("2011-01-01 00:00:00")))
+                            .withNewLastTransitionTime(StatusUtils.iso8601(new SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse("2011-01-01 00:00:00")))
                             .withNewType("NotReady")
                             .withNewStatus("True")
                             .build())

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -16,16 +16,29 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
+import java.util.Date;
 
 public class StatusUtils {
     private static final String V1ALPHA1 = Constants.RESOURCE_GROUP_NAME + "/" + Constants.V1ALPHA1;
 
     /**
      * Returns the current timestamp in ISO 8601 format, for example "2019-07-23T09:08:12.356Z".
+     * 
      * @return the current timestamp in ISO 8601 format, for example "2019-07-23T09:08:12.356Z".
      */
     public static String iso8601Now() {
         return ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
+    }
+
+    /**
+     * Returns the timestamp of the provided date in ISO 8601 format, for example "2019-07-23T09:08:12.356Z".
+     *
+     * @param date The date for which should the ISO 8601 timestamp be provided
+     *
+     * @return the current timestamp in ISO 8601 format, for example "2019-07-23T09:08:12.356Z".
+     */
+    public static String iso8601(Date date) {
+        return ZonedDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
     }
 
     public static Condition buildConditionFromException(String type, String status, Throwable error) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The timestamp in the `conditions` array in the status of the Kafka CR should follow the ISO-8601 standard

```yaml
  status:
    clusterId: s-YIFfe1TVO8A7J-G_RCGQ
    conditions:
    - lastTransitionTime: "2021-03-09T12:41:17.058Z"
      status: "True"
      type: Ready
    listeners:
      # ...
```

This should close close #4538

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging