### PR TITLE
Rename master docs on the website to developing

### DIFF
--- a/.azure/scripts/docu-push-to-website.sh
+++ b/.azure/scripts/docu-push-to-website.sh
@@ -10,10 +10,10 @@ ssh-add github_deploy_key
 git clone git@github.com:strimzi/strimzi.github.io.git /tmp/website
 
 # Operator docs
-rm -rf  /tmp/website/docs/operators/master/images
-rm -rf  /tmp/website/docs/operators/master/full/images
-cp -vrL documentation/htmlnoheader/*                        /tmp/website/docs/operators/master
-cp -vrL documentation/html/*                                /tmp/website/docs/operators/master/full
+rm -rf  /tmp/website/docs/operators/developing/images
+rm -rf  /tmp/website/docs/operators/developing/full/images
+cp -vrL documentation/htmlnoheader/*                        /tmp/website/docs/operators/developing
+cp -vrL documentation/html/*                                /tmp/website/docs/operators/developing/full
 
 # Contributing Guide
 rm -rf  /tmp/website/contributing/guide/images

--- a/.azure/scripts/docu-push-to-website.sh
+++ b/.azure/scripts/docu-push-to-website.sh
@@ -10,10 +10,10 @@ ssh-add github_deploy_key
 git clone git@github.com:strimzi/strimzi.github.io.git /tmp/website
 
 # Operator docs
-rm -rf  /tmp/website/docs/operators/developing/images
-rm -rf  /tmp/website/docs/operators/developing/full/images
-cp -vrL documentation/htmlnoheader/*                        /tmp/website/docs/operators/developing
-cp -vrL documentation/html/*                                /tmp/website/docs/operators/developing/full
+rm -rf  /tmp/website/docs/operators/in-development/images
+rm -rf  /tmp/website/docs/operators/in-development/full/images
+cp -vrL documentation/htmlnoheader/*                        /tmp/website/docs/operators/in-development
+cp -vrL documentation/html/*                                /tmp/website/docs/operators/in-development/full
 
 # Contributing Guide
 rm -rf  /tmp/website/contributing/guide/images


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Every build of the `main` branch push the current documentation to the Strimzi website. There it is currently available as _Master_ documentation. In order to change the URL following the _inclusive language_, we need to rename the URL. Thsi PR updates the directory structure where we push the new rendered docs files on the website.