### PR TITLE
Openssl refactor

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
@@ -24,16 +24,6 @@ public interface CertManager {
     void generateSelfSignedCert(File keyFile, File certFile, Subject sbj, int days) throws IOException;
 
     /**
-     * Generate a self-signed certificate
-     *
-     * @param keyFile path to the file which will contain the private key
-     * @param certFile path to the file which will contain the self signed certificate
-     * @param days certificate duration
-     * @throws IOException If an input or output file could not be read/written.
-     */
-    void generateSelfSignedCert(File keyFile, File certFile, int days) throws IOException;
-
-    /**
      * Renew a new self-signed certificate, keeping the existing private key
      * @param keyFile path to the file containing the existing private key
      * @param certFile path to the file which contains the old certificate and
@@ -102,35 +92,11 @@ public interface CertManager {
      * @param caKey path to the file containing the CA private key
      * @param caCert path to the file containing the CA certificate
      * @param crtFile path to the file which will contain the signed certificate
-     * @param days certificate duration
-     * @throws IOException If an input or output file could not be read/written.
-     */
-    void generateCert(File csrFile, File caKey, File caCert, File crtFile, int days) throws IOException;
-
-    /**
-     * Generate a certificate signed by a Certificate Authority
-     *
-     * @param csrFile path to the file containing the certificate sign request
-     * @param caKey path to the file containing the CA private key
-     * @param caCert path to the file containing the CA certificate
-     * @param crtFile path to the file which will contain the signed certificate
      * @param sbj subject information
      * @param days certificate duration
      * @throws IOException If an input or output file could not be read/written.
      */
     void generateCert(File csrFile, File caKey, File caCert, File crtFile, Subject sbj, int days) throws IOException;
-
-    /**
-     * Generate a certificate signed by a Certificate Authority
-     *
-     * @param csrFile path to the file containing the certificate sign request
-     * @param caKey CA private key bytes
-     * @param caCert CA certificate bytes
-     * @param crtFile path to the file which will contain the signed certificate
-     * @param days certificate duration
-     * @throws IOException If an input or output file could not be read/written.
-     */
-    void generateCert(File csrFile, byte[] caKey, byte[] caCert, File crtFile, int days) throws IOException;
 
     /**
      * Generate a certificate signed by a Certificate Authority

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -276,7 +276,7 @@ public class OpenSslCertManager implements CertManager {
                     .newCertsDir(newCertsDir)
                     .basicConstraints("critical,CA:true,pathlen:" + pathLength)
                     .keyUsage("critical,keyCertSign,cRLSign")
-                    .exec();
+                    .exec(false);
 
             // The key will be in pkcs#1 format (bracketed by BEGIN/END RSA PRIVATE KEY)
             // Convert it to pkcs#8 format (bracketed by BEGIN/END PRIVATE KEY)

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -577,9 +577,10 @@ public class OpenSslCertManager implements CertManager {
             pb.environment().put("STRIMZI_keyUsage", keyUsage);
             return this;
         }
-        public OpensslArgs database(Path database, Path attr) {
+        public OpensslArgs database(Path database, Path attr) throws IOException {
             // Some versions of openssl require the presence of a index.txt.attr file
             // https://serverfault.com/questions/857131/odd-error-while-using-openssl
+            Files.writeString(attr, "unique_subject = no\n");
             pb.environment().put("STRIMZI_database", database != null ? database.toFile().getAbsolutePath() : "STRIMZI_database");
             return this;
         }

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -24,166 +24,249 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import static java.util.Arrays.asList;
-
 /**
- * An OpenSSL based certificates manager
+ * An OpenSSL based certificate manager.
+ * @see "Chapter 11 of 'Bulletproof SSL and TLS' by Ivan Ristic"
  */
 public class OpenSslCertManager implements CertManager {
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = new DateTimeFormatterBuilder()
+            .appendValue(ChronoField.YEAR, 4)
+            .appendValue(ChronoField.MONTH_OF_YEAR, 2)
+            .appendValue(ChronoField.DAY_OF_MONTH, 2)
+            .appendValue(ChronoField.HOUR_OF_DAY, 2)
+            .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+            .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+            .appendOffsetId().toFormatter();
     public static final int MAXIMUM_CN_LENGTH = 64;
 
     private static final Logger log = LogManager.getLogger(OpenSslCertManager.class);
+    public static final ZoneId UTC = ZoneId.of("UTC");
 
     public OpenSslCertManager() {}
 
     @Override
-    public void generateSelfSignedCert(File keyFile, File certFile, int days) throws IOException {
-        generateSelfSignedCert(keyFile, certFile, null, days);
+    public void generateSelfSignedCert(File keyFile, File certFile, Subject sbj, int days) throws IOException {
+        Instant now = Instant.now();
+        ZonedDateTime notBefore = now.atZone(UTC);
+        ZonedDateTime notAfter = now.plus(days, ChronoUnit.DAYS).atZone(UTC);
+        generateRootCaCert(keyFile, certFile, sbj, notBefore, notAfter, 0);
     }
 
-    @Override
-    public void generateSelfSignedCert(File keyFile, File certFile, Subject sbj, int days) throws IOException {
-
-        List<String> cmd = new ArrayList<>(asList("openssl", "req", "-x509", "-new", "-days", String.valueOf(days), "-batch", "-nodes",
-                "-out", certFile.getAbsolutePath(), "-keyout", keyFile.getAbsolutePath()));
-
-        File sna = null;
-        if (sbj != null) {
-
-            if (sbj.subjectAltNames() != null && sbj.subjectAltNames().size() > 0) {
-
-                // subject alt names need to be in an openssl configuration file
-                sna = buildConfigFile(sbj, true);
-                cmd.addAll(asList("-config", sna.toPath().toString(), "-extensions", "v3_req"));
-            }
-
-            cmd.addAll(asList("-subj", sbj.toString()));
+    public void generateRootCaCert(File keyFile, File certFile, Subject subject,
+                                   ZonedDateTime notBefore, ZonedDateTime notAfter, int pathLength) throws IOException {
+        Objects.requireNonNull(keyFile);
+        Objects.requireNonNull(certFile);
+        Objects.requireNonNull(subject);
+        checkValidity(notBefore, notAfter);
+        if (pathLength < 0) {
+            throw new IllegalArgumentException("pathLength cannot be negative: " + pathLength);
+        }
+        if (subject.subjectAltNames() != null && !subject.subjectAltNames().isEmpty()) {
+            throw new IllegalArgumentException("CA certificates should not have Subject Alternative Names");
         }
 
-        exec(cmd);
+        // Generate a CSR for the key
+        Path tmpKey = null;
+        Path defaultConfig = null;
+        Path csrFile = null;
+        Path newCertsDir = null;
+        Path database = null;
 
-        if (sna != null) {
-            if (!sna.delete()) {
-                log.warn("{} cannot be deleted", sna.getName());
-            }
+        try {
+            tmpKey = Files.createTempFile(null, null);
+            // Generate a key pair
+            new OpensslArgs("openssl", "genrsa")
+                    .optArg("-out", tmpKey)
+                    .opt("4096")
+                    .exec();
+
+            csrFile = Files.createTempFile(null, null);
+            new OpensslArgs("openssl", "req")
+                    .opt("-new")
+                    .optArg("-key", tmpKey)
+                    .optArg("-out", csrFile)
+                    .optArg("-subj", subject)
+                    .exec();
+
+            // Generate a self signed cert for the CA
+            database = Files.createTempFile(null, null);
+            newCertsDir = Files.createTempDirectory(null);
+            defaultConfig = createDefaultConfig();
+            new OpensslArgs("openssl", "ca")
+                    .opt("-utf8").opt("-batch").opt("-notext")
+                    .opt("-selfsign")
+                    .optArg("-in", csrFile)
+                    .optArg("-out", certFile)
+                    .optArg("-keyfile", tmpKey)
+                    .optArg("-startdate", notBefore)
+                    .optArg("-enddate", notAfter)
+                    .optArg("-subj", subject)
+                    .optArg("-config", defaultConfig)
+                    .database(database)
+                    .newCertsDir(newCertsDir)
+                    .basicConstraints("critical,CA:true,pathlen:" + pathLength)
+                    .keyUsage("critical,keyCertSign,cRLSign")
+                    .exec();
+
+            // The key will be in pkcs#1 format (bracketed by BEGIN/END RSA PRIVATE KEY)
+            // Convert it to pkcs#8 format (bracketed by BEGIN/END PRIVATE KEY)
+            new OpensslArgs("openssl", "pkcs8")
+                    .opt("-topk8").opt("-nocrypt")
+                    .optArg("-in", tmpKey)
+                    .optArg("-out", keyFile)
+                    .exec();
+        } finally {
+            delete(tmpKey);
+            delete(database);
+            delete(newCertsDir);
+            delete(csrFile);
+            delete(defaultConfig);
         }
+    }
+
+    void checkValidity(ZonedDateTime notBefore, ZonedDateTime notAfter) {
+        Objects.requireNonNull(notBefore);
+        Objects.requireNonNull(notAfter);
+        if (!notBefore.isBefore(notAfter)) {
+            throw new IllegalArgumentException("Invalid notBefore and notAfter: " + notBefore + " must be before " + notAfter);
+        }
+    }
+
+    static void delete(Path fileOrDir) throws IOException {
+        if (fileOrDir != null)
+            if (Files.isDirectory(fileOrDir)) {
+                Files.walk(fileOrDir)
+                        .sorted(Comparator.reverseOrder())
+                        .forEach(path -> {
+                            try {
+                                Files.delete(path);
+                            } catch (IOException e) {
+                                log.debug("File could not be deleted: {}", fileOrDir);
+                            }
+                        });
+            } else {
+                if (!Files.deleteIfExists(fileOrDir)) {
+                    log.debug("File not deleted, because it did not exist: {}", fileOrDir);
+                }
+            }
     }
 
     @Override
     public void addCertToTrustStore(File certFile, String certAlias, File trustStoreFile, String trustStorePassword)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
-
+        FileInputStream isTrustStore = null;
         try {
-            FileInputStream isTrustStore = null;
-            try {
-                // check if the truststore file is empty or not, for loading its content eventually
-                // the KeyStore class is able to create an empty store if the input stream is null
-                if (trustStoreFile.length() > 0) {
-                    isTrustStore = new FileInputStream(trustStoreFile);
-                }
+            // check if the truststore file is empty or not, for loading its content eventually
+            // the KeyStore class is able to create an empty store if the input stream is null
+            if (trustStoreFile.length() > 0) {
+                isTrustStore = new FileInputStream(trustStoreFile);
+            }
 
-                try (FileInputStream isCertificate = new FileInputStream(certFile)) {
+            try (FileInputStream isCertificate = new FileInputStream(certFile)) {
 
-                    CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
-                    X509Certificate certificate = (X509Certificate) certFactory.generateCertificate(isCertificate);
+                CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+                X509Certificate certificate = (X509Certificate) certFactory.generateCertificate(isCertificate);
 
-                    KeyStore trustStore = KeyStore.getInstance("PKCS12");
-                    trustStore.load(isTrustStore, trustStorePassword.toCharArray());
-                    trustStore.setEntry(certAlias, new KeyStore.TrustedCertificateEntry(certificate), null);
+                KeyStore trustStore = KeyStore.getInstance("PKCS12");
+                trustStore.load(isTrustStore, trustStorePassword.toCharArray());
+                trustStore.setEntry(certAlias, new KeyStore.TrustedCertificateEntry(certificate), null);
 
-                    try (FileOutputStream osTrustStore = new FileOutputStream(trustStoreFile)) {
-                        trustStore.store(osTrustStore, trustStorePassword.toCharArray());
-                    }
-                }
-            } finally {
-                if (isTrustStore != null) {
-                    isTrustStore.close();
+                try (FileOutputStream osTrustStore = new FileOutputStream(trustStoreFile)) {
+                    trustStore.store(osTrustStore, trustStorePassword.toCharArray());
                 }
             }
-        } catch (IOException | CertificateException | KeyStoreException | NoSuchAlgorithmException e) {
-            throw e;
+        } finally {
+            if (isTrustStore != null) {
+                isTrustStore.close();
+            }
         }
     }
 
     @Override
     public void addKeyAndCertToKeyStore(File keyFile, File certFile, String alias, File keyStoreFile, String keyStorePassword) throws IOException {
-
-        List<String> cmd = asList("openssl", "pkcs12", "-export", "-in", certFile.getAbsolutePath(),
-                "-inkey", keyFile.getAbsolutePath(), "-name", alias, "-out", keyStoreFile.getAbsolutePath(), "-passout",
-                "pass:" + keyStorePassword);
-
-        exec(cmd);
+        new OpensslArgs("openssl", "pkcs12")
+                .opt("-export")
+                .optArg("-in", certFile)
+                .optArg("-inkey", keyFile)
+                .optArg("-name", alias)
+                .optArg("-out", keyStoreFile)
+                .optArg("-passout", "pass:" + keyStorePassword)
+                .exec();
     }
 
     @Override
     public void deleteFromTrustStore(List<String> aliases, File trustStoreFile, String trustStorePassword)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
-
-        try {
-            try (FileInputStream isTrustStore = new FileInputStream(trustStoreFile)) {
-                KeyStore trustStore = KeyStore.getInstance("PKCS12");
-                trustStore.load(isTrustStore, trustStorePassword.toCharArray());
-                for (String alias : aliases) {
-                    trustStore.deleteEntry(alias);
-                }
-                try (FileOutputStream osTrustStore = new FileOutputStream(trustStoreFile)) {
-                    trustStore.store(osTrustStore, trustStorePassword.toCharArray());
-                }
+        try (FileInputStream isTrustStore = new FileInputStream(trustStoreFile)) {
+            KeyStore trustStore = KeyStore.getInstance("PKCS12");
+            trustStore.load(isTrustStore, trustStorePassword.toCharArray());
+            for (String alias : aliases) {
+                trustStore.deleteEntry(alias);
             }
-        } catch (IOException | CertificateException | KeyStoreException | NoSuchAlgorithmException e) {
-            throw e;
+            try (FileOutputStream osTrustStore = new FileOutputStream(trustStoreFile)) {
+                trustStore.store(osTrustStore, trustStorePassword.toCharArray());
+            }
         }
     }
 
     @Override
     public void renewSelfSignedCert(File keyFile, File certFile, Subject sbj, int days) throws IOException {
+        if (days <= 0) {
+            throw new IllegalArgumentException("Invalid validityDays " + days);
+        }
+
         // See https://serverfault.com/a/501513
 
-        //openssl req -new -key root.key -out newcsr.csr
-        File csrFile = Files.createTempFile("renewal", ".csr").toFile();
+        Path sna = null;
+        Path csrFile = null;
+        try {
+            csrFile = Files.createTempFile(null, null);
 
-        List<String> cmd = new ArrayList<>(asList("openssl", "req",
-                "-new",
-                "-batch",
-                "-out", csrFile.getAbsolutePath(),
-                "-key", keyFile.getAbsolutePath()));
-        if (sbj != null) {
-            if (sbj.subjectAltNames() != null && sbj.subjectAltNames().size() > 0) {
-                File sna = buildConfigFile(sbj, true);
-                cmd.addAll(asList("-config", sna.toPath().toString(), "-extensions", "v3_req"));
+            OpensslArgs args = new OpensslArgs("openssl", "req")
+                    .opt("-new")
+                    .opt("-batch")
+                    .optArg("-out", csrFile)
+                    .optArg("-key", keyFile);
+            if (sbj != null) {
+                if (sbj.subjectAltNames() != null && sbj.subjectAltNames().size() > 0) {
+                    sna = buildConfigFile(sbj, true);
+                    args.optArg("-config", sna, true).optArg("-extensions", "v3_req");
+                }
+                args.optArg("-subj", sbj);
             }
-            cmd.addAll(asList("-subj", sbj.toString()));
-        }
 
-        exec(cmd);
+            args.exec();
+            delete(sna);
 
-        //openssl x509 -req -days 3650 -in newcsr.csr -signkey root.key -out newroot.pem
-        List<String> cmd2 = new ArrayList<>(asList("openssl", "x509",
-                "-req",
-                "-days", String.valueOf(days),
-                "-in", csrFile.getAbsolutePath(),
-                "-signkey", keyFile.getAbsolutePath(),
-                "-out", certFile.getAbsolutePath()));
-
-        // subject alt names need to be in an openssl configuration file
-        File sna = buildConfigFile(sbj, true);
-        cmd2.addAll(asList("-extfile", sna.toPath().toString(), "-extensions", "v3_req"));
-
-        exec(cmd2);
-
-        if (!sna.delete()) {
-            log.warn("{} cannot be deleted", sna.getName());
-        }
-
-        if (!csrFile.delete()) {
-            log.warn("{} cannot be deleted", csrFile.getName());
+            // subject alt names need to be in an openssl configuration file
+            sna = buildConfigFile(sbj, true);
+            new OpensslArgs("openssl", "x509")
+                    .opt("-req")
+                    .optArg("-days", String.valueOf(days))
+                    .optArg("-in", csrFile)
+                    .optArg("-signkey", keyFile)
+                    .optArg("-out", certFile)
+                    .optArg("-extfile", sna, true)
+                    .optArg("-extensions", "v3_req")
+                    .exec();
+        } finally {
+            delete(sna);
+            delete(csrFile);
         }
     }
 
@@ -194,9 +277,9 @@ public class OpenSslCertManager implements CertManager {
      * @return openssl configuration file with subject alt names added
      * @throws IOException
      */
-    private File buildConfigFile(Subject sbj, boolean isCa) throws IOException {
-        File sna = createDefaultConfig().toFile();
-        try (BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(sna, true), StandardCharsets.UTF_8))) {
+    private Path buildConfigFile(Subject sbj, boolean isCa) throws IOException {
+        Path sna = createDefaultConfig();
+        try (BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(sna.toFile(), true), StandardCharsets.UTF_8))) {
             if (isCa) {
                 out.append("basicConstraints = critical,CA:true,pathlen:0\n");
             }
@@ -223,77 +306,88 @@ public class OpenSslCertManager implements CertManager {
     @Override
     public void generateCsr(File keyFile, File csrFile, Subject sbj) throws IOException {
 
-        List<String> cmd = new ArrayList<>(asList("openssl", "req", "-new", "-batch", "-nodes",
-                "-keyout", keyFile.getAbsolutePath(), "-out", csrFile.getAbsolutePath()));
+        OpensslArgs cmd = new OpensslArgs("openssl", "req")
+                .opt("-new").opt("-batch").opt("-nodes")
+                .optArg("-keyout", keyFile)
+                .optArg("-out", csrFile);
 
-        File sna = null;
-        if (sbj != null) {
+        Path sna = null;
+        try {
+            if (sbj != null) {
 
-            if (sbj.subjectAltNames() != null && sbj.subjectAltNames().size() > 0) {
+                if (sbj.subjectAltNames() != null && sbj.subjectAltNames().size() > 0) {
 
-                // subject alt names need to be in an openssl configuration file
-                sna = buildConfigFile(sbj, false);
-                cmd.addAll(asList("-config", sna.toPath().toString(), "-extensions", "v3_req"));
+                    // subject alt names need to be in an openssl configuration file
+                    sna = buildConfigFile(sbj, false);
+                    cmd.optArg("-config", sna, true).optArg("-extensions", "v3_req");
+                }
+
+                cmd.optArg("-subj", sbj);
             }
 
-            cmd.addAll(asList("-subj", sbj.toString()));
+            cmd.exec();
+        } finally {
+            delete(sna);
         }
-
-        exec(cmd);
-
-        if (sna != null) {
-            if (!sna.delete()) {
-                log.warn("{} cannot be deleted", sna.getName());
-            }
-        }
-    }
-
-    @Override
-    public void generateCert(File csrFile, File caKey, File caCert, File crtFile, int days) throws IOException {
-        generateCert(csrFile, caKey, caCert, crtFile, null, days);
-    }
-
-    @Override
-    public void generateCert(File csrFile, byte[] caKey, byte[] caCert, File crtFile, int days) throws IOException {
-        generateCert(csrFile, caKey, caCert, crtFile, null, days);
     }
 
     @Override
     public void generateCert(File csrFile, File caKey, File caCert, File crtFile, Subject sbj, int days) throws IOException {
+        Instant now = Instant.now();
+        ZonedDateTime notBefore = now.atZone(UTC);
+        ZonedDateTime notAfter = now.plus(days, ChronoUnit.DAYS).atZone(UTC);
+        generateCert(csrFile, caKey, caCert, crtFile, sbj, notBefore, notAfter);
+    }
 
-        List<String> cmd = new ArrayList<>(asList("openssl", "x509", "-req", "-days", String.valueOf(days),
-            "-in", csrFile.getAbsolutePath(), "-CA", caCert.getAbsolutePath(), "-CAkey", caKey.getAbsolutePath(), "-CAcreateserial",
-            "-out", crtFile.getAbsolutePath()));
+    public void generateCert(File csrFile, File caKey, File caCert, File crtFile, Subject sbj, ZonedDateTime notBefore, ZonedDateTime notAfter) throws IOException {
 
-        File sna = null;
-        if (sbj != null) {
+        checkValidity(notBefore, notAfter);
 
-            if (sbj.subjectAltNames() != null && sbj.subjectAltNames().size() > 0) {
+        Path defaultConfig = null;
+        Path database = null;
+        Path newCertsDir = null;
+        Path sna = null;
+        try {
+            defaultConfig = createDefaultConfig();
+            database = Files.createTempFile(null, null);
+            newCertsDir = Files.createTempDirectory(null);
+            OpensslArgs cmd = new OpensslArgs("openssl", "ca")
+                    .opt("-utf8").opt("-batch").opt("-notext")
+                    .optArg("-in", csrFile)
+                    .optArg("-out", crtFile)
+                    .optArg("-cert", caCert)
+                    .optArg("-keyfile", caKey)
+                    .optArg("-startdate", notBefore)
+                    .optArg("-enddate", notAfter)
+                    .optArg("-config", defaultConfig, true);
 
-                // subject alt names need to be in an openssl configuration file
-                sna = buildConfigFile(sbj, false);
-                cmd.addAll(asList("-extfile", sna.toPath().toString(), "-extensions", "v3_req"));
+            if (sbj != null) {
+
+                if (sbj.subjectAltNames() != null && sbj.subjectAltNames().size() > 0) {
+                    cmd.optArg("-extensions", "v3_req");
+                    // subject alt names need to be in an openssl configuration file
+                    sna = buildConfigFile(sbj, false);
+                    cmd.optArg("-extfile", sna, true);
+                }
             }
-        }
 
-        exec(cmd);
-
-        if (sna != null) {
-            if (!sna.delete()) {
-                log.warn("{} cannot be deleted", sna.getName());
-            }
+            cmd.database(database).newCertsDir(newCertsDir);
+            cmd.exec();
+        } finally {
+            delete(database);
+            delete(newCertsDir);
+            delete(defaultConfig);
+            delete(sna);
         }
 
         // We need to remove CA serial file
         Path path = Paths.get(caCert.getPath().replaceAll(".[a-zA-Z0-9]+$", ".srl"));
-        if (Files.exists(path)) {
-            Files.delete(path);
-        }
+        delete(path);
     }
 
     private Path createDefaultConfig() throws IOException {
         try (InputStream is = getClass().getClassLoader().getResourceAsStream("openssl.conf")) {
-            Path openSslConf = Files.createTempFile("openssl-", ".conf");
+            Path openSslConf = Files.createTempFile(null, null);
             Files.copy(is, openSslConf, StandardCopyOption.REPLACE_EXISTING);
             return openSslConf;
         }
@@ -301,54 +395,129 @@ public class OpenSslCertManager implements CertManager {
 
     @Override
     public void generateCert(File csrFile, byte[] caKey, byte[] caCert, File crtFile, Subject sbj, int days) throws IOException {
-
-        File caKeyFile = Files.createTempFile("ca-key-", ".key").toFile();
-        Files.write(caKeyFile.toPath(), caKey);
-
-        File caCertFile = Files.createTempFile("ca-crt-", ".crt").toFile();
-        Files.write(caCertFile.toPath(), caCert);
-
-        generateCert(csrFile, caKeyFile, caCertFile, crtFile, sbj, days);
-
-        if (!caKeyFile.delete()) {
-            log.warn("{} cannot be deleted", caKeyFile.getName());
-        }
-        if (!caCertFile.delete()) {
-            log.warn("{} cannot be deleted", caCertFile.getName());
-        }
-    }
-
-    private void exec(List<String> cmd) throws IOException {
-        File out = null;
-
+        Path caKeyFile = null;
+        Path caCertFile = null;
         try {
-
-            out = Files.createTempFile("openssl-", Integer.toString(cmd.hashCode())).toFile();
-
-            ProcessBuilder processBuilder = new ProcessBuilder(cmd)
-                    .redirectOutput(out)
-                    .redirectErrorStream(true);
-            log.debug("Running command {}", processBuilder.command());
-
-            Process proc = processBuilder.start();
-
-            OutputStream outputStream = proc.getOutputStream();
-            // close subprocess' stdin
-            outputStream.close();
-
-            int result = proc.waitFor();
-            String stdout = Files.readString(out.toPath(), Charset.defaultCharset());
-
-            log.debug(stdout);
-            log.debug("result {}", result);
-
-        } catch (InterruptedException ignored) {
+            caKeyFile = Files.write(Files.createTempFile(null, null), caKey);
+            caCertFile = Files.write(Files.createTempFile(null, null), caCert);
+            generateCert(csrFile, caKeyFile.toFile(), caCertFile.toFile(), crtFile, sbj, days);
         } finally {
-            if (out != null) {
-                if (!out.delete()) {
-                    log.warn("{} cannot be deleted", out.getName());
-                }
-            }
+            delete(caKeyFile);
+            delete(caCertFile);
         }
     }
+
+    /** Helper for building arg lists */
+    private static class OpensslArgs {
+        ProcessBuilder pb = new ProcessBuilder();
+        public OpensslArgs(String binary, String command) {
+            pb.command().add(binary);
+            pb.command().add(command);
+        }
+        public OpensslArgs optArg(String opt, File file) throws IOException {
+            return optArg(opt, file, false);
+        }
+        public OpensslArgs optArg(String opt, File file, boolean mayLog) throws IOException {
+            if (mayLog && log.isTraceEnabled()) {
+                log.trace("Contents of {} for option {} is:\n{}", file, opt, Files.readString(file.toPath()));
+            }
+            opt(opt);
+            pb.command().add(file.getAbsolutePath());
+            return this;
+        }
+        public OpensslArgs optArg(String opt, Path file) throws IOException {
+            return optArg(opt, file.toFile(), false);
+        }
+        public OpensslArgs optArg(String opt, Path file, boolean mayLog) throws IOException {
+            return optArg(opt, file.toFile(), mayLog);
+        }
+        public OpensslArgs optArg(String opt, ZonedDateTime dateTime) {
+            opt(opt);
+            pb.command().add(DATE_TIME_FORMATTER.format(dateTime));
+            return this;
+        }
+        public OpensslArgs opt(String option) {
+            pb.command().add(option);
+            return this;
+        }
+
+        public OpensslArgs optArg(String opt, Subject subject) {
+            opt(opt);
+            pb.command().add(subject.toString());
+            return this;
+        }
+
+        public OpensslArgs optArg(String opt, String s) {
+            opt(opt);
+            pb.command().add(s);
+            return this;
+        }
+
+        public OpensslArgs basicConstraints(String basicConstraints) {
+            pb.environment().put("STRIMZI_basicConstraints", basicConstraints);
+            return this;
+        }
+        public OpensslArgs keyUsage(String keyUsage) {
+            pb.environment().put("STRIMZI_keyUsage", keyUsage);
+            return this;
+        }
+        public OpensslArgs database(Path database) {
+            pb.environment().put("STRIMZI_database", database != null ? database.toFile().getAbsolutePath() : "STRIMZI_database");
+            return this;
+        }
+        public OpensslArgs newCertsDir(Path newCertsDir) {
+            pb.environment().put("STRIMZI_new_certs_dir", newCertsDir != null ? newCertsDir.toFile().getAbsolutePath() : "STRIMZI_new_certs_dir");
+            return this;
+        }
+
+        public void exec() throws IOException {
+
+            if (!pb.environment().containsKey("STRIMZI_basicConstraints")) {
+                basicConstraints("critical,CA:false");
+            }
+            if (!pb.environment().containsKey("STRIMZI_keyUsage")) {
+                keyUsage("critical,digitalSignature,keyEncipherment");
+            }
+            if (!pb.environment().containsKey("STRIMZI_database")) {
+                pb.environment().put("STRIMZI_database", "/dev/null");
+            }
+            if (!pb.environment().containsKey("STRIMZI_new_certs_dir")) {
+                pb.environment().put("STRIMZI_new_certs_dir", "/dev/null");
+            }
+
+            Path out = null;
+            try {
+                out = Files.createTempFile(null, null);
+                pb.redirectErrorStream(true)
+                        .redirectOutput(out.toFile());
+
+                log.debug("Running command {}", pb.command());
+
+                Process proc = pb.start();
+
+                OutputStream outputStream = proc.getOutputStream();
+                // close subprocess' stdin
+                outputStream.close();
+
+                int result = proc.waitFor();
+
+                if (result != 0) {
+                    log.error(Files.readString(out, Charset.defaultCharset()));
+                    log.error("result {}", result);
+                    throw new RuntimeException("openssl status code " + result);
+                } else {
+                    if (log.isTraceEnabled()) {
+                        log.trace(Files.readString(out, Charset.defaultCharset()));
+                    }
+                    log.debug("result {}", result);
+                }
+
+            } catch (InterruptedException ignored) {
+            } finally {
+                delete(out);
+            }
+
+        }
+    }
+
 }

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -489,7 +489,7 @@ public class OpenSslCertManager implements CertManager {
             }
 
             cmd.database(database, attr).newCertsDir(newCertsDir);
-            cmd.exec();
+            cmd.exec(false);
         } finally {
             delete(database);
             delete(attr);

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -194,7 +194,7 @@ public class OpenSslCertManager implements CertManager {
                     .newCertsDir(newCertsDir)
                     .basicConstraints("critical,CA:true,pathlen:" + pathLength)
                     .keyUsage("critical,keyCertSign,cRLSign")
-                    .exec();
+                    .exec(false);
 
             // The key will be in pkcs#1 format (bracketed by BEGIN/END RSA PRIVATE KEY)
             // Convert it to pkcs#8 format (bracketed by BEGIN/END PRIVATE KEY)
@@ -590,6 +590,10 @@ public class OpenSslCertManager implements CertManager {
         }
 
         public void exec() throws IOException {
+            exec(true);
+        }
+
+        public void exec(boolean failOnNonZero) throws IOException {
 
             if (!pb.environment().containsKey("STRIMZI_basicConstraints")) {
                 basicConstraints("critical,CA:false");
@@ -620,7 +624,7 @@ public class OpenSslCertManager implements CertManager {
 
                 int result = proc.waitFor();
 
-                if (result != 0) {
+                if (failOnNonZero && result != 0) {
                     String output = Files.readString(out, Charset.defaultCharset());
                     if (!log.isDebugEnabled()) {
                         // Include the command if we've not logged it already

--- a/certificate-manager/src/main/java/io/strimzi/certs/Subject.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/Subject.java
@@ -4,16 +4,68 @@
  */
 package io.strimzi.certs;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Represents the subject for a certificate
  */
 public class Subject {
 
+    static class Builder {
+        private String organizationName;
+        private String commonName;
+        private Map<String, Set<String>> subjectAltNames;
+        public Builder withCommonName(String commonName) {
+            this.commonName = commonName;
+            return this;
+        }
+        public Builder withOrganizationName(String organizationName) {
+            this.organizationName = organizationName;
+            return this;
+        }
+        public Builder withSubjectAlternativeName(String type, String san) {
+            if (subjectAltNames == null) {
+                subjectAltNames = new HashMap<>();
+            }
+            subjectAltNames.computeIfAbsent(type, k -> new HashSet<>()).add(san);
+            return this;
+        }
+        public Builder addDnsName(String dnsName) {
+            return withSubjectAlternativeName("DNS", dnsName);
+        }
+        public Builder withIpName(String ip) {
+            return withSubjectAlternativeName("IP", ip);
+        }
+        public Subject build() {
+            Map<String, String> san = new HashMap<>();
+            if (subjectAltNames != null) {
+                for (Map.Entry<String, Set<String>> entry : subjectAltNames.entrySet()) {
+                    int i = 0;
+                    for (String n : entry.getValue()) {
+                        san.put(entry.getKey() + "." + (i++), n);
+                    }
+                }
+            }
+            return new Subject(commonName, organizationName, san);
+        }
+
+    }
+
     private String organizationName;
     private String commonName;
     private Map<String, String> subjectAltNames;
+
+    public Subject() {
+    }
+
+    private Subject(String commonName, String organizationName, Map<String, String> subjectAltNames) {
+        this.organizationName = organizationName;
+        this.commonName = commonName;
+        this.subjectAltNames = subjectAltNames;
+    }
 
     public String organizationName() {
         return organizationName;

--- a/certificate-manager/src/main/resources/openssl.conf
+++ b/certificate-manager/src/main/resources/openssl.conf
@@ -1,11 +1,50 @@
-[req]
-distinguished_name = req_distinguished_name
-req_extensions = v3_req
+[ ca ]
+default_ca           = strimzi_ca_section
 
-[req_distinguished_name]
+[ strimzi_ca_section ]
+database             = ${ENV::STRIMZI_database}
+new_certs_dir        = ${ENV::STRIMZI_new_certs_dir}
+email_in_dn          = no
+rand_serial          =
+default_md           = sha512
+policy               = policy_c_o_match
+default_days         = 1
+x509_extensions      = strimzi_x509_extensions
 
-[v3_req]
+[ policy_c_o_match ]
+# Issued cert's O is optional
+organizationName     = optional
+# Issued cert's CN must be supplied
+commonName           = optional
+
+[ strimzi_x509_extensions ]
+subjectKeyIdentifier = hash
+basicConstraints     = ${ENV::STRIMZI_basicConstraints}
+keyUsage             = ${ENV::STRIMZI_keyUsage}
+
+[ server_ext ]
+basicConstraints     = critical,CA:false
+extendedKeyUsage     = clientAuth,serverAuth
+keyUsage             = critical,digitalSignature,keyEncipherment
+subjectKeyIdentifier = hash
+
+#[ client_ext ]
+#basicConstraints     = critical,CA:false
+#extendedKeyUsage     = clientAuth
+#keyUsage             = critical,digitalSignature
+#subjectKeyIdentifier = hash
+
+[ req ]
+# Used for renewSelfSignedCert() only
+x509_extensions      = strimzi_x509_extensions
+distinguished_name   = req_distinguished_name
+prompt               = no
+req_extensions       = v3_req
+
+[ req_distinguished_name ]
+
+[ v3_req ]
+# Used for renewSelfSignedCert() only
 # basicConstraints = critical,CA:true,pathlen:1 may be added programmatically
 # "subjectAltName = @alt_names" may be added programmatically
-
 # [alt_names] section may be added programmatically

--- a/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerTest.java
@@ -23,7 +23,6 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.CertificateParsingException;
-import java.security.cert.PKIXCertPathValidatorResult;
 import java.security.cert.PKIXParameters;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
@@ -242,11 +241,9 @@ public class OpenSslCertManagerTest {
 
         PKIXParameters pkixp = new PKIXParameters(trustAnchors);
         pkixp.setRevocationEnabled(false);
-        pkixp.setDate(new Date(now.plus(90, ChronoUnit.MINUTES).getEpochSecond()*1000));
+        pkixp.setDate(new Date(now.plus(90, ChronoUnit.MINUTES).getEpochSecond() * 1000));
 
-        CertPathValidator cpv = CertPathValidator.getInstance("PKIX");
-        PKIXCertPathValidatorResult pcpvr =
-                (PKIXCertPathValidatorResult)cpv.validate(cp, pkixp);
+        CertPathValidator.getInstance("PKIX").validate(cp, pkixp);
 
         leafKey.delete();
         csr.delete();

--- a/certificate-manager/src/test/java/io/strimzi/certs/SecretCertProviderTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/SecretCertProviderTest.java
@@ -48,7 +48,7 @@ public class SecretCertProviderTest {
         File cert = File.createTempFile("crt-", ".crt");
         File store = File.createTempFile("crt-", ".str");
 
-        ssl.generateSelfSignedCert(key, cert, 365);
+        ssl.generateSelfSignedCert(key, cert, new Subject.Builder().withCommonName("Test CA").build(), 365);
         ssl.addCertToTrustStore(cert, "ca", store, "123456");
 
         Secret secret = secretCertProvider.createSecret("my-namespace", "my-secret",
@@ -81,7 +81,7 @@ public class SecretCertProviderTest {
         File key = File.createTempFile("key-", ".key");
         File cert = File.createTempFile("crt-", ".crt");
 
-        ssl.generateSelfSignedCert(key, cert, 365);
+        ssl.generateSelfSignedCert(key, cert, new Subject.Builder().withCommonName("Test CA").build(), 365);
 
         Secret secret = secretCertProvider.createSecret("my-namespace", "my-secret",
                 "ca.key", "ca.crt",
@@ -93,7 +93,7 @@ public class SecretCertProviderTest {
         File addedKey = File.createTempFile("added-key-", ".key");
         File addedCert = File.createTempFile("added-crt-", ".crt");
 
-        ssl.generateSelfSignedCert(addedKey, addedCert, 365);
+        ssl.generateSelfSignedCert(addedKey, addedCert, new Subject.Builder().withCommonName("Test CA").build(), 365);
 
         secret = secretCertProvider.addSecret(secret, "added-key", "added-cert", addedKey, addedCert);
 

--- a/certificate-manager/src/test/resources/log4j2.properties
+++ b/certificate-manager/src/test/resources/log4j2.properties
@@ -5,7 +5,7 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-DEBUG}
+rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false

--- a/certificate-manager/src/test/resources/log4j2.properties
+++ b/certificate-manager/src/test/resources/log4j2.properties
@@ -5,7 +5,7 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
+rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-DEBUG}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false

--- a/certificate-manager/src/test/resources/log4j2.properties
+++ b/certificate-manager/src/test/resources/log4j2.properties
@@ -5,7 +5,7 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-TRACE}
+rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false

--- a/certificate-manager/src/test/resources/log4j2.properties
+++ b/certificate-manager/src/test/resources/log4j2.properties
@@ -5,7 +5,7 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
+rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-TRACE}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/MockCertManager.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/MockCertManager.java
@@ -192,19 +192,6 @@ public class MockCertManager implements CertManager {
     }
 
     /**
-     * Generate a self-signed certificate
-     *
-     * @param keyFile  path to the file which will contain the private key
-     * @param certFile path to the file which will contain the self signed certificate
-     * @param days     certificate duration
-     * @throws IOException
-     */
-    @Override
-    public void generateSelfSignedCert(File keyFile, File certFile, int days) throws IOException {
-        generateSelfSignedCert(keyFile, certFile, null, days);
-    }
-
-    /**
      * Renew a new self-signed certificate, keeping the existing private key
      *
      * @param keyFile  path to the file containing the existing private key
@@ -253,38 +240,8 @@ public class MockCertManager implements CertManager {
         write(csrFile, "csr file");
     }
 
-    /**
-     * Generate a certificate signed by a Certificate Authority
-     *
-     * @param csrFile path to the file containing the certificate sign request
-     * @param caKey   path to the file containing the CA private key
-     * @param caCert  path to the file containing the CA certificate
-     * @param crtFile path to the file which will contain the signed certificate
-     * @param days    certificate duration
-     * @throws IOException
-     */
-    @Override
-    public void generateCert(File csrFile, File caKey, File caCert, File crtFile, int days) throws IOException {
-        write(crtFile, "crt file");
-    }
-
     @Override
     public void generateCert(File csrFile, File caKey, File caCert, File crtFile, Subject sbj, int days) throws IOException {
-        write(crtFile, "crt file");
-    }
-
-    /**
-     * Generate a certificate signed by a Certificate Authority
-     *
-     * @param csrFile path to the file containing the certificate sign request
-     * @param caKey   CA private key bytes
-     * @param caCert  CA certificate bytes
-     * @param crtFile path to the file which will contain the signed certificate
-     * @param days    certificate duration
-     * @throws IOException
-     */
-    @Override
-    public void generateCert(File csrFile, byte[] caKey, byte[] caCert, File crtFile, int days) throws IOException {
         write(crtFile, "crt file");
     }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This is a refactoring and feature of the `OpenSslCertManager`. It does the following:

* Uses `openssl ca` for CA operations, which is a more powerful, but less friendly, tool. This is necessary to support creating certificates with defined end dates, rather than cert validity periods always being defined as `[now, now+days]`.
* Adds support for generating intermediate CA certificates.
* Generates the RSA keypair explicitly. There's currently no actual benefit to this, but it would allow us to support ECDSA certificates very easily should we decide that's worth doing.
* Removes some of the overload that were only used by tests (i.e. added no value).
* Adds more assertions to the tests.
* Cleans up how the list of `openssl` process options are constructed, using a helper class. There's now the ability to log (at trace level) the config files being used, which can be helpful when debugging. Keys and certs are not logged.
* Adds a `Builder` for `Subject`, because it had a super-awkward API. I've not refactored all the old call sites though.
