### PR TITLE
Fix Kafka binaries cache in Regression and Upgrade tests without image build

### DIFF
--- a/.azure/templates/system_test_general.yaml
+++ b/.azure/templates/system_test_general.yaml
@@ -44,6 +44,10 @@ jobs:
       displayName: "Build Strimzi images"
       condition: eq(variables['docker_tag'], 'latest')
 
+    - bash: mkdir -p docker-images/kafka/tmp/archives
+      displayName: "Create dir for Kafka binaries cache"
+      condition: ne(variables['docker_tag'], 'latest')
+
       # We need to set DOCKER_REGISTRY to IP and port of service, which is created by minikube registry addon, port is always 80
       # Default value for PRs is localhost:5000 because we need to push built images into minikube registry and make them available for pods
     - script: |


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Kafka binaries cache is used to deal with slow downloads of Kafka binaries. However, when system tests are run against release, they do not build their own images but use the already build ones. And therefore they do not create the directory which is being cached. That causes the cache to fail later. This PR tries to add additional step run when the image build is not run to manually create the directory and that way make sure the cache tasks passes.