### PR TITLE
Test for CruiseControl rootlogger level change

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -52,6 +52,7 @@ public interface Constants {
     long CO_OPERATION_TIMEOUT_MEDIUM = Duration.ofMinutes(2).toMillis();
     long RECONCILIATION_INTERVAL = Duration.ofSeconds(30).toMillis();
     long LOGGING_RELOADING_INTERVAL = Duration.ofSeconds(30).toMillis();
+    long CC_LOG_CONFIG_RELOAD = Duration.ofSeconds(5).toMillis();
 
     // Keycloak
     long KEYCLOAK_DEPLOYMENT_POLL = Duration.ofSeconds(5).toMillis();
@@ -301,6 +302,7 @@ public interface Constants {
     String CRUISE_CONTROL_CONFIGURATION_ENV = "CRUISE_CONTROL_CONFIGURATION";
     String CRUISE_CONTROL_CAPACITY_FILE_PATH = "/tmp/capacity.json";
     String CRUISE_CONTROL_CONFIGURATION_FILE_PATH = "/tmp/cruisecontrol.properties";
+    String CRUISE_CONTROL_LOG_FILE_PATH = "/opt/cruise-control/custom-config/log4j2.properties";
 
     /**
      * Default listeners names

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.ContainerEnvVarBuilder;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.k8s.KubeClusterResource;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
@@ -322,6 +323,18 @@ public class StUtils {
             return mapper.writeValueAsString(node);
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    public static String getLineFromPod(String podName, String filePath, String grepString) {
+        return getLineFromPodContainer(podName, null, filePath, grepString);
+    }
+
+    public static String getLineFromPodContainer(String podName, String containerName, String filePath, String grepString) {
+        if (containerName == null) {
+            return KubeClusterResource.cmdKubeClient().execInPod(podName, "grep", "-i", grepString, filePath).out().trim();
+        } else {
+            return KubeClusterResource.cmdKubeClient().execInPodContainer(podName, containerName, "grep", "-i", grepString, filePath).out().trim();
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Michal Tóth <mtoth@redhat.com>

Test which verifies functionality of CruiseControl logger level change.

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation #4640 
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

