### PR TITLE
Use packaging/install... in upgrade preparations on azure

### DIFF
--- a/.azure/scripts/setup_upgrade.sh
+++ b/.azure/scripts/setup_upgrade.sh
@@ -2,16 +2,16 @@
 
 sed -i "s#quay.io/strimzi/test-client:latest#${DOCKER_REGISTRY}/${DOCKER_ORG}/test-client:${DOCKER_TAG}#g" systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
 
-sed -i "s#:latest#:${DOCKER_TAG}#g" install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
-sed -i "s#/opt/${DOCKER_REGISTRY}#/opt#g" install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
-sed -i "s#quay.io/strimzi/kafka#${DOCKER_REGISTRY}/${DOCKER_ORG}/kafka#g" install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
-sed -i "s#quay.io/strimzi/operator#${DOCKER_REGISTRY}/${DOCKER_ORG}/operator#g" install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
-sed -i "s#quay.io/strimzi/jmxtrans#${DOCKER_REGISTRY}/${DOCKER_ORG}/jmxtrans#g" install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
+sed -i "s#:latest#:${DOCKER_TAG}#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
+sed -i "s#/opt/${DOCKER_REGISTRY}#/opt#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
+sed -i "s#quay.io/strimzi/kafka#${DOCKER_REGISTRY}/${DOCKER_ORG}/kafka#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
+sed -i "s#quay.io/strimzi/operator#${DOCKER_REGISTRY}/${DOCKER_ORG}/operator#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
+sed -i "s#quay.io/strimzi/jmxtrans#${DOCKER_REGISTRY}/${DOCKER_ORG}/jmxtrans#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
 
 sed -i "s#strimzi/kafka:latest#${DOCKER_ORG}/kafka:${DOCKER_TAG}#g" systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
 sed -i "s#strimzi/operator:latest#${DOCKER_ORG}/operator:${DOCKER_TAG}#g" systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
 
-cat install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
+cat packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
 cat systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
 cat systemtest/src/test/resources/upgrade/StrimziDowngradeST.json
 


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

We forgot to change paths for upgrade preparations in azure pipelines.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

