### PR TITLE
[DOC] Replace master optimization goals with main optimization goals

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/RebalanceOptions.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/RebalanceOptions.java
@@ -10,7 +10,7 @@ public class RebalanceOptions {
 
     /** Sets whether this rebalance only provides an optimisation proposal (true) or starts a rebalance (false) */
     private boolean isDryRun;
-    /** List of optimisation goal class names, must be a sub-set of the configured master goals and include all hard.goals unless skipHardGoals=true */
+    /** List of optimisation goal class names, must be a sub-set of the configured main goals and include all hard.goals unless skipHardGoals=true */
     private List<String> goals;
     /** Include additional information in the response from the Cruise Control Server */
     private boolean verbose;

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -37,7 +37,7 @@ NOTE: Intra-broker disk goals, "Write your own" goals, and Kafka assigner goals 
 [discrete]
 == Goals configuration in Strimzi custom resources
 
-You configure optimization goals in `Kafka` and `KafkaRebalance` custom resources. Cruise Control has configurations for xref:hard-soft-goals[hard] optimization goals that must be satisfied, as well as xref:master-goals[master], xref:#default-goals[default], and xref:#user-provided-goals[user-provided] optimization goals. 
+You configure optimization goals in `Kafka` and `KafkaRebalance` custom resources. Cruise Control has configurations for xref:hard-soft-goals[hard] optimization goals that must be satisfied, as well as xref:main-goals[main], xref:#default-goals[default], and xref:#user-provided-goals[user-provided] optimization goals. 
 Optimization goals for resource distribution (disk, network inbound, network outbound, and CPU) are subject to xref:capacity-configuration[capacity limits] on broker resources.
 
 The following sections describe each goal configuration in more detail.
@@ -57,7 +57,7 @@ An optimization proposal that does _not_ satisfy all the hard goals is rejected 
 NOTE: For example, you might have a soft goal to distribute a topic's replicas evenly across the cluster (the topic replica distribution goal). 
 Cruise Control will ignore this goal if doing so enables all the configured hard goals to be met.
 
-In Cruise Control, the following xref:master-goals[master optimization goals] are preset as hard goals:
+In Cruise Control, the following xref:main-goals[main optimization goals] are preset as hard goals:
 
 [source]
 RackAwareGoal; MinTopicLeadersPerBrokerGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CpuCapacityGoal
@@ -99,29 +99,29 @@ Increasing the number of configured hard goals will reduce the likelihood of Cru
 If `skipHardGoalCheck: true` is specified in the `KafkaRebalance` custom resource, Cruise Control does _not_ check that the list of user-provided optimization goals (in `KafkaRebalance.spec.goals`) contains _all_ the configured hard goals (`hard.goals`). 
 Therefore, if some, but not all, of the user-provided optimization goals are in the `hard.goals` list, Cruise Control will still treat them as hard goals even if `skipHardGoalCheck: true` is specified.
 
-[[master-goals]]
+[[main-goals]]
 [discrete]
-=== Master optimization goals
+=== Main optimization goals
 
-The _master optimization goals_ are available to all users.
-Goals that are not listed in the master optimization goals are not available for use in Cruise Control operations.
+The _main optimization goals_ are available to all users.
+Goals that are not listed in the main optimization goals are not available for use in Cruise Control operations.
 
-Unless you change the Cruise Control xref:proc-deploying-cruise-control-{context}[deployment configuration], Strimzi will inherit the following master optimization goals from Cruise Control, in descending priority order:
+Unless you change the Cruise Control xref:proc-deploying-cruise-control-{context}[deployment configuration], Strimzi will inherit the following main optimization goals from Cruise Control, in descending priority order:
 
 [source]
 RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CpuCapacityGoal; ReplicaDistributionGoal; PotentialNwOutGoal; DiskUsageDistributionGoal; NetworkInboundUsageDistributionGoal; NetworkOutboundUsageDistributionGoal; CpuUsageDistributionGoal; TopicReplicaDistributionGoal; LeaderReplicaDistributionGoal; LeaderBytesInDistributionGoal; PreferredLeaderElectionGoal
 
 Six of these goals are preset as xref:hard-soft-goals[hard goals].
 
-To reduce complexity, we recommend that you use the inherited master optimization goals, unless you need to _completely_ exclude one or more goals from use in `KafkaRebalance` resources. The priority order of the master optimization goals can be modified, if desired, in the configuration for xref:default-goals[default optimization goals].
+To reduce complexity, we recommend that you use the inherited main optimization goals, unless you need to _completely_ exclude one or more goals from use in `KafkaRebalance` resources. The priority order of the main optimization goals can be modified, if desired, in the configuration for xref:default-goals[default optimization goals].
 
-You configure master optimization goals, if necessary, in the Cruise Control deployment configuration: `Kafka.spec.cruiseControl.config.goals`
+You configure main optimization goals, if necessary, in the Cruise Control deployment configuration: `Kafka.spec.cruiseControl.config.goals`
 
-* To accept the inherited master optimization goals, do not specify the `goals` property in `Kafka.spec.cruiseControl.config`.
+* To accept the inherited main optimization goals, do not specify the `goals` property in `Kafka.spec.cruiseControl.config`.
 
-* If you need to modify the inherited master optimization goals, specify a list of goals, in descending priority order, in the `goals` configuration option.
+* If you need to modify the inherited main optimization goals, specify a list of goals, in descending priority order, in the `goals` configuration option.
 
-NOTE: If you change the inherited master optimization goals, you must ensure that the hard goals, if configured in the `hard.goals` property in `Kafka.spec.cruiseControl.config`, are a subset of the master optimization goals that you configured. Otherwise, errors will occur when generating optimization proposals.
+NOTE: If you change the inherited main optimization goals, you must ensure that the hard goals, if configured in the `hard.goals` property in `Kafka.spec.cruiseControl.config`, are a subset of the main optimization goals that you configured. Otherwise, errors will occur when generating optimization proposals.
 
 [[default-goals]]
 [discrete]
@@ -132,13 +132,13 @@ For more information about the cached optimization proposal, see xref:con-optimi
 
 You can override the default optimization goals by setting xref:user-provided-goals[user-provided optimization goals] in a `KafkaRebalance` custom resource.
 
-Unless you specify `default.goals` in the Cruise Control xref:proc-deploying-cruise-control-{context}[deployment configuration], the master optimization goals are used as the default optimization goals. 
-In this case, the cached optimization proposal is generated using the master optimization goals.
+Unless you specify `default.goals` in the Cruise Control xref:proc-deploying-cruise-control-{context}[deployment configuration], the main optimization goals are used as the default optimization goals. 
+In this case, the cached optimization proposal is generated using the main optimization goals.
 
-* To use the master optimization goals as the default goals, do not specify the `default.goals` property in `Kafka.spec.cruiseControl.config`.
+* To use the main optimization goals as the default goals, do not specify the `default.goals` property in `Kafka.spec.cruiseControl.config`.
 
 * To modify the default optimization goals, edit the `default.goals` property in `Kafka.spec.cruiseControl.config`.
-You must use a subset of the master optimization goals.
+You must use a subset of the main optimization goals.
  
 .Example `Kafka` configuration for default optimization goals
 
@@ -168,7 +168,7 @@ spec:
       # ...         
 ----
 
-If no default optimization goals are specified, the cached proposal is generated using the master optimization goals.
+If no default optimization goals are specified, the cached proposal is generated using the main optimization goals.
 
 [[user-provided-goals]]
 [discrete]
@@ -188,7 +188,7 @@ So, you create a `KafkaRebalance` custom resource containing a single user-provi
 User-provided optimization goals must:
 
 * Include all configured xref:hard-soft-goals[hard goals], or an error occurs
-* Be a subset of the master optimization goals
+* Be a subset of the main optimization goals
 
 To ignore the configured hard goals when generating an optimization proposal, add the `skipHardGoalCheck: true` property to the `KafkaRebalance` custom resource. See xref:proc-generating-optimization-proposals-{context}[]. 
 

--- a/documentation/modules/cruise-control/proc-deploying-cruise-control.adoc
+++ b/documentation/modules/cruise-control/proc-deploying-cruise-control.adoc
@@ -71,7 +71,7 @@ spec:
 # ...
 ----
 <1> Specifies capacity limits for broker resources. For more information, see xref:capacity-configuration[Capacity configuration].
-<2> Defines the Cruise Control configuration, including the default optimization goals (in `default.goals`) and any customizations to the master optimization goals (in `goals`) or the hard goals (in `hard.goals`). 
+<2> Defines the Cruise Control configuration, including the default optimization goals (in `default.goals`) and any customizations to the main optimization goals (in `goals`) or the hard goals (in `hard.goals`). 
 You can provide any xref:ref-cruise-control-configuration-{context}[standard Cruise Control configuration option] apart from those managed directly by Strimzi. 
 For more information on configuring optimization goals, see xref:con-optimization-goals-{context}[]. 
 <3> CPU and memory resources reserved for Cruise Control. For more information, see xref:con-common-configuration-resources-reference[].


### PR DESCRIPTION
### Type of change

- Documentation

### Description

As part of the _inclusive language_, this PR renames the _Master optimization goals_ to _Main optimization goals_ in our Cruise Control documentation.

### Checklist

- [x] Update documentation

