### PR TITLE
Avoid using withNewConfigMapKeyRef which seems to cause issues in some Java environments

### DIFF
--- a/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/CrdUpgradeCommandIT.java
+++ b/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/CrdUpgradeCommandIT.java
@@ -106,7 +106,7 @@ public class CrdUpgradeCommandIT {
                             .withNewJmxPrometheusExporterMetricsConfig()
                                 .withNewValueFrom()
                                     .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder()
-                                            .withKey("zoo-metrics")
+                                            .withKey("kafka-metrics")
                                             .withName("metrics-cm")
                                             .withOptional(false)
                                             .build())

--- a/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/CrdUpgradeCommandIT.java
+++ b/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/CrdUpgradeCommandIT.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.kafka.api.conversion.cli;
 
+import io.fabric8.kubernetes.api.model.ConfigMapKeySelectorBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
@@ -74,7 +75,11 @@ public class CrdUpgradeCommandIT {
                             .endEphemeralStorage()
                             .withNewJmxPrometheusExporterMetricsConfig()
                                 .withNewValueFrom()
-                                    .withNewConfigMapKeyRef("zoo-metrics", "metrics-cm", false)
+                                    .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder()
+                                            .withKey("zoo-metrics")
+                                            .withName("metrics-cm")
+                                            .withOptional(false)
+                                            .build())
                                 .endValueFrom()
                             .endJmxPrometheusExporterMetricsConfig()
                         .endZookeeper()
@@ -100,7 +105,11 @@ public class CrdUpgradeCommandIT {
                             .endEphemeralStorage()
                             .withNewJmxPrometheusExporterMetricsConfig()
                                 .withNewValueFrom()
-                                    .withNewConfigMapKeyRef("kafka-metrics", "metrics-cm", false)
+                                    .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder()
+                                            .withKey("zoo-metrics")
+                                            .withName("metrics-cm")
+                                            .withOptional(false)
+                                            .build())
                                 .endValueFrom()
                             .endJmxPrometheusExporterMetricsConfig()
                         .endKafka()

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -1004,7 +1004,11 @@ class LoggingChangeST extends AbstractST {
                 .editKafka()
                 .withExternalLogging(new ExternalLoggingBuilder()
                     .withNewValueFrom()
-                        .withNewConfigMapKeyRef("log4j.properties", "external-cm", false)
+                        .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder()
+                                .withKey("log4j.properties")
+                                .withName("external-cm")
+                                .withOptional(false)
+                                .build())
                     .endValueFrom()
                     .build())
                 .endKafka()
@@ -1022,7 +1026,11 @@ class LoggingChangeST extends AbstractST {
         KafkaResource.replaceKafkaResource(clusterName, kafka -> kafka.getSpec().getKafka().setLogging(
             new ExternalLoggingBuilder()
                 .withNewValueFrom()
-                    .withNewConfigMapKeyRef("log4j.properties", "not-existing-cm-name", false)
+                    .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder()
+                            .withKey("log4j.properties")
+                            .withName("non-existing-cm-name")
+                            .withOptional(false)
+                            .build())
                 .endValueFrom()
                 .build()));
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It looks like in some environments, using `withNewConfigMapKeyRef` does not compile:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile (default-testCompile) on project api-conversion: Compilation failure
[ERROR] /user_me/Documents/workspace/strimzi-kafka-operator-0.22.0-test/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/CrdUpgradeCommandIT.java:[77,37] cannot find symbol
[ERROR]   symbol:   method withNewConfigMapKeyRef(java.lang.String,java.lang.String,boolean)
[ERROR]   location: interface io.strimzi.api.kafka.model.JmxPrometheusExporterMetricsFluent.ValueFromNested<io.strimzi.api.kafka.model.ZookeeperClusterSpecFluent.JmxPrometheusExporterMetricsConfigNested<io.strimzi.api.kafka.model.KafkaSpecFluent.ZookeeperNested<io.strimzi.api.kafka.model.KafkaFluent.SpecNested<io.strimzi.api.kafka.model.KafkaBuilder>>>>
```

This PR might fix it? (it does not happen on my environment, so hard to judge if this helps)