### PR TITLE
[DOC] remove references to KafkaListeners schema

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
@@ -298,31 +298,3 @@ The application pods must be running in the same namespace as the Kafka broker.
 * Only application pods running in namespaces matching the labels `project: myproject` and `project: myproject2` can connect to the `tls` listener.
 
 The syntax of the `networkPolicyPeers` field is the same as the `from` field in `NetworkPolicy` resources.
-
-[id='property-listener-bwc-{context}']
-.Backwards compatibility with `KafkaListeners`
-
-`GenericKafkaListener` replaces the `KafkaListeners` schema, which is now deprecated.
-
-To convert the listeners configured using the `KafkaListeners` schema into the format of the `GenericKafkaListener` schema, with backwards compatibility,
-use the following names, ports and types:
-
-[source,yaml,subs="+quotes,attributes"]
-----
-listeners:
-  #...
-  - name: plain
-    port: 9092
-    type: internal
-    tls: false
-  - name: tls
-    port: 9093
-    type: internal
-    tls: true
-  - name: external
-    port: 9094
-    type: _EXTERNAL-LISTENER-TYPE_ <1>
-    tls: true
-# ...
-----
-<1> Options: `ingress`, `loadbalancer`, `nodeport`, `route`

--- a/documentation/modules/overview/con-configuration-points-listeners.adoc
+++ b/documentation/modules/overview/con-configuration-points-listeners.adoc
@@ -10,28 +10,17 @@ Listeners are used to connect to Kafka brokers.
 Strimzi provides a generic `GenericKafkaListener` schema with properties to configure listeners through the `Kafka` resource.
 
 The `GenericKafkaListener` provides a flexible approach to listener configuration.
-
 You can specify properties to configure _internal_ listeners for connecting within the Kubernetes cluster, or _external_ listeners for connecting outside the Kubernetes cluster.
 
-.Generic listener configuration
-
 Each listener is xref:proc-config-kafka-{context}[defined as an array in the `Kafka` resource].
-
-For more information on listener configuration, see the xref:type-GenericKafkaListener-reference[`GenericKafkaListener` schema reference].
-
-Generic listener configuration replaces the previous approach to listener configuration using the xref:type-KafkaListeners-reference[`KafkaListeners` schema reference],
-which is *deprecated*.
-However, you can xref:property-listener-bwc-reference[convert the old format into the new format] with backwards compatibility.
-
-The `KafkaListeners` schema uses sub-properties for `plain`, `tls` and `external` listeners, with fixed ports for each.
-Because of the limits inherent in the architecture of the schema, it is only possible to configure three listeners, with configuration options limited to the type of listener.
-
-With the `GenericKafkaListener` schema, you can configure as many listeners as required,
-as long as their names and ports are unique.
+You can configure as many listeners as required, as long as their names and ports are unique.
 
 You might want to configure multiple external listeners, for example, to handle access from networks that require different authentication mechanisms.
 Or you might need to join your Kubernetes network to an outside network.
 In which case, you can configure internal listeners (using the `useServiceDnsDomain` property) so that the Kubernetes service DNS domain (typically `.cluster.local`) is not used.
+
+For more information on the configuration options available for listeners,
+see the link:{BookURLUsing}#type-GenericKafkaListener-reference[`GenericKafkaListener` schema reference].
 
 .Configuring listeners to secure access to Kafka brokers
 You can configure listeners for secure connection using authentication.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

References to deprecated `KafkaListeners` schema removed from the _Using Guide_.
Instructions on how to upgrade listener config retained in the _Deploying Guide_.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

