### PR TITLE
Add info on m2e-apt Eclipse plug-in for annotation processor config

### DIFF
--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -11,7 +11,7 @@ This document gives a detailed breakdown of the various build processes and opti
 - [Building Strimzi](#building-strimzi)
 - [Helm Chart](#helm-chart)
 - [Running system tests](#running-system-tests)
-- [DCO Signoff](#cdo-signoff)
+- [DCO Signoff](#dco-signoff)
 - [IDE build problems](#ide-build-problems)
 - [Building container images for other platforms with Docker `buildx`](#building-container-images-for-other-platforms-with-docker-buildx)
 
@@ -270,6 +270,8 @@ You can also run the Checkstyle plugin for every commit you make by adding a pre
 ## IDE build problems
 
 The build also uses a Java annotation processor. Some IDEs (such as IntelliJ's IDEA) by default don't run the annotation processor in their build process. You can run `mvn clean install -DskipTests -DskipITs` to run the annotation processor as part of the `maven` build and the IDE should then be able to use the generated classes. It is also possible to configure the IDE to run the annotation processor directly.
+
+Eclipse users may find the [m2e-apt plugin](https://marketplace.eclipse.org/content/m2e-apt) useful for the automatic configuration of Eclipse projects for annotation processing.
 
 ## Building container images for other platforms with Docker `buildx`
 


### PR DESCRIPTION
Signed-off-by: Michael Edgar <medgar@redhat.com>

### Type of change

- Documentation

### Description

Add information to the DEV_GUIDE for Eclipse users and the m2e-apt plug-in for handling configuration of annotation processing.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

