### PR TITLE
[systemtest] Fix for `testKafkaPodImagePullBackOff`

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -190,7 +190,8 @@ public class KafkaRollerST extends AbstractST {
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, 3, 3).build());
 
-        String kafkaImage = KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(clusterName).get().getSpec().getKafka().getImage();
+        String kafkaImage = kubeClient().getStatefulSet(KafkaResources.kafkaStatefulSetName(clusterName))
+            .getSpec().getTemplate().getSpec().getContainers().get(0).getImage();
 
         KafkaResource.replaceKafkaResource(clusterName, kafka -> {
             kafka.getSpec().getKafka().setImage("quay.io/strimzi/kafka:not-existent-tag");


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Fix

### Description

In some cases when we don't have (somehow) access to our `quay.io/strimzi` repo, the ZK doesn't pull the images specified in tests and then the test fails in `assertTrue(checkIfExactlyOneKafkaPodIsNotReady(clusterName));` check. This PR adds "fix" for this -> the image will be get from the Kafka, so if there is different repo, from which we are pulling the image, it will be used and ZK will not fail.

### Checklist

- [x] Make sure all tests pass


