### PR TITLE
Fix master build errors caused by moved TestSeparator class

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
-import static io.strimzi.systemtest.interfaces.TestSeparator.LOGGER;
+import static io.strimzi.test.interfaces.TestSeparator.LOGGER;
 import static io.strimzi.systemtest.resources.ResourceManager.CR_CREATION_TIMEOUT;
 import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

After merging #4555 the master build is failing because the class `TestSeparator` has been moved. This PR fixes the issue.