### PR TITLE
Preserve unknown fields for lists of maps

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -867,7 +867,7 @@ public class CrdGenerator {
                 || long.class.equals(elementType)) {
             itemResult.put("type", "integer");
         } else if (Map.class.equals(elementType)) {
-            preserveUnknownFields(itemResult, elementType);
+            preserveUnknownFields(itemResult);
             itemResult.put("type", "object");
         } else  {
             buildObjectSchema(crApiVersion, itemResult, elementType, true, description);
@@ -882,7 +882,9 @@ public class CrdGenerator {
         Type typeAnno = element.getAnnotation(Type.class);
         if (typeAnno == null) {
             typeName = typeName(type);
-            preserveUnknownFields(result, type);
+            if (Map.class.equals(type)) {
+                preserveUnknownFields(result);
+            }
         } else {
             typeName = typeAnno.value();
         }
@@ -891,8 +893,8 @@ public class CrdGenerator {
         return result;
     }
 
-    private void preserveUnknownFields(ObjectNode result, Class type)    {
-        if (crdApiVersion.compareTo(V1) >= 0 && Map.class.equals(type)) {
+    private void preserveUnknownFields(ObjectNode result)    {
+        if (crdApiVersion.compareTo(V1) >= 0) {
             result.put("x-kubernetes-preserve-unknown-fields", true);
         }
     }

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -867,6 +867,7 @@ public class CrdGenerator {
                 || long.class.equals(elementType)) {
             itemResult.put("type", "integer");
         } else if (Map.class.equals(elementType)) {
+            preserveUnknownFields(result, elementType);
             itemResult.put("type", "object");
         } else  {
             buildObjectSchema(crApiVersion, itemResult, elementType, true, description);
@@ -881,15 +882,19 @@ public class CrdGenerator {
         Type typeAnno = element.getAnnotation(Type.class);
         if (typeAnno == null) {
             typeName = typeName(type);
-            if (crdApiVersion.compareTo(V1) >= 0 && Map.class.equals(type)) {
-                result.put("x-kubernetes-preserve-unknown-fields", true);
-            }
+            preserveUnknownFields(result, type);
         } else {
             typeName = typeAnno.value();
         }
         result.put("type", typeName);
 
         return result;
+    }
+
+    private void preserveUnknownFields(ObjectNode result, Class type)    {
+        if (crdApiVersion.compareTo(V1) >= 0 && Map.class.equals(type)) {
+            result.put("x-kubernetes-preserve-unknown-fields", true);
+        }
     }
 
     private void addDescription(ApiVersion crApiVersion, ObjectNode result, AnnotatedElement element) {

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -867,7 +867,7 @@ public class CrdGenerator {
                 || long.class.equals(elementType)) {
             itemResult.put("type", "integer");
         } else if (Map.class.equals(elementType)) {
-            preserveUnknownFields(result, elementType);
+            preserveUnknownFields(itemResult, elementType);
             itemResult.put("type", "object");
         } else  {
             buildObjectSchema(crApiVersion, itemResult, elementType, true, description);

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -1633,8 +1633,8 @@ spec:
                 connectors:
                   type: array
                   items:
+                    x-kubernetes-preserve-unknown-fields: true
                     type: object
-                  x-kubernetes-preserve-unknown-fields: true
                   description: List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.
                 labelSelector:
                   type: string

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -1634,6 +1634,7 @@ spec:
                   type: array
                   items:
                     type: object
+                  x-kubernetes-preserve-unknown-fields: true
                   description: List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.
                 labelSelector:
                   type: string

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1829,8 +1829,8 @@ spec:
               connectors:
                 type: array
                 items:
+                  x-kubernetes-preserve-unknown-fields: true
                   type: object
-                x-kubernetes-preserve-unknown-fields: true
                 description: List of MirrorMaker 2.0 connector statuses, as reported
                   by the Kafka Connect REST API.
               labelSelector:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1830,6 +1830,7 @@ spec:
                 type: array
                 items:
                   type: object
+                x-kubernetes-preserve-unknown-fields: true
                 description: List of MirrorMaker 2.0 connector statuses, as reported
                   by the Kafka Connect REST API.
               labelSelector:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When using Maps in CRDs with `apiextensions/v1`, `x-kubernetes-preserve-unknown-fields` needs to be set to `true`. The CRD generator currently does that for maps, but not for lists of maps. This PR fixes it.

Without this, the CR will not store the MM2 connector data. And as a result when MM2 is deployed, it will be reconciled in a never ending loop because the status stored by Kube is never the same as what the operator updates it to (because Kube removes the unstructured data). Once the preservation of unknown fields is properly enabled, the problem seems to disappear.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally