### PR TITLE
[MO] - additional logging + check emptiness

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.strimzi.test.TestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -24,6 +26,7 @@ import java.util.stream.Collectors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
 
+    private static final Logger LOGGER = LogManager.getLogger(TestKafkaVersion.class);
     private static List<TestKafkaVersion> kafkaVersions;
 
     static {
@@ -33,7 +36,13 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
             Collections.sort(supportedKafkaVersions);
 
             kafkaVersions = supportedKafkaVersions;
-        } catch (IOException e) {
+
+            if (kafkaVersions == null || kafkaVersions.size() == 0) {
+                throw new Exception("There is no one Kafka version supported inside " + TestUtils.USER_PATH + "/../kafka-versions.yaml file");
+            }
+
+            LOGGER.info("These are following supported Kafka versions:\n{}", kafkaVersions.toString());
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This PR adding logging to `TestKafkaVersion.class` and with that check for the emptiness of supported Kafka. 

Why?

We once got into a situation where our CI tests could spin up Kafka cluster and there was an NPE. This problem was not simply found at all. In the end, we found out that it was because the Kafka version of the map was empty. Thanks to this check, the problem will be eliminated.


### Checklist

- [x] Make sure all tests pass