### PR TITLE
[DOC] Fix incorrect container image used in the OAuth Authorization docs

### DIFF
--- a/documentation/modules/oauth/con-oauth-authorization-keycloak-example.adoc
+++ b/documentation/modules/oauth/con-oauth-authorization-keycloak-example.adoc
@@ -153,7 +153,7 @@ First, a new interactive pod container is run using a Strimzi Kafka image to con
 
 [source,shell,subs="attributes"]
 ----
-kubectl run -ti --rm --restart=Never --image=quay.io/strimzi/kafka:latest-kafka-{DefaultKafkaVersion} kafka-cli -- /bin/sh
+kubectl run -ti --rm --restart=Never --image={DockerKafkaImageCurrent} kafka-cli -- /bin/sh
 ----
 
 NOTE: If `kubectl` times out waiting on the image download, subsequent attempts may result in an _AlreadyExists_ error.


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The OAuth Auhtorization section in our docs has a hardcoded `latest` image in one of its commands. That should be replaced with the `{DockerKafkaImageCurrent}` variable to point to the released image in releases.

This should be cherry-picked for 0.22.