### PR TITLE
Issue 1370: Added try to catch doubles with m

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/Quantities.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/Quantities.java
@@ -104,23 +104,16 @@ class Quantities {
      * @return The equivalent number of "millicpus".
      */
     public static int parseCpuAsMilliCpus(String cpu) {
-        int suffixIndex = cpu.length();
-        int factor = 1000;
-        for (int i = 0; i < cpu.length(); i++) {
-            char ch = cpu.charAt(i);
-            if (ch < '0' || '9' < ch) {
-                suffixIndex = i;
-                if ("m".equals(cpu.substring(i))) {
-                    factor = 1;
-                    break;
-                } else if (cpu.substring(i).startsWith(".")) {
-                    return (int) (Double.parseDouble(cpu) * 1000L);
-                } else {
-                    throw new IllegalArgumentException("Failed to parse CPU quantity \"" + cpu + "\"");
-                }
+        int suffixIndex = cpu.length() - 1;
+        try {
+            if ("m".equals(cpu.substring(suffixIndex))) {
+                return Integer.parseInt(cpu.substring(0, suffixIndex));
+            } else {
+                return (int) (Double.parseDouble(cpu) * 1000L);
             }
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Failed to parse CPU quantity \"" + cpu + "\"");
         }
-        return factor * Integer.parseInt(cpu.substring(0, suffixIndex));
     }
 
     public static String formatMilliCpu(int milliCpu) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/QuantitiesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/QuantitiesTest.java
@@ -125,12 +125,12 @@ public class QuantitiesTest {
         try {
             parseCpuAsMilliCpus("0.0m");
             fail();
-        } catch (NumberFormatException e) { }
+        } catch (IllegalArgumentException e) { }
 
         try {
             parseCpuAsMilliCpus("0.1m");
             fail();
-        } catch (NumberFormatException e) { }
+        } catch (IllegalArgumentException e) { }
     }
 
     @Test


### PR DESCRIPTION
### Type of change
- Bugfix

### Description

Added a try case to catch incorrect input cpu values with "m" in the end:
https://github.com/strimzi/strimzi-kafka-operator/issues/1370

### Checklist

- [ ] Make sure all tests pass
- [ ] Reference relevant issue(s) and close them after merging
