### PR TITLE
Allow empty tokenEndpointUri in OAuth PLAIN to assume token in password

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -438,9 +438,6 @@ public class ListenersValidator {
             if (!oAuth.isEnablePlain() && !oAuth.isEnableOauthBearer()) {
                 errors.add("listener " + listenerName + ": At least one of 'enablePlain', 'enableOauthBearer' has to be set to 'true'");
             }
-            if (oAuth.isEnablePlain() && oAuth.getTokenEndpointUri() == null) {
-                errors.add("listener " + listenerName + ": When 'enablePlain' is 'true' the 'tokenEndpointUri' has to be specified.");
-            }
             boolean hasJwksRefreshSecondsValidInput = oAuth.getJwksRefreshSeconds() != null && oAuth.getJwksRefreshSeconds() > 0;
             boolean hasJwksExpirySecondsValidInput = oAuth.getJwksExpirySeconds() != null && oAuth.getJwksExpirySeconds() > 0;
             boolean hasJwksMinRefreshPauseSecondsValidInput = oAuth.getJwksMinRefreshPauseSeconds() != null && oAuth.getJwksMinRefreshPauseSeconds() >= 0;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ListenersValidatorTest {
@@ -765,7 +766,7 @@ public class ListenersValidatorTest {
         assertThat(exception.getMessage(), allOf(
                 containsString("listener listener1: At least one of 'enablePlain', 'enableOauthBearer' has to be set to 'true'")));
 
-        // enable plain
+        // enable plain with neither introspectionEndpointUri nor jwksEndpointUri set
         authBuilder.withEnablePlain(true);
         listener = listenerBuilder.withAuth(authBuilder.build())
                 .build();
@@ -773,7 +774,15 @@ public class ListenersValidatorTest {
 
         exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(3, listeners2));
         assertThat(exception.getMessage(), allOf(
-                containsString("listener listener1: When 'enablePlain' is 'true' the 'tokenEndpointUri' has to be specified.")));
+                containsString("listener listener1: Introspection endpoint URI or JWKS endpoint URI has to be specified")));
+
+        // enable plain with jwksEndpointUri set but tokenEndpointUri not set
+        authBuilder.withJwksEndpointUri("http://localhost:8080/jwks").withCheckIssuer(false);
+        listener = listenerBuilder.withAuth(authBuilder.build())
+                .build();
+        List<GenericKafkaListener> listeners3 = asList(listener);
+
+        assertDoesNotThrow(() -> ListenersValidator.validate(3, listeners3));
     }
 
     @Test

--- a/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
@@ -26,10 +26,6 @@
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
         </repository>
-        <repository>
-            <id>oauth-staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1098/</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.6.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.7.1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.7.2</strimzi-oauth.version>
         <cruise-control.version>2.5.37</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
     </properties>
@@ -25,6 +25,10 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>oauth-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1098/</url>
         </repository>
     </repositories>
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
@@ -26,10 +26,6 @@
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
         </repository>
-        <repository>
-            <id>oauth-staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1098/</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.7.1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.7.2</strimzi-oauth.version>
         <cruise-control.version>2.5.37</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
     </properties>
@@ -25,6 +25,10 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>oauth-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1098/</url>
         </repository>
     </repositories>
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
@@ -26,10 +26,6 @@
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
         </repository>
-        <repository>
-            <id>oauth-staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1098/</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.7.1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.7.2</strimzi-oauth.version>
         <cruise-control.version>2.5.46</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
     </properties>
@@ -25,6 +25,10 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>oauth-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1098/</url>
         </repository>
     </repositories>
 

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -43,7 +43,7 @@
 
 //OAuth attributes and links
 :oauth2-site: link:https://oauth.net/2/[OAuth 2.0 site^]
-:oauth-version: 0.7.1
+:oauth-version: 0.7.2
 :keycloak-server-doc: link:https://www.keycloak.org/documentation.html[Keycloak documentation^]
 :keycloak-authorization-services: link:https://www.keycloak.org/docs/latest/authorization_services/index.html[Authorization Services^]
 :oauth-blog: link:https://strimzi.io/2019/10/25/kafka-authentication-using-oauth-2.0.html[Kafka authentication using OAuth 2.0^]

--- a/pom.xml
+++ b/pom.xml
@@ -145,13 +145,6 @@
         <skip.surefire.tests>${skipTests}</skip.surefire.tests>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>oauth-staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1098/</url>
-        </repository>
-    </repositories>
-
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <jaeger.version>1.3.2</jaeger.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
-        <strimzi-oauth.version>0.7.1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.7.2</strimzi-oauth.version>
         <commons-codec.version>1.13</commons-codec.version>
         <registry.version>1.3.0.Final</registry.version>
 
@@ -144,6 +144,13 @@
         <!--suppress UnresolvedMavenProperty -->
         <skip.surefire.tests>${skipTests}</skip.surefire.tests>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>oauth-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1098/</url>
+        </repository>
+    </repositories>
 
     <distributionManagement>
         <snapshotRepository>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_
- Enhancement / new feature

### Description

_Please describe your pull request_

When the oauth plain mode is updated with https://github.com/strimzi/strimzi-kafka-oauth/pull/107, this change in strimzi-kafka-operator will allow this configuration by not forbidding an empty `TokenEndpointUri` value.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards
