### PR TITLE
Try to fix Azure build for release tags

### DIFF
--- a/.azure/templates/default_variables.yaml
+++ b/.azure/templates/default_variables.yaml
@@ -7,13 +7,13 @@ variables:
     tag: latest
     commit: latest
   ${{ if ne( variables['Build.SourceBranchName'], 'master' ) }}:
-    ${{ if startsWith( variables['Build.SourceBranchName'], 'release-' ) }}:
+    ${{ if startsWith( variables['Build.SourceBranchName'], 'refs/tags/' ) }}:
       pull_request: false
       docker_org: strimzi
       docker_registry: quay.io
       commit: release
       tag: release
-    ${{ if not(startsWith( variables['Build.SourceBranchName'], 'release-' )) }}:
+    ${{ if not(startsWith( variables['Build.SourceBranchName'], 'refs/tags/' )) }}:
       pull_request: true
       docker_org: strimzi
       docker_registry: localhost:5000


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Azure pipeline currently doesn't properly build and push container images for release tags. This PR tries to fix it.