### PR TITLE
[DOC] remove asciidoc parts from using guide

### DIFF
--- a/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
@@ -24,7 +24,7 @@ MirrorMaker 2.0 can be used with more than one source cluster.
 image::mirrormaker.png[MirrorMaker 2.0 replication]
 
 By default, a check for new topics in the source cluster is made every 10 minutes.
-You can change the frequency by adding `refresh.topics.interval.seconds` to the source connector configuration of the `KafkaMirrorMaker2` resource.
+You can change the frequency by adding `refresh.topics.interval.seconds` to the source connector configuration.
 However, increasing the frequency of the operation might affect overall performance.
 
 = Cluster configuration
@@ -61,7 +61,7 @@ The MirrorMaker 2.0 architecture supports unidirectional replication in an _acti
 You can use an _active/passive_ cluster configuration to make backups or migrate data to another cluster.
 In this situation, you might not want automatic renaming of remote topics.
 
-You can override automatic renaming by adding `IdentityReplicationPolicy` to the source connector configuration of the `KafkaMirrorMaker2` resource.
+You can override automatic renaming by adding `IdentityReplicationPolicy` to the source connector configuration.
 With this configuration applied, topics retain their original names.
 
 == Topic configuration synchronization
@@ -95,7 +95,7 @@ If the active cluster goes down, consumer applications can switch to the passive
 
 To use topic offset synchronization:
 
-* Enable the synchronization by adding `sync.group.offsets.enabled` to the checkpoint connector configuration of the `KafkaMirrorMaker2` resource,
+* Enable the synchronization by adding `sync.group.offsets.enabled` to the checkpoint connector configuration,
 and setting the property to `true`. Synchronization is disabled by default.
 * Add the `IdentityReplicationPolicy` to the source and checkpoint connector configuration so that topics in the target cluster retain their original names.
 

--- a/documentation/using/master.adoc
+++ b/documentation/using/master.adoc
@@ -28,9 +28,9 @@ include::assemblies/managing/assembly-management-tasks.adoc[leveloffset=+1]
 [id='api_reference-{context}']
 :parent-context: {context}
 :context: reference
-//schema part
-== Custom resource API reference
 
+== Custom resource API reference
 include::modules/con-common-configuration-properties.adoc[leveloffset=+1]
-include::modules/appendix_crds.adoc[]
+=== Schema properties
+include::modules/appendix_crds.adoc[leveloffset=+1]
 :context: {parent-context}

--- a/documentation/using/master.adoc
+++ b/documentation/using/master.adoc
@@ -5,11 +5,9 @@ include::shared/attributes.adoc[]
 
 = Using Strimzi
 
-//overview part
-include::assemblies/assembly-overview.adoc[]
+include::assemblies/assembly-overview.adoc[leveloffset=+1]
 
-//configuring part
-include::assemblies/configuring/assembly-deployment-configuration.adoc[]
+include::assemblies/configuring/assembly-deployment-configuration.adoc[leveloffset=+1]
 
 include::assemblies/assembly-securing-external-listeners.adoc[leveloffset=+1]
 
@@ -25,16 +23,14 @@ include::assemblies/tracing/assembly-distributed-tracing.adoc[leveloffset=+1]
 
 include::assemblies/security/assembly-security.adoc[leveloffset=+1]
 
-//managing part
-include::assemblies/managing/assembly-management-tasks.adoc[]
+include::assemblies/managing/assembly-management-tasks.adoc[leveloffset=+1]
 
 [id='api_reference-{context}']
 :parent-context: {context}
 :context: reference
 //schema part
-= Custom resource API reference
+== Custom resource API reference
 
-include::modules/con-common-configuration-properties.adoc[]
-== Schema properties
+include::modules/con-common-configuration-properties.adoc[leveloffset=+1]
 include::modules/appendix_crds.adoc[]
 :context: {parent-context}


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Removes asciidoc _parts_ from the Using Guide, as they were not presenting well on the web site.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

