### PR TITLE
Resolve minor build and linting issues, rely on server validation for IT CRDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,17 @@
 # Maven build targets
-**/target/*
+target/
 
 # Maven release files
 *.releaseBackup
 release.properties
 
 # Eclipse specific
-**/.project
-**/.settings/*
-**/.prefs
-**/.classpath
-/target/
+.project
+.settings/
+.prefs
+.classpath
+.apt_generated/
+.apt_generated_tests/
 
 # IntelliJ IDEA specific
 .idea/

--- a/api-conversion/pom.xml
+++ b/api-conversion/pom.xml
@@ -115,6 +115,7 @@
                         </goals>
                         <configuration>
                             <appendAssemblyId>false</appendAssemblyId>
+                            <tarLongFileMode>posix</tarLongFileMode>
                             <descriptors>
                                 <descriptor>src/main/assembly/zip.xml</descriptor>
                             </descriptors>

--- a/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/converter/KafkaConverter.java
+++ b/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/converter/KafkaConverter.java
@@ -72,9 +72,9 @@ public class KafkaConverter extends Converter<Kafka> {
         Conversion.replaceLogging("/spec/entityOperator/topicOperator/logging", "log4j2.properties"),
         Conversion.replaceLogging("/spec/entityOperator/userOperator/logging", "log4j2.properties"),
         Conversion.replaceLogging("/spec/cruiseControl/logging", "log4j2.properties"),
-        new MetricsConversion<>("/spec/kafka", KafkaClusterSpec.class, "kafka"),
-        new MetricsConversion<>("/spec/zookeeper", ZookeeperClusterSpec.class, "zookeeper"),
-        new MetricsConversion<>("/spec/cruiseControl", CruiseControlSpec.class, "cruise-control")
+        new MetricsConversion<Kafka>("/spec/kafka", KafkaClusterSpec.class, "kafka"),
+        new MetricsConversion<Kafka>("/spec/zookeeper", ZookeeperClusterSpec.class, "zookeeper"),
+        new MetricsConversion<Kafka>("/spec/cruiseControl", CruiseControlSpec.class, "cruise-control")
     );
 
     public KafkaConverter() {

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -97,19 +97,16 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -118,7 +115,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven.compiler.version}</version>
                 <executions>
                     <execution>
                         <id>default-compile</id>
@@ -126,8 +122,8 @@
                         <goals>
                             <goal>compile</goal>
                         </goals>
-                        <configuration combine.self="override">
-                            <compilerArgs>
+                        <configuration>
+                            <compilerArgs combine.self="override">
                                 <arg>-Xlint:unchecked,deprecation</arg>
                             </compilerArgs>
                         </configuration>
@@ -138,8 +134,8 @@
                         <goals>
                             <goal>testCompile</goal>
                         </goals>
-                        <configuration combine.self="override">
-                            <compilerArgs>
+                        <configuration>
+                            <compilerArgs combine.self="override">
                                 <arg>-Xlint:deprecation</arg>
                             </compilerArgs>
                         </configuration>
@@ -162,7 +158,7 @@
                             <executable>java</executable>
                             <arguments>
                                 <argument>-classpath</argument>
-                                <argument>${pom.basedir}${file.separator}target${file.separator}classes${path.separator}${pom.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
+                                <argument>${project.basedir}${file.separator}target${file.separator}classes${path.separator}${project.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
                                 <argument>io.strimzi.crdgenerator.CrdGenerator</argument>
                                 <argument>--label</argument><argument>app:strimzi</argument>
                                 <argument>--label</argument><argument>strimzi.io/crd-install:true</argument>
@@ -195,7 +191,7 @@
                             <executable>java</executable>
                             <arguments>
                                 <argument>-classpath</argument>
-                                <argument>${pom.basedir}${file.separator}target${file.separator}classes${path.separator}${pom.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
+                                <argument>${project.basedir}${file.separator}target${file.separator}classes${path.separator}${project.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
                                 <argument>io.strimzi.crdgenerator.CrdGenerator</argument>
                                 <argument>--label</argument><argument>app:strimzi</argument>
                                 <argument>--label</argument><argument>strimzi.io/crd-install:true</argument>
@@ -204,14 +200,14 @@
                                 <argument>--api-versions</argument><argument>v1beta2</argument>
                                 <argument>--storage-version</argument><argument>v1beta2</argument>
                                 <argument>--yaml</argument>
-                                <argument>io.strimzi.api.kafka.model.Kafka=${pom.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}040-Crd-kafka.yaml</argument>
-                                <argument>io.strimzi.api.kafka.model.KafkaConnect=${pom.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}041-Crd-kafkaconnect.yaml</argument>
-                                <argument>io.strimzi.api.kafka.model.KafkaConnectS2I=${pom.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}042-Crd-kafkaconnects2i.yaml</argument>
-                                <argument>io.strimzi.api.kafka.model.KafkaMirrorMaker=${pom.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}045-Crd-kafkamirrormaker.yaml</argument>
-                                <argument>io.strimzi.api.kafka.model.KafkaBridge=${pom.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}046-Crd-kafkabridge.yaml</argument>
-                                <argument>io.strimzi.api.kafka.model.KafkaConnector=${pom.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}047-Crd-kafkaconnector.yaml</argument>
-                                <argument>io.strimzi.api.kafka.model.KafkaMirrorMaker2=${pom.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}048-Crd-kafkamirrormaker2.yaml</argument>
-                                <argument>io.strimzi.api.kafka.model.KafkaRebalance=${pom.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}049-Crd-kafkarebalance.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.Kafka=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}040-Crd-kafka.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaConnect=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}041-Crd-kafkaconnect.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaConnectS2I=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}042-Crd-kafkaconnects2i.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaMirrorMaker=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}045-Crd-kafkamirrormaker.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaBridge=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}046-Crd-kafkabridge.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaConnector=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}047-Crd-kafkaconnector.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaMirrorMaker2=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}048-Crd-kafkamirrormaker2.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaRebalance=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}049-Crd-kafkarebalance.yaml</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -230,7 +226,7 @@
                             <executable>java</executable>
                             <arguments>
                                 <argument>-classpath</argument>
-                                <argument>${pom.basedir}${file.separator}target${file.separator}classes${path.separator}${pom.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
+                                <argument>${project.basedir}${file.separator}target${file.separator}classes${path.separator}${project.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
                                 <argument>io.strimzi.crdgenerator.CrdGenerator</argument>
                                 <argument>--label</argument><argument>app:strimzi</argument>
                                 <argument>--label</argument><argument>strimzi.io/crd-install:true</argument>
@@ -239,8 +235,8 @@
                                 <argument>--api-versions</argument><argument>v1alpha1,v1beta1,v1beta2</argument>
                                 <argument>--storage-version</argument><argument>v1beta2</argument>
                                 <argument>--yaml</argument>
-                                <argument>io.strimzi.api.kafka.model.KafkaTopic=${pom.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}043-Crd-kafkatopic.yaml</argument>
-                                <argument>io.strimzi.api.kafka.model.KafkaUser=${pom.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}044-Crd-kafkauser.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaTopic=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}043-Crd-kafkatopic.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaUser=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}044-Crd-kafkauser.yaml</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -254,7 +250,7 @@
                             <executable>java</executable>
                             <arguments>
                                 <argument>-classpath</argument>
-                                <argument>${pom.basedir}${file.separator}target${file.separator}classes${path.separator}${pom.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
+                                <argument>${project.basedir}${file.separator}target${file.separator}classes${path.separator}${project.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
                                 <argument>io.strimzi.crdgenerator.DocGenerator</argument>
                                 <argument>--linker</argument>
                                 <argument>io.strimzi.crdgenerator.KubeLinker</argument>
@@ -271,7 +267,7 @@
                                 <argument>io.strimzi.api.kafka.model.KafkaMirrorMaker2</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaRebalance</argument>
                             </arguments>
-                            <workingDirectory>${pom.basedir}${file.separator}..${file.separator}documentation</workingDirectory>
+                            <workingDirectory>${project.basedir}${file.separator}..${file.separator}documentation</workingDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
@@ -56,7 +56,7 @@ public abstract class AbstractCrdIT implements TestSeparator {
         RuntimeException deletionException = null;
         try {
             try {
-                cmdKubeClient().create(resourceFile);
+                cmdKubeClient().create(resourceFile, false);
             } catch (RuntimeException t) {
                 creationException = t;
             }

--- a/certificate-manager/pom.xml
+++ b/certificate-manager/pom.xml
@@ -37,20 +37,16 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>${jupiter.version}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>${jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
-      <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
-
 </project>

--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -151,30 +151,25 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${jupiter.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-junit5</artifactId>
-            <version>${vertx-junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/config-model-generator/pom.xml
+++ b/config-model-generator/pom.xml
@@ -24,12 +24,10 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.12</artifactId>
-            <version>${kafka-metadata-version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>${kafka-metadata-version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/config-model-generator/pom.xml
+++ b/config-model-generator/pom.xml
@@ -16,6 +16,22 @@
         <config-model-file>../cluster-operator/src/main/resources/kafka-${kafka-metadata-version}-config-model.json</config-model-file>
     </properties>
 
+    <dependencyManagement>
+        <!-- Manage versions to allow for override via the CLI with system property. -->
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka_2.12</artifactId>
+                <version>${kafka-metadata-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka-metadata-version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.strimzi</groupId>
@@ -54,5 +70,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/config-model/pom.xml
+++ b/config-model/pom.xml
@@ -19,21 +19,16 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${jupiter.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-
 </project>

--- a/crd-generator/pom.xml
+++ b/crd-generator/pom.xml
@@ -49,19 +49,16 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>${jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>${jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
-      <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kafka-agent/pom.xml
+++ b/kafka-agent/pom.xml
@@ -26,13 +26,11 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.12</artifactId>
-            <version>${kafka.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/kafka-init/pom.xml
+++ b/kafka-init/pom.xml
@@ -49,7 +49,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${jupiter.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
@@ -60,13 +59,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kafka-init/pom.xml
+++ b/kafka-init/pom.xml
@@ -53,7 +53,6 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>${junit.platform.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/mockkube/pom.xml
+++ b/mockkube/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.3</version>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
@@ -56,24 +55,20 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${jupiter.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -83,7 +78,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -112,18 +112,15 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${jupiter.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-junit5</artifactId>
-            <version>${vertx-junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -130,7 +130,6 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>${junit.platform.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -751,6 +751,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-junit5</artifactId>
                 <version>${vertx-junit5.version}</version>
@@ -1036,7 +1042,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>${maven.dependency.version}</version>
                 <executions>
                     <execution>
                         <id>analyze</id>

--- a/pom.xml
+++ b/pom.xml
@@ -777,6 +777,11 @@
                 <artifactId>junit-platform-commons</artifactId>
                 <version>${junit.platform.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>${junit.platform.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -109,7 +109,6 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>${junit.platform.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -104,7 +104,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${jupiter.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -116,13 +115,11 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-commons</artifactId>
-            <version>${junit.platform.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -139,13 +136,11 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>${kafka.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.12</artifactId>
-            <version>${kafka.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -178,19 +173,16 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web-client</artifactId>
-            <version>${vertx.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-junit5</artifactId>
-            <version>${vertx.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <version>${vertx.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -200,19 +192,16 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>${hamcrest.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-oauth-client</artifactId>
-            <version>${strimzi-oauth.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${fasterxml.jackson-databind.version}</version>
         </dependency>
         <dependency>
             <groupId>io.strimzi</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -50,7 +50,6 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>${jayway-jsonpath.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -105,19 +104,16 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <version>${vertx.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${jupiter.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>${hamcrest.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -125,6 +125,7 @@ public final class TestUtils {
             try {
                 result = ready.getAsBoolean();
             } catch (Exception e) {
+                LOGGER.info("Exception waiting for {}, {}", description, e.getMessage());
                 result = false;
             }
             long timeLeft = deadline - System.currentTimeMillis();

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -98,8 +98,15 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
 
     @Override
     @SuppressWarnings("unchecked")
-    public K create(File file) {
-        Exec.exec(null, namespacedCommand(CREATE, "-f", file.getAbsolutePath()), 0, false, true);
+    public K create(File file, boolean localValidation) {
+        List<String> command = namespacedCommand(CREATE, "-f", file.getAbsolutePath());
+
+        if (!localValidation) {
+            // Disable local CLI validation, delegated to host
+            command.add("--validate=false");
+        }
+
+        Exec.exec(null, command, 0, false, true);
 
         return (K) this;
     }

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
@@ -38,7 +38,11 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
     /** Creates the resources in the given files. */
     K create(File... files);
 
-    K create(File file);
+    default K create(File file) {
+        return create(file, true);
+    }
+
+    K create(File file, boolean localValidation);
 
     /** Creates the resources in the given files. */
     K apply(File... files);

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -118,24 +118,20 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${jupiter.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-junit5</artifactId>
-            <version>${vertx-junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -163,17 +159,14 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>${micrometer.version}</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>${micrometer.version}</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-micrometer-metrics</artifactId>
-            <version>${vertx.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -64,24 +64,20 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${jupiter.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-junit5</artifactId>
-            <version>${vertx-junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

While setting up Strimzi for local build and IDE import, I came across several warnings and errors (related to generating the tar.gz for api-conversion). I'm still working through my local build/configuration, but I want to open this PR to get feedback/comments sooner rather than later in case changes are needed/desired.

- Update .gitignore for sub-module Eclipse/Maven output & configuration
- Use tarLongFileMode=posix for maven-assembly-plugin to accommodate larger group ID values (see https://maven.apache.org/plugins/maven-assembly-plugin/faq.html#tarFileModes) that may occur in local builds
- Specify generic type parameter to resolve Eclipse JDT linting error
- Log message of caught exception in `TestUtils#waitFor`
- Disable local validation for CRD integration tests 
- Remove specification of dependency/plugin versions when duplicate of managed artifact
- Move `combine.self="override"` within plugin `<configuration>` element to the applicable option
- Replace deprecated `pom.basedir` with `project.basedir`

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

