### PR TITLE
NEW(Tests) OAuth2 with SASL plain test

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
@@ -33,7 +33,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -74,7 +73,6 @@ public class OauthPlainST extends OauthAbstractST {
         ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
     }
 
-    @Disabled("Example Kafka Clients do not support this yet - https://github.com/strimzi/client-examples/pull/54")
     @Test
     void testSaslPlainProducerConsumer() {
         String plainAdditionalConfig =

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
@@ -33,6 +33,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -71,6 +72,42 @@ public class OauthPlainST extends OauthAbstractST {
 
         oauthInternalClientJob.createAndWaitForReadiness(oauthInternalClientJob.consumerStrimziOauthPlain().build());
         ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, NAMESPACE, MESSAGE_COUNT);
+    }
+
+    @Disabled("Example Kafka Clients do not support this yet - https://github.com/strimzi/client-examples/pull/54")
+    @Test
+    void testSaslPlainProducerConsumer() {
+        String plainAdditionalConfig =
+                "sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=%s password=%s;\n" +
+                        "sasl.mechanism=PLAIN";
+
+        KafkaOauthExampleClients plainSaslOauthConsumerClientsJob = new KafkaOauthExampleClients.Builder()
+                .withConsumerName(OAUTH_CLIENT_AUDIENCE_CONSUMER)
+                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(oauthClusterName))
+                .withTopicName(TOPIC_NAME)
+                .withMessageCount(MESSAGE_COUNT)
+                .withOAuthClientId(OAUTH_CLIENT_NAME)
+                .withOAuthClientSecret(OAUTH_CLIENT_SECRET)
+                .withOAuthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                .withAdditionalConfig(String.format(plainAdditionalConfig, OAUTH_CLIENT_AUDIENCE_CONSUMER, OAUTH_CLIENT_AUDIENCE_SECRET))
+                .build();
+
+        KafkaOauthExampleClients plainSaslOauthProducerClientsJob = new KafkaOauthExampleClients.Builder()
+                .withProducerName(OAUTH_CLIENT_AUDIENCE_PRODUCER)
+                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(oauthClusterName))
+                .withTopicName(TOPIC_NAME)
+                .withMessageCount(MESSAGE_COUNT)
+                .withOAuthClientId(OAUTH_CLIENT_NAME)
+                .withOAuthClientSecret(OAUTH_CLIENT_SECRET)
+                .withOAuthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                .withAdditionalConfig(String.format(plainAdditionalConfig, OAUTH_CLIENT_AUDIENCE_PRODUCER, OAUTH_CLIENT_AUDIENCE_SECRET))
+                .build();
+
+        plainSaslOauthProducerClientsJob.createAndWaitForReadiness(plainSaslOauthProducerClientsJob.producerStrimziOauthPlain().build());
+        ClientUtils.waitForClientSuccess(OAUTH_CLIENT_AUDIENCE_PRODUCER, NAMESPACE, MESSAGE_COUNT);
+
+        plainSaslOauthConsumerClientsJob.createAndWaitForReadiness(plainSaslOauthConsumerClientsJob.consumerStrimziOauthPlain().build());
+        ClientUtils.waitForClientSuccess(OAUTH_CLIENT_AUDIENCE_CONSUMER, NAMESPACE, MESSAGE_COUNT);
     }
 
     @Test


### PR DESCRIPTION
This is a test for https://github.com/strimzi/strimzi-kafka-operator/pull/3961/ Integration of OAuth over PLAIN
Test passes fine with my changes to kafka example clients. Changes are in PR https://github.com/strimzi/client-examples/pull/54

Currently I have used junit 5 annotation `@Disabled` which does not seem to work for me when I am executing single test from IDEA UI.

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

