### PR TITLE
[DOC] Pause reconciliation of custom resources

### DIFF
--- a/documentation/assemblies/managing/assembly-management-tasks.adoc
+++ b/documentation/assemblies/managing/assembly-management-tasks.adoc
@@ -10,6 +10,9 @@ This chapter covers tasks to maintain a deployment of Strimzi.
 //using kubectl commands and status
 include::assembly-working-with-resources.adoc[leveloffset=+1]
 
+//pausing reconciliation of custom resources
+include::modules/proc-pausing-reconciliation.adoc[leveloffset=+1]
+
 //performing manual rolling updates
 include::assembly-rolling-updates.adoc[leveloffset=+1]
 

--- a/documentation/modules/managing/proc-pausing-reconciliation.adoc
+++ b/documentation/modules/managing/proc-pausing-reconciliation.adoc
@@ -10,14 +10,12 @@ Sometimes it is useful to pause the reconciliation of custom resources managed b
 so that you can perform fixes or make updates.
 If reconciliations are paused, any changes to custom resources are ignored by Strimzi Operators until the pause ends.
 
-If you want to pause reconciliation of a custom resource, set the `pause-reconciliation` annotation to `true` in its configuration.
+If you want to pause reconciliation of a custom resource, set the `strimzi.io/pause-reconciliation` annotation to `true` in its configuration.
 This instructs the appropriate Operator to pause reconciliation of the custom resource.
 For example, you can apply the annotation to the `KafkaConnect` resource so that reconciliation by the Cluster Operator is paused.
 
 You can also _create_ a custom resource with the pause annotation enabled.
 The custom resource is created, but it is ignored.
-
-To resume reconciliation, you can set the annotation to `false`, or remove the annotation.
 
 IMPORTANT: It is not currently possible to pause reconciliation of `KafkaTopic` resources.
 
@@ -31,23 +29,50 @@ IMPORTANT: It is not currently possible to pause reconciliation of `KafkaTopic` 
 +
 [source,shell,subs="+quotes"]
 ----
-kubectl annotate _KIND-OF-CUSTOM-RESOURCE_ _NAME-OF-CUSTOM-RESOURCE_ strimzi.io/pause-reconciliation: "true"
+kubectl annotate _KIND-OF-CUSTOM-RESOURCE_ _NAME-OF-CUSTOM-RESOURCE_ strimzi.io/pause-reconciliation="true"
 ----
 +
 For example, for the `KafkaConnect` custom resource:
 +
 [source,shell,subs="+quotes"]
 ----
-kubectl annotate KafkaConnect my-connect strimzi.io/pause-reconciliation: "true"
+kubectl annotate KafkaConnect my-connect strimzi.io/pause-reconciliation="true"
 ----
 
-. Check that the status of the custom resource has changed to `ReconciliationPaused`:
+. Check that the status conditions of the custom resource shows a change to `ReconciliationPaused`:
 +
 [source,shell,subs="+quotes"]
 ----
 kubectl describe _KIND-OF-CUSTOM-RESOURCE_ _NAME-OF-CUSTOM-RESOURCE_
 ----
++
+The `type` condition changes to `ReconciliationPaused` at the `lastTransitionTime`.
++
+.Example custom resource with a paused reconciliation condition type
+[source,shell,subs="+quotes"]
+----
+apiVersion: {KafkaApiVersion}
+kind: KafkaConnect
+metadata:
+  annotations:
+    strimzi.io/pause-reconciliation: "true"
+    strimzi.io/use-connector-resources: "true"
+  creationTimestamp: 2021-03-12T10:47:11Z
+  #...
+spec:
+  # ...
+status:
+  conditions:
+  - lastTransitionTime: 2021-03-12T10:47:41.689249Z
+    status: "True"
+    type: ReconciliationPaused
+----
+
+.Resuming from pause
+
+* To resume reconciliation, you can set the annotation to `false`, or remove the annotation.
 
 .Additional resources
 
 * xref:assembly-customizing-kubernetes-resources-str[Customizing Kubernetes resources]
+* xref:con-custom-resources-status-str[Finding the status of a custom resource]

--- a/documentation/modules/managing/proc-pausing-reconciliation.adoc
+++ b/documentation/modules/managing/proc-pausing-reconciliation.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// assembly-management-tasks.adoc
+
+[id='proc-pausing-reconciliation-{context}']
+
+= Pausing reconciliation of custom resources
+
+Sometimes it is useful to pause the reconciliation of custom resources managed by Strimzi Operators,
+so that you can perform fixes or make updates.
+If reconciliations are paused, any changes to custom resources are ignored by Strimzi Operators until the pause ends.
+
+If you want to pause reconciliation of a custom resource, set the `pause-reconciliation` annotation to `true` in its configuration.
+This instructs the appropriate Operator to pause reconciliation of the custom resource.
+For example, you can apply the annotation to the `KafkaConnect` resource so that reconciliation by the Cluster Operator is paused.
+
+You can also _create_ a custom resource with the pause annotation enabled.
+The custom resource is created, but it is ignored.
+
+To resume reconciliation, you can set the annotation to `false`, or remove the annotation.
+
+IMPORTANT: It is not currently possible to pause reconciliation of `KafkaTopic` resources.
+
+.Prerequisites
+
+* The Strimzi Operator that manages the custom resource is running.
+
+.Procedure
+
+. Annotate the custom resource in Kubernetes, setting `pause-reconciliation` to `true`:
++
+[source,shell,subs="+quotes"]
+----
+kubectl annotate _KIND-OF-CUSTOM-RESOURCE_ _NAME-OF-CUSTOM-RESOURCE_ strimzi.io/pause-reconciliation: "true"
+----
++
+For example, for the `KafkaConnect` custom resource:
++
+[source,shell,subs="+quotes"]
+----
+kubectl annotate KafkaConnect my-connect strimzi.io/pause-reconciliation: "true"
+----
+
+. Check that the status of the custom resource has changed to `ReconciliationPaused`:
++
+[source,shell,subs="+quotes"]
+----
+kubectl describe _KIND-OF-CUSTOM-RESOURCE_ _NAME-OF-CUSTOM-RESOURCE_
+----
+
+.Additional resources
+
+* xref:assembly-customizing-kubernetes-resources-str[Customizing Kubernetes resources]

--- a/documentation/modules/managing/proc-pausing-reconciliation.adoc
+++ b/documentation/modules/managing/proc-pausing-reconciliation.adoc
@@ -8,13 +8,13 @@
 
 Sometimes it is useful to pause the reconciliation of custom resources managed by Strimzi Operators,
 so that you can perform fixes or make updates.
-If reconciliations are paused, any changes to custom resources are ignored by Strimzi Operators until the pause ends.
+If reconciliations are paused, any changes made to custom resources are ignored by the Operators until the pause ends.
 
 If you want to pause reconciliation of a custom resource, set the `strimzi.io/pause-reconciliation` annotation to `true` in its configuration.
 This instructs the appropriate Operator to pause reconciliation of the custom resource.
 For example, you can apply the annotation to the `KafkaConnect` resource so that reconciliation by the Cluster Operator is paused.
 
-You can also _create_ a custom resource with the pause annotation enabled.
+You can also create a custom resource with the pause annotation enabled.
 The custom resource is created, but it is ignored.
 
 IMPORTANT: It is not currently possible to pause reconciliation of `KafkaTopic` resources.
@@ -39,7 +39,7 @@ For example, for the `KafkaConnect` custom resource:
 kubectl annotate KafkaConnect my-connect strimzi.io/pause-reconciliation="true"
 ----
 
-. Check that the status conditions of the custom resource shows a change to `ReconciliationPaused`:
+. Check that the status conditions of the custom resource show a change to `ReconciliationPaused`:
 +
 [source,shell,subs="+quotes"]
 ----
@@ -51,7 +51,7 @@ The `type` condition changes to `ReconciliationPaused` at the `lastTransitionTim
 .Example custom resource with a paused reconciliation condition type
 [source,shell,subs="+quotes"]
 ----
-apiVersion: {KafkaApiVersion}
+apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnect
 metadata:
   annotations:


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
New procedure for the _Managing Strimzi_ section of the _Using Guide_:

- _Pausing reconciliation of custom resources_ 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

