### PR TITLE
Prepare the Strimzi Operators repo to rename the master branch to main

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -2,7 +2,7 @@
 trigger:
   branches:
     include:
-      - 'master'
+      - 'main'
       - 'release-*'
   tags:
     include:

--- a/.azure/scripts/build.sh
+++ b/.azure/scripts/build.sh
@@ -60,18 +60,18 @@ fi
 # Push artifatcs (Docker containers, JARs, docs)
 if [ "$BUILD_REASON" == "PullRequest" ] ; then
     echo "Building Pull Request - nothing to push"
-elif [[ "$BRANCH" != "refs/tags/"* ]] && [ "$BRANCH" != "refs/heads/master" ]; then
-    echo "Not in master branch and not in release tag - nothing to push"
+elif [[ "$BRANCH" != "refs/tags/"* ]] && [ "$BRANCH" != "refs/heads/main" ]; then
+    echo "Not in main branch and not in release tag - nothing to push"
 else
     if [ "${MAIN_BUILD}" == "TRUE" ] ; then
-        echo "Main build on master branch or release tag - going to push to Docker Hub, Nexus and website"
+        echo "Main build on main branch or release tag - going to push to Docker Hub, Nexus and website"
         
         echo "Login into Docker Hub ..."
         docker login -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REGISTRY
 
         export DOCKER_ORG=strimzi
         
-        if [ "$BRANCH" == "refs/heads/master" ]; then
+        if [ "$BRANCH" == "refs/heads/main" ]; then
             export DOCKER_TAG="latest"
         else
             export DOCKER_TAG="${BRANCH#refs/tags/}"
@@ -80,7 +80,7 @@ else
         echo "Pushing to docker org $DOCKER_ORG"
         make docker_push
 
-        if [ "$BRANCH" == "refs/heads/master" ]; then
+        if [ "$BRANCH" == "refs/heads/main" ]; then
             make docu_pushtowebsite
         fi
 

--- a/.azure/scripts/docu-push-to-website.sh
+++ b/.azure/scripts/docu-push-to-website.sh
@@ -33,6 +33,6 @@ git config user.email "ci@strimzi.io"
 
 git add -A
 git commit -s -m "Update documentation (Travis CI build ${TRAVIS_BUILD_NUMBER})" --allow-empty
-git push origin master
+git push origin main
 
 popd

--- a/.azure/templates/default_variables.yaml
+++ b/.azure/templates/default_variables.yaml
@@ -1,12 +1,12 @@
 # Default variables for jobs
 variables:
-  ${{ if eq( variables['Build.SourceBranch'], 'refs/heads/master' ) }}:
+  ${{ if eq( variables['Build.SourceBranch'], 'refs/heads/main' ) }}:
     pull_request: false
     docker_org: strimzi
     docker_registry: quay.io
     tag: latest
     commit: latest
-  ${{ if ne( variables['Build.SourceBranch'], 'refs/heads/master' ) }}:
+  ${{ if ne( variables['Build.SourceBranch'], 'refs/heads/main' ) }}:
     ${{ if startsWith( variables['Build.SourceBranch'], 'refs/tags/' ) }}:
       pull_request: false
       docker_org: strimzi

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Strimzi Community Code of Conduct
 
-Strimzi Community Code of Conduct is defined in the [governance repository](https://github.com/strimzi/governance/blob/master/CODE_OF_CONDUCT.md).
+Strimzi Community Code of Conduct is defined in the [governance repository](https://github.com/strimzi/governance/blob/main/CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ If you want to get in touch with us first before contributing, you can use:
 
 # How to become a maintainer
 
-The governance of the project is defined in the [GOVERNANCE.md](https://github.com/strimzi/strimzi-kafka-operator/blob/master/GOVERNANCE.md) file in the Strimzi Github repository, but in summary certain members of the community are the "maintainers" who decide the direction of the project. New maintainers can be elected by a ⅔ majority vote of the existing maintainers.
+The governance of the project is defined in the [GOVERNANCE.md](https://github.com/strimzi/strimzi-kafka-operator/blob/main/GOVERNANCE.md) file in the Strimzi Github repository, but in summary certain members of the community are the "maintainers" who decide the direction of the project. New maintainers can be elected by a ⅔ majority vote of the existing maintainers.
 
 So as to be transparent and to ensure that all potential maintainers are judged fairly and consistently the following criteria should be taken into account in electing new maintainers:
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TOPDIR=$(dir $(lastword $(MAKEFILE_LIST)))
 
 include ./Makefile.os
 
-GITHUB_VERSION ?= master
+GITHUB_VERSION ?= main
 RELEASE_VERSION ?= latest
 CHART_SEMANTIC_RELEASE_VERSION ?= $(shell cat ./release.version | tr A-Z a-z)
 BRIDGE_VERSION ?= $(shell cat ./bridge.version | tr A-Z a-z)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Run Apache Kafka on Kubernetes and OpenShift
 
-[![Build Status](https://dev.azure.com/cncf/strimzi/_apis/build/status/build?branchName=master)](https://dev.azure.com/cncf/strimzi/_build/latest?definitionId=16&branchName=master)
+[![Build Status](https://dev.azure.com/cncf/strimzi/_apis/build/status/build?branchName=main)](https://dev.azure.com/cncf/strimzi/_build/latest?definitionId=16&branchName=main)
 [![GitHub release](https://img.shields.io/github/release/strimzi/strimzi-kafka-operator.svg)](https://github.com/strimzi/strimzi-kafka-operator/releases/latest)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Twitter Follow](https://img.shields.io/twitter/follow/strimziio.svg?style=social&label=Follow&style=for-the-badge)](https://twitter.com/strimziio)
@@ -17,7 +17,7 @@ To get up and running quickly, check our [Quick Start for Minikube, OKD (OpenShi
 
 ## Documentation
 
-Documentation to the current _master_ branch as well as all releases can be found on our [website][strimzi].
+Documentation to the current _main_ branch as well as all releases can be found on our [website][strimzi].
 
 ## Getting help
 
@@ -50,8 +50,8 @@ All bugs, tasks or enhancements are tracked as [GitHub issues](https://github.co
 might be a good start for new contributors are marked with ["good-start"](https://github.com/strimzi/strimzi-kafka-operator/labels/good-start)
 label.
 
-The [Dev guide](https://github.com/strimzi/strimzi-kafka-operator/blob/master/development-docs/DEV_GUIDE.md) describes how to build Strimzi.
-Before submitting a patch, please make sure to understand, how to test your changes before opening a PR [Test guide](https://github.com/strimzi/strimzi-kafka-operator/blob/master/development-docs/TESTING.md).
+The [Dev guide](https://github.com/strimzi/strimzi-kafka-operator/blob/main/development-docs/DEV_GUIDE.md) describes how to build Strimzi.
+Before submitting a patch, please make sure to understand, how to test your changes before opening a PR [Test guide](https://github.com/strimzi/strimzi-kafka-operator/blob/main/development-docs/TESTING.md).
 
 The [Documentation Contributor Guide](https://strimzi.io/contributing/guide/) describes how to contribute to Strimzi documentation.
 

--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -173,7 +173,7 @@ Other build options:
 
 ### Kafka versions
 
-As part of the Docker image build several different versions of Kafka will be built, which can increase build times. Which Kafka versions are to be built are defined in the [kafka-versions.yaml](https://github.com/strimzi/strimzi-kafka-operator/blob/master/kafka-versions.yaml) file. Unwanted versions can be commented out to speed up the build process. 
+As part of the Docker image build several different versions of Kafka will be built, which can increase build times. Which Kafka versions are to be built are defined in the [kafka-versions.yaml](https://github.com/strimzi/strimzi-kafka-operator/blob/main/kafka-versions.yaml) file. Unwanted versions can be commented out to speed up the build process. 
 
 ### Maven Settings
 

--- a/development-docs/RELEASE.md
+++ b/development-docs/RELEASE.md
@@ -11,7 +11,7 @@ The `release` target will not build the Docker images - they should be built and
 The release process should normally look like this:
 
 1. Create a release branch
-2. On the `master` git branch of the operators repository:
+2. On the `main` git branch of the operators repository:
   * Update the versions to the next SNAPSHOT version using the `next_version` `make` target. For example to update the next version to `0.6.0-SNAPSHOT` run: `make NEXT_VERSION=0.6.0-SNAPSHOT next_version`.
 
 3. Run `make clean`
@@ -35,21 +35,20 @@ The release process should normally look like this:
     * Copy files from the operators repository `documentation/html` to `docs/operators/latest/full` in the website repository
   * Update the Helm Chart repository file by copying `helm-charts/helm3/index.yaml` in the operators GitHub repository to `charts/index.yaml` in the website GitHub repsoitory.
 
-12. _(only for GA, not for RCs)_ The maven artifacts (`api` module) will be automatically staged from Azure during the tag build. It has to be releases from [Sonatype](https://oss.sonatype.org/#stagingRepositories) to get to the main Maven repositories.
-13. _(only for GA, not for RCs)_ On the `master` git branch of the operators repository:
-  * Copy the `packaging/helm-charts/index.yaml` from the `release` branch to `master`
+12. _(only for GA, not for RCs)_ On the `main` git branch of the operators repository:
+  * Copy the `packaging/helm-charts/index.yaml` from the `release` branch to `main`
   * Update the `ProductVersion` variable in `documentation/using/shared/attributes.doc`
-  * Update the `install`, `examples` and `helm-chart` directories in the `master` branch with the newly released files
+  * Update the `install`, `examples` and `helm-chart` directories in the `main` branch with the newly released files
 
+13. _(only for GA, not for RCs)_ The maven artifacts (`api` module) will be automatically staged from Azure during the tag build. It has to be releases from [Sonatype](https://oss.sonatype.org/#stagingRepositories) to get to the main Maven repositories.
 14. _(only for GA, not for RCs)_ Update the Strimzi manifest files in Operator Hub [community operators](https://github.com/operator-framework/community-operators) repository and submit a pull request upstream. *Note*: Instructions for this step need updating.
 15. _(only for GA, not for RCs)_ Add the new version to the `systemtest/src/test/resources/upgrade/StrimziUpgradeST.json` file for the upgrade tests
 16. _(only for GA, not for RCs)_ Add the new version to the `systemtest/src/test/resources/upgrade/StrimziDowngradeST.json` file and remove the old one for the downgrade tests
 
-
 ## Updating Kafka Bridge version
 
 The version of Strimzi Kafka Bridge is defined in the file `./bridge.version`.
-Even the master branch is using this fixed version and not the version build from the `master` branch of Kafka Bridge.
+Even the `main` branch is using this fixed version and not the version build from the `main` branch of Kafka Bridge.
 If you need to update the Kafka bridge to newer version, you should do it with following steps:
 
 1. Edit the `bridge.version` file and update it to contain the new Bridge version

--- a/documentation/contributing/contributor-guide.adoc
+++ b/documentation/contributing/contributor-guide.adoc
@@ -18,18 +18,18 @@ Once you have your local repository set up and have up to date copies of upstrea
 .Procedure
 . Open your terminal
 . `cd` to the directory where your documentation resides
-. Checkout the master branch
+. Checkout the main branch
 +
 [source]
 ----
-$ git checkout master
+$ git checkout main
 ----
 . Update your local repository and fork with the upstream content
 +
 [source]
 ----
-$ git pull upstream master
-$ git push origin master --force
+$ git pull upstream main
+$ git push origin main --force
 ----
 . Create a new branch for your work (using the issue number is helpful)
 +
@@ -67,7 +67,7 @@ $ git push origin HEAD
 +
 [source]
 ----
-$ git pull upstream master
+$ git pull upstream main
 $ git push -f origin HEAD
 ----
 . Visit your fork on GitHub

--- a/documentation/contributing/git-tips.adoc
+++ b/documentation/contributing/git-tips.adoc
@@ -7,7 +7,7 @@ To delete all of your branches except the branch you are on:
 
 [source]
 ----
-$ git checkout master
+$ git checkout main
 $ for br in `git branch` ; do git branch -D $br ; done
 ----
 
@@ -15,7 +15,7 @@ To delete one branch:
 
 [source,options="nowrap",subs="+quotes"]
 ----
-$ git checkout master
+$ git checkout main
 $ git branch -D <branch-name>
 ----
 
@@ -27,7 +27,7 @@ To resolve a merge conflict in an existing pull request:
 ----
 $ git checkout <branch-name>
 $ git branch -u origin <branch-name>
-$ git pull --rebase upstream master
+$ git pull --rebase upstream main
 $ git push -f origin HEAD
 ----
 
@@ -37,11 +37,11 @@ If your fork is both ahead of and behind the origin you can reset your fork to m
 
 [source]
 ----
-$ git checkout master
-$ git reset --hard upstream/master
-$ git push origin master --force
-$ git pull upstream master
-$ git push origin master --force
+$ git checkout main
+$ git reset --hard upstream/main
+$ git push origin main --force
+$ git pull upstream main
+$ git push origin main --force
 ----
 
 == Using `ssh-agent` to save your SSH key's passphrase
@@ -52,7 +52,7 @@ Before using the `ssh-agent` you will see a prompt to enter your passphrase afte
 
 [source]
 ----
-[amq-repo]$ git pull --rebase upstream master
+[amq-repo]$ git pull --rebase upstream main
 Enter passphrase for key '/home/<username>/.ssh/id_rsa':
 ----
 
@@ -75,12 +75,12 @@ Identity added: /home/<username>/.ssh/id_rsa (/home/<username>/.ssh/id_rsa)
 
 This is the process you can use if you need commits another writer has submitted in a merge request that is not yet merged.
 
-. Check out a new topic branch from upstream/master as you normally do.
+. Check out a new topic branch from upstream/main as you normally do.
 +
 [source,options="nowrap",subs="+quotes"]
 ----
 $ git fetch upstream
-$ git checkout -b <new-topic-branch> upstream/master
+$ git checkout -b <new-topic-branch> upstream/main
 ----
 . If you have not yet added that writer’s remote repository, add it now.
 +

--- a/documentation/contributing/introduction.adoc
+++ b/documentation/contributing/introduction.adoc
@@ -27,7 +27,7 @@ https://github.com/strimzi/strimzi-kafka-operator[`strimzi-kafka-operator`^] (Gi
 https://github.com/strimzi/strimzi-kafka-bridge[`strimzi-kafka-bridge`^] (GitHub):: The public GitHub repo hosts all of the Strimzi Kafka Bridge code.
 https://github.com/strimzi/strimzi-kafka-oauth[`strimzi-kafka-oauth`^] (GitHub):: The public GitHub repo hosts all of the Strimzi OAuth 2.0 code.
 
-The main documentation is in the Strimzi Operators repository, in the https://github.com/strimzi/strimzi-kafka-operator/tree/master/documentation[`documentation` folder^].
+The main documentation is in the Strimzi Operators repository, in the https://github.com/strimzi/strimzi-kafka-operator/tree/main/documentation[`documentation` folder^].
 The _documentation_ folder is split into _category_ folders to manage the content.
 
 Documentation category folders contain files related to Strimzi guides (Deploying, Quickstart, Overview, Using), and the files that provide the content for one or more of these guides – _assemblies_ and _modules_.

--- a/documentation/contributing/make-tooling.adoc
+++ b/documentation/contributing/make-tooling.adoc
@@ -1,7 +1,7 @@
 [[make-tooling]]
 = Using make with documentation
 
-When you make changes to the documentation, it is a good practice to do a local test build to verify the book builds successfully and renders as you expect before you submit the merge request back to upstream master.
+When you make changes to the documentation, it is a good practice to do a local test build to verify the book builds successfully and renders as you expect before you submit the merge request back to upstream main.
 
 Make is a useful tool for building your documentation and pushing it to a public website so that peer and quality reviewers can see your edits as the user would.
 

--- a/helm-charts/helm3/strimzi-kafka-operator/Chart.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.22.1
 description: 'Strimzi: Apache Kafka running on Kubernetes'
 home: https://strimzi.io/
-icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
 keywords:
 - kafka
 - queue

--- a/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -39,7 +39,7 @@ If you encounter any issues while using Strimzi, you can get help using:
 
 ### License
 
-Strimzi is licensed under the [Apache License, Version 2.0](https://github.com/strimzi/strimzi-kafka-operator/blob/master/LICENSE).
+Strimzi is licensed under the [Apache License, Version 2.0](https://github.com/strimzi/strimzi-kafka-operator/blob/main/LICENSE).
 
 ## Prerequisites
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/Chart.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "0.1.0"
 description: "Strimzi: Apache Kafka running on Kubernetes"
 name: strimzi-kafka-operator
 version: 0.1.0
-icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
 keywords:
 - kafka
 - queue

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -39,7 +39,7 @@ If you encounter any issues while using Strimzi, you can get help using:
 
 ### License
 
-Strimzi is licensed under the [Apache License, Version 2.0](https://github.com/strimzi/strimzi-kafka-operator/blob/master/LICENSE).
+Strimzi is licensed under the [Apache License, Version 2.0](https://github.com/strimzi/strimzi-kafka-operator/blob/main/LICENSE).
 
 ## Prerequisites
 

--- a/packaging/helm-charts/index.yaml
+++ b/packaging/helm-charts/index.yaml
@@ -7,7 +7,7 @@ entries:
     description: 'Strimzi: Apache Kafka running on Kubernetes'
     digest: e7e45ef15e090a1a6b751f3f83400e9396388ee4d0032d0c2314c006bcb3bfe0
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -35,7 +35,7 @@ entries:
     description: 'Strimzi: Apache Kafka running on Kubernetes'
     digest: fce438f55a5275d0e3303d34c2ad0be9032f18679c109d6712ee26f06419cb55
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -63,7 +63,7 @@ entries:
     description: 'Strimzi: Apache Kafka running on Kubernetes'
     digest: cc6b08c97386fd60b0050bb424df095b4646621c5b4f45602716802ef1e1a48f
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -90,7 +90,7 @@ entries:
     description: 'Strimzi: Apache Kafka running on Kubernetes'
     digest: 807252a88f3279a59be42e8c3d9b65a8b7c048f5674de7293797c0d34c81581e
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -117,7 +117,7 @@ entries:
     description: 'Strimzi: Apache Kafka running on Kubernetes'
     digest: bd5d6005bbf1fa03984088fca7401d6ab59d04337dc47f60abc0512577b202a4
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -144,7 +144,7 @@ entries:
     description: 'Strimzi: Apache Kafka running on Kubernetes'
     digest: 320f960e9f62622c9e8cbe49566bad449659ba40116d9112338ef1e40b9b61c2
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -171,7 +171,7 @@ entries:
     description: 'Strimzi: Apache Kafka running on Kubernetes'
     digest: 9aefea97d6e6a98fbb5ce90d209063d4723f33088a9bf0d83144397805b09fe5
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -198,7 +198,7 @@ entries:
     description: 'Strimzi: Apache Kafka running on Kubernetes'
     digest: 1ceb11bbaa54b8da7548602a1f4f918bca8b40530d8dd3fc0d54f59479247a8f
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -225,7 +225,7 @@ entries:
     description: 'Strimzi: Apache Kafka running on Kubernetes'
     digest: 935ca1bdae17604fc345da108c2f9f3a4bb633bdebad233b5c7832d7ffa83145
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -250,7 +250,7 @@ entries:
     description: 'Strimzi: Apache Kafka running on Kubernetes'
     digest: 07242fa5dec47c32abb576b7b84c8cecad77a7a67828308ee3f018d90b377588
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -275,7 +275,7 @@ entries:
     description: 'Strimzi: Apache Kafka running on Kubernetes'
     digest: 29e14d47a0d4ab62687a919712358443c22fce8e36cb1aa59e52a1737b8aba9a
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -300,7 +300,7 @@ entries:
     description: 'Strimzi: Apache Kafka running on Kubernetes'
     digest: 0ae2d41bfd5c79b50b89fcdbfab6c53a7a8f810d4a994ba07b916c3d07943802
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -325,7 +325,7 @@ entries:
     description: 'Strimzi: Apache Kafka running on Kubernetes'
     digest: 56783fda7344527405c63778fb32207b6b191b3c5dfdaccbc0eee9d70fe43a29
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -350,7 +350,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: d13f6b16093fb42fdcb0faeed18562b335586747fde9b9c9654b00f258918b69
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -375,7 +375,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: 19b2654650bff0bf2b449820ce5104bf6cce3a4f72babea32e5217c6fa751601
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -400,7 +400,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: 2d9941e9f73e0e57ed521ddffbd1eb1a5edb39d891cdf7756ecd73e761075b55
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -425,7 +425,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: a9e82303e02d412e4e1b5e13d2b9b2d5c6290d6411f3aa78cd7647cd617dfd89
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -450,7 +450,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: 42f957fc2d2df0943e75cf274baba3c839e65e4aafb70e0593e77d69be715098
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -475,7 +475,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: 58bb338054aff06dc0ebbdd13f544ec7802bb4dac8a23c32b7533bfa78c4209d
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -500,7 +500,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: 03086beb8771c0fe95fd6ef8003ea68dd79f81e66937456c3957d2dd79aa15b8
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -525,7 +525,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: 2c8ae7ee38f49cb57ed501a89128d503bb28e034855b2d9cc6f504bd9f65c35d
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -550,7 +550,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: eb5d8fb9f8861a98c22ded2a7143597d49d2276ea55225af2564c365ad2f356d
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -575,7 +575,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: 8d429c9b44b2fffe14ff5f00e462934fbdaa83374d7b7221b186c4e24690ef8a
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -600,7 +600,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: d172fa9e91e254e4ba2057ec70a8c047402513f585e07edce59a96fb6d59dd90
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -625,7 +625,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: d915c029ee9692a1eab7d51d71c415db1a533756eb3bf1a997e5769f127601e0
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -650,7 +650,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: 2e21d3a86d3fd6f36b259f19086b93c478da1b9e0f9dccbfaa379d87091ce457
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -675,7 +675,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: 67d28bf30bad5fbae8a63c4e1bc2065c2b9fd4a88e9dec78e82ddb57d9c49a79
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -700,7 +700,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: 331b9bab35aea7413716e8b79e773f653909afc53209f25ff0033fc6a8dbc06a
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -725,7 +725,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: 0ae660efb5f445a98649d4a6768d09defe8fabebf0ca807fac9075376f460944
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue
@@ -750,7 +750,7 @@ entries:
     description: 'Strimzi: Kafka as a Service'
     digest: 684868a46604411a151d90579f15e065320ba636c2afd25702b508fe11b30c64
     home: https://strimzi.io/
-    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
     - queue


### PR DESCRIPTION
### Type of change

- Task

### Description

As part of renaming the `master` branch to `main`, we need to update different links and references in the CIs. This PR does some preparation for it:
* Renames different Azure references
* Updates different links
* Prepares the push script to the website to use `main` to be ready for renaming the branch in the website repo as well
* Updates the release guide