### PR TITLE
Removed stale code linked to v1beta1 in kafkaCluster.java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Support for configuring custom Authorizer implementation 
 * Changed Reconciliation interval for Topic Operator from 90 to 120 seconds (to keep it the same as for other operators)
 * Changed Zookeeper session timeout default value to 18 seconds for Topic and User Operators (for improved resiliency)
+* Removed stale code for externalTrafficPolicy and loadBalanceRangeSources from v1beta1 templates
 
 ### Changes, deprecations and removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 * Support for configuring custom Authorizer implementation 
 * Changed Reconciliation interval for Topic Operator from 90 to 120 seconds (to keep it the same as for other operators)
 * Changed Zookeeper session timeout default value to 18 seconds for Topic and User Operators (for improved resiliency)
-* Removed stale code for externalTrafficPolicy and loadBalanceRangeSources from v1beta1 templates
 
 ### Changes, deprecations and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -517,40 +517,6 @@ public class KafkaCluster extends AbstractModel {
                 result.templateHeadlessServiceAnnotations = template.getBrokersService().getMetadata().getAnnotations();
             }
 
-            if (template.getExternalBootstrapService() != null) {
-                if (template.getExternalBootstrapService().getMetadata() != null) {
-                    result.templateExternalBootstrapServiceLabels = template.getExternalBootstrapService().getMetadata().getLabels();
-                    result.templateExternalBootstrapServiceAnnotations = template.getExternalBootstrapService().getMetadata().getAnnotations();
-                }
-
-                result.templateExternalBootstrapServiceTrafficPolicy = template.getExternalBootstrapService().getExternalTrafficPolicy();
-
-                if (result.isExposedWithLoadBalancer()) {
-                    result.templateExternalBootstrapServiceLoadBalancerSourceRanges = template.getExternalBootstrapService().getLoadBalancerSourceRanges();
-                } else if (template.getExternalBootstrapService().getLoadBalancerSourceRanges() != null
-                        && template.getExternalBootstrapService().getLoadBalancerSourceRanges().size() > 0) {
-                    // LoadBalancerSourceRanges have been set, but LaodBalancers are not used
-                    log.warn("The Kafka.spec.kafka.template.externalBootstrapService.loadBalancerSourceRanges option can be used only with load balancer type listeners");
-                }
-            }
-
-            if (template.getPerPodService() != null) {
-                if (template.getPerPodService().getMetadata() != null) {
-                    result.templatePerPodServiceLabels = template.getPerPodService().getMetadata().getLabels();
-                    result.templatePerPodServiceAnnotations = template.getPerPodService().getMetadata().getAnnotations();
-                }
-
-                result.templatePerPodServiceTrafficPolicy = template.getPerPodService().getExternalTrafficPolicy();
-
-                if (result.isExposedWithLoadBalancer()) {
-                    result.templatePerPodServiceLoadBalancerSourceRanges = template.getPerPodService().getLoadBalancerSourceRanges();
-                } else if (template.getPerPodService().getLoadBalancerSourceRanges() != null
-                        && template.getPerPodService().getLoadBalancerSourceRanges().size() > 0) {
-                    // LoadBalancerSourceRanges have been set, but LoadBalancers are not used
-                    log.warn("The Kafka.spec.kafka.template.perPodService.loadBalancerSourceRanges option can be used only with load balancer type listeners");
-                }
-            }
-
             if (template.getExternalBootstrapRoute() != null && template.getExternalBootstrapRoute().getMetadata() != null) {
                 result.templateExternalBootstrapRouteLabels = template.getExternalBootstrapRoute().getMetadata().getLabels();
                 result.templateExternalBootstrapRouteAnnotations = template.getExternalBootstrapRoute().getMetadata().getAnnotations();
@@ -839,8 +805,6 @@ public class KafkaCluster extends AbstractModel {
                 if (loadBalancerSourceRanges != null
                         && !loadBalancerSourceRanges.isEmpty()) {
                     service.getSpec().setLoadBalancerSourceRanges(loadBalancerSourceRanges);
-                } else if (templateExternalBootstrapServiceLoadBalancerSourceRanges != null) {
-                    service.getSpec().setLoadBalancerSourceRanges(templateExternalBootstrapServiceLoadBalancerSourceRanges);
                 }
 
                 List<String> finalizers = ListenersUtils.finalizers(listener);
@@ -854,9 +818,8 @@ public class KafkaCluster extends AbstractModel {
                 ExternalTrafficPolicy etp = ListenersUtils.externalTrafficPolicy(listener);
                 if (etp != null) {
                     service.getSpec().setExternalTrafficPolicy(etp.toValue());
-                } else if (templateExternalBootstrapServiceTrafficPolicy != null) {
-                    service.getSpec().setExternalTrafficPolicy(templateExternalBootstrapServiceTrafficPolicy.toValue());
                 }
+
             }
 
             services.add(service);
@@ -907,8 +870,6 @@ public class KafkaCluster extends AbstractModel {
                 if (loadBalancerSourceRanges != null
                         && !loadBalancerSourceRanges.isEmpty()) {
                     service.getSpec().setLoadBalancerSourceRanges(loadBalancerSourceRanges);
-                } else if (templatePerPodServiceLoadBalancerSourceRanges != null) {
-                    service.getSpec().setLoadBalancerSourceRanges(templatePerPodServiceLoadBalancerSourceRanges);
                 }
 
                 List<String> finalizers = ListenersUtils.finalizers(listener);
@@ -922,9 +883,8 @@ public class KafkaCluster extends AbstractModel {
                 ExternalTrafficPolicy etp = ListenersUtils.externalTrafficPolicy(listener);
                 if (etp != null) {
                     service.getSpec().setExternalTrafficPolicy(etp.toValue());
-                } else if (templatePerPodServiceTrafficPolicy != null) {
-                    service.getSpec().setExternalTrafficPolicy(templatePerPodServiceTrafficPolicy.toValue());
                 }
+
             }
 
             services.add(service);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -221,11 +221,6 @@ public class KafkaCluster extends AbstractModel {
     protected SecurityContext templateKafkaContainerSecurityContext;
     protected SecurityContext templateInitContainerSecurityContext;
 
-    protected ExternalTrafficPolicy templateExternalBootstrapServiceTrafficPolicy;
-    protected List<String> templateExternalBootstrapServiceLoadBalancerSourceRanges;
-    protected ExternalTrafficPolicy templatePerPodServiceTrafficPolicy;
-    protected List<String> templatePerPodServiceLoadBalancerSourceRanges;
-
     // Configuration defaults
     private static final int DEFAULT_REPLICAS = 3;
     public static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder().withTimeoutSeconds(5)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -517,6 +517,20 @@ public class KafkaCluster extends AbstractModel {
                 result.templateHeadlessServiceAnnotations = template.getBrokersService().getMetadata().getAnnotations();
             }
 
+            if (template.getExternalBootstrapService() != null) {
+                if (template.getExternalBootstrapService().getMetadata() != null) {
+                    result.templateExternalBootstrapServiceLabels = template.getExternalBootstrapService().getMetadata().getLabels();
+                    result.templateExternalBootstrapServiceAnnotations = template.getExternalBootstrapService().getMetadata().getAnnotations();
+                }
+            }
+
+            if (template.getPerPodService() != null) {
+                if (template.getPerPodService().getMetadata() != null) {
+                    result.templatePerPodServiceLabels = template.getPerPodService().getMetadata().getLabels();
+                    result.templatePerPodServiceAnnotations = template.getPerPodService().getMetadata().getAnnotations();
+                }
+            }
+
             if (template.getExternalBootstrapRoute() != null && template.getExternalBootstrapRoute().getMetadata() != null) {
                 result.templateExternalBootstrapRouteLabels = template.getExternalBootstrapRoute().getMetadata().getLabels();
                 result.templateExternalBootstrapRouteAnnotations = template.getExternalBootstrapRoute().getMetadata().getAnnotations();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -819,7 +819,6 @@ public class KafkaCluster extends AbstractModel {
                 if (etp != null) {
                     service.getSpec().setExternalTrafficPolicy(etp.toValue());
                 }
-
             }
 
             services.add(service);
@@ -884,7 +883,6 @@ public class KafkaCluster extends AbstractModel {
                 if (etp != null) {
                     service.getSpec().setExternalTrafficPolicy(etp.toValue());
                 }
-
             }
 
             services.add(service);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -896,12 +896,12 @@ public class KafkaClusterTest {
 
         // Check external bootstrap service
         Service ext = kc.generateExternalBootstrapServices().get(0);
-        assertThat(ext.getSpec().getExternalTrafficPolicy(), is(ExternalTrafficPolicy.LOCAL.toValue()));
+        assertThat(ext.getSpec().getExternalTrafficPolicy(), is(nullValue()));
 
         // Check per pod services
         for (int i = 0; i < replicas; i++)  {
             Service srv = kc.generateExternalServices(i).get(0);
-            assertThat(srv.getSpec().getExternalTrafficPolicy(), is(ExternalTrafficPolicy.LOCAL.toValue()));
+            assertThat(srv.getSpec().getExternalTrafficPolicy(), is(nullValue()));
         }
     }
 
@@ -1008,12 +1008,12 @@ public class KafkaClusterTest {
 
         // Check external bootstrap service
         Service ext = kc.generateExternalBootstrapServices().get(0);
-        assertThat(ext.getSpec().getExternalTrafficPolicy(), is(ExternalTrafficPolicy.CLUSTER.toValue()));
+        assertThat(ext.getSpec().getExternalTrafficPolicy(), is(nullValue()));
 
         // Check per pod services
         for (int i = 0; i < replicas; i++)  {
             Service srv = kc.generateExternalServices(i).get(0);
-            assertThat(srv.getSpec().getExternalTrafficPolicy(), is(ExternalTrafficPolicy.CLUSTER.toValue()));
+            assertThat(srv.getSpec().getExternalTrafficPolicy(), is(nullValue()));
         }
     }
 
@@ -1163,12 +1163,12 @@ public class KafkaClusterTest {
 
         // Check external bootstrap service
         Service ext = kc.generateExternalBootstrapServices().get(0);
-        assertThat(ext.getSpec().getLoadBalancerSourceRanges(), is(sourceRanges));
+        assertThat(ext.getSpec().getLoadBalancerSourceRanges(), is(emptyList()));
 
         // Check per pod services
         for (int i = 0; i < replicas; i++)  {
             Service srv = kc.generateExternalServices(i).get(0);
-            assertThat(srv.getSpec().getLoadBalancerSourceRanges(), is(sourceRanges));
+            assertThat(srv.getSpec().getLoadBalancerSourceRanges(), is(emptyList()));
         }
     }
 
@@ -1842,13 +1842,13 @@ public class KafkaClusterTest {
 
         // Check External Bootstrap service
         svc = kc.generateExternalBootstrapServices().get(0);
-        assertThat(svc.getMetadata().getLabels().entrySet().containsAll(exSvcLabels.entrySet()), is(true));
-        assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(exSvcAnots.entrySet()), is(true));
+        assertThat(svc.getMetadata().getLabels().entrySet().containsAll(exSvcLabels.entrySet()), is(false));
+        assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(exSvcAnots.entrySet()), is(false));
 
         // Check per pod service
         svc = kc.generateExternalServices(0).get(0);
-        assertThat(svc.getMetadata().getLabels().entrySet().containsAll(perPodSvcLabels.entrySet()), is(true));
-        assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(perPodSvcAnots.entrySet()), is(true));
+        assertThat(svc.getMetadata().getLabels().entrySet().containsAll(perPodSvcLabels.entrySet()), is(false));
+        assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(perPodSvcAnots.entrySet()), is(false));
 
         // Check Bootstrap Route
         Route rt = kc.generateExternalBootstrapRoutes().get(0);


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

externalTrafficPolicy and loadBalancingSourceRanges original input methods have been discontinued in favor of listener configurations in v1beta2 to make them per listener. Removed stale code from kafkaCluster.java and reconfigured unit tests with changes in mind.

Resolves --> #4627 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

