### PR TITLE
Use null instead of emptyList as a default loadBalancerSourceRanges

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
@@ -18,7 +18,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +42,7 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
     private String ingressClass;
     private NodeAddressType preferredNodePortAddressType;
     private ExternalTrafficPolicy externalTrafficPolicy;
-    private List<String> loadBalancerSourceRanges = new ArrayList<>(0);
+    private List<String> loadBalancerSourceRanges;
     private List<String> finalizers;
     private Boolean useServiceDnsDomain;
     private GenericKafkaListenerConfigurationBootstrap bootstrap;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -535,7 +535,7 @@ public class ListenersUtils {
         if (listener.getConfiguration() != null) {
             return listener.getConfiguration().getLoadBalancerSourceRanges();
         } else {
-            return Collections.emptyList();
+            return null;
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -558,14 +557,14 @@ public class ListenersUtilsTest {
 
     @Test
     public void testLoadBalancerSourceRanges() {
-        assertThat(ListenersUtils.loadBalancerSourceRanges(newLoadBalancer), is(emptyList()));
-        assertThat(ListenersUtils.loadBalancerSourceRanges(oldExternal), is(emptyList()));
-        assertThat(ListenersUtils.loadBalancerSourceRanges(newLoadBalancer), is(emptyList()));
+        assertThat(ListenersUtils.loadBalancerSourceRanges(newLoadBalancer), is(nullValue()));
+        assertThat(ListenersUtils.loadBalancerSourceRanges(oldExternal), is(nullValue()));
+        assertThat(ListenersUtils.loadBalancerSourceRanges(newLoadBalancer), is(nullValue()));
         assertThat(ListenersUtils.loadBalancerSourceRanges(newLoadBalancer2), containsInAnyOrder("10.0.0.0/8", "130.211.204.1/32"));
-        assertThat(ListenersUtils.loadBalancerSourceRanges(oldPlain), is(emptyList()));
-        assertThat(ListenersUtils.loadBalancerSourceRanges(newTls), is(emptyList()));
-        assertThat(ListenersUtils.loadBalancerSourceRanges(newNodePort), is(emptyList()));
-        assertThat(ListenersUtils.loadBalancerSourceRanges(newNodePort3), is(emptyList()));
+        assertThat(ListenersUtils.loadBalancerSourceRanges(oldPlain), is(nullValue()));
+        assertThat(ListenersUtils.loadBalancerSourceRanges(newTls), is(nullValue()));
+        assertThat(ListenersUtils.loadBalancerSourceRanges(newNodePort), is(nullValue()));
+        assertThat(ListenersUtils.loadBalancerSourceRanges(newNodePort3), is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `loadBalancerSourceRanges` field is currently using `emptyList` as the default value. That is not needed and it also means that when creating the resources using the `api` module it renders the empty list as the default value. This PR changes it to use `null`.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally