### PR TITLE
[systemtest] Make exec log less verbose

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -45,11 +45,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -176,24 +176,21 @@ public abstract class AbstractST implements TestSeparator {
      */
     public void applyClusterOperatorInstallFiles(String namespace) {
         clusterOperatorConfigs.clear();
-        Map<File, String> operatorFiles = Arrays.stream(new File(CO_INSTALL_DIR).listFiles()).sorted()
+        List<File> operatorFiles = Arrays.stream(new File(CO_INSTALL_DIR).listFiles()).sorted()
                 .filter(File::isFile)
                 .filter(file ->
                         !file.getName().matches(".*(Binding|Deployment)-.*"))
-                .collect(Collectors.toMap(
-                    file -> file,
-                    f -> TestUtils.getContent(f, TestUtils::toYamlString),
-                    (x, y) -> x,
-                    LinkedHashMap::new));
-        for (Map.Entry<File, String> entry : operatorFiles.entrySet()) {
-            LOGGER.info("Creating configuration file: {}", entry.getKey());
-            String fileContents = entry.getValue();
-            if (Environment.isNamespaceRbacScope()) {
-                fileContents = switchClusterRolesToRoles(fileContents);
+                .collect(Collectors.toList());
 
+        for (File operatorFile : operatorFiles) {
+            File createFile = operatorFile;
+            if (operatorFile.getName().contains("ClusterRole-")) {
+                createFile = switchClusterRolesToRolesIfNeeded(createFile);
             }
-            clusterOperatorConfigs.push(entry.getKey().getPath());
-            cmdKubeClient().namespace(namespace).replaceContent(fileContents);
+
+            LOGGER.info("Creating configuration file: {}", createFile.getAbsolutePath());
+            cmdKubeClient().namespace(namespace).createOrReplace(createFile);
+            clusterOperatorConfigs.push(createFile.getPath());
         }
     }
 
@@ -201,12 +198,20 @@ public abstract class AbstractST implements TestSeparator {
      * Replace all references to ClusterRole to Role.
      * This includes ClusterRoles themselves as well as RoleBindings that reference them.
      */
-    public static String switchClusterRolesToRoles(String fileContents) {
-        String newContents = fileContents.replace("ClusterRole", "Role");
-        if (!newContents.equals(fileContents)) {
-            LOGGER.info("Replaced ClusterRole for Role");
+    public static File switchClusterRolesToRolesIfNeeded(File oldFile) {
+        if (Environment.isNamespaceRbacScope()) {
+            try {
+                File tmpFile = File.createTempFile("rbac-" + oldFile.getName().replace(".yaml", ""), ".yaml");
+                TestUtils.writeFile(tmpFile.getAbsolutePath(), TestUtils.readFile(oldFile).replace("ClusterRole", "Role"));
+                LOGGER.info("Replaced ClusterRole for Role");
+
+                return tmpFile;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            return oldFile;
         }
-        return newContents;
     }
 
     /**

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -203,7 +203,7 @@ public abstract class AbstractST implements TestSeparator {
             try {
                 File tmpFile = File.createTempFile("rbac-" + oldFile.getName().replace(".yaml", ""), ".yaml");
                 TestUtils.writeFile(tmpFile.getAbsolutePath(), TestUtils.readFile(oldFile).replace("ClusterRole", "Role"));
-                LOGGER.info("Replaced ClusterRole for Role");
+                LOGGER.info("Replaced ClusterRole for Role in {}", oldFile.getAbsolutePath());
 
                 return tmpFile;
             } catch (IOException e) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -241,9 +241,11 @@ public abstract class AbstractST implements TestSeparator {
 
         if (cluster.cluster() instanceof Minishift || cluster.cluster() instanceof OpenShift) {
             // This is needed in case you are using internal kubernetes registry and you want to pull images from there
-            for (String namespace : namespaces) {
-                LOGGER.debug("Setting group policy for Openshift registry in namespace: " + namespace);
-                Exec.exec(null, Arrays.asList("oc", "policy", "add-role-to-group", "system:image-puller", "system:serviceaccounts:" + namespace, "-n", Environment.STRIMZI_ORG), 0, false, false);
+            if (kubeClient().getNamespace(Environment.STRIMZI_ORG) != null) {
+                for (String namespace : namespaces) {
+                    LOGGER.debug("Setting group policy for Openshift registry in namespace: " + namespace);
+                    Exec.exec(null, Arrays.asList("oc", "policy", "add-role-to-group", "system:image-puller", "system:serviceaccounts:" + namespace, "-n", Environment.STRIMZI_ORG), 0, false, false);
+                }
             }
         }
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
@@ -46,6 +46,7 @@ import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Tag(REGRESSION)
@@ -68,6 +69,9 @@ public class MultipleClusterOperatorsST extends AbstractST {
 
     @IsolatedTest
     void testMultipleCOsInDifferentNamespaces(ExtensionContext extensionContext) {
+        // TODO issue #4152 - temporarily disabled for Namespace RBAC scoped
+        assumeFalse(Environment.isNamespaceRbacScope());
+
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
         String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
 

--- a/test/src/main/java/io/strimzi/test/executor/Exec.java
+++ b/test/src/main/java/io/strimzi/test/executor/Exec.java
@@ -166,7 +166,7 @@ public class Exec {
                 if (logToOutput) {
                     LOGGER.info("Command: {}", String.join(" ", command));
                     if (input != null) {
-                        LOGGER.info("Input: {}", input.trim());
+                        LOGGER.debug("Input: {}", input.trim());
                     }
                     LOGGER.info("RETURN code: {}", ret);
                     if (!executor.out().isEmpty()) {

--- a/test/src/main/java/io/strimzi/test/executor/Exec.java
+++ b/test/src/main/java/io/strimzi/test/executor/Exec.java
@@ -163,10 +163,11 @@ public class Exec {
             Exec executor = new Exec();
             ret = executor.execute(input, command, timeout);
             synchronized (LOCK) {
-                if (logToOutput) {
-                    LOGGER.info("Command: {}", String.join(" ", command));
-                    if (input != null) {
-                        LOGGER.debug("Input: {}", input.trim());
+                if (logToOutput || ret != 0) {
+                    String log = ret != 0 ? "Failed to exec command" : "Command";
+                    LOGGER.info("{}: {}", log, String.join(" ", command));
+                    if (input != null && !input.contains("CusomResourceDefinition")) {
+                        LOGGER.info("Input: {}", input.trim());
                     }
                     LOGGER.info("RETURN code: {}", ret);
                     if (!executor.out().isEmpty()) {

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
@@ -46,6 +46,8 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
     /** Deletes the resources in the given files. */
     K delete(File... files);
 
+    K createOrReplace(File file);
+
     default K create(String... files) {
         return create(asList(files).stream().map(File::new).collect(toList()).toArray(new File[0]));
     }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

After #4595 the log of STs become too verbose -> on every exec the whole files were printed (which is not good in case of applying/creating CRDs).
This PR changes log level to `debug` for printing extra info, so the log of ST can be cleaner and also shorter.

Before:
https://gist.github.com/im-konge/9e0efc1f5e363f8fbddc549fc84fb3e9

After - STs:
```
2021-03-23 13:05:14 [main] INFO  [KubeClusterResource:160] Using Namespace listeners
2021-03-23 13:05:14 [main] INFO  [KubeClusterResource:80] Changing to listeners namespace
2021-03-23 13:05:14 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/010-ServiceAccount-strimzi-cluster-operator.yaml
2021-03-23 13:05:15 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
2021-03-23 13:05:16 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
2021-03-23 13:05:16 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/030-ClusterRole-strimzi-kafka-broker.yaml
2021-03-23 13:05:17 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
2021-03-23 13:05:18 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/032-ClusterRole-strimzi-topic-operator.yaml
2021-03-23 13:05:18 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/033-ClusterRole-strimzi-kafka-client.yaml
2021-03-23 13:05:19 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/040-Crd-kafka.yaml
2021-03-23 13:05:20 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
2021-03-23 13:05:21 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
2021-03-23 13:05:23 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
2021-03-23 13:05:23 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/044-Crd-kafkauser.yaml
2021-03-23 13:05:24 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
2021-03-23 13:05:25 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
2021-03-23 13:05:26 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
2021-03-23 13:05:27 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
2021-03-23 13:05:28 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/049-Crd-kafkarebalance.yaml
2021-03-23 13:05:29 [main] INFO  [AbstractST:191] Creating configuration file: /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
2021-03-23 13:05:30 [main] INFO  [NetworkPolicyResource:212] NetworkPolicy successfully set to: true for namespace: listeners
2021-03-23 13:05:30 [main] INFO  [ClusterRoleBindingResource:43] Creating ClusterRoleBinding in test case ListenersST from /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/021-ClusterRoleBinding-strimzi-cluster-operator.yaml in namespace listeners
2021-03-23 13:05:30 [main] INFO  [ResourceManager:145] Create/Update of ClusterRoleBinding strimzi-cluster-operator in namespace (not set)
2021-03-23 13:05:30 [main] INFO  [ResourceManager:197] Resource strimzi-cluster-operator in namespace null is io.strimzi.systemtest.resources.ResourceManager$$Lambda$490/0x00000008403cb840@77bbadc!
2021-03-23 13:05:30 [main] INFO  [ClusterRoleBindingResource:43] Creating ClusterRoleBinding in test case ListenersST from /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml in namespace listeners
2021-03-23 13:05:30 [main] INFO  [ResourceManager:145] Create/Update of ClusterRoleBinding strimzi-cluster-operator-kafka-broker-delegation in namespace (not set)
2021-03-23 13:05:31 [main] INFO  [ResourceManager:197] Resource strimzi-cluster-operator-kafka-broker-delegation in namespace null is io.strimzi.systemtest.resources.ResourceManager$$Lambda$490/0x00000008403cb840@25ad4f71!
2021-03-23 13:05:31 [main] INFO  [ClusterRoleBindingResource:43] Creating ClusterRoleBinding in test case ListenersST from /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-client-delegation.yaml in namespace listeners
2021-03-23 13:05:31 [main] INFO  [ResourceManager:145] Create/Update of ClusterRoleBinding strimzi-cluster-operator-kafka-client-delegation in namespace (not set)
2021-03-23 13:05:31 [main] INFO  [ResourceManager:197] Resource strimzi-cluster-operator-kafka-client-delegation in namespace null is io.strimzi.systemtest.resources.ResourceManager$$Lambda$490/0x00000008403cb840@455c1d8c!
2021-03-23 13:05:31 [main] INFO  [RoleBindingResource:44] Creating RoleBinding from /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml in namespace listeners
2021-03-23 13:05:31 [main] INFO  [RoleBindingResource:44] Creating RoleBinding from /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml in namespace listeners
2021-03-23 13:05:31 [main] INFO  [RoleBindingResource:44] Creating RoleBinding from /home/lkral/work/streams/strimzi-kafka-operator/systemtest/../packaging/install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml in namespace listeners
2021-03-23 13:05:32 [main] INFO  [ResourceManager:145] Create/Update of Deployment strimzi-cluster-operator in namespace listeners
2021-03-23 13:05:33 [main] INFO  [DeploymentUtils:151] Wait for Deployment: strimzi-cluster-operator will be ready
2021-03-23 13:05:49 [main] INFO  [DeploymentUtils:158] Deployment: strimzi-cluster-operator is ready
2021-03-23 13:05:49 [main] INFO  [DeploymentUtils:170] Waiting for 1 Pod(s) of Deployment strimzi-cluster-operator to be ready
2021-03-23 13:06:00 [main] INFO  [DeploymentUtils:173] Deployment strimzi-cluster-operator is ready
2021-03-23 13:06:00 [main] INFO  [ResourceManager:197] Resource strimzi-cluster-operator in namespace listeners is io.strimzi.systemtest.resources.ResourceManager$$Lambda$490/0x00000008403cb840@df921b1!
```

After - ITs:
```
2021-03-23 12:55:31 INFO [Exec:168] Failed to exec command: minikube status
2021-03-23 12:55:31 INFO [Exec:172] RETURN code: 85
2021-03-23 12:55:31 INFO [Exec:174] ======STDOUT START=======
2021-03-23 12:55:31 INFO [Exec:175] * Profile "minikube" not found. Run "minikube profile list" to view all profiles.
  - To start a cluster, run: "minikube start"
2021-03-23 12:55:31 INFO [Exec:176] ======STDOUT END======
2021-03-23 12:55:31 WARN [KubeCluster:80] Cluster minikube is not running!
2021-03-23 12:55:33 WARN [KubeCluster:80] Cluster kubectl is not running!
2021-03-23 12:55:33 WARN [KubeCluster:83] Cluster minishift is not installed!
2021-03-23 12:55:36 INFO [KubeCluster:90] Using cluster: oc
2021-03-23 12:55:36 INFO [KubeClusterResource:52] Cluster default namespace is default
2021-03-23 12:55:36 INFO [KubeClusterResource:53] Cluster command line client default namespace is default
2021-03-23 12:55:37 INFO [KubeClusterResource:154] Creating Namespace kafkabridge-crd-it
2021-03-23 12:55:38 INFO [KubeClusterResource:160] Using Namespace kafkabridge-crd-it
2021-03-23 12:55:38 INFO [KubeClusterResource:80] Changing to kafkabridge-crd-it namespace
2021-03-23 12:55:38 INFO [KubeClusterResource:210] Creating resources /home/lkral/work/streams/strimzi-kafka-operator/api/../packaging/install/cluster-operator/046-Crd-kafkabridge.yaml in Namespace kafkabridge-crd-it
2021-03-23 12:55:39 INFO [TimeMeasuringSystem:70] ============ ADDING RECORD ========
2021-03-23 12:55:39 INFO [TimeMeasuringSystem:96] Start time of operation TEST_EXECUTION is correctly stored
2021-03-23 12:55:39 INFO [TestSeparator:29] ############################################################################
2021-03-23 12:55:39 INFO [TestSeparator:30] io.strimzi.api.kafka.model.KafkaBridgeCrdIT.testKafkaBridgeWithMissingRequired-STARTED
2021-03-23 12:55:51 INFO [Exec:168] Failed to exec command: oc --namespace kafkabridge-crd-it create -f /home/lkral/work/streams/strimzi-kafka-operator/api/target/test-classes/io/strimzi/api/kafka/model/KafkaBridge-with-missing-required-property.yaml
2021-03-23 12:55:51 INFO [Exec:172] RETURN code: 1
2021-03-23 12:55:51 INFO [Exec:179] ======STDERR START=======
2021-03-23 12:55:51 INFO [Exec:180] The KafkaBridge "test-kafka-bridge" is invalid: spec.bootstrapServers: Required value
2021-03-23 12:55:51 INFO [Exec:181] ======STDERR END======
2021-03-23 12:55:52 INFO [Exec:168] Failed to exec command: oc --namespace kafkabridge-crd-it delete -f /home/lkral/work/streams/strimzi-kafka-operator/api/target/test-classes/io/strimzi/api/kafka/model/KafkaBridge-with-missing-required-property.yaml
2021-03-23 12:55:52 INFO [Exec:172] RETURN code: 1
2021-03-23 12:55:52 INFO [Exec:179] ======STDERR START=======
2021-03-23 12:55:52 INFO [Exec:180] Error from server (NotFound): error when deleting "/home/lkral/work/streams/strimzi-kafka-operator/api/target/test-classes/io/strimzi/api/kafka/model/KafkaBridge-with-missing-required-property.yaml": kafkabridges.kafka.strimzi.io "test-kafka-bridge" not found
2021-03-23 12:55:52 INFO [Exec:181] ======STDERR END======
2021-03-23 12:55:52 WARN [BaseCmdKubeClient:158] Failed to delete /home/lkral/work/streams/strimzi-kafka-operator/api/target/test-classes/io/strimzi/api/kafka/model/KafkaBridge-with-missing-required-property.yaml!
2021-03-23 12:55:52 WARN [TimeMeasuringSystem:125] End time of operation TEST_EXECUTION is not set due to exception: java.lang.NullPointerException
2021-03-23 12:55:52 INFO [TestSeparator:36] io.strimzi.api.kafka.model.KafkaBridgeCrdIT.testKafkaBridgeWithMissingRequired-FINISHED
2021-03-23 12:55:52 INFO [TestSeparator:37] ############################################################################
2021-03-23 12:55:52 INFO [KubeClusterResource:222] Deleting resources /home/lkral/work/streams/strimzi-kafka-operator/api/../packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
2021-03-23 12:55:53 INFO [KubeClusterResource:179] Deleting Namespace kafkabridge-crd-it
2021-03-23 12:56:00 INFO [Exec:168] Failed to exec command: oc --namespace kafkabridge-crd-it get Namespace kafkabridge-crd-it -o yaml
2021-03-23 12:56:00 INFO [Exec:172] RETURN code: 1
2021-03-23 12:56:00 INFO [Exec:179] ======STDERR START=======
2021-03-23 12:56:00 INFO [Exec:180] Error from server (NotFound): namespaces "kafkabridge-crd-it" not found
2021-03-23 12:56:00 INFO [Exec:181] ======STDERR END======
2021-03-23 12:56:00 INFO [KubeClusterResource:185] Using Namespace kafkabridge-crd-it
2021-03-23 12:56:00 INFO [KubeClusterResource:80] Changing to kafkabridge-crd-it namespace
```
### Checklist

- [ ] Make sure all tests pass

