### PR TITLE
[jenkins] Run PR jobs on latest-stable released version of k8s

### DIFF
--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -31,6 +31,7 @@ pipeline {
         TEST_HELM2_VERSION = "v2.17.0"
         TEST_HELM3_VERSION = "v3.4.2"
         TEST_CLUSTER = "minikube"
+        KUBE_VERSION = "stable"
     }
     stages {
         stage('Clean WS') {

--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -31,7 +31,6 @@ pipeline {
         TEST_HELM2_VERSION = "v2.17.0"
         TEST_HELM3_VERSION = "v3.4.2"
         TEST_CLUSTER = "minikube"
-        KUBE_VERSION = "stable"
     }
     stages {
         stage('Clean WS') {
@@ -92,7 +91,7 @@ pipeline {
                         env.KUBE_VERSION = env.ghprbCommentBody.split('kube_version=')[1].split(/\s/)[0]
                     } else {
                         // Default version (the oldest supported by Strimzi)
-                        env.KUBE_VERSION = "1.16.0"
+                        env.KUBE_VERSION = "stable"
                     }
                     println("ENV_VARS: ${env.ENV_VARS}")
                     env.BUILD_PROJECT_STATUS = false


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

Because we are using  k8s version `1.16.0` on both Azure and Jenkins, it sometimes doesn't show us some problems on "newer" versions and potential bugs are found late. We should run Azure against last supported version (`1.16.0`) and Jenkins against the latest version.

This PR adding `KUBE_VERSION` env set to `stable` (which is latest released stable version of k8s) 

### Checklist

- [x] Make sure all tests pass
