### PR TITLE
Pushing crd-annotations artifact to nexus

### DIFF
--- a/.azure/scripts/push-to-nexus.sh
+++ b/.azure/scripts/push-to-nexus.sh
@@ -5,7 +5,7 @@ export GPG_TTY=$(tty)
 echo $GPG_SIGNING_KEY | base64 -d > signing.gpg
 gpg --batch --import signing.gpg
 
-GPG_EXECUTABLE=gpg mvn -B $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -pl ./,crd-generator,crd-annotations,api,api-conversion,test-container -P ossrh deploy
+GPG_EXECUTABLE=gpg mvn -B $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -pl ./,crd-annotations,crd-generator,api,api-conversion,test-container -P ossrh deploy
 
 rm -rf signing.gpg
 gpg --delete-keys

--- a/.azure/scripts/push-to-nexus.sh
+++ b/.azure/scripts/push-to-nexus.sh
@@ -5,7 +5,7 @@ export GPG_TTY=$(tty)
 echo $GPG_SIGNING_KEY | base64 -d > signing.gpg
 gpg --batch --import signing.gpg
 
-GPG_EXECUTABLE=gpg mvn -B $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -pl ./,crd-generator,api,api-conversion,test-container -P ossrh deploy
+GPG_EXECUTABLE=gpg mvn -B $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -pl ./,crd-generator,crd-annotations,api,api-conversion,test-container -P ossrh deploy
 
 rm -rf signing.gpg
 gpg --delete-keys

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -87,6 +87,7 @@
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.strimzi</groupId>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR fixes #4728 about pushing crd-annotations artifact to nexus.
It also set the `test` artifact as "test" scoped for the api module.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

