### PR TITLE
Remove deprecated annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 * Remove support for Kafka 2.5.x
 
+### Changes, deprecations and removals
+
+* The following annotations have been removed and cannot be used anymore:
+  * `cluster.operator.strimzi.io/delete-claim` (used internally only - replaced by `strimzi.io/delete-claim`)
+  * `operator.strimzi.io/generation` (used internally only - replaced by `strimzi.io/generation`)
+  * `operator.strimzi.io/delete-pod-and-pvc` (use `strimzi.io/delete-pod-and-pvc` instead)
+  * `operator.strimzi.io/manual-rolling-update` (use `strimzi.io/manual-rolling-update` instead)
+
 ## 0.22.0
 
 * Add `v1beta2` version for all resources. `v1beta2` removes all deprecated fields.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -79,7 +79,6 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorageOverride;
 import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.api.kafka.model.template.PodManagementPolicy;
-import io.strimzi.operator.cluster.ClusterOperator;
 import io.strimzi.operator.common.MetricsAndLogging;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Util;
@@ -152,9 +151,6 @@ public abstract class AbstractModel {
      */
     public static final String ANNO_STRIMZI_IO_STORAGE = Annotations.STRIMZI_DOMAIN + "storage";
     public static final String ANNO_STRIMZI_IO_DELETE_CLAIM = Annotations.STRIMZI_DOMAIN + "delete-claim";
-
-    @Deprecated
-    public static final String ANNO_CO_STRIMZI_IO_DELETE_CLAIM = ClusterOperator.STRIMZI_CLUSTER_OPERATOR_DOMAIN + "/delete-claim";
 
     private static final String ENV_VAR_HTTP_PROXY = "HTTP_PROXY";
     private static final String ENV_VAR_HTTPS_PROXY = "HTTPS_PROXY";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -775,15 +775,13 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          *
          * @return  Future with the result of the rolling update
          */
-        @SuppressWarnings("deprecation")
         Future<Void> kafkaManualPodRollingUpdate(StatefulSet sts) {
             return podOperations.listAsync(namespace, kafkaCluster.getSelectorLabels())
                     .compose(pods -> {
                         List<String> podsToRoll = new ArrayList<>(0);
 
                         for (Pod pod : pods)    {
-                            if (Annotations.booleanAnnotation(pod, Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE,
-                                    false, Annotations.ANNO_OP_STRIMZI_IO_MANUAL_ROLLING_UPDATE)) {
+                            if (Annotations.booleanAnnotation(pod, Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, false)) {
                                 podsToRoll.add(pod.getMetadata().getName());
                             }
                         }
@@ -811,14 +809,12 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          *
          * @return  Future with the result of the rolling update
          */
-        @SuppressWarnings("deprecation")
         Future<ReconciliationState> kafkaManualRollingUpdate() {
             Future<StatefulSet> futsts = kafkaSetOperations.getAsync(namespace, KafkaCluster.kafkaClusterName(name));
             if (futsts != null) {
                 return futsts.compose(sts -> {
                     if (sts != null) {
-                        if (Annotations.booleanAnnotation(sts, Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE,
-                                false, Annotations.ANNO_OP_STRIMZI_IO_MANUAL_ROLLING_UPDATE)) {
+                        if (Annotations.booleanAnnotation(sts, Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, false)) {
                             // User trigger rolling update of the whole StatefulSet
                             return maybeRollKafka(sts, pod -> {
                                 if (pod == null) {
@@ -849,15 +845,13 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          *
          * @return  Future with the result of the rolling update
          */
-        @SuppressWarnings("deprecation")
         Future<Void> zkManualPodRollingUpdate(StatefulSet sts) {
             return podOperations.listAsync(namespace, zkCluster.getSelectorLabels())
                     .compose(pods -> {
                         List<String> podsToRoll = new ArrayList<>(0);
 
                         for (Pod pod : pods)    {
-                            if (Annotations.booleanAnnotation(pod, Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE,
-                                    false, Annotations.ANNO_OP_STRIMZI_IO_MANUAL_ROLLING_UPDATE)) {
+                            if (Annotations.booleanAnnotation(pod, Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, false)) {
                                 podsToRoll.add(pod.getMetadata().getName());
                             }
                         }
@@ -885,14 +879,12 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          *
          * @return  Future with the result of the rolling update
          */
-        @SuppressWarnings("deprecation")
         Future<ReconciliationState> zkManualRollingUpdate() {
             Future<StatefulSet> futsts = zkSetOperations.getAsync(namespace, ZookeeperCluster.zookeeperClusterName(name));
             if (futsts != null) {
                 return futsts.compose(sts -> {
                     if (sts != null) {
-                        if (Annotations.booleanAnnotation(sts, Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE,
-                                false, Annotations.ANNO_OP_STRIMZI_IO_MANUAL_ROLLING_UPDATE)) {
+                        if (Annotations.booleanAnnotation(sts, Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, false)) {
                             // User trigger rolling update of the whole StatefulSet
                             return zkSetOperations.maybeRollingUpdate(sts, pod -> {
                                 log.debug("{}: Rolling Zookeeper pod {} due to manual rolling update",
@@ -2785,7 +2777,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          * @param existingPvcsFuture    Future which will return a list of PVCs which actually exist
          * @return
          */
-        @SuppressWarnings("deprecation")
         Future<Void> maybeCleanPodAndPvc(StatefulSetOperator stsOperator, StatefulSet sts, List<PersistentVolumeClaim> desiredPvcs, Future<List<PersistentVolumeClaim>> existingPvcsFuture)  {
             if (sts != null) {
                 log.debug("{}: Considering manual cleaning of Pods for StatefulSet {}", reconciliation, sts.getMetadata().getName());
@@ -2797,8 +2788,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     Pod pod = podOperations.get(namespace, podName);
 
                     if (pod != null) {
-                        if (Annotations.booleanAnnotation(pod, AbstractScalableResourceOperator.ANNO_STRIMZI_IO_DELETE_POD_AND_PVC,
-                                false, AbstractScalableResourceOperator.ANNO_OP_STRIMZI_IO_DELETE_POD_AND_PVC)) {
+                        if (Annotations.booleanAnnotation(pod, AbstractScalableResourceOperator.ANNO_STRIMZI_IO_DELETE_POD_AND_PVC, false)) {
                             log.debug("{}: Pod and PVCs for {} should be deleted based on annotation", reconciliation, podName);
 
                             return existingPvcsFuture

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -204,17 +204,13 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
         return templateMetadata(desired).getName() + "-" + podId;
     }
 
-    @SuppressWarnings("deprecation")
     private void setGeneration(StatefulSet desired, int nextGeneration) {
         Map<String, String> annotations = Annotations.annotations(desired.getSpec().getTemplate());
-        annotations.remove(ANNO_OP_STRIMZI_IO_GENERATION);
         annotations.put(ANNO_STRIMZI_IO_GENERATION, String.valueOf(nextGeneration));
     }
 
-    @SuppressWarnings("deprecation")
     protected void incrementGeneration(StatefulSet current, StatefulSet desired) {
-        final int generation = Annotations.intAnnotation(current.getSpec().getTemplate(), ANNO_STRIMZI_IO_GENERATION,
-                INIT_GENERATION, ANNO_OP_STRIMZI_IO_GENERATION);
+        final int generation = Annotations.intAnnotation(current.getSpec().getTemplate(), ANNO_STRIMZI_IO_GENERATION, INIT_GENERATION);
         final int nextGeneration = generation + 1;
         setGeneration(desired, nextGeneration);
     }
@@ -226,13 +222,11 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
      * @param resource the StatefulSet.
      * @return The {@code strimzi.io/generation} of the given StatefulSet.
      */
-    @SuppressWarnings("deprecation")
     public static int getStsGeneration(StatefulSet resource) {
         if (resource == null) {
             return NO_GENERATION;
         }
-        return Annotations.intAnnotation(resource.getSpec().getTemplate(), ANNO_STRIMZI_IO_GENERATION,
-                NO_GENERATION, ANNO_OP_STRIMZI_IO_GENERATION);
+        return Annotations.intAnnotation(resource.getSpec().getTemplate(), ANNO_STRIMZI_IO_GENERATION, NO_GENERATION);
     }
 
     /**
@@ -240,13 +234,11 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
      * @param resource the Pod.
      * @return The {@code strimzi.io/generation} of the given Pod.
      */
-    @SuppressWarnings("deprecation")
     public static int getPodGeneration(Pod resource) {
         if (resource == null) {
             return NO_GENERATION;
         }
-        return Annotations.intAnnotation(resource, ANNO_STRIMZI_IO_GENERATION,
-                NO_GENERATION, ANNO_OP_STRIMZI_IO_GENERATION);
+        return Annotations.intAnnotation(resource, ANNO_STRIMZI_IO_GENERATION, NO_GENERATION);
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
@@ -159,7 +159,7 @@ public class JbodStorageTest {
                             boolean isDeleteClaim = ((PersistentClaimStorage) volume).isDeleteClaim();
                             assertThat("deleteClaim value did not match for volume : " + volume.toString(),
                                     Annotations.booleanAnnotation(pvc, AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM,
-                                            false, AbstractModel.ANNO_CO_STRIMZI_IO_DELETE_CLAIM),
+                                            false),
                                     is(isDeleteClaim));
 
                         }

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -41,8 +41,6 @@ public class Annotations {
     // This annotation with related possible values (approve, stop, refresh) is set by the user for interacting
     // with the rebalance operator in order to start, stop, or refresh rebalancing proposals and operations.
     public static final String ANNO_STRIMZI_IO_REBALANCE = STRIMZI_DOMAIN + "rebalance";
-    @Deprecated
-    public static final String ANNO_OP_STRIMZI_IO_MANUAL_ROLLING_UPDATE = "operator." + Annotations.STRIMZI_DOMAIN + "manual-rolling-update";
 
     /**
      * Annotations for restarting KafkaConnector and KafkaMirrorMaker2 connectors or tasks

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableResourceOperator.java
@@ -30,11 +30,7 @@ public abstract class AbstractScalableResourceOperator<C extends KubernetesClien
         extends AbstractReadyResourceOperator<C, T, L, R> {
 
     public static final String ANNO_STRIMZI_IO_GENERATION = Annotations.STRIMZI_DOMAIN + "generation";
-    @Deprecated
-    public static final String ANNO_OP_STRIMZI_IO_GENERATION = "operator." + Annotations.STRIMZI_DOMAIN + "generation";
     public static final String ANNO_STRIMZI_IO_DELETE_POD_AND_PVC = Annotations.STRIMZI_DOMAIN + "delete-pod-and-pvc";
-    @Deprecated
-    public static final String ANNO_OP_STRIMZI_IO_DELETE_POD_AND_PVC = "operator." + Annotations.STRIMZI_DOMAIN + "delete-pod-and-pvc";
 
     private final Logger log = LogManager.getLogger(getClass());
 


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR removes the deprecated annotations:
  * `cluster.operator.strimzi.io/delete-claim` (used internally only - replaced by `strimzi.io/delete-claim`)
  * `operator.strimzi.io/generation` (used internally only - replaced by `strimzi.io/generation`)
  * `operator.strimzi.io/delete-pod-and-pvc` (use `strimzi.io/delete-pod-and-pvc` instead)
  * `operator.strimzi.io/manual-rolling-update` (use `strimzi.io/manual-rolling-update` instead)

This should close #4251 

### Checklist

- [x] Make sure all tests pass
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md