### PR TITLE
Add maxConnections and maxConnectionCreationRate configurations to listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## 0.23.0
 
+* Make it possible to configure maximum number of connections maximum connection creation rate in listener configuration
 * Add support for configuring finalizers for `loadbalancer` type listeners
 * Remove support for Kafka 2.5.x
 * Remove direct ZooKeeper access for handling user quotas in the User Operator. Add usage of Admin Client API instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 0.23.0
 
-* Make it possible to configure maximum number of connections maximum connection creation rate in listener configuration
+* Make it possible to configure maximum number of connections and maximum connection creation rate in listener configuration
 * Add support for configuring finalizers for `loadbalancer` type listeners
 * Remove support for Kafka 2.5.x
 * Remove direct ZooKeeper access for handling user quotas in the User Operator. Add usage of Admin Client API instead.

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
@@ -47,6 +47,8 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
     private Boolean useServiceDnsDomain;
     private GenericKafkaListenerConfigurationBootstrap bootstrap;
     private List<GenericKafkaListenerConfigurationBroker> brokers;
+    private Integer maxConnections;
+    private Integer maxConnectionCreationRate;
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -166,6 +168,29 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
 
     public void setBrokers(List<GenericKafkaListenerConfigurationBroker> brokers) {
         this.brokers = brokers;
+    }
+
+    @Description("The maximum number of connections we allow for this listener in the broker at any time. " +
+            "New connections are blocked if the limit is reached.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Integer getMaxConnections() {
+        return maxConnections;
+    }
+
+    public void setMaxConnections(Integer maxConnections) {
+        this.maxConnections = maxConnections;
+    }
+
+    @Description("The maximum connection creation rate we allow in this listener at any time. " +
+            "New connections will be throttled if the limit is reached." +
+            "Supported only on Kafka 2.7.0 and newer.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Integer getMaxConnectionCreationRate() {
+        return maxConnectionCreationRate;
+    }
+
+    public void setMaxConnectionCreationRate(Integer maxConnectionCreationRate) {
+        this.maxConnectionCreationRate = maxConnectionCreationRate;
     }
 
     @Override

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
@@ -479,6 +479,17 @@ spec:
                                 with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers.
                                 This field can be used only with `loadbalancer` type
                                 listeners.
+                            maxConnectionCreationRate:
+                              type: integer
+                              description: The maximum connection creation rate we
+                                allow in this listener at any time. New connections
+                                will be throttled if the limit is reached.Supported
+                                only on Kafka 2.7.0 and newer.
+                            maxConnections:
+                              type: integer
+                              description: The maximum number of connections we allow
+                                for this listener in the broker at any time. New connections
+                                are blocked if the limit is reached.
                             preferredNodePortAddressType:
                               type: string
                               enum:
@@ -6331,6 +6342,17 @@ spec:
                                   see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers.
                                   This field can be used only with `loadbalancer`
                                   type listeners.
+                              maxConnectionCreationRate:
+                                type: integer
+                                description: The maximum connection creation rate
+                                  we allow in this listener at any time. New connections
+                                  will be throttled if the limit is reached.Supported
+                                  only on Kafka 2.7.0 and newer.
+                              maxConnections:
+                                type: integer
+                                description: The maximum number of connections we
+                                  allow for this listener in the broker at any time.
+                                  New connections are blocked if the limit is reached.
                               preferredNodePortAddressType:
                                 type: string
                                 enum:
@@ -14719,6 +14741,17 @@ spec:
                                   see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers.
                                   This field can be used only with `loadbalancer`
                                   type listeners.
+                              maxConnectionCreationRate:
+                                type: integer
+                                description: The maximum connection creation rate
+                                  we allow in this listener at any time. New connections
+                                  will be throttled if the limit is reached.Supported
+                                  only on Kafka 2.7.0 and newer.
+                              maxConnections:
+                                type: integer
+                                description: The maximum number of connections we
+                                  allow for this listener in the broker at any time.
+                                  New connections are blocked if the limit is reached.
                               preferredNodePortAddressType:
                                 type: string
                                 enum:

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -240,7 +240,7 @@ public class KafkaBrokerConfigurationBuilder {
     /**
      * Configures the listener. This method is used only internally.
      *
-     * @param listenerName  The name of the listener under which it is used in the KAfka broker configuration file
+     * @param listenerName  The name of the listener as it is referenced in the Kafka broker configuration file
      * @param configuration The configuration of the listener (null if not specified by the user in the Kafka CR)
      */
     private void configureListener(String listenerName, GenericKafkaListenerConfiguration configuration) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -18,6 +18,7 @@ import io.strimzi.api.kafka.model.listener.KafkaListenerAuthentication;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationOAuth;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationScramSha512;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationTls;
+import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration;
 import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters;
 import io.strimzi.kafka.oauth.server.plain.ServerPlainConfig;
@@ -181,6 +182,7 @@ public class KafkaBrokerConfigurationBuilder {
             listeners.add(listenerName + "://0.0.0.0:" + port);
             advertisedListeners.add(String.format("%s://${STRIMZI_%s_ADVERTISED_HOSTNAME}:${STRIMZI_%s_ADVERTISED_PORT}", listenerName, envVarListenerName, envVarListenerName));
             configureAuthentication(listenerName, securityProtocol, listener.isTls(), listener.getAuth());
+            configureListener(listenerName, listener.getConfiguration());
 
             if (listener.isTls())   {
                 CertAndKeySecretSource customServerCert = null;
@@ -233,6 +235,26 @@ public class KafkaBrokerConfigurationBuilder {
         writer.println("listener.name.replication-9091.ssl.truststore.type=PKCS12");
         writer.println("listener.name.replication-9091.ssl.client.auth=required");
         writer.println();
+    }
+
+    /**
+     * Configures the listener. This method is used only internally.
+     *
+     * @param listenerName  The name of the listener under which it is used in the KAfka broker configuration file
+     * @param configuration The configuration of the listener (null if not specified by the user in the Kafka CR)
+     */
+    private void configureListener(String listenerName, GenericKafkaListenerConfiguration configuration) {
+        if (configuration != null)  {
+            String listenerNameInProperty = listenerName.toLowerCase(Locale.ENGLISH);
+
+            if (configuration.getMaxConnections() != null)  {
+                writer.println(String.format("listener.name.%s.max.connections=%d", listenerNameInProperty, configuration.getMaxConnections()));
+            }
+
+            if (configuration.getMaxConnectionCreationRate() != null)  {
+                writer.println(String.format("listener.name.%s.max.connection.creation.rate=%d", listenerNameInProperty, configuration.getMaxConnectionCreationRate()));
+            }
+        }
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -412,6 +412,70 @@ public class KafkaBrokerConfigurationBuilderTest {
     }
 
     @Test
+    public void testConnectionLimits()  {
+        GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
+                .withName("listener1")
+                .withPort(9100)
+                .withType(KafkaListenerType.INTERNAL)
+                .withTls(false)
+                .withNewConfiguration()
+                    .withMaxConnections(100)
+                    .withMaxConnectionCreationRate(10)
+                .endConfiguration()
+                .build();
+
+        GenericKafkaListener listener2 = new GenericKafkaListenerBuilder()
+                .withName("listener2")
+                .withPort(9101)
+                .withType(KafkaListenerType.INTERNAL)
+                .withTls(false)
+                .withNewConfiguration()
+                    .withMaxConnections(1000)
+                    .withMaxConnectionCreationRate(50)
+                .endConfiguration()
+                .build();
+
+        GenericKafkaListener listener3 = new GenericKafkaListenerBuilder()
+                .withName("listener3")
+                .withPort(9102)
+                .withType(KafkaListenerType.INTERNAL)
+                .withTls(false)
+                .withNewConfiguration()
+                .endConfiguration()
+                .build();
+
+        GenericKafkaListener listener4 = new GenericKafkaListenerBuilder()
+                .withName("listener4")
+                .withPort(9103)
+                .withType(KafkaListenerType.INTERNAL)
+                .withTls(false)
+                .build();
+
+        String configuration = new KafkaBrokerConfigurationBuilder()
+                .withListeners("my-cluster", "my-namespace", asList(listener1, listener2, listener3, listener4))
+                .build();
+
+        assertThat(configuration, isEquivalent("listener.name.replication-9091.ssl.keystore.location=/tmp/kafka/cluster.keystore.p12",
+                "listener.name.replication-9091.ssl.keystore.password=${CERTS_STORE_PASSWORD}",
+                "listener.name.replication-9091.ssl.keystore.type=PKCS12",
+                "listener.name.replication-9091.ssl.truststore.location=/tmp/kafka/cluster.truststore.p12",
+                "listener.name.replication-9091.ssl.truststore.password=${CERTS_STORE_PASSWORD}",
+                "listener.name.replication-9091.ssl.truststore.type=PKCS12",
+                "listener.name.replication-9091.ssl.client.auth=required",
+                "listener.name.listener1-9100.max.connections=100",
+                "listener.name.listener1-9100.max.connection.creation.rate=10",
+                "listener.name.listener2-9101.max.connections=1000",
+                "listener.name.listener2-9101.max.connection.creation.rate=50",
+                "listeners=REPLICATION-9091://0.0.0.0:9091,LISTENER1-9100://0.0.0.0:9100,LISTENER2-9101://0.0.0.0:9101,LISTENER3-9102://0.0.0.0:9102,LISTENER4-9103://0.0.0.0:9103",
+                "advertised.listeners=REPLICATION-9091://my-cluster-kafka-${STRIMZI_BROKER_ID}.my-cluster-kafka-brokers.my-namespace.svc:9091,LISTENER1-9100://${STRIMZI_LISTENER1_9100_ADVERTISED_HOSTNAME}:${STRIMZI_LISTENER1_9100_ADVERTISED_PORT},LISTENER2-9101://${STRIMZI_LISTENER2_9101_ADVERTISED_HOSTNAME}:${STRIMZI_LISTENER2_9101_ADVERTISED_PORT},LISTENER3-9102://${STRIMZI_LISTENER3_9102_ADVERTISED_HOSTNAME}:${STRIMZI_LISTENER3_9102_ADVERTISED_PORT},LISTENER4-9103://${STRIMZI_LISTENER4_9103_ADVERTISED_HOSTNAME}:${STRIMZI_LISTENER4_9103_ADVERTISED_PORT}",
+                "listener.security.protocol.map=REPLICATION-9091:SSL,LISTENER1-9100:PLAINTEXT,LISTENER2-9101:PLAINTEXT,LISTENER3-9102:PLAINTEXT,LISTENER4-9103:PLAINTEXT",
+                "inter.broker.listener.name=REPLICATION-9091",
+                "sasl.enabled.mechanisms=",
+                "ssl.secure.random.implementation=SHA1PRNG",
+                "ssl.endpoint.identification.algorithm=HTTPS"));
+    }
+
+    @Test
     public void testWithPlainListenersWithoutAuth()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("plain")

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -307,6 +307,10 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |string
 |finalizers                    1.2+<.<|A list of finalizers which will be configured for the `LoadBalancer` type Services created for this listener. If supported by the platform, the finalizer `service.kubernetes.io/load-balancer-cleanup` to make sure that the external load balancer is deleted together with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers. This field can be used only with `loadbalancer` type listeners.
 |string array
+|maxConnectionCreationRate     1.2+<.<|The maximum connection creation rate we allow in this listener at any time. New connections will be throttled if the limit is reached.Supported only on Kafka 2.7.0 and newer.
+|integer
+|maxConnections                1.2+<.<|The maximum number of connections we allow for this listener in the broker at any time. New connections are blocked if the limit is reached.
+|integer
 |preferredNodePortAddressType  1.2+<.<|Defines which address type should be used as the node address. Available types are: `ExternalDNS`, `ExternalIP`, `InternalDNS`, `InternalIP` and `Hostname`. By default, the addresses will be used in the following order (the first one found will be used):
 * `ExternalDNS`
 * `ExternalIP`

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -301,6 +301,12 @@ spec:
                                 items:
                                   type: string
                                 description: A list of finalizers which will be configured for the `LoadBalancer` type Services created for this listener. If supported by the platform, the finalizer `service.kubernetes.io/load-balancer-cleanup` to make sure that the external load balancer is deleted together with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers. This field can be used only with `loadbalancer` type listeners.
+                              maxConnectionCreationRate:
+                                type: integer
+                                description: The maximum connection creation rate we allow in this listener at any time. New connections will be throttled if the limit is reached.Supported only on Kafka 2.7.0 and newer.
+                              maxConnections:
+                                type: integer
+                                description: The maximum number of connections we allow for this listener in the broker at any time. New connections are blocked if the limit is reached.
                               preferredNodePortAddressType:
                                 type: string
                                 enum:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -483,6 +483,17 @@ spec:
                                 with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers.
                                 This field can be used only with `loadbalancer` type
                                 listeners.
+                            maxConnectionCreationRate:
+                              type: integer
+                              description: The maximum connection creation rate we
+                                allow in this listener at any time. New connections
+                                will be throttled if the limit is reached.Supported
+                                only on Kafka 2.7.0 and newer.
+                            maxConnections:
+                              type: integer
+                              description: The maximum number of connections we allow
+                                for this listener in the broker at any time. New connections
+                                are blocked if the limit is reached.
                             preferredNodePortAddressType:
                               type: string
                               enum:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Kafka allows to configure for each listener the maximum number of opened connections and the maximum number of connections created per second. This PR adds these options to the listener configuration, to let the users configure these for each listener.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md