### PR TITLE
Pass option for test_only properly

### DIFF
--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -67,12 +67,12 @@ pipeline {
                     }
                     println("EXCLUDE_GROUPS: ${env.EXCLUDE_GROUPS}")
                     if (env.ghprbCommentBody.contains('test_only')) {
-                        env.TEST_ONLY = true
+                        env.TEST_ONLY = "true"
                         env.DOCKER_REGISTRY = "quay.io"
                         env.DOCKER_ORG="strimzi"
                         env.DOCKER_TAG = "latest"
                     } else {
-                        env.TEST_ONLY = false
+                        env.TEST_ONLY = "false"
                         env.DOCKER_ORG="strimzi"
                         env.DOCKER_REGISTRY = "172.30.1.1:5000"
                         env.DOCKER_TAG="pr"
@@ -146,7 +146,7 @@ pipeline {
         }
         stage('Build images') {
             when {
-                environment name: 'TEST_ONLY', value: false
+                environment name: 'TEST_ONLY', value: 'false'
             }
             steps {
                 script {

--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -146,7 +146,7 @@ pipeline {
         }
         stage('Build images') {
             when {
-                environment name: 'TEST_ONLY', value: 'false'
+                environment name: 'TEST_ONLY', value: false
             }
             steps {
                 script {

--- a/systemtest/scripts/results_info.sh
+++ b/systemtest/scripts/results_info.sh
@@ -48,6 +48,12 @@ FAILED_TESTS=$(find "${RESULTS_PATH}" -name 'TEST*.xml' -type f -print0 | xargs 
 echo ${FAILED_TESTS}
 echo "Creating body ..."
 
+if [[ ${TEST_ONLY} == "true" ]]; then
+	TEST_ONLY="test_only"
+else
+	TEST_ONLY=""
+fi
+
 TMP_FAILED_TESTS=$(find "${RESULTS_PATH}" -name 'TEST*.xml' -type f -print0 | xargs -0 sed -n "s#\(<testcase.*time=\"[0-9]*,\{0,1\}[0-9]\{1,3\}\..*[^\/]>\)#\1#p" | awk -F '"' '{ if($2 != "") {print $4 "#" $2} else { print $4 }}')
 COMMAND="@strimzi-ci run tests ${TEST_ONLY} profile=${TEST_PROFILE} testcase="
 


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

`test_only` is not reported properly in case of failure. Instead of a proper string, it adds to rerun cmd only true or false which is useless.



