### PR TITLE
Fix re-run command when whole ST class fails in before all

### DIFF
--- a/systemtest/scripts/results_info.sh
+++ b/systemtest/scripts/results_info.sh
@@ -48,7 +48,7 @@ FAILED_TESTS=$(find "${RESULTS_PATH}" -name 'TEST*.xml' -type f -print0 | xargs 
 echo ${FAILED_TESTS}
 echo "Creating body ..."
 
-TMP_FAILED_TESTS=$(find "${RESULTS_PATH}" -name 'TEST*.xml' -type f -print0 | xargs -0 sed -n "s#\(<testcase.*time=\"[0-9]*,\{0,1\}[0-9]\{1,3\}\..*[^\/]>\)#\1#p" | awk -F '"' '{print "" $4 "#" $2}')
+TMP_FAILED_TESTS=$(find "${RESULTS_PATH}" -name 'TEST*.xml' -type f -print0 | xargs -0 sed -n "s#\(<testcase.*time=\"[0-9]*,\{0,1\}[0-9]\{1,3\}\..*[^\/]>\)#\1#p" | awk -F '"' '{ if($2 != "") {print $4 "#" $2} else { print $4 }}')
 COMMAND="@strimzi-ci run tests ${TEST_ONLY} profile=${TEST_PROFILE} testcase="
 
 for line in ${TMP_FAILED_TESTS}


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Fix

### Description

When we executing tests where the `@BeforeAll` sections fails before the single tests are started, the Jenkins `re-run command` looks like this:
```
Re-run command:
@strimzi-ci run tests false profile=regression,acceptance testcase=io.strimzi.systemtest.security.SecurityST#,io.strimzi.systemtest.bridge.HttpBridgeKafkaExternalListenersST#,io.strimzi.systemtest.log.LoggingChangeST#,io.strimzi.systemtest.kafka.listeners.ListenersST#
```
This PR fixes this "behavior". Result:
```
**Re-run command**:
@strimzi-ci run tests  profile=regression testcase=io.strimzi.systemtest.operators.ReconciliationST#testPauseReconciliationInKafkaRebalanceAndTopic
```
```
**Re-run command**:
@strimzi-ci run tests  profile=regression,acceptance testcase=io.strimzi.systemtest.kafka.listeners.ListenersST,io.strimzi.systemtest.log.LoggingChangeST,io.strimzi.systemtest.security.SecurityST,io.strimzi.systemtest.bridge.HttpBridgeKafkaExternalListenersST
```

### Checklist

- [x] Make sure all tests pass
