### PR TITLE
Allow for additional Kafka (Streams) properties - #4694.

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
@@ -126,6 +126,9 @@ public class Config {
 
     public static final String TC_USE_ZOOKEEPER_TOPIC_STORE = "STRIMZI_USE_ZOOKEEPER_TOPIC_STORE";
 
+    public static final String TC_ADDITIONAL_KAFKA_PROPERTIES = "STRIMZI_ADDITIONAL_KAFKA_PROPERTIES";
+    public static final String TC_ADDITIONAL_KAFKA_PROPERTIES_DELIMITER = "STRIMZI_ADDITIONAL_KAFKA_PROPERTIES_DELIMITER";
+
     private static final Map<String, Value<?>> CONFIG_VALUES = new HashMap<>();
 
     /** A comma-separated list of key=value pairs for selecting Resources that describe topics. */
@@ -196,6 +199,10 @@ public class Config {
     /** Do we use old ZooKeeper based TopicStore */
     public static final Value<Boolean> USE_ZOOKEEPER_TOPIC_STORE = new Value<>(TC_USE_ZOOKEEPER_TOPIC_STORE, BOOLEAN, "false");
 
+    /** Additional Kafka (Streams) properties */
+    public static final Value<String> ADDITIONAL_KAFKA_PROPERTIES = new Value<>(TC_ADDITIONAL_KAFKA_PROPERTIES, STRING, false);
+    public static final Value<String> ADDITIONAL_KAFKA_PROPERTIES_DELIMITER = new Value<>(TC_ADDITIONAL_KAFKA_PROPERTIES_DELIMITER, STRING, "\\|");
+
     static {
         Map<String, Value<?>> configValues = CONFIG_VALUES;
         addConfigValue(configValues, LABELS);
@@ -222,6 +229,8 @@ public class Config {
         addConfigValue(configValues, APPLICATION_SERVER);
         addConfigValue(configValues, STALE_RESULT_TIMEOUT_MS);
         addConfigValue(configValues, USE_ZOOKEEPER_TOPIC_STORE);
+        addConfigValue(configValues, ADDITIONAL_KAFKA_PROPERTIES);
+        addConfigValue(configValues, ADDITIONAL_KAFKA_PROPERTIES_DELIMITER);
     }
 
     static void addConfigValue(Map<String, Value<?>> configValues, Value<?> cv) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -149,6 +149,18 @@ public class Session extends AbstractVerticle {
         LOGGER.info("Starting");
         Properties kafkaClientProps = new Properties();
 
+        // first add additional props, so that we can override them with more specific
+        String additionalKafkaProperties = config.get(Config.ADDITIONAL_KAFKA_PROPERTIES);
+        if (additionalKafkaProperties != null) {
+            String[] props = additionalKafkaProperties.split(config.get(Config.ADDITIONAL_KAFKA_PROPERTIES_DELIMITER));
+            if (props.length % 2 != 0) {
+                throw new IllegalArgumentException("Invalid additional Kafka properties (odd number of tokens after delimiter split): " + additionalKafkaProperties);
+            }
+            for (int i = 0; i < props.length; i += 2) {
+                kafkaClientProps.put(props[i], props[i + 1]);
+            }
+        }
+
         String dnsCacheTtl = System.getenv("STRIMZI_DNS_CACHE_TTL") == null ? "30" : System.getenv("STRIMZI_DNS_CACHE_TTL");
         Security.setProperty("networkaddress.cache.ttl", dnsCacheTtl);
         kafkaClientProps.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.get(Config.KAFKA_BOOTSTRAP_SERVERS));

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ConfigTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ConfigTest.java
@@ -69,11 +69,23 @@ public class ConfigTest {
 
     @Test
     public void testTopicMetadataMaxAttemptsIsSetCorrectly() {
-
         Map<String, String> map = new HashMap<>(MANDATORY);
         map.put(Config.TC_TOPIC_METADATA_MAX_ATTEMPTS, "3");
 
         Config c = new Config(map);
-        assertThat(c.get(Config.TOPIC_METADATA_MAX_ATTEMPTS).intValue(), is(3));
+        assertThat(c.get(Config.TOPIC_METADATA_MAX_ATTEMPTS), is(3));
+    }
+
+    @Test
+    public void testAdditionalKafkaProperties() {
+        Map<String, String> map = new HashMap<>(MANDATORY);
+        map.put(Config.TC_ADDITIONAL_KAFKA_PROPERTIES, "key1|value1");
+
+        Config c = new Config(map);
+        String akp = c.get(Config.ADDITIONAL_KAFKA_PROPERTIES);
+        String[] split = akp.split(c.get(Config.ADDITIONAL_KAFKA_PROPERTIES_DELIMITER));
+        assertThat(split.length, is(2));
+        assertThat(split[0], is("key1"));
+        assertThat(split[1], is("value1"));
     }
 }


### PR DESCRIPTION
Signed-off-by: Ales Justin <ales.justin@gmail.com>

### Type of change

- Enhancement / new feature

### Description

Add a way to specify additional Kafka client / Streams properties.

### Checklist

- [X] Write tests
- [ ] Update documentation -- @PaulRMellor this needs to be added ... if/when this gets merged
