### PR TITLE
Do not set the deprecated Ingress class annotation by default anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   * `operator.strimzi.io/generation` (used internally only - replaced by `strimzi.io/generation`)
   * `operator.strimzi.io/delete-pod-and-pvc` (use `strimzi.io/delete-pod-and-pvc` instead)
   * `operator.strimzi.io/manual-rolling-update` (use `strimzi.io/manual-rolling-update` instead)
+* When the `class` field is configured in the `configuration` section of an Ingress-type listener, Strimzi will not automatically set the deprecated `kubernetes.io/ingress.class` annotation anymore. In case you still need this annotation, you can set it manually in the listener configuration using the [`annotations` field](https://strimzi.io/docs/operators/latest/full/using.html#property-listener-config-annotations-reference) or in the [`.spec.kafka.template` section](https://strimzi.io/docs/operators/latest/full/using.html#type-KafkaClusterTemplate-reference).  
 
 ## 0.22.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1230,11 +1230,7 @@ public class KafkaCluster extends AbstractModel {
      * @return Map with the annotations
      */
     private Map<String, String> generateInternalIngressAnnotations(String ingressClass) {
-        Map<String, String> internalAnnotations = new HashMap<>(4);
-
-        if (ingressClass != null) {
-            internalAnnotations.put("kubernetes.io/ingress.class", ingressClass);
-        }
+        Map<String, String> internalAnnotations = new HashMap<>(3);
 
         internalAnnotations.put("ingress.kubernetes.io/ssl-passthrough", "true");
         internalAnnotations.put("nginx.ingress.kubernetes.io/ssl-passthrough", "true");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -2647,7 +2647,6 @@ public class KafkaClusterTest {
         // Check bootstrap ingress
         Ingress bing = kc.generateExternalBootstrapIngresses().get(0);
         assertThat(bing.getMetadata().getName(), is(KafkaCluster.serviceName(cluster)));
-        assertThat(bing.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is(nullValue()));
         assertThat(bing.getSpec().getIngressClassName(), is(nullValue()));
         assertThat(bing.getMetadata().getAnnotations().get("dns-annotation"), is("my-kafka-bootstrap.com"));
         assertThat(bing.getMetadata().getLabels().get("label"), is("label-value"));
@@ -2664,7 +2663,6 @@ public class KafkaClusterTest {
 
         io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress bingV1Beta1 = kc.generateExternalBootstrapIngressesV1Beta1().get(0);
         assertThat(bingV1Beta1.getMetadata().getName(), is(KafkaCluster.serviceName(cluster)));
-        assertThat(bingV1Beta1.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is(nullValue()));
         assertThat(bingV1Beta1.getSpec().getIngressClassName(), is(nullValue()));
         assertThat(bingV1Beta1.getMetadata().getAnnotations().get("dns-annotation"), is("my-kafka-bootstrap.com"));
         assertThat(bingV1Beta1.getMetadata().getLabels().get("label"), is("label-value"));
@@ -2683,7 +2681,6 @@ public class KafkaClusterTest {
         for (int i = 0; i < replicas; i++)  {
             Ingress ing = kc.generateExternalIngresses(i).get(0);
             assertThat(ing.getMetadata().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
-            assertThat(ing.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is(nullValue()));
             assertThat(ing.getSpec().getIngressClassName(), is(nullValue()));
             assertThat(ing.getMetadata().getAnnotations().get("dns-annotation"), is("my-kafka-broker.com"));
             assertThat(ing.getMetadata().getLabels().get("label"), is("label-value"));
@@ -2700,7 +2697,6 @@ public class KafkaClusterTest {
 
             io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingV1Beta1 = kc.generateExternalIngressesV1Beta1(i).get(0);
             assertThat(ingV1Beta1.getMetadata().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
-            assertThat(ingV1Beta1.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is(nullValue()));
             assertThat(ingV1Beta1.getSpec().getIngressClassName(), is(nullValue()));
             assertThat(ingV1Beta1.getMetadata().getAnnotations().get("dns-annotation"), is("my-kafka-broker.com"));
             assertThat(ingV1Beta1.getMetadata().getLabels().get("label"), is("label-value"));
@@ -2762,21 +2758,17 @@ public class KafkaClusterTest {
 
          // Check bootstrap ingress
         Ingress bing = kc.generateExternalBootstrapIngresses().get(0);
-        assertThat(bing.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is("nginx-internal"));
         assertThat(bing.getSpec().getIngressClassName(), is("nginx-internal"));
 
         io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress bingV1Beta1 = kc.generateExternalBootstrapIngressesV1Beta1().get(0);
-        assertThat(bingV1Beta1.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is("nginx-internal"));
         assertThat(bingV1Beta1.getSpec().getIngressClassName(), is("nginx-internal"));
 
         // Check per pod ingress
         for (int i = 0; i < replicas; i++)  {
             Ingress ing = kc.generateExternalIngresses(i).get(0);
-            assertThat(ing.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is("nginx-internal"));
             assertThat(ing.getSpec().getIngressClassName(), is("nginx-internal"));
 
             io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingV1Beta1 = kc.generateExternalIngressesV1Beta1(i).get(0);
-            assertThat(ingV1Beta1.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is("nginx-internal"));
             assertThat(ingV1Beta1.getSpec().getIngressClassName(), is("nginx-internal"));
         }
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In 0.22, we added support for `networking/v1` Ingress API. This does not use the old and deprecated `kubernetes.io/ingress.class` annotation anymore to configure the Ingress class. Instead it has a dedicated `ingressClassName` in the spec. In 0.22, when the `class` field in the Ingress listener was configured, we set both at the same time - the annotation and the spec. But it turns out Kubernetes is rejecting this configuration and allows only one of these two to be used. This was not discovered initially in 0.22, since it seems to work fine when modifying the Ingress resource. Only creating new Ingress resource is rejected.

This PR fixes this behaviour and by default will set only the `.spec.ingressClassName` field. If the user is using old legacy Ingress controller which still needs the annotation, it can be easily set through the `.spec.kafka.template` section or in the `annotations` field in listener configuration.

While this is not ideal and changes the behaviour for some existing users, it makes it possible to use the Ingress listener for both old and new users. And the `kubernetes.io/ingress.class` annotation is anyway deprecated. So people should be using it less and less.

This should close #4679 

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md