### PR TITLE
Push images into minikube internal registry in case of images are built during PR job

### DIFF
--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -74,7 +74,7 @@ pipeline {
                     } else {
                         env.TEST_ONLY = "false"
                         env.DOCKER_ORG="strimzi"
-                        env.DOCKER_REGISTRY = "172.30.1.1:5000"
+                        env.DOCKER_REGISTRY = sh(script: "kubectl get service registry -n kube-system -o=jsonpath='{.spec.clusterIP}'", returnStdout: true).trim() + ":80"
                         env.DOCKER_TAG="pr"
                     }
                     if (env.ghprbCommentBody.contains('install_type=')) {

--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -112,6 +112,10 @@ pipeline {
                 timeout(time: 10, unit: 'MINUTES') {
                     script {
                         lib.setupKubernetes()
+                        if (!env.TEST_ONLY) {
+                            env.DOCKER_REGISTRY = sh(script: "kubectl get service registry -n kube-system -o=jsonpath='{.spec.clusterIP}'", returnStdout: true).trim() + ":80"
+                        }
+                        println("DOCKER_REGISTRY: ${env.DOCKER_REGISTRY}")
                     }
                 }
             }

--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -75,7 +75,7 @@ pipeline {
                     } else {
                         env.TEST_ONLY = "false"
                         env.DOCKER_ORG="strimzi"
-                        env.DOCKER_REGISTRY = "local"
+                        env.DOCKER_REGISTRY = "localhost:5000"
                         env.DOCKER_TAG="pr"
                     }
                     if (env.ghprbCommentBody.contains('install_type=')) {
@@ -103,7 +103,6 @@ pipeline {
                     println("DOCKER_TAG: ${env.DOCKER_TAG}")
                     println("CLUSTER_OPERATOR_INSTALL_TYPE: ${env.CLUSTER_OPERATOR_INSTALL_TYPE}")
                     println("KUBE_VERSION: ${env.KUBE_VERSION}")
-
                 }
             }
         }
@@ -112,10 +111,6 @@ pipeline {
                 timeout(time: 10, unit: 'MINUTES') {
                     script {
                         lib.setupKubernetes()
-                        if (env.TEST_ONLY == "false") {
-                            env.DOCKER_REGISTRY = sh(script: "kubectl get service registry -n kube-system -o=jsonpath='{.spec.clusterIP}'", returnStdout: true).trim() + ":80"
-                        }
-                        println("DOCKER_REGISTRY: ${env.DOCKER_REGISTRY}")
                     }
                 }
             }
@@ -156,6 +151,8 @@ pipeline {
                 script {
                     lib.buildStrimziImages()
                     env.BUILD_DOCKER_IMAGE_STATUS = true
+                    env.DOCKER_REGISTRY = sh(script: "kubectl get service registry -n kube-system -o=jsonpath='{.spec.clusterIP}'", returnStdout: true).trim() + ":80"
+                    println("DOCKER_REGISTRY: ${env.DOCKER_REGISTRY}")
                 }
             }
         }

--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -46,6 +46,7 @@ pipeline {
         stage('Parse parameters from comment') {
             steps {
                 script {
+                    lib = evaluate readFile('./.jenkins/jenkins.groovy')
                     println("Comment body: ${env.ghprbCommentBody}")
                     env.TEST_CASE = params.TEST_CASE
                     env.TEST_PROFILE = params.TEST_PROFILE
@@ -110,7 +111,6 @@ pipeline {
             steps {
                 timeout(time: 10, unit: 'MINUTES') {
                     script {
-                        lib = evaluate readFile('./.jenkins/jenkins.groovy')
                         lib.setupKubernetes()
                     }
                 }

--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -75,7 +75,7 @@ pipeline {
                     } else {
                         env.TEST_ONLY = "false"
                         env.DOCKER_ORG="strimzi"
-                        env.DOCKER_REGISTRY = sh(script: "kubectl get service registry -n kube-system -o=jsonpath='{.spec.clusterIP}'", returnStdout: true).trim() + ":80"
+                        env.DOCKER_REGISTRY = "local"
                         env.DOCKER_TAG="pr"
                     }
                     if (env.ghprbCommentBody.contains('install_type=')) {
@@ -112,7 +112,7 @@ pipeline {
                 timeout(time: 10, unit: 'MINUTES') {
                     script {
                         lib.setupKubernetes()
-                        if (!env.TEST_ONLY) {
+                        if (env.TEST_ONLY == "false") {
                             env.DOCKER_REGISTRY = sh(script: "kubectl get service registry -n kube-system -o=jsonpath='{.spec.clusterIP}'", returnStdout: true).trim() + ":80"
                         }
                         println("DOCKER_REGISTRY: ${env.DOCKER_REGISTRY}")

--- a/.jenkins/jenkins.groovy
+++ b/.jenkins/jenkins.groovy
@@ -19,13 +19,6 @@ def installYq(String workspace) {
     sh(script: "${workspace}/.azure/scripts/install_yq.sh")
 }
 
-def installKubectl(String kubeVersion) {
-    sh(script: """
-        curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v${kubeVersion}/bin/linux/amd64/kubectl && chmod +x kubectl
-        sudo cp kubectl /usr/bin
-    """)
-}
-
 def buildStrimziImages() {
     sh(script: """
         MVN_ARGS='-Dsurefire.rerunFailingTestsCount=5 -Dfailsafe.rerunFailingTestsCount=2' make docker_build

--- a/.jenkins/jenkins.groovy
+++ b/.jenkins/jenkins.groovy
@@ -21,7 +21,7 @@ def installYq(String workspace) {
 
 def installKubectl(String kubeVersion) {
     sh(script: """
-        curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${kubeVersion}/bin/linux/amd64/kubectl && chmod +x kubectl
+        curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v${kubeVersion}/bin/linux/amd64/kubectl && chmod +x kubectl
         sudo cp kubectl /usr/bin
     """)
 }

--- a/.jenkins/jenkins.groovy
+++ b/.jenkins/jenkins.groovy
@@ -21,6 +21,7 @@ def installYq(String workspace) {
 
 def buildStrimziImages() {
     sh(script: """
+        eval \$(minikube docker-env)
         MVN_ARGS='-Dsurefire.rerunFailingTestsCount=5 -Dfailsafe.rerunFailingTestsCount=2' make docker_build
         make docker_tag
         make docker_push

--- a/.jenkins/jenkins.groovy
+++ b/.jenkins/jenkins.groovy
@@ -19,6 +19,13 @@ def installYq(String workspace) {
     sh(script: "${workspace}/.azure/scripts/install_yq.sh")
 }
 
+def installKubectl(String kubeVersion) {
+    sh(script: """
+        curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${kubeVersion}/bin/linux/amd64/kubectl && chmod +x kubectl
+        sudo cp kubectl /usr/bin
+    """)
+}
+
 def buildStrimziImages() {
     sh(script: """
         MVN_ARGS='-Dsurefire.rerunFailingTestsCount=5 -Dfailsafe.rerunFailingTestsCount=2' make docker_build

--- a/.jenkins/jenkins.groovy
+++ b/.jenkins/jenkins.groovy
@@ -20,8 +20,11 @@ def installYq(String workspace) {
 }
 
 def buildStrimziImages() {
-    sh(script: "MVN_ARGS='-Dsurefire.rerunFailingTestsCount=5 -Dfailsafe.rerunFailingTestsCount=2' make docker_build")
-    sh(script: "make docker_tag")
+    sh(script: """
+        MVN_ARGS='-Dsurefire.rerunFailingTestsCount=5 -Dfailsafe.rerunFailingTestsCount=2' make docker_build
+        make docker_tag
+        make docker_push
+    """)
 }
 
 def runSystemTests(String workspace, String testCases, String testProfile, String excludeGroups) {


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

When we started using minikube internal registry, we kinda forgot to enhance the image build for PR job. This PR does it.

### Checklist

- [x] Make sure all tests pass

