### PR TITLE
Add topic name to the topic status

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaTopicStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaTopicStatus.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model.status;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.Constants;
+import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -19,9 +20,20 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "observedGeneration" })
+@JsonPropertyOrder({ "topicName", "conditions", "observedGeneration" })
 @EqualsAndHashCode
 @ToString(callSuper = true)
 public class KafkaTopicStatus extends Status {
     private static final long serialVersionUID = 1L;
+
+    private String topicName;
+
+    @Description("Topic name")
+    public String getTopicName() {
+        return topicName;
+    }
+
+    public void setTopicName(String topicName) {
+        this.topicName = topicName;
+    }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaTopicStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaTopicStatus.java
@@ -20,7 +20,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "topicName", "conditions", "observedGeneration" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "topicName" })
 @EqualsAndHashCode
 @ToString(callSuper = true)
 public class KafkaTopicStatus extends Status {

--- a/api/src/test/resources/io/strimzi/api/kafka/model/043-Crd-kafkatopic.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/043-Crd-kafkatopic.yaml
@@ -82,6 +82,9 @@ spec:
         status:
           type: object
           properties:
+            topicName:
+              type: string
+              description: Topic name.
             conditions:
               type: array
               items:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/043-Crd-kafkatopic.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/043-Crd-kafkatopic.yaml
@@ -82,9 +82,6 @@ spec:
         status:
           type: object
           properties:
-            topicName:
-              type: string
-              description: Topic name.
             conditions:
               type: array
               items:
@@ -116,4 +113,7 @@ spec:
               type: integer
               description: The generation of the CRD that was last reconciled by the
                 operator.
+            topicName:
+              type: string
+              description: Topic name.
           description: The status of the topic.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2192,6 +2192,8 @@ Used in: xref:type-KafkaTopic-{context}[`KafkaTopic`]
 [options="header"]
 |====
 |Property                   |Description
+|topicName           1.2+<.<|Topic name.
+|string
 |conditions          1.2+<.<|List of status conditions.
 |xref:type-Condition-{context}[`Condition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2192,12 +2192,12 @@ Used in: xref:type-KafkaTopic-{context}[`KafkaTopic`]
 [options="header"]
 |====
 |Property                   |Description
-|topicName           1.2+<.<|Topic name.
-|string
 |conditions          1.2+<.<|List of status conditions.
 |xref:type-Condition-{context}[`Condition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
+|topicName           1.2+<.<|Topic name.
+|string
 |====
 
 [id='type-KafkaUser-{context}']

--- a/examples/topic/kafka-topic.yaml
+++ b/examples/topic/kafka-topic.yaml
@@ -10,5 +10,3 @@ spec:
   config:
     retention.ms: 7200000
     segment.bytes: 1073741824
- 
-

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
@@ -97,6 +97,9 @@ spec:
                 observedGeneration:
                   type: integer
                   description: The generation of the CRD that was last reconciled by the operator.
+                topicName:
+                  type: string
+                  description: Topic name.
               description: The status of the topic.
     - name: v1beta1
       served: true
@@ -174,6 +177,9 @@ spec:
                 observedGeneration:
                   type: integer
                   description: The generation of the CRD that was last reconciled by the operator.
+                topicName:
+                  type: string
+                  description: Topic name.
               description: The status of the topic.
     - name: v1alpha1
       served: true
@@ -251,4 +257,7 @@ spec:
                 observedGeneration:
                   type: integer
                   description: The generation of the CRD that was last reconciled by the operator.
+                topicName:
+                  type: string
+                  description: Topic name.
               description: The status of the topic.

--- a/packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -77,6 +77,9 @@ spec:
           status:
             type: object
             properties:
+              topicName:
+                type: string
+                description: Topic name.
               conditions:
                 type: array
                 items:
@@ -166,6 +169,9 @@ spec:
           status:
             type: object
             properties:
+              topicName:
+                type: string
+                description: Topic name.
               conditions:
                 type: array
                 items:
@@ -255,6 +261,9 @@ spec:
           status:
             type: object
             properties:
+              topicName:
+                type: string
+                description: Topic name.
               conditions:
                 type: array
                 items:

--- a/packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -77,9 +77,6 @@ spec:
           status:
             type: object
             properties:
-              topicName:
-                type: string
-                description: Topic name.
               conditions:
                 type: array
                 items:
@@ -111,6 +108,9 @@ spec:
                 type: integer
                 description: The generation of the CRD that was last reconciled by
                   the operator.
+              topicName:
+                type: string
+                description: Topic name.
             description: The status of the topic.
   - name: v1beta1
     served: true
@@ -169,9 +169,6 @@ spec:
           status:
             type: object
             properties:
-              topicName:
-                type: string
-                description: Topic name.
               conditions:
                 type: array
                 items:
@@ -203,6 +200,9 @@ spec:
                 type: integer
                 description: The generation of the CRD that was last reconciled by
                   the operator.
+              topicName:
+                type: string
+                description: Topic name.
             description: The status of the topic.
   - name: v1alpha1
     served: true
@@ -261,9 +261,6 @@ spec:
           status:
             type: object
             properties:
-              topicName:
-                type: string
-                description: Topic name.
               conditions:
                 type: array
                 items:
@@ -295,4 +292,7 @@ spec:
                 type: integer
                 description: The generation of the CRD that was last reconciled by
                   the operator.
+              topicName:
+                type: string
+                description: Topic name.
             description: The status of the topic.

--- a/packaging/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/packaging/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -108,6 +108,9 @@ spec:
                 type: integer
                 description: The generation of the CRD that was last reconciled by
                   the operator.
+              topicName:
+                type: string
+                description: Topic name.
             description: The status of the topic.
   - name: v1beta1
     served: true
@@ -197,6 +200,9 @@ spec:
                 type: integer
                 description: The generation of the CRD that was last reconciled by
                   the operator.
+              topicName:
+                type: string
+                description: Topic name.
             description: The status of the topic.
   - name: v1alpha1
     served: true
@@ -286,4 +292,7 @@ spec:
                 type: integer
                 description: The generation of the CRD that was last reconciled by
                   the operator.
+              topicName:
+                type: string
+                description: Topic name.
             description: The status of the topic.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicDiff.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicDiff.java
@@ -225,7 +225,7 @@ class TopicDiff {
         Objects.requireNonNull(source.getTopicName());
         Objects.requireNonNull(target.getTopicName());
         if (!source.getTopicName().equals(target.getTopicName())) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Kafka topics cannot be renamed, but KafkaTopic's spec.topicName has changed.");
         }
         Map<String, Difference> differences = new HashMap<>();
         if (source.getNumPartitions() != target.getNumPartitions()) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -1012,7 +1012,7 @@ class TopicOperator {
 
 
 
-                    if (topic.getStatus() == null || (topic.getStatus() != null && topic.getStatus().getTopicName() == null)) {
+                    if (topic.getStatus() == null || topic.getStatus().getTopicName() == null) {
                         String specTopicName = new TopicName(topic).toString();
                         kts.setTopicName(specTopicName);
                     } else {


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Refactoring

### Description

The K8S KafkaTopic resource does contain `topicName` field. It should not be changed since K8S resource should be bounded to exactly one Kafka Topic. Changing `spec.topicName` brings inconsistency between K8S and Kafka topics.

Putting (and not changing) the `topicName` to the status makes it unambiguous with what `spec.topicName` was topic created.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

