### PR TITLE
ST OauthExampleClients can use custom clientId/secret

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaOauthExampleClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaOauthExampleClients.java
@@ -13,13 +13,21 @@ import java.security.InvalidParameterException;
 public class KafkaOauthExampleClients extends KafkaBasicExampleClients {
 
     private final String oauthClientId;
+    private String oauthProducerClientId = null;
+    private String oauthConsumerClientId = null;
     private final String oauthClientSecret;
+    private String oauthProducerSecret = null;
+    private String oauthConsumerSecret = null;
     private final String oauthTokenEndpointUri;
     private final String userName;
 
     public static class Builder extends KafkaBasicExampleClients.Builder {
         private String oauthClientId;
+        private String oauthProducerClientId;
+        private String oauthConsumerClientId;
         private String oauthClientSecret;
+        private String oauthProducerSecret;
+        private String oauthConsumerSecret;
         private String oauthTokenEndpointUri;
         private String userName;
 
@@ -28,8 +36,28 @@ public class KafkaOauthExampleClients extends KafkaBasicExampleClients {
             return this;
         }
 
+        public Builder withOAuthProducerClientId(String oauthProducerClientId) {
+            this.oauthProducerClientId = oauthProducerClientId;
+            return this;
+        }
+
+        public Builder withOAuthConsumerClientId(String oauthConsumerClientId) {
+            this.oauthConsumerClientId = oauthConsumerClientId;
+            return this;
+        }
+
         public Builder withOAuthClientSecret(String oauthClientSecret) {
             this.oauthClientSecret = oauthClientSecret;
+            return this;
+        }
+
+        public Builder withOAuthProducerSecret(String oauthProducerSecret) {
+            this.oauthProducerSecret = oauthProducerSecret;
+            return this;
+        }
+
+        public Builder withOAuthConsumerSecret(String oauthConsumerSecret) {
+            this.oauthConsumerSecret = oauthConsumerSecret;
             return this;
         }
 
@@ -91,10 +119,18 @@ public class KafkaOauthExampleClients extends KafkaBasicExampleClients {
 
     protected KafkaOauthExampleClients(KafkaOauthExampleClients.Builder builder) {
         super(builder);
-        if (builder.oauthClientId == null || builder.oauthClientId.isEmpty()) throw new InvalidParameterException("OAuth client id is not set.");
-        if (builder.oauthClientSecret == null || builder.oauthClientSecret.isEmpty()) throw new InvalidParameterException("OAuth client secret is not set.");
+        if ((builder.oauthClientId == null || builder.oauthClientId.isEmpty()) &&
+                (builder.oauthConsumerClientId == null && builder.oauthProducerClientId == null)) throw new InvalidParameterException("OAuth clientId is not set.");
+        if (builder.oauthClientSecret == null || builder.oauthClientSecret.isEmpty() &&
+                (builder.oauthProducerSecret == null && builder.oauthConsumerSecret == null)) throw new InvalidParameterException("OAuth client secret is not set.");
+
         if (builder.oauthTokenEndpointUri == null || builder.oauthTokenEndpointUri.isEmpty()) throw new InvalidParameterException("OAuth token endpoint url is not set.");
         if (builder.userName == null || builder.userName.isEmpty()) builder.userName = builder.oauthClientId;
+
+        if (builder.oauthProducerClientId != null) oauthProducerClientId = builder.oauthProducerClientId;
+        if (builder.oauthProducerSecret != null) oauthProducerSecret = builder.oauthProducerSecret;
+        if (builder.oauthConsumerClientId != null) oauthConsumerClientId = builder.oauthConsumerClientId;
+        if (builder.oauthConsumerSecret != null) oauthConsumerSecret = builder.oauthConsumerSecret;
 
         oauthClientId = builder.oauthClientId;
         oauthClientSecret = builder.oauthClientSecret;
@@ -150,13 +186,13 @@ public class KafkaOauthExampleClients extends KafkaBasicExampleClients {
                         .editFirstContainer()
                             .addNewEnv()
                                 .withName("OAUTH_CLIENT_ID")
-                                .withValue(oauthClientId)
+                                .withValue(oauthProducerClientId != null ? oauthProducerClientId : oauthClientId)
                             .endEnv()
                             .addNewEnv()
                                 .withName("OAUTH_CLIENT_SECRET")
                                 .editOrNewValueFrom()
                                     .withNewSecretKeyRef()
-                                        .withName(oauthClientSecret)
+                                        .withName(oauthProducerSecret != null ? oauthProducerSecret : oauthClientSecret)
                                         .withKey("clientSecret")
                                     .endSecretKeyRef()
                                 .endValueFrom()
@@ -205,7 +241,7 @@ public class KafkaOauthExampleClients extends KafkaBasicExampleClients {
                                 .withName("USER_CRT")
                                 .withNewValueFrom()
                                     .withNewSecretKeyRef()
-                                        .withName(userName)
+                                        .withName(oauthProducerClientId != null ? oauthProducerClientId : userName)
                                         .withKey("user.crt")
                                     .endSecretKeyRef()
                                 .endValueFrom()
@@ -214,7 +250,7 @@ public class KafkaOauthExampleClients extends KafkaBasicExampleClients {
                                 .withName("USER_KEY")
                                 .withNewValueFrom()
                                     .withNewSecretKeyRef()
-                                        .withName(userName)
+                                        .withName(oauthProducerClientId != null ? oauthProducerClientId : userName)
                                         .withKey("user.key")
                                     .endSecretKeyRef()
                                 .endValueFrom()
@@ -238,13 +274,13 @@ public class KafkaOauthExampleClients extends KafkaBasicExampleClients {
                         .editFirstContainer()
                             .addNewEnv()
                                 .withName("OAUTH_CLIENT_ID")
-                                .withValue(oauthClientId)
+                                .withValue(oauthConsumerClientId != null ? oauthConsumerClientId : oauthClientId)
                             .endEnv()
                             .addNewEnv()
                                 .withName("OAUTH_CLIENT_SECRET")
                                 .editOrNewValueFrom()
                                     .withNewSecretKeyRef()
-                                        .withName(oauthClientSecret)
+                                        .withName(oauthConsumerSecret != null ? oauthConsumerSecret : oauthClientSecret)
                                         .withKey("clientSecret")
                                     .endSecretKeyRef()
                                 .endValueFrom()
@@ -297,7 +333,7 @@ public class KafkaOauthExampleClients extends KafkaBasicExampleClients {
                                 .withName("USER_CRT")
                                 .withNewValueFrom()
                                     .withNewSecretKeyRef()
-                                        .withName(userName)
+                                        .withName(oauthConsumerClientId != null ? oauthConsumerClientId : userName)
                                         .withKey("user.crt")
                                     .endSecretKeyRef()
                                 .endValueFrom()
@@ -306,7 +342,7 @@ public class KafkaOauthExampleClients extends KafkaBasicExampleClients {
                                 .withName("USER_KEY")
                                 .withNewValueFrom()
                                     .withNewSecretKeyRef()
-                                        .withName(userName)
+                                        .withName(oauthConsumerClientId != null ? oauthConsumerClientId : userName)
                                         .withKey("user.key")
                                     .endSecretKeyRef()
                                 .endValueFrom()

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaOauthExampleClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaOauthExampleClients.java
@@ -147,6 +147,10 @@ public class KafkaOauthExampleClients extends KafkaBasicExampleClients {
         super.updateBuilder(builder);
         return builder
             .withOAuthClientId(getOauthClientId())
+            .withOAuthProducerClientId(getOauthProducerClientId())
+            .withOAuthProducerSecret(getOauthProducerSecret())
+            .withOAuthConsumerClientId(getOauthConsumerClientId())
+            .withOAuthConsumerSecret(getOauthConsumerSecret())
             .withOAuthClientSecret(getOauthClientSecret())
             .withOAuthTokenEndpointUri(getOauthTokenEndpointUri())
             .withUserName(getClientUserName());
@@ -159,6 +163,22 @@ public class KafkaOauthExampleClients extends KafkaBasicExampleClients {
 
     public String getOauthClientId() {
         return oauthClientId;
+    }
+
+    public String getOauthProducerClientId() {
+        return oauthProducerClientId;
+    }
+
+    public String getOauthConsumerClientId() {
+        return oauthConsumerClientId;
+    }
+
+    public String getOauthProducerSecret() {
+        return oauthProducerSecret;
+    }
+
+    public String getOauthConsumerSecret() {
+        return oauthConsumerSecret;
     }
 
     public String getOauthClientSecret() {


### PR DESCRIPTION
SystemTests Client minor Enhancement, which adds OauthExampleClients to use custom Secret/ClientID or use shared one. 


- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
