### PR TITLE
[DOC] Listener configuration is not only for external listeners anymore

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBootstrap.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBootstrap.adoc
@@ -160,7 +160,7 @@ listeners:
 === `annotations`
 
 Use the `annotations` property to add annotations to Kubernetes resources related to the listeners.
-You can use these annotations for example to instrument DNS tooling such as {KubernetesExternalDNS}, which automatically assigns DNS names to the loadbalancer services.
+You can use these annotations, for example, to instrument DNS tooling such as {KubernetesExternalDNS}, which automatically assigns DNS names to the loadbalancer services.
 
 .Example of an external listener of type `loadbalancer` using `annotations`
 [source,yaml,subs="attributes+"]

--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBootstrap.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBootstrap.adoc
@@ -1,5 +1,3 @@
-Configures bootstrap service overrides for external listeners.
-
 Broker service equivalents of `nodePort`, `host`, `loadBalancerIP` and `annotations` properties are configured in the xref:type-GenericKafkaListenerConfigurationBroker-reference[`GenericKafkaListenerConfigurationBroker` schema].
 
 [id='property-listener-config-altnames-{context}']
@@ -7,7 +5,7 @@ Broker service equivalents of `nodePort`, `host`, `loadBalancerIP` and `annotati
 
 You can specify alternative names for the bootstrap service.
 The names are added to the broker certificates and can be used for TLS hostname verification.
-The `alternativeNames` property is applicable to all types of external listeners.
+The `alternativeNames` property is applicable to all types of listeners.
 
 .Example of an external `route` listener configured with an additional bootstrap address
 [source,yaml,subs="attributes+"]
@@ -161,8 +159,8 @@ listeners:
 [id='property-listener-config-annotations-{context}']
 === `annotations`
 
-Use the `annotations` property to add annotations to `loadbalancer`, `nodeport` or `ingress` listeners.
-You can use these annotations to instrument DNS tooling such as {KubernetesExternalDNS}, which automatically assigns DNS names to the loadbalancer services.
+Use the `annotations` property to add annotations to Kubernetes resources related to the listeners.
+You can use these annotations for example to instrument DNS tooling such as {KubernetesExternalDNS}, which automatically assigns DNS names to the loadbalancer services.
 
 .Example of an external listener of type `loadbalancer` using `annotations`
 [source,yaml,subs="attributes+"]

--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBroker.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBroker.adoc
@@ -1,7 +1,5 @@
-Configures broker service overrides for external listeners.
-
 You can see example configuration for the `nodePort`, `host`, `loadBalancerIP` and `annotations` properties in the xref:type-GenericKafkaListenerConfigurationBootstrap-reference[`GenericKafkaListenerConfigurationBootstrap` schema],
-which configures bootstrap service overrides for external listeners.
+which configures bootstrap service overrides.
 
 [id='property-listener-config-broker-{context}']
 .Advertised addresses for brokers
@@ -9,9 +7,9 @@ which configures bootstrap service overrides for external listeners.
 By default, Strimzi tries to automatically determine the hostnames and ports that your Kafka cluster advertises to its clients.
 This is not sufficient in all situations, because the infrastructure on which Strimzi is running might not provide the right hostname or port through which Kafka can be accessed.
 
-You can specify a broker ID and customize the advertised hostname and port in the `configuration` property of the external listener.
+You can specify a broker ID and customize the advertised hostname and port in the `configuration` property of the listener.
 Strimzi will then automatically configure the advertised address in the Kafka brokers and add it to the broker certificates so it can be used for TLS hostname verification.
-Overriding the advertised host and ports is available for all types of external listeners.
+Overriding the advertised host and ports is available for all types of listeners.
 
 .Example of an external `route` listener configured with overrides for advertised addresses
 [source,yaml,subs="attributes+"]


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The documentation sections describing configuration of listeners state on several places that it is applicable only to external listeners. This is not the case anymore and this is probably just caused by a copy-paste of the docs when introducing the new array based listeners.