### PR TITLE
Add cluster before/after load information to rebalance optimization proposal in a ConfigMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 * In the past, when no Ingress class was specified in the Ingress-type listener in the Kafka custom resource, the 
   `kubernetes.io/ingress.class` annotation was automatically set to `nginx`. Because of the support for the new 
   IngressClass resource and the new `ingressClassName` field in the Ingress resource, the default value will not be set 
-  anymore. Please use the `class` field in `.spec.kafka.listeners[].configuration` to specify the class name. 
+  anymore. Please use the `class` field in `.spec.kafka.listeners[].configuration` to specify the class name.
 * The `KafkaConnectS2I` custom resource is deprecated and will be removed in the future. You can use the new [`KafkaConnect` build feature](https://strimzi.io/docs/operators/latest/full/deploying.html#creating-new-image-using-kafka-connect-build-str) instead.
 * Removed support for Helm2 charts as that version is now unsupported. There is no longer the need for separate `helm2` and `helm3` binaries, only `helm` (version 3) is required.
 * The following annotations are deprecated for a long time and will be removed in 0.23.0:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add Kafka Quotas plugin with produce, consume, and storage quotas
 * Remove topics and groups "blacklist" pattern from KafkaMirrorMaker2 CRD
 * Support pausing reconciliation of KafkaTopic CR with annotation `strimzi.io/pause-reconciliation`
+* Support for broker load information added to the rebalance optimization proposal. Information on the load difference, before and after a rebalance is stored in a ConfigMap
 
 ## 0.23.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -358,7 +358,7 @@ public class KafkaRebalanceAssemblyOperator
         RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder = convertRebalanceSpecToRebalanceOptions(kafkaRebalance.getSpec());
 
         return computeNextStatus(reconciliation, host, apiClient, kafkaRebalance, currentState, rebalanceAnnotation, rebalanceOptionsBuilder)
-           .compose(desiredStatusandMap -> {
+           .compose(desiredStatusAndMap -> {
                // More events related to resource modification might be queued with a stale state. (potentially updated by the rebalance holding the lock)
                // Due to possible long rebalancing operations that take the lock for the entire period,
                // do a new get to retrieve the current resource state.
@@ -366,8 +366,8 @@ public class KafkaRebalanceAssemblyOperator
                             .compose(currentKafkaRebalance -> {
                                 if (currentKafkaRebalance != null) {
                                     return configMapOperator.reconcile(kafkaRebalance.getMetadata().getNamespace(),
-                                            kafkaRebalance.getMetadata().getName(), desiredStatusandMap.getLoadMap())
-                                            .compose(i -> updateStatus(currentKafkaRebalance, desiredStatusandMap.getStatus(), null))
+                                            kafkaRebalance.getMetadata().getName(), desiredStatusAndMap.getLoadMap())
+                                            .compose(i -> updateStatus(currentKafkaRebalance, desiredStatusAndMap.getStatus(), null))
                                             .compose(updatedKafkaRebalance -> {
                                                 log.info("{}: State updated to [{}] with annotation {}={} ",
                                                         reconciliation,
@@ -585,7 +585,6 @@ public class KafkaRebalanceAssemblyOperator
     /**
      * A wrapper class containing used to bind the ConfigMap and the status together.
      */
-
     static class MapAndStatus<T, K> {
 
         T loadMap;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -643,7 +643,7 @@ public class KafkaRebalanceAssemblyOperator
                 .withName(kafkaRebalance.getMetadata().getName())
                 .withLabels(Collections.singletonMap("app", "strimzi"))
                 .endMetadata()
-                .withData(Collections.singletonMap(BROKER_LOAD_KEY, beforeAndAfterBrokerLoad.encodePrettily()))
+                .withData(Collections.singletonMap(BROKER_LOAD_KEY, beforeAndAfterBrokerLoad.encode()))
                 .build();
 
         return new MapAndStatus<>(rebalanceMap, proposalJson.getJsonObject(CruiseControlRebalanceKeys.SUMMARY.getKey()).getMap());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApi.java
@@ -14,7 +14,6 @@ public interface CruiseControlApi {
     String CC_REST_API_ERROR_KEY = "errorMessage";
     String CC_REST_API_PROGRESS_KEY = "progress";
     String CC_REST_API_USER_ID_HEADER = "User-Task-ID";
-    String CC_REST_API_SUMMARY = "summary";
 
     /**
      *  Gets the state of the Cruise Control server.

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStatusTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.operator.cluster.operator.assembly;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.strimzi.api.kafka.model.KafkaRebalance;
+import io.strimzi.api.kafka.model.KafkaRebalanceBuilder;
+import io.strimzi.api.kafka.model.KafkaRebalanceSpec;
+import io.strimzi.api.kafka.model.KafkaRebalanceSpecBuilder;
+import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlLoadParameters;
+import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlRebalanceKeys;
+import io.strimzi.operator.common.model.Labels;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.keycloak.util.JsonSerialization.mapper;
+
+
+public class KafkaRebalanceStatusTest {
+
+    private static final int BROKER_ONE_KEY = 1;
+    private static final String BROKER_LOAD_KEY = "brokerLoad";
+    private static final String RESOURCE_NAME = "my-rebalance";
+    private static final String CLUSTER_NAMESPACE = "cruise-control-namespace";
+    private static final String CLUSTER_NAME = "kafka-cruise-control-test-cluster";
+
+
+    private KafkaRebalance createKafkaRebalance(String namespace, String clusterName, String resourceName,
+                                                KafkaRebalanceSpec kafkaRebalanceSpec) {
+        return new KafkaRebalanceBuilder()
+                .withNewMetadata()
+                .withNamespace(namespace)
+                .withName(resourceName)
+                .withLabels(clusterName != null ? Collections.singletonMap(Labels.STRIMZI_CLUSTER_LABEL, CLUSTER_NAME) : null)
+                .endMetadata()
+                .withSpec(kafkaRebalanceSpec)
+                .build();
+    }
+
+    public static JsonObject buildOptimizationProposal() {
+
+        JsonObject proposal = new JsonObject();
+
+        JsonObject summary = new JsonObject();
+
+        JsonObject brokersBeforeObject = new JsonObject();
+        JsonArray brokerLoadBeforeArray = new JsonArray();
+        JsonObject brokerOneBefore = new JsonObject();
+        brokerOneBefore.put(CruiseControlRebalanceKeys.BROKER_ID.getKey(), BROKER_ONE_KEY);
+        brokerOneBefore.put(CruiseControlLoadParameters.CPU_PERCENTAGE.getCruiseControlKey(), 10.0);
+        brokerOneBefore.put(CruiseControlLoadParameters.REPLICAS.getCruiseControlKey(), 10);
+        brokerLoadBeforeArray.add(brokerOneBefore);
+        brokersBeforeObject.put(CruiseControlRebalanceKeys.BROKERS.getKey(), brokerLoadBeforeArray);
+
+        JsonObject brokersAfterObject = new JsonObject();
+        JsonArray brokerLoadAfterArray = new JsonArray();
+        JsonObject brokerOneAfter = new JsonObject();
+        brokerOneAfter.put(CruiseControlRebalanceKeys.BROKER_ID.getKey(), BROKER_ONE_KEY);
+        brokerOneAfter.put(CruiseControlLoadParameters.CPU_PERCENTAGE.getCruiseControlKey(), 20.0);
+        brokerOneAfter.put(CruiseControlLoadParameters.REPLICAS.getCruiseControlKey(), 5);
+        brokerLoadAfterArray.add(brokerOneAfter);
+        brokersAfterObject.put(CruiseControlRebalanceKeys.BROKERS.getKey(), brokerLoadAfterArray);
+
+        proposal.put(CruiseControlRebalanceKeys.SUMMARY.getKey(), summary);
+        proposal.put(CruiseControlRebalanceKeys.LOAD_BEFORE_OPTIMIZATION.getKey(), brokersBeforeObject);
+        proposal.put(CruiseControlRebalanceKeys.LOAD_AFTER_OPTIMIZATION.getKey(), brokersAfterObject);
+
+        return proposal;
+
+    }
+
+    @Test
+    public void testLoadParamExtract() {
+
+        JsonObject proposal = buildOptimizationProposal();
+
+        JsonArray loadBeforeArray = proposal.getJsonObject(CruiseControlRebalanceKeys.LOAD_BEFORE_OPTIMIZATION.getKey())
+                .getJsonArray(CruiseControlRebalanceKeys.BROKERS.getKey());
+
+        Map<Integer, Map<String, Object>> output = KafkaRebalanceAssemblyOperator.extractLoadParameters(loadBeforeArray);
+
+        assertThat(output, hasKey(BROKER_ONE_KEY));
+        assertThat(output.get(BROKER_ONE_KEY), hasEntry(CruiseControlLoadParameters.CPU_PERCENTAGE.getKafkaRebalanceStatusKey(), 10.0));
+        assertThat(output.get(BROKER_ONE_KEY), hasEntry(CruiseControlLoadParameters.REPLICAS.getKafkaRebalanceStatusKey(), 10));
+
+    }
+
+    @Test
+    public void testCreateLoadMap() {
+
+        JsonObject proposal = buildOptimizationProposal();
+
+        JsonArray loadBeforeArray = proposal.getJsonObject(CruiseControlRebalanceKeys.LOAD_BEFORE_OPTIMIZATION.getKey())
+                .getJsonArray(CruiseControlRebalanceKeys.BROKERS.getKey());
+        JsonArray loadAfterArray = proposal.getJsonObject(CruiseControlRebalanceKeys.LOAD_AFTER_OPTIMIZATION.getKey())
+                .getJsonArray(CruiseControlRebalanceKeys.BROKERS.getKey());
+
+        JsonObject output = KafkaRebalanceAssemblyOperator.parseLoadStats(
+                loadBeforeArray, loadAfterArray);
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            Map<String, LinkedHashMap<String, String>> outputMap = mapper.readValue(output.encodePrettily(), Map.class);
+            assertThat(outputMap, hasKey("1"));
+
+            LinkedHashMap<String, LinkedHashMap> m = (LinkedHashMap) outputMap.get("1");
+
+            assertThat(outputMap.get("1"), hasKey(CruiseControlLoadParameters.CPU_PERCENTAGE.getKafkaRebalanceStatusKey()));
+
+            ArrayList<Integer> replicas = new ArrayList<>();
+            replicas.add((Integer) m.get("replicas").get("before"));
+            replicas.add((Integer) m.get("replicas").get("after"));
+            replicas.add((Integer) m.get("replicas").get("diff"));
+
+            assertThat(replicas.get(0), is(10));
+            assertThat(replicas.get(1), is(5));
+            assertThat(replicas.get(2), is(-5));
+
+            assertThat(outputMap.get("1"), hasKey(CruiseControlLoadParameters.REPLICAS.getKafkaRebalanceStatusKey()));
+
+            ArrayList<Double> cpu = new ArrayList<>();
+            cpu.add((Double) m.get("cpuPercentage").get("before"));
+            cpu.add((Double) m.get("cpuPercentage").get("after"));
+            cpu.add((Double) m.get("cpuPercentage").get("diff"));
+
+            assertThat(cpu.get(0), is(10.));
+            assertThat(cpu.get(1), is(20.0));
+            assertThat(cpu.get(2), is(10.0));
+
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testProcessProposal() {
+
+        JsonObject proposal = buildOptimizationProposal();
+
+        KafkaRebalance kr =
+                createKafkaRebalance(CLUSTER_NAMESPACE, CLUSTER_NAME, RESOURCE_NAME, new KafkaRebalanceSpecBuilder().build());
+
+        KafkaRebalanceAssemblyOperator.MapandStatus<ConfigMap, Map<String, Object>> output = KafkaRebalanceAssemblyOperator.processOptimizationProposal(kr, proposal);
+
+        assertTrue(output.getStatus().containsKey(CruiseControlRebalanceKeys.SUMMARY.getKey()));
+
+        Map<String, String> brokerMap = output.getLoadMap().getData();
+
+        try {
+
+            ObjectMapper mapper = new ObjectMapper();
+
+            Map<String, LinkedHashMap<String, String>> brokerLoadMap = mapper.readValue(brokerMap.get("brokerLoad"), LinkedHashMap.class);
+
+            assertThat(brokerMap, hasKey(BROKER_LOAD_KEY));
+
+            LinkedHashMap<String, LinkedHashMap<String, Object>> m = (LinkedHashMap) brokerLoadMap.get("1");
+
+            assertThat(m, hasKey(CruiseControlLoadParameters.CPU_PERCENTAGE.getKafkaRebalanceStatusKey()));
+
+            ArrayList<Double> cpu = new ArrayList<>();
+            cpu.add((Double) m.get("cpuPercentage").get("before"));
+            cpu.add((Double) m.get("cpuPercentage").get("after"));
+            cpu.add((Double) m.get("cpuPercentage").get("diff"));
+
+            assertThat(cpu.get(0), is(10.0));
+            assertThat(cpu.get(1), is(20.0));
+            assertThat(cpu.get(2), is(10.0));
+
+
+            assertThat(m, hasKey(CruiseControlLoadParameters.REPLICAS.getKafkaRebalanceStatusKey()));
+
+            ArrayList<Integer> replicas = new ArrayList<>();
+            replicas.add((Integer) m.get("replicas").get("before"));
+            replicas.add((Integer) m.get("replicas").get("after"));
+            replicas.add((Integer) m.get("replicas").get("diff"));
+
+            assertThat(replicas.get(0), is(10));
+            assertThat(replicas.get(1), is(5));
+            assertThat(replicas.get(2), is(-5));
+
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStatusTest.java
@@ -154,7 +154,7 @@ public class KafkaRebalanceStatusTest {
         KafkaRebalance kr =
                 createKafkaRebalance(CLUSTER_NAMESPACE, CLUSTER_NAME, RESOURCE_NAME, new KafkaRebalanceSpecBuilder().build());
 
-        KafkaRebalanceAssemblyOperator.MapandStatus<ConfigMap, Map<String, Object>> output = KafkaRebalanceAssemblyOperator.processOptimizationProposal(kr, proposal);
+        KafkaRebalanceAssemblyOperator.MapAndStatus<ConfigMap, Map<String, Object>> output = KafkaRebalanceAssemblyOperator.processOptimizationProposal(kr, proposal);
 
         assertTrue(output.getStatus().containsKey(CruiseControlRebalanceKeys.SUMMARY.getKey()));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStatusTest.java
@@ -27,7 +27,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KafkaRebalanceStatusTest {
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
@@ -19,9 +19,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 
 import static io.strimzi.operator.cluster.JSONObjectMatchers.hasEntry;
-import static io.strimzi.operator.cluster.JSONObjectMatchers.hasKey;
 import static io.strimzi.operator.cluster.JSONObjectMatchers.hasKeys;
-import static io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlApi.CC_REST_API_SUMMARY;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
@@ -143,30 +141,10 @@ public class CruiseControlClientTest {
         String userTaskID = MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID;
 
         Checkpoint checkpoint = context.checkpoint();
-        client.getUserTaskStatus(HOST, PORT, userTaskID)
-            .onComplete(context.succeeding(result -> context.verify(() -> {
-                assertThat(result.getUserTaskId(), is(MockCruiseControl.USER_TASK_REBALANCE_NO_GOALS_RESPONSE_UTID));
-                assertThat(result.getJson().getJsonObject(CC_REST_API_SUMMARY), is(notNullValue()));
-                checkpoint.flag();
-            })));
+        client.getUserTaskStatus(HOST, PORT, userTaskID).onComplete(context.succeeding(result -> {
+            context.verify(() -> assertThat(result.getUserTaskId(), is(MockCruiseControl.USER_TASK_REBALANCE_NO_GOALS_RESPONSE_UTID)));
+            context.verify(() -> assertThat(result.getJson().getJsonObject(CruiseControlRebalanceKeys.SUMMARY.getKey()), is(notNullValue())));
+            checkpoint.flag();
+        }));
     }
-
-    @Test
-    public void testCCGetRebalanceVerboseUserTask(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-
-        MockCruiseControl.setupCCUserTasksResponseNoGoals(ccServer, 0, 0);
-
-        CruiseControlApi client = new CruiseControlApiImpl(vertx);
-        String userTaskID = MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID;
-
-        Checkpoint checkpoint = context.checkpoint();
-        client.getUserTaskStatus(HOST, PORT, userTaskID)
-            .onComplete(context.succeeding(result -> context.verify(() -> {
-                assertThat(result.getUserTaskId(), is(MockCruiseControl.USER_TASK_REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID));
-                assertThat(result.getJson(), hasKey(CC_REST_API_SUMMARY));
-                assertThat(result.getJson().getJsonObject(CC_REST_API_SUMMARY), is(notNullValue()));
-                checkpoint.flag();
-            })));
-    }
-
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
@@ -40,7 +40,7 @@ public class MockCruiseControl {
     private static final String VERBOSE = "verbose";
     private static final String USER_TASK = "user-task";
     private static final String RESPONSE = "response";
-
+    
     public static final String REBALANCE_NO_GOALS_RESPONSE_UTID = REBALANCE + SEP + NO_GOALS + SEP + RESPONSE;
     public static final String REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID = REBALANCE + SEP + NO_GOALS + SEP + VERBOSE + SEP + RESPONSE;
     public static final String USER_TASK_REBALANCE_NO_GOALS = USER_TASK + SEP + REBALANCE + SEP + NO_GOALS;
@@ -190,7 +190,7 @@ public class MockCruiseControl {
                                 .withMethod("POST")
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.JSON.key, "true"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.DRY_RUN.key, "true|false"))
-                                .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "false"))
+                                .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "true|false"))
                                 .withPath(CruiseControlEndpoints.REBALANCE.path),
                         Times.exactly(pendingCalls))
                 .respond(
@@ -251,7 +251,7 @@ public class MockCruiseControl {
                                 .withMethod("POST")
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.JSON.key, "true"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.DRY_RUN.key, "true|false"))
-                                .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "false"))
+                                .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "true|false"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.GOALS.key, ".+"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.SKIP_HARD_GOAL_CHECK.key, "false"))
                                 .withPath(CruiseControlEndpoints.REBALANCE.path))
@@ -264,7 +264,7 @@ public class MockCruiseControl {
 
         // Response if the user has set custom goals which do not include all configured hard.goals
         // Note: This uses the no-goals example response but the difference between custom goals and default goals is not tested here
-        JsonBody jsonSummary = getJsonFromResource("CC-Rebalance-no-goals.json");
+        JsonBody jsonSummary = getJsonFromResource("CC-Rebalance-no-goals-verbose.json");
 
         ccServer
                 .when(
@@ -272,7 +272,7 @@ public class MockCruiseControl {
                                 .withMethod("POST")
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.JSON.key, "true"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.DRY_RUN.key, "true|false"))
-                                .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "false"))
+                                .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "true|false"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.GOALS.key, ".+"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.SKIP_HARD_GOAL_CHECK.key, "true"))
                                 .withPath(CruiseControlEndpoints.REBALANCE.path))
@@ -350,8 +350,26 @@ public class MockCruiseControl {
                                 .withDelay(TimeUnit.SECONDS, RESPONSE_DELAY_SEC));
 
         // User tasks response for the rebalance request with no goals set (verbose)
+        JsonBody jsonActiveVerbose = getJsonFromResource("CC-User-task-rebalance-no-goals-verbose-Active.json");
         JsonBody jsonInExecutionVerbose = getJsonFromResource("CC-User-task-rebalance-no-goals-verbose-inExecution.json");
         JsonBody jsonCompletedVerbose = getJsonFromResource("CC-User-task-rebalance-no-goals-verbose-completed.json");
+
+        // The first activeCalls times respond that with a status of "Active"
+        ccServer
+                .when(
+                        request()
+                                .withMethod("GET")
+                                .withQueryStringParameter(Parameter.param(CruiseControlParameters.JSON.key, "true"))
+                                .withQueryStringParameter(Parameter.param(CruiseControlParameters.FETCH_COMPLETE.key, "true"))
+                                .withQueryStringParameter(
+                                        Parameter.param(CruiseControlParameters.USER_TASK_IDS.key, REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID))
+                                .withPath(CruiseControlEndpoints.USER_TASKS.path),
+                        Times.exactly(activeCalls))
+                .respond(
+                        response()
+                                .withBody(jsonActiveVerbose)
+                                .withHeaders(header("User-Task-ID", USER_TASK_REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID))
+                                .withDelay(TimeUnit.SECONDS, RESPONSE_DELAY_SEC));
 
         ccServer
                 .when(

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/operator/assembly/CruiseControlJSON/CC-User-task-rebalance-no-goals-verbose-Active.json
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/operator/assembly/CruiseControlJSON/CC-User-task-rebalance-no-goals-verbose-Active.json
@@ -1,0 +1,1 @@
+{"userTasks":[{"Status":"Active","UserTaskId":"rebalance-no-goals-verbose-response","StartMs":"1579874383374"}],"version":1}

--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -117,7 +117,7 @@ To extract the JSON string from the ConfigMap, use the following command:
 
 [source,shell,subs=+quotes]
 ----
-kubectl get configmap my-rebalance -o json | jq .data
+kubectl get configmap _my-rebalance_ -o json | jq .data
 ----
 
 The following table explains the properties contained in the optimization proposal's broker load ConfigMap:

--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -109,7 +109,7 @@ m¦excludedBrokersForReplicaMove
 [discrete]
 === Broker load
 
-The broker load is stored in a ConfigMap (with the same name as the KafakRebalance custom resource) as a JSON formatted string. This JSON string consists of a JSON object with keys for each broker IDs linking to a number of metrics for each broker
+The broker load is stored in a ConfigMap (with the same name as the KafakRebalance custom resource) as a JSON formatted string. This JSON string consists of a JSON object with keys for each broker IDs linking to a number of metrics for each broker.
 Each metric consist of three values.
 The first is the metric value before the optimization proposal is applied, the second is the expected value of the metric after the proposal is applied, and the third is the difference between the first two values (after minus before).
 

--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -106,7 +106,6 @@ m¦excludedBrokersForReplicaMove
 === Broker load
 
 The broker load section lists all broker IDs and provides a number of metrics for each broker. 
-For each broker a number of metrics (described in the table below) are listed. 
 Each metric is linked to an array containing three values.
 The first is the metric value before the optimization proposal is applied, the second is the expected value of the metric after the proposal is applied, and the third is the difference between the first two values (after minus before).
 

--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -113,7 +113,7 @@ The broker load is stored in a ConfigMap (with the same name as the KafakRebalan
 Each metric consist of three values.
 The first is the metric value before the optimization proposal is applied, the second is the expected value of the metric after the proposal is applied, and the third is the difference between the first two values (after minus before).
 
-To extract the JSON string from the ConfigMap, use the following command:
+To extract the JSON string from the ConfigMap you could use the following command, which uses the jq command line JSON parser tool:
 
 [source,shell,subs=+quotes]
 ----

--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -34,7 +34,14 @@ Consider a shorter interval for fast changing clusters, although this increases 
 [discrete]
 == Contents of optimization proposals
 
-The following table describes the properties contained in an optimization proposal:
+An optimization proposal consists of two main sections: the _summary_ and the _broker load_.
+The summary provides an overview of the proposed cluster rebalance and indicates the scale of the changes involved.
+The broker load allows you to see the impact of the proposed rebalance on each of the brokers in the cluster.
+
+[discrete]
+=== Summary
+
+The following table explains the properties contained in the optimization proposal's summary section:
 
 .Properties contained in an optimization proposal
 [cols="35,65",options="header",stripes="none",separator=¦]
@@ -94,10 +101,46 @@ m¦excludedBrokersForReplicaMove
 
 |===
 
+
+[discrete]
+=== Broker load
+
+The broker load section lists all broker IDs and provides a number of metrics for each broker. 
+For each broker a number of metrics (described in the table below) are listed. 
+Each metric is linked to an array containing three values.
+The first is the metric value before the optimization proposal is applied, the second is the expected value of the metric after the proposal is applied, and the third is the difference between the first two values (after minus before).
+
+The following table explains the properties contained in the optimization proposal's broker load section:
+
+[cols="35,65",options="header",stripes="none"]
+|======================================================================================================
+
+| JSON property               | Description
+
+m| leaders                     | The number of replicas on this broker that are partition leaders.
+
+m| replicas                    | The number of replicas on this broker.
+
+m| cpuPercentage               | The CPU utilization as a percentage of the defined capacity.
+
+m| diskUsedPercentage          | The disk utilization as a percentage of the defined capacity.
+
+m| diskUsedMB                  | The absolute disk usage in MB.
+
+m| networkOutRate              | The total network output rate for the broker.
+
+m| leaderNetworkInRate         | The network input rate for all partition leader replicas on this broker.
+
+m| followerNetworkInRate       | The network input rate for all follower replicas on this broker.
+
+m| potentialMaxNetworkOutRate  | The hypothetical maximum network output rate that would be realized if this broker became the leader of all the replicas it currently hosts.
+
+|======================================================================================================
+
 .Additional resources
 
 * xref:con-optimization-goals-{context}[] 
 
 * xref:proc-generating-optimization-proposals-{context}[] 
 
-* xref:proc-approving-optimization-proposal-{context}[] 
+* xref:proc-approving-optimization-proposal-{context}[]

--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -117,7 +117,7 @@ To extract the JSON string from the ConfigMap you could use the following comman
 
 [source,shell,subs=+quotes]
 ----
-kubectl get configmap _my-rebalance_ -o json | jq '.["data"]["brokerLoad.json"]|fromjson|.'
+kubectl get configmap _MY-REBALANCE_ -o json | jq '.["data"]["brokerLoad.json"]|fromjson|.'
 ----
 
 The following table explains the properties contained in the optimization proposal's broker load ConfigMap:

--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -117,7 +117,7 @@ To extract the JSON string from the ConfigMap, use the following command:
 
 [source,shell,subs=+quotes]
 ----
-kubectl get configmap _my-rebalance_ -o json | jq .data
+kubectl get configmap _my-rebalance_ -o json | jq '.["data"]["brokerLoad.json"]|fromjson|.'
 ----
 
 The following table explains the properties contained in the optimization proposal's broker load ConfigMap:

--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -36,7 +36,7 @@ Consider a shorter interval for fast changing clusters, although this increases 
 
 An optimization proposal consists of two main sections: the _summary_ and the _broker load_.
 The summary provides an overview of the proposed cluster rebalance and indicates the scale of the changes involved.
-The broker load allows you to see the impact of the proposed rebalance on each of the brokers in the cluster.
+The broker load shows before and after values for the proposed rebalance, so you can see the impact on each of the brokers in the cluster.
 
 [discrete]
 === Summary
@@ -105,8 +105,8 @@ m¦excludedBrokersForReplicaMove
 [discrete]
 === Broker load
 
-The broker load section lists all broker IDs and provides a number of metrics for each broker. 
-Each metric is linked to an array containing three values.
+The broker load is a json string which consist of all broker IDs and provides a number of metrics for each broker.
+Each metric consist of three values.
 The first is the metric value before the optimization proposal is applied, the second is the expected value of the metric after the proposal is applied, and the third is the difference between the first two values (after minus before).
 
 The following table explains the properties contained in the optimization proposal's broker load section:

--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -34,7 +34,11 @@ Consider a shorter interval for fast changing clusters, although this increases 
 [discrete]
 == Contents of optimization proposals
 
-An optimization proposal consists of two main sections: the _summary_ and the _broker load_.
+An optimization proposal consists of two main sections:
+
+* The _summary_ is stored in the `status` of the `KafkaRebalance` resource.
+* The _broker load_ is stored in a ConfigMap that contains data as a JSON string.
+
 The summary provides an overview of the proposed cluster rebalance and indicates the scale of the changes involved.
 The broker load shows before and after values for the proposed rebalance, so you can see the impact on each of the brokers in the cluster.
 
@@ -105,11 +109,14 @@ m¦excludedBrokersForReplicaMove
 [discrete]
 === Broker load
 
-The broker load is a json string which consist of all broker IDs and provides a number of metrics for each broker.
+The broker load is stored in a ConfigMap (with the same name as the KafakRebalance custom resource) as a JSON formatted string. This JSON string consists of a JSON object with keys for each broker IDs linking to a number of metrics for each broker
 Each metric consist of three values.
 The first is the metric value before the optimization proposal is applied, the second is the expected value of the metric after the proposal is applied, and the third is the difference between the first two values (after minus before).
 
-The following table explains the properties contained in the optimization proposal's broker load section:
+To extract the JSON string from the ConfigMap, use the following command:
+`kubectl describe configmap my-rebalance`
+
+The following table explains the properties contained in the optimization proposal's broker load ConfigMap:
 
 [cols="35,65",options="header",stripes="none"]
 |======================================================================================================

--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -114,7 +114,11 @@ Each metric consist of three values.
 The first is the metric value before the optimization proposal is applied, the second is the expected value of the metric after the proposal is applied, and the third is the difference between the first two values (after minus before).
 
 To extract the JSON string from the ConfigMap, use the following command:
-`kubectl describe configmap my-rebalance`
+
+[source,shell,subs=+quotes]
+----
+kubectl get configmap my-rebalance -o json | jq .data
+----
 
 The following table explains the properties contained in the optimization proposal's broker load ConfigMap:
 

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlLoadParameters.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlLoadParameters.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This enum contains keys for the JSON object that contains the broker before and after load information. Each entry
+ * contains the Cruise Control keys, taken from the com.linkedin.kafka.cruisecontrol.servlet.response.stats.BasicStats
+ * class, and a more readable key name used for the KafkaRebalance status. The type field is used to distinguish key
+ * that require different castings when extracted to create the [before, after, difference] arrays for the
+ * KafkaRebalance status.
+ */
+public enum CruiseControlLoadParameters {
+
+    LEADERS("Leaders", "leaders", "int"),
+    REPLICAS("Replicas", "replicas", "int"),
+    CPU_PERCENTAGE("CpuPct", "cpuPercentage", "double"),
+    DISK_PERCENTAGE("DiskPct", "diskUsedPercentage", "double"),
+    DISK_MB("DiskMB", "diskUsedMB", "double"),
+    NETWORK_OUT_RATE("NwOutRate", "networkOutRateKB", "double"),
+    LEADER_NETWORK_IN_RATE("LeaderNwInRate", "leaderNetworkInRateKB", "double"),
+    FOLLOWER_NETWORK_IN_RATE("FollowerNwInRate", "followerNetworkInRateKB", "double"),
+    POTENTIAL_MAX_NETWORK_OUT_RATE("PnwOutRate", "potentialMaxNetworkOutRateKB", "double");
+
+    /** The key used in the load JSON object returned by Cruise Control. */
+    private String cruiseControlKey;
+    /** The key used for the KafakRebalance status field. */
+    private String kafkaRebalanceStatusKey;
+    /** The type of value stored in the relevant field. */
+    private String type;
+
+    CruiseControlLoadParameters(String cruiseControlKey, String kafkaRebalanceStatusKey, String type) {
+        this.cruiseControlKey = cruiseControlKey;
+        this.kafkaRebalanceStatusKey = kafkaRebalanceStatusKey;
+        this.type = type;
+    }
+
+    public String getCruiseControlKey() {
+        return cruiseControlKey;
+    }
+
+    public String getKafkaRebalanceStatusKey() {
+        return kafkaRebalanceStatusKey;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    private static List<CruiseControlLoadParameters> filterByType(String filterType) {
+        return Arrays.stream(CruiseControlLoadParameters.values())
+                .filter(loadParameter -> loadParameter.getType() != null)
+                .filter(loadParameter -> loadParameter.getType().equals(filterType))
+                .collect(Collectors.toList());
+    }
+
+    public static List<CruiseControlLoadParameters> getIntegerParameters() {
+        return filterByType("int");
+    }
+
+    public static List<CruiseControlLoadParameters> getDoubleParameters() {
+        return filterByType("double");
+    }
+
+}

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlLoadParameters.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlLoadParameters.java
@@ -54,8 +54,7 @@ public enum CruiseControlLoadParameters {
 
     private static List<CruiseControlLoadParameters> filterByType(String filterType) {
         return Arrays.stream(CruiseControlLoadParameters.values())
-                .filter(loadParameter -> loadParameter.getType() != null)
-                .filter(loadParameter -> loadParameter.getType().equals(filterType))
+                .filter(loadParameter -> filterType.equals(loadParameter.getType()))
                 .collect(Collectors.toList());
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRebalanceKeys.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRebalanceKeys.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
+
+/**
+ * This enum contains the keys used in the various levels of the JSON object returned by the Cruise Control
+ * rebalance endpoint.
+ */
+public enum CruiseControlRebalanceKeys {
+
+    SUMMARY("summary"),
+    ORIGINAL_RESPONSE("originalResponse"),
+    LOAD_BEFORE_OPTIMIZATION("loadBeforeOptimization"),
+    LOAD_AFTER_OPTIMIZATION("loadAfterOptimization"),
+    BROKERS("brokers"),
+    BROKER_ID("Broker");
+
+    private String key;
+
+    CruiseControlRebalanceKeys(String key) {
+        this.key = key;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -159,9 +159,11 @@ public class CruiseControlIsolatedST extends AbstractST {
 
         LOGGER.info("Checking status of KafkaRebalance");
         KafkaRebalanceStatus kafkaRebalanceStatus = KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(NAMESPACE).withName(clusterName).get().getStatus();
-        assertThat(kafkaRebalanceStatus.getOptimizationResult().get("excludedTopics").toString(), containsString(excludedTopic1));
-        assertThat(kafkaRebalanceStatus.getOptimizationResult().get("excludedTopics").toString(), containsString(excludedTopic2));
-        assertThat(kafkaRebalanceStatus.getOptimizationResult().get("excludedTopics").toString(), not(containsString(includedTopic)));
+        Map<String, Object> optimizationResult = kafkaRebalanceStatus.getOptimizationResult();
+        Map<String, Object> optimizationSummary = (Map<String, Object>) optimizationResult.get("summary");
+        assertThat(optimizationSummary.get("excludedTopics").toString(), containsString(excludedTopic1));
+        assertThat(optimizationSummary.get("excludedTopics").toString(), containsString(excludedTopic2));
+        assertThat(optimizationSummary.get("excludedTopics").toString(), not(containsString(includedTopic)));
 
         KafkaRebalanceUtils.annotateKafkaRebalanceResource(clusterName, KafkaRebalanceAnnotation.approve);
         KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(clusterName, KafkaRebalanceState.Ready);

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -159,11 +159,9 @@ public class CruiseControlIsolatedST extends AbstractST {
 
         LOGGER.info("Checking status of KafkaRebalance");
         KafkaRebalanceStatus kafkaRebalanceStatus = KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(NAMESPACE).withName(clusterName).get().getStatus();
-        Map<String, Object> optimizationResult = kafkaRebalanceStatus.getOptimizationResult();
-        Map<String, Object> optimizationSummary = (Map<String, Object>) optimizationResult.get("summary");
-        assertThat(optimizationSummary.get("excludedTopics").toString(), containsString(excludedTopic1));
-        assertThat(optimizationSummary.get("excludedTopics").toString(), containsString(excludedTopic2));
-        assertThat(optimizationSummary.get("excludedTopics").toString(), not(containsString(includedTopic)));
+        assertThat(kafkaRebalanceStatus.getOptimizationResult().get("excludedTopics").toString(), containsString(excludedTopic1));
+        assertThat(kafkaRebalanceStatus.getOptimizationResult().get("excludedTopics").toString(), containsString(excludedTopic2));
+        assertThat(kafkaRebalanceStatus.getOptimizationResult().get("excludedTopics").toString(), not(containsString(includedTopic)));
 
         KafkaRebalanceUtils.annotateKafkaRebalanceResource(clusterName, KafkaRebalanceAnnotation.approve);
         KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(clusterName, KafkaRebalanceState.Ready);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- 
### Description

Enhancement

Description
This PR addresses #3279 and it is an extension of the PR #3471.  The load information is added in a configMap which is attached to the Kafka Rebalance Assembly Operator. Each broker has its own entry with multiple metrics that show arrays consisting of [before, after, difference] values. An example status is shown below: 


```Status:
  Conditions:
    Last Transition Time:  2020-08-05T14:59:40.766999Z
    Status:                True
    Type:                  ProposalReady
  Observed Generation:     1
  Optimization Result:
    Broker Load:
      0:
        Cpu Percentage:
          0.36882564425468445
          0.3104616701602936
          -0.05836397409439087
        Disk Used MB:
          0.08218097686767578
          0.061748504638671875
          -0.020432472229003906
        Disk Used Percentage:
          8.218097686767578e-05
          6.174850463867188e-05
          -2.0432472229003904e-05
        Follower Network In Rate:
          0.01287756860256195
          0.021891381591558456
          0.009013812988996506
        Leader Network In Rate:
          0.04915750026702881
          0.03794153034687042
          -0.011215969920158386
        Leaders:
          22
          1
          -21
        Network Out Rate:
          0.08511605020612478
          0.07390008121728897
          -0.011215968988835812
        Potential Max Network Out Rate:
          0.09799361787736416
          0.09579146280884743
          -0.0022021550685167313
        Replicas:
          43
          39
          -4
      1:
        Cpu Percentage:
          0.0057828957214951515
          0.041537750512361526
          0.035754854790866375
        Disk Used MB:
          0.014960289001464844
          0.029038429260253906
          0.014078140258789062
        Disk Used Percentage:
          1.4960289001464843e-05
          2.9038429260253908e-05
          1.4078140258789065e-05
        Follower Network In Rate:
          0.01352857705205679
          0.008375635370612144
          -0.005152941681444645
        Leader Network In Rate:
          0.011323668994009495
          0.0182796698063612
          0.006956000812351704
        Leaders:
          22
          34
          12
        Network Out Rate:
          0.011323668994009495
          0.0182796698063612
          0.006956000812351704
        Potential Max Network Out Rate:
          0.024852246046066284
          0.026655305176973343
          0.0018030591309070587
        Replicas:
          44
          47
          3
      2:
        Cpu Percentage:
          0.005323501303792
          0.027932610362768173
          0.022609109058976173
        Disk Used MB:
          0.02252483367919922
          0.028879165649414062
          0.006354331970214844
        Disk Used Percentage:
          2.252483367919922e-05
          2.8879165649414063e-05
          6.354331970214844e-06
        Follower Network In Rate:
          0.010815710760653019
          0.006954839453101158
          -0.003860871307551861
        Leader Network In Rate:
          0.014682217501103878
          0.01894218660891056
          0.004259969107806683
        Leaders:
          21
          30
          9
        Network Out Rate:
          0.014682217501103878
          0.01894218660891056
          0.004259969107806683
        Potential Max Network Out Rate:
          0.025497928261756897
          0.02589702606201172
          0.0003990978002548218
        Replicas:
          42
          43
          1
    Summary:
      Data To Move MB:  0
      Excluded Brokers For Leadership:
      Excluded Brokers For Replica Move:
      Excluded Topics:
      Intra Broker Data To Move MB:         0
      Monitored Partitions Percentage:      100
      Num Intra Broker Replica Movements:   0
      Num Leader Movements:                 9
      Num Replica Movements:                36
      On Demand Balancedness Score After:   78.01176356230222
      On Demand Balancedness Score Before:  78.01176356230222
      Recent Windows:                       1
  Session Id:                               1b7a2642-e49a-4012-ba3d-afa5c6ca9af4
Events:                                     <none> ```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

