### PR TITLE
Fix duplicate dependencies in test module

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -83,10 +83,6 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model-networking</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-model-apiextensions</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `io.fabric8:kubernetes-model-networking` dependency in the `test` module is declared twice and that results in the following warning:

```
2021-03-21T15:30:15.9682197Z [WARNING] 
2021-03-21T15:30:15.9745756Z [WARNING] Some problems were encountered while building the effective model for io.strimzi:test:jar:0.23.0-SNAPSHOT
2021-03-21T15:30:15.9763365Z [WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.fabric8:kubernetes-model-networking:jar -> duplicate declaration of version (?) @ line 84, column 21
2021-03-21T15:30:15.9788302Z [WARNING] 
2021-03-21T15:30:15.9798941Z [WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
2021-03-21T15:30:15.9831442Z [WARNING] 
2021-03-21T15:30:15.9842389Z [WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
2021-03-21T15:30:15.9843983Z [WARNING] 
```