### PR TITLE
Add support fo configuring finalizers for loadbalancer type listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## 0.23.0
 
+* Add support for configuring finalizers for `loadbalancer` type listeners
 * Remove support for Kafka 2.5.x
 * Remove direct ZooKeeper access for handling user quotas in the User Operator. Add usage of Admin Client API instead.
 * Migrate to CRD v1 (required by Kubernetes 1.22+)

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
@@ -44,6 +44,7 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
     private NodeAddressType preferredNodePortAddressType;
     private ExternalTrafficPolicy externalTrafficPolicy;
     private List<String> loadBalancerSourceRanges = new ArrayList<>(0);
+    private List<String> finalizers;
     private Boolean useServiceDnsDomain;
     private GenericKafkaListenerConfigurationBootstrap bootstrap;
     private List<GenericKafkaListenerConfigurationBroker> brokers;
@@ -121,6 +122,19 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
 
     public void setLoadBalancerSourceRanges(List<String> loadBalancerSourceRanges) {
         this.loadBalancerSourceRanges = loadBalancerSourceRanges;
+    }
+
+    @Description("A list of finalizers which will be configured for the `LoadBalancer` type Services created for this listener. " +
+            "If supported by the platform, the finalizer `service.kubernetes.io/load-balancer-cleanup` to make sure that the external load balancer is deleted together with the service." +
+            "For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers. " +
+            "This field can be used only with `loadbalancer` type listeners.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<String> getFinalizers() {
+        return finalizers;
+    }
+
+    public void setFinalizers(List<String> finalizers) {
+        this.finalizers = finalizers;
     }
 
     @Description("Configures whether the Kubernetes service DNS domain should be used or not. " +

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
@@ -467,6 +467,18 @@ spec:
                                 can be used only with `ingress` type listener. If
                                 not specified, the default Ingress controller will
                                 be used.
+                            finalizers:
+                              type: array
+                              items:
+                                type: string
+                              description: A list of finalizers which will be configured
+                                for the `LoadBalancer` type Services created for this
+                                listener. If supported by the platform, the finalizer
+                                `service.kubernetes.io/load-balancer-cleanup` to make
+                                sure that the external load balancer is deleted together
+                                with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers.
+                                This field can be used only with `loadbalancer` type
+                                listeners.
                             preferredNodePortAddressType:
                               type: string
                               enum:
@@ -6306,6 +6318,19 @@ spec:
                                   can be used only with `ingress` type listener. If
                                   not specified, the default Ingress controller will
                                   be used.
+                              finalizers:
+                                type: array
+                                items:
+                                  type: string
+                                description: A list of finalizers which will be configured
+                                  for the `LoadBalancer` type Services created for
+                                  this listener. If supported by the platform, the
+                                  finalizer `service.kubernetes.io/load-balancer-cleanup`
+                                  to make sure that the external load balancer is
+                                  deleted together with the service.For more information,
+                                  see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers.
+                                  This field can be used only with `loadbalancer`
+                                  type listeners.
                               preferredNodePortAddressType:
                                 type: string
                                 enum:
@@ -14681,6 +14706,19 @@ spec:
                                   can be used only with `ingress` type listener. If
                                   not specified, the default Ingress controller will
                                   be used.
+                              finalizers:
+                                type: array
+                                items:
+                                  type: string
+                                description: A list of finalizers which will be configured
+                                  for the `LoadBalancer` type Services created for
+                                  this listener. If supported by the platform, the
+                                  finalizer `service.kubernetes.io/load-balancer-cleanup`
+                                  to make sure that the external load balancer is
+                                  deleted together with the service.For more information,
+                                  see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers.
+                                  This field can be used only with `loadbalancer`
+                                  type listeners.
                               preferredNodePortAddressType:
                                 type: string
                                 enum:

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -858,15 +858,19 @@ public class KafkaCluster extends AbstractModel {
                 if (loadBalancerIP != null) {
                     service.getSpec().setLoadBalancerIP(loadBalancerIP);
                 }
-            }
 
-            if (KafkaListenerType.LOADBALANCER == listener.getType()) {
                 List<String> loadBalancerSourceRanges = ListenersUtils.loadBalancerSourceRanges(listener);
                 if (loadBalancerSourceRanges != null
                         && !loadBalancerSourceRanges.isEmpty()) {
                     service.getSpec().setLoadBalancerSourceRanges(loadBalancerSourceRanges);
                 } else if (templateExternalBootstrapServiceLoadBalancerSourceRanges != null) {
                     service.getSpec().setLoadBalancerSourceRanges(templateExternalBootstrapServiceLoadBalancerSourceRanges);
+                }
+
+                List<String> finalizers = ListenersUtils.finalizers(listener);
+                if (finalizers != null
+                        && !finalizers.isEmpty()) {
+                    service.getMetadata().setFinalizers(finalizers);
                 }
             }
 
@@ -922,15 +926,19 @@ public class KafkaCluster extends AbstractModel {
                 if (loadBalancerIP != null) {
                     service.getSpec().setLoadBalancerIP(loadBalancerIP);
                 }
-            }
 
-            if (KafkaListenerType.LOADBALANCER == listener.getType()) {
                 List<String> loadBalancerSourceRanges = ListenersUtils.loadBalancerSourceRanges(listener);
                 if (loadBalancerSourceRanges != null
                         && !loadBalancerSourceRanges.isEmpty()) {
                     service.getSpec().setLoadBalancerSourceRanges(loadBalancerSourceRanges);
                 } else if (templatePerPodServiceLoadBalancerSourceRanges != null) {
                     service.getSpec().setLoadBalancerSourceRanges(templatePerPodServiceLoadBalancerSourceRanges);
+                }
+
+                List<String> finalizers = ListenersUtils.finalizers(listener);
+                if (finalizers != null
+                        && !finalizers.isEmpty()) {
+                    service.getMetadata().setFinalizers(finalizers);
                 }
             }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -540,6 +540,20 @@ public class ListenersUtils {
     }
 
     /**
+     * Finds load balancer finalizers
+     *
+     * @param listener  Listener for which the load balancer finalizers should be found
+     * @return          Load Balancer finalizers or null if not specified
+     */
+    public static List<String> finalizers(GenericKafkaListener listener)    {
+        if (listener.getConfiguration() != null) {
+            return listener.getConfiguration().getFinalizers();
+        } else {
+            return null;
+        }
+    }
+
+    /**
      * Finds external traffic policy
      *
      * @param listener  Listener for which the external traffic policy should be found

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -75,6 +75,7 @@ public class ListenersValidator {
                 validateIngressClass(errors, listener);
                 validateExternalTrafficPolicy(errors, listener);
                 validateLoadBalancerSourceRanges(errors, listener);
+                validateFinalizers(errors, listener);
                 validatePreferredAddressType(errors, listener);
 
                 if (listener.getConfiguration().getBootstrap() != null) {
@@ -242,6 +243,20 @@ public class ListenersValidator {
                 && listener.getConfiguration().getLoadBalancerSourceRanges() != null
                 && !listener.getConfiguration().getLoadBalancerSourceRanges().isEmpty())    {
             errors.add("listener " + listener.getName() + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener");
+        }
+    }
+
+    /**
+     * Validates that finalizers is used only with Loadbalancer type listener
+     *
+     * @param errors    List where any found errors will be added
+     * @param listener  Listener which needs to be validated
+     */
+    private static void validateFinalizers(Set<String> errors, GenericKafkaListener listener) {
+        if (!KafkaListenerType.LOADBALANCER.equals(listener.getType())
+                && listener.getConfiguration().getFinalizers() != null
+                && !listener.getConfiguration().getFinalizers().isEmpty())    {
+            errors.add("listener " + listener.getName() + " cannot configure finalizers because it is not LoadBalancer based listener");
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
@@ -191,6 +191,7 @@ public class ListenersUtilsTest {
             .withNewConfiguration()
                 .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
                 .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
+                .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
                 .withNewBootstrap()
                     .withAlternativeNames(asList("my-lb-1", "my-lb-2"))
                     .withLoadBalancerIP("130.211.204.1")
@@ -565,6 +566,18 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.loadBalancerSourceRanges(newTls), is(emptyList()));
         assertThat(ListenersUtils.loadBalancerSourceRanges(newNodePort), is(emptyList()));
         assertThat(ListenersUtils.loadBalancerSourceRanges(newNodePort3), is(emptyList()));
+    }
+
+    @Test
+    public void testFinalizers() {
+        assertThat(ListenersUtils.finalizers(newLoadBalancer), is(nullValue()));
+        assertThat(ListenersUtils.finalizers(oldExternal), is(nullValue()));
+        assertThat(ListenersUtils.finalizers(newLoadBalancer), is(nullValue()));
+        assertThat(ListenersUtils.finalizers(newLoadBalancer2), containsInAnyOrder("service.kubernetes.io/load-balancer-cleanup"));
+        assertThat(ListenersUtils.finalizers(oldPlain), is(nullValue()));
+        assertThat(ListenersUtils.finalizers(newTls), is(nullValue()));
+        assertThat(ListenersUtils.finalizers(newNodePort), is(nullValue()));
+        assertThat(ListenersUtils.finalizers(newNodePort3), is(nullValue()));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -236,6 +236,7 @@ public class ListenersValidatorTest {
                     .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                     .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
+                    .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
                     .withNewBootstrap()
                         .withAlternativeNames(asList("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
@@ -273,6 +274,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure ingressClass because it is not Ingress based listener",
                 "listener " + name + " cannot configure externalTrafficPolicy because it is not LoadBalancer or NodePort based listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
+                "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure preferredAddressType because it is not NodePort based listener",
                 "listener " + name + " cannot configure bootstrap.host because it is not Route ot Ingress based listener",
                 "listener " + name + " cannot configure bootstrap.loadBalancerIP because it is not LoadBalancer based listener",
@@ -303,6 +305,7 @@ public class ListenersValidatorTest {
                     .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                     .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
+                    .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
                     .withNewBootstrap()
                         .withAlternativeNames(asList("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
@@ -360,6 +363,7 @@ public class ListenersValidatorTest {
                     .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                     .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
+                    .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
                     .withNewBootstrap()
                         .withAlternativeNames(asList("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
@@ -394,6 +398,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure ingressClass because it is not Ingress based listener",
                 "listener " + name + " cannot configure useServiceDnsDomain because it is not internal listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
+                "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure bootstrap.host because it is not Route ot Ingress based listener",
                 "listener " + name + " cannot configure bootstrap.loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure brokers[].host because it is not Route ot Ingress based listener",
@@ -438,6 +443,7 @@ public class ListenersValidatorTest {
                     .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                     .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
+                    .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
                     .withNewBootstrap()
                         .withAlternativeNames(asList("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
@@ -476,6 +482,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure useServiceDnsDomain because it is not internal listener",
                 "listener " + name + " cannot configure externalTrafficPolicy because it is not LoadBalancer or NodePort based listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
+                "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure preferredAddressType because it is not NodePort based listener",
                 "listener " + name + " cannot configure bootstrap.loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure bootstrap.nodePort because it is not NodePort based listener",
@@ -534,6 +541,7 @@ public class ListenersValidatorTest {
                     .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                     .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
+                    .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
                     .withNewBootstrap()
                         .withAlternativeNames(asList("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
@@ -568,6 +576,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure useServiceDnsDomain because it is not internal listener",
                 "listener " + name + " cannot configure externalTrafficPolicy because it is not LoadBalancer or NodePort based listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
+                "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure preferredAddressType because it is not NodePort based listener",
                 "listener " + name + " cannot configure bootstrap.loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure bootstrap.nodePort because it is not NodePort based listener",

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -305,6 +305,8 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |xref:type-GenericKafkaListenerConfigurationBroker-{context}[`GenericKafkaListenerConfigurationBroker`] array
 |class                         1.2+<.<|Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener. If not specified, the default Ingress controller will be used.
 |string
+|finalizers                    1.2+<.<|A list of finalizers which will be configured for the `LoadBalancer` type Services created for this listener. If supported by the platform, the finalizer `service.kubernetes.io/load-balancer-cleanup` to make sure that the external load balancer is deleted together with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers. This field can be used only with `loadbalancer` type listeners.
+|string array
 |preferredNodePortAddressType  1.2+<.<|Defines which address type should be used as the node address. Available types are: `ExternalDNS`, `ExternalIP`, `InternalDNS`, `InternalIP` and `Hostname`. By default, the addresses will be used in the following order (the first one found will be used):
 * `ExternalDNS`
 * `ExternalIP`

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -296,6 +296,11 @@ spec:
                               class:
                                 type: string
                                 description: Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener. If not specified, the default Ingress controller will be used.
+                              finalizers:
+                                type: array
+                                items:
+                                  type: string
+                                description: A list of finalizers which will be configured for the `LoadBalancer` type Services created for this listener. If supported by the platform, the finalizer `service.kubernetes.io/load-balancer-cleanup` to make sure that the external load balancer is deleted together with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers. This field can be used only with `loadbalancer` type listeners.
                               preferredNodePortAddressType:
                                 type: string
                                 enum:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -471,6 +471,18 @@ spec:
                                 can be used only with `ingress` type listener. If
                                 not specified, the default Ingress controller will
                                 be used.
+                            finalizers:
+                              type: array
+                              items:
+                                type: string
+                              description: A list of finalizers which will be configured
+                                for the `LoadBalancer` type Services created for this
+                                listener. If supported by the platform, the finalizer
+                                `service.kubernetes.io/load-balancer-cleanup` to make
+                                sure that the external load balancer is deleted together
+                                with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers.
+                                This field can be used only with `loadbalancer` type
+                                listeners.
                             preferredNodePortAddressType:
                               type: string
                               enum:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In public cloud, it sometimes happens that the external load balancer gets orphaned when the `LoadBalancer` type service is deleted. To prevent this, users can use the `service.kubernetes.io/load-balancer-cleanup` finalizer (see more [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers)). However, this is supported only on some platforms. So we cannot really hardcode it by default. 

So this PR adds an option to configure the finalizers in `.spec.kafka.listeners[].configuration.finalizers. That allows users to configure it optionally.

This should close #4500

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md