### PR TITLE
[DOC] Kafka Exporter docs changes

### DIFF
--- a/documentation/assemblies/metrics/assembly_metrics-kafka-exporter.adoc
+++ b/documentation/assemblies/metrics/assembly_metrics-kafka-exporter.adoc
@@ -14,6 +14,8 @@ Lag data is exposed as Prometheus metrics, which can then be presented in Grafan
 
 If you are already using Prometheus and Grafana for monitoring of built-in Kafka metrics, you can configure Prometheus to also scrape the Kafka Exporter Prometheus endpoint.
 
+Strimzi includes an example Grafana dashboard for Kafka Exporter in `examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json`.
+
 include::modules/kafka-exporter/con_kafka-exporter-lag.adoc[leveloffset=+1]
 include::modules/kafka-exporter/con_kafka-exporter-alerts.adoc[leveloffset=+1]
 include::modules/kafka-exporter/ref_kafka-exporter-metrics.adoc[leveloffset=+1]

--- a/documentation/assemblies/metrics/assembly_metrics-kafka-exporter.adoc
+++ b/documentation/assemblies/metrics/assembly_metrics-kafka-exporter.adoc
@@ -14,7 +14,7 @@ Lag data is exposed as Prometheus metrics, which can then be presented in Grafan
 
 If you are already using Prometheus and Grafana for monitoring of built-in Kafka metrics, you can configure Prometheus to also scrape the Kafka Exporter Prometheus endpoint.
 
-Strimzi includes an example Grafana dashboard for Kafka Exporter in `examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json`.
+Strimzi includes an example Kafka Exporter dashboard in `examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json`.
 
 include::modules/kafka-exporter/con_kafka-exporter-lag.adoc[leveloffset=+1]
 include::modules/kafka-exporter/con_kafka-exporter-alerts.adoc[leveloffset=+1]

--- a/documentation/modules/metrics/kafka-exporter/ref_kafka-exporter-metrics.adoc
+++ b/documentation/modules/metrics/kafka-exporter/ref_kafka-exporter-metrics.adoc
@@ -6,9 +6,10 @@
 
 = Exposing Kafka Exporter metrics
 
-Lag information is exposed by Kafka Exporter as Prometheus metrics for presentation in Grafana.
+Lag information is exposed by Kafka Exporter as Prometheus metrics for presentation in Grafana. 
 
-Kafka Exporter exposes metrics data for brokers, topics and consumer groups.
+Kafka Exporter exposes metrics data for brokers, topics and consumer groups. 
+These metrics are displayed on the example `strimzi-kafka-exporter` dashboard.
 
 The data extracted is described here.
 
@@ -57,3 +58,5 @@ The data extracted is described here.
 |`kafka_consumergroup_lag`
 |Current approximate lag for a consumer group at a topic partition
 |===
+
+Consumer group metrics are only displayed on the Kafka Exporter dashboard if at least one consumer group has a lag greater than zero.

--- a/documentation/modules/metrics/proc_metrics-grafana-dashboard.adoc
+++ b/documentation/modules/metrics/proc_metrics-grafana-dashboard.adoc
@@ -7,15 +7,16 @@
 = Enabling the example Grafana dashboards
 
 Strimzi provides xref:ref-metrics-config-files-{context}[example dashboard configuration files for Grafana].
-Example dashboards are provided in the `examples/metrics` directory as JSON files:
+Example dashboards are provided in the `examples/metrics/grafana-dashboards` directory as JSON files:
 
 * `strimzi-kafka.json`
 * `strimzi-zookeeper.json`
+* `strimzi-operators.json`
 * `strimzi-kafka-connect.json`
 * `strimzi-kafka-mirror-maker-2.json`
-* `strimzi-operators.json`
 * `strimzi-kafka-bridge.json`
 * `strimzi-cruise-control.json`
+* `strimzi-kafka-exporter.json`
 
 The example dashboards are a good starting point for monitoring key metrics, but they do not represent all available metrics.
 You can modify the example dashboards or add other metrics, depending on your infrastructure.
@@ -36,7 +37,6 @@ NOTE: The name of the Grafana pod is different for each user.
 ----
 kubectl get service grafana
 ----
-
 +
 For example:
 +
@@ -131,6 +131,20 @@ Strimzi ZooKeeper:: Shows metrics for:
 * JVM garbage collection count
 * Amount of time it takes for the server to respond to a client request (maximum, minimum and average)
 
+Strimzi Operators:: Shows metrics for:
++
+* Custom resources
+* Successful custom resource reconciliations per hour
+* Failed custom resource reconciliations per hour
+* Reconciliations without locks per hour
+* Reconciliations started hour
+* Periodical reconciliations per hour
+* Maximum reconciliation time
+* Average reconciliation time
+* JVM memory used
+* JVM garbage collection time
+* JVM garbage collection count
+
 Strimzi Kafka Connect:: Shows metrics for:
 +
 * Total incoming byte rate
@@ -149,16 +163,25 @@ Strimzi Kafka MirrorMaker 2:: Shows metrics for:
 * JVM memory used
 * JVM garbage collection time
 
-Strimzi Operators:: Shows metrics for:
+Strimzi Kafka Bridge:: Shows metrics for:
 +
-* Custom resources
-* Successful custom resource reconciliations per hour
-* Failed custom resource reconciliations per hour
-* Reconciliations without locks per hour
-* Reconciliations started hour
-* Periodical reconciliations per hour
-* Maximum reconciliation time
-* Average reconciliation time
-* JVM memory used
-* JVM garbage collection time
-* JVM garbage collection count
+* ???
+* ???
+* ???
+* ???
+
+Strimzi Cruise Control:: Shows metrics for:
++
+* ???
+* ???
+* ???
+* ???
+
+Strimzi Kafka Exporter:: Shows metrics for:
++
+* Number of Kafka brokers
+* Topics and replicas
+* Consumer groups
+
+For the full list of Kafka Exporter metrics, see xref:ref-metrics-kafka-exporter--{context}[].
+ 

--- a/documentation/modules/metrics/proc_metrics-grafana-dashboard.adoc
+++ b/documentation/modules/metrics/proc_metrics-grafana-dashboard.adoc
@@ -163,25 +163,9 @@ Strimzi Kafka MirrorMaker 2:: Shows metrics for:
 * JVM memory used
 * JVM garbage collection time
 
-Strimzi Kafka Bridge:: Shows metrics for:
-+
-* ???
-* ???
-* ???
-* ???
+Strimzi Kafka Bridge:: See xref:assembly-kafka-bridge-{context}[].
 
-Strimzi Cruise Control:: Shows metrics for:
-+
-* ???
-* ???
-* ???
-* ???
+Strimzi Cruise Control:: See xref:assembly-cruise-control-{context}[].
 
-Strimzi Kafka Exporter:: Shows metrics for:
-+
-* Number of Kafka brokers
-* Topics and replicas
-* Consumer groups
-
-For the full list of Kafka Exporter metrics, see xref:ref-metrics-kafka-exporter--{context}[].
+Strimzi Kafka Exporter:: See xref:proc-kafka-exporter-enabling-{context}[]. 
  

--- a/documentation/modules/metrics/ref_metrics-config-files.adoc
+++ b/documentation/modules/metrics/ref_metrics-config-files.adoc
@@ -7,7 +7,7 @@
 
 = Example metrics files
 
-You can find example Grafana dashboards and other metrics configuration files in the {ExampleMetrics}[`examples/metrics` directory^].
+You can find example Grafana dashboards and other metrics configuration files in the `examples/metrics` directory.
 
 .Example metrics files provided with Strimzi
 [source]

--- a/documentation/modules/metrics/ref_metrics-config-files.adoc
+++ b/documentation/modules/metrics/ref_metrics-config-files.adoc
@@ -39,7 +39,7 @@ metrics
 ├── kafka-metrics.yaml <12>
 └── kafka-mirror-maker-2-metrics.yaml <13>
 --
-<1> Grafana dashboards.
+<1> Example Grafana dashboards for the different Strimzi components.
 <2> Installation file for the Grafana image.
 <3> Additional configuration to scrape metrics for CPU, memory and disk volume usage, which comes directly from the Kubernetes cAdvisor agent and kubelet on the nodes.
 <4> Hook definitions for sending notifications through Alertmanager.
@@ -64,6 +64,7 @@ Example Grafana dashboards are provided for monitoring:
 * Kafka MirrorMaker 2.0
 * xref:assembly-kafka-bridge-{context}[Kafka Bridge]
 * xref:assembly-cruise-control-{context}[Cruise Control]
+* xref:assembly-kafka-exporter-{context}[Kafka Exporter]
 
 All dashboards provide JVM metrics, as well as metrics specific to the component.
 For example, the Grafana dashboard for Strimzi Operators provides information on the number of reconciliations or custom resources they are processing.
@@ -71,11 +72,9 @@ For example, the Grafana dashboard for Strimzi Operators provides information on
 [id='ref-metrics-yaml-files-{context}']
 == Example Prometheus metrics configuration
 
-Strimzi uses the link:https://github.com/prometheus/jmx_exporter[Prometheus JMX Exporter^] to expose JMX metrics using an HTTP endpoint,
-which is then scraped by the Prometheus server.
+Strimzi uses the link:https://github.com/prometheus/jmx_exporter[Prometheus JMX Exporter^] to expose JMX metrics using an HTTP endpoint, which is then scraped by the Prometheus server.
 
-Grafana dashboards are dependent on Prometheus JMX Exporter relabeling rules,
-which are defined for Strimzi components as custom resource configuration.
+Grafana dashboards are dependent on Prometheus JMX Exporter relabeling rules, which are defined for Strimzi components as custom resource configuration.
 
 A label is a name-value pair.
 Relabeling is the process of writing a label dynamically.

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -35,7 +35,6 @@
 :ReleaseDownload: https://github.com/strimzi/strimzi-kafka-operator/releases[GitHub^]
 
 //Monitoring links
-:ExampleMetrics: link:https://github.com/strimzi/strimzi-kafka-operator/tree/{GithubVersion}/examples/metrics/
 :GrafanaHome: link:https://grafana.com/[Grafana Labs^]
 :JMXExporter: link:https://github.com/prometheus/jmx_exporter[JMX Exporter documentation^]
 :PrometheusHome: link:https://github.com/prometheus[Prometheus^]
@@ -169,7 +168,6 @@
 
 //EXCLUSIVE TO STRIMZI
 :sectlinks:
-:GithubVersion: master
 
 // Helm Chart - deploy cluster operator
 :ChartName: strimzi-kafka-operator


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Guide(s) updated: _Deploying and upgrading Strimzi_

This docs PR makes a few changes related to Kafka Exporter.

- Mention the example Grafana dashboard for Kafka Exporter in a few more places. 
- Add a note that consumer group metrics only display if there is some lag.
- Add missing dashboards for Cruise Control and Kafka Bridge to the list in "Enabling the example Grafana dashboards"
- Remove the link attribute that was pointing to the [master branch](https://github.com/strimzi/strimzi-kafka-operator/tree/master/examples/metrics). I think it's better to mention the `examples/metrics` directory rather than linking to GitHub. 

NOTE: I checked that the `:GithubVersion: master` attribute is not used anywhere else in the documentation.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

