### PR TITLE
Fix bad AuthZ example in deploying guide and improve also other AuthZ examples

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.KafkaAuthorizationCustom.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaAuthorizationCustom.adoc
@@ -23,6 +23,11 @@ You can add configuration for initializing the custom authorizer using `Kafka.sp
 .An example of custom authorization configuration under `Kafka.spec`
 [source,yaml,subs="attributes+"]
 ----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+  namespace: myproject
 spec:
   kafka:
     # ...

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaAuthorizationOpa.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaAuthorizationOpa.adoc
@@ -31,15 +31,24 @@ For more information see xref:con-securing-kafka-authorization-str[Kafka authori
 .An example of Open Policy Agent authorizer configuration
 [source,yaml,subs=attributes+]
 ----
-authorization:
-  type: opa
-  url: http://opa:8181/v1/data/kafka/allow
-  allowOnError: false
-  initialCacheCapacity: 1000
-  maximumCacheSize: 10000
-  expireAfterMs: 60000
-  superUsers:
-    - CN=fred
-    - sam
-    - CN=edward
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+  namespace: myproject
+spec:
+  kafka:
+    # ...
+    authorization:
+      type: opa
+      url: http://opa:8181/v1/data/kafka/allow
+      allowOnError: false
+      initialCacheCapacity: 1000
+      maximumCacheSize: 10000
+      expireAfterMs: 60000
+      superUsers:
+        - CN=fred
+        - sam
+        - CN=edward
+    # ...
 ----

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaAuthorizationSimple.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaAuthorizationSimple.adoc
@@ -15,12 +15,21 @@ For more information see xref:con-securing-kafka-authorization-str[Kafka authori
 .An example of simple authorization configuration
 [source,yaml,subs="attributes+"]
 ----
-authorization:
-  type: simple
-  superUsers:
-    - CN=client_1
-    - user_2
-    - CN=client_3
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+  namespace: myproject
+spec:
+  kafka:
+    # ...
+    authorization:
+      type: simple
+      superUsers:
+        - CN=client_1
+        - user_2
+        - CN=client_3
+    # ...
 ----
 
 NOTE: The `super.user` configuration option in the `config` property in `Kafka.spec.kafka` is ignored.

--- a/documentation/modules/con-securing-kafka-authorization.adoc
+++ b/documentation/modules/con-securing-kafka-authorization.adoc
@@ -30,10 +30,19 @@ If a user uses TLS client authentication, their username is the common name from
 .An example configuration with super users
 [source,yaml,subs="attributes+"]
 ----
-authorization:
-  type: simple
-  superUsers:
-    - CN=client_1
-    - user_2
-    - CN=client_3
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+  namespace: myproject
+spec:
+  kafka:
+    # ...
+    authorization:
+      type: simple
+      superUsers:
+        - CN=client_1
+        - user_2
+        - CN=client_3
+    # ...
 ----

--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -44,7 +44,7 @@ See the _Deploying and Upgrading Strimzi_ guide for instructions on deploying a:
 +
 The properties you can configure are shown in this example configuration:
 +
-[source,shell,subs="+attributes"]
+[source,yaml,subs="+attributes"]
 ----
 apiVersion: {KafkaApiVersion}
 kind: Kafka

--- a/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
+++ b/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
@@ -88,10 +88,10 @@ spec:
         preferredNodePortAddressType: InternalDNS <7>
         _bootstrap and broker service overrides_ <8>
         #...
-      authorization: <9>
-        type: simple
-        superUsers:
-          - super-user-name <10>
+    authorization: <9>
+      type: simple
+      superUsers:
+        - super-user-name <10>
   # ...
 ----
 <1> Configuration options for enabling external listeners are described in the link:{BookURLUsing}#type-GenericKafkaListener-reference[Generic Kafka listener schema reference^].

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -48,24 +48,24 @@ kind: Kafka
 metadata:
   name: my-cluster
 spec:
-  kafka
-  # ...
-  authorization:
-    type: *keycloak* <1>
-    tokenEndpointUri: <__https://<auth-server-address>/auth/realms/external/protocol/openid-connect/token__> <2>
-    clientId: kafka <3>
-    delegateToKafkaAcls: false <4>
-    disableTlsHostnameVerification: false <5>
-    superUsers: <6>
+  kafka:
+    # ...
+    authorization:
+      type: *keycloak* <1>
+      tokenEndpointUri: <__https://<auth-server-address>/auth/realms/external/protocol/openid-connect/token__> <2>
+      clientId: kafka <3>
+      delegateToKafkaAcls: false <4>
+      disableTlsHostnameVerification: false <5>
+      superUsers: <6>
       - CN=fred
       - sam
       - CN=edward
-    tlsTrustedCertificates: <7>
-    - secretName: oauth-server-cert
-      certificate: ca.crt
-    grantsRefreshPeriodSeconds: 60 <8>
-    grantsRefreshPoolSize: 5 <9>
-  #...
+      tlsTrustedCertificates: <7>
+      - secretName: oauth-server-cert
+        certificate: ca.crt
+      grantsRefreshPeriodSeconds: 60 <8>
+      grantsRefreshPoolSize: 5 <9>
+    #...
 ----
 <1> Type `keycloak` enables Keycloak authorization.
 <2> URI of the Keycloak token endpoint. For production, always use HTTPs.


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The example in https://strimzi.io/docs/operators/0.22.1/deploying.html#setup-external-clients-str has badly aligned authorization and does not work properly. This PR fixes the alignment there and also another bug in the OAuth Authorization section. It also improves other AuthZ examples to make it more clear where they belong.

### Checklist

- [x] Update documentation