### PR TITLE
[systemtest] Fixups for LoggingChangesST tests and fix of exception message inside the `AbstractModel.java`

### DIFF
--- a/.azure/regression-pipeline.yaml
+++ b/.azure/regression-pipeline.yaml
@@ -67,8 +67,7 @@ jobs:
     parameters:
       name: 'regression_all_remaining'
       display_name: 'regression-bundle VII. - remaining system tests'
-      # !LoggingChangeST is skipped because it can be flaky on Azure
-      test_case: '!kafka/**/*ST,!mirrormaker/**/*ST,!connect/**/*ST,!security/**/*ST,!LoggingChangeST,!operators/**/*ST,!rollingupdate/**/*ST,!watcher/**/*ST,!tracing/**/*ST'
+      test_case: '!kafka/**/*ST,!mirrormaker/**/*ST,!connect/**/*ST,!security/**/*ST,!operators/**/*ST,!rollingupdate/**/*ST,!watcher/**/*ST,!tracing/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
       timeout: 360

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -494,9 +494,11 @@ public abstract class AbstractModel {
                 if (externalCm != null && externalCm.getData() != null && externalCm.getData().containsKey(externalLogging.getValueFrom().getConfigMapKeyRef().getKey())) {
                     return maybeAddMonitorIntervalToExternalLogging(externalCm.getData().get(externalLogging.getValueFrom().getConfigMapKeyRef().getKey()));
                 } else {
-                    throw new InvalidResourceException("ConfigMap " + externalLogging.getValueFrom().getConfigMapKeyRef().getName()
-                            + "with external logging configuration does not exist or doesn't contain the configuration under the {} key"
-                            + externalLogging.getValueFrom().getConfigMapKeyRef().getKey() + ".");
+                    throw new InvalidResourceException(
+                        String.format("ConfigMap %s with external logging configuration does not exist or doesn't contain the configuration under the %s key.",
+                            externalLogging.getValueFrom().getConfigMapKeyRef().getName(),
+                            externalLogging.getValueFrom().getConfigMapKeyRef().getKey())
+                    );
                 }
             } else {
                 throw new InvalidResourceException("Property logging.valueFrom has to be specified when using external logging.");

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -172,7 +172,7 @@ public class ResourceManager {
     }
 
     @SafeVarargs
-    public final <T extends HasMetadata> void deleteResource(T... resources) throws Exception {
+    public final <T extends HasMetadata> void deleteResource(T... resources) {
         for (T resource : resources) {
             ResourceType<T> type = findResourceType(resource);
             if (type == null) {
@@ -201,13 +201,16 @@ public class ResourceManager {
 
         ResourceType<T> type = findResourceType(resource);
         assertNotNull(type);
-
         boolean[] resourceReady = new boolean[1];
 
-        TestUtils.waitFor("Resource condition:" + condition + " is fulfilled", Constants.GLOBAL_POLL_INTERVAL_MEDIUM, ResourceOperation.getTimeoutForResourceReadiness(resource.getKind()),
+        TestUtils.waitFor("Resource condition: " + condition + " is fulfilled for resource " + resource.getKind() + ":" + resource.getMetadata().getName(),
+            Constants.GLOBAL_POLL_INTERVAL_MEDIUM, ResourceOperation.getTimeoutForResourceReadiness(resource.getKind()),
             () -> {
                 T res = type.get(resource.getMetadata().getNamespace(), resource.getMetadata().getName());
                 resourceReady[0] =  condition.test(res);
+                if (!resourceReady[0]) {
+                    type.delete(res);
+                }
                 return resourceReady[0];
             });
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceType.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceType.java
@@ -27,7 +27,7 @@ public interface ResourceType<T extends HasMetadata> {
     /**
      * Delete specific resource based on T type using Kubernetes API
      */
-    void delete(T resource) throws Exception;
+    void delete(T resource);
 
     /**
      * Check if this resource is marked as ready or not with wait.

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
@@ -33,7 +33,7 @@ public class KafkaBridgeResource implements ResourceType<KafkaBridge> {
         kafkaBridgeClient().inNamespace(resource.getMetadata().getNamespace()).createOrReplace(resource);
     }
     @Override
-    public void delete(KafkaBridge resource) throws Exception {
+    public void delete(KafkaBridge resource) {
         kafkaBridgeClient().inNamespace(resource.getMetadata().getNamespace()).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaClientsResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaClientsResource.java
@@ -33,7 +33,7 @@ public class KafkaClientsResource implements ResourceType<Deployment> {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createOrReplaceDeployment(resource);
     }
     @Override
-    public void delete(Deployment resource) throws Exception {
+    public void delete(Deployment resource) {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteDeployment(resource.getMetadata().getNamespace(), resource.getMetadata().getName());
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -33,7 +33,7 @@ public class KafkaConnectResource implements ResourceType<KafkaConnect> {
         kafkaConnectClient().inNamespace(resource.getMetadata().getNamespace()).withName(resource.getMetadata().getName()).createOrReplace(resource);
     }
     @Override
-    public void delete(KafkaConnect resource) throws Exception {
+    public void delete(KafkaConnect resource) {
         kafkaConnectClient().inNamespace(resource.getMetadata().getNamespace()).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
@@ -35,7 +35,7 @@ public class KafkaConnectS2IResource implements ResourceType<KafkaConnectS2I> {
         kafkaConnectS2IClient().inNamespace(resource.getMetadata().getNamespace()).withName(resource.getMetadata().getName()).createOrReplace(resource);
     }
     @Override
-    public void delete(KafkaConnectS2I resource) throws Exception {
+    public void delete(KafkaConnectS2I resource) {
         kafkaConnectS2IClient().inNamespace(resource.getMetadata().getNamespace()).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
@@ -34,7 +34,7 @@ public class KafkaConnectorResource implements ResourceType<KafkaConnector> {
         kafkaConnectorClient().inNamespace(resource.getMetadata().getNamespace()).createOrReplace(resource);
     }
     @Override
-    public void delete(KafkaConnector resource) throws Exception {
+    public void delete(KafkaConnector resource) {
         kafkaConnectorClient().inNamespace(resource.getMetadata().getNamespace()).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
@@ -31,7 +31,7 @@ public class KafkaMirrorMaker2Resource implements ResourceType<KafkaMirrorMaker2
         kafkaMirrorMaker2Client().inNamespace(resource.getMetadata().getNamespace()).createOrReplace(resource);
     }
     @Override
-    public void delete(KafkaMirrorMaker2 resource) throws Exception {
+    public void delete(KafkaMirrorMaker2 resource) {
         kafkaMirrorMaker2Client().inNamespace(resource.getMetadata().getNamespace()).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
@@ -31,7 +31,7 @@ public class KafkaMirrorMakerResource implements ResourceType<KafkaMirrorMaker> 
         kafkaMirrorMakerClient().inNamespace(resource.getMetadata().getNamespace()).createOrReplace(resource);
     }
     @Override
-    public void delete(KafkaMirrorMaker resource) throws Exception {
+    public void delete(KafkaMirrorMaker resource) {
         kafkaMirrorMakerClient().inNamespace(resource.getMetadata().getNamespace()).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaRebalanceResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaRebalanceResource.java
@@ -35,7 +35,7 @@ public class KafkaRebalanceResource implements ResourceType<KafkaRebalance> {
         kafkaRebalanceClient().inNamespace(resource.getMetadata().getNamespace()).createOrReplace(resource);
     }
     @Override
-    public void delete(KafkaRebalance resource) throws Exception {
+    public void delete(KafkaRebalance resource) {
         kafkaRebalanceClient().inNamespace(resource.getMetadata().getNamespace()).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -39,7 +39,7 @@ public class KafkaResource implements ResourceType<Kafka> {
     }
 
     @Override
-    public void delete(Kafka resource) throws Exception {
+    public void delete(Kafka resource) {
         kafkaClient().inNamespace(resource.getMetadata().getNamespace()).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
@@ -33,7 +33,7 @@ public class KafkaTopicResource implements ResourceType<KafkaTopic> {
         kafkaTopicClient().inNamespace(resource.getMetadata().getNamespace()).createOrReplace(resource);
     }
     @Override
-    public void delete(KafkaTopic resource) throws Exception {
+    public void delete(KafkaTopic resource) {
         kafkaTopicClient().inNamespace(resource.getMetadata().getNamespace()).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
@@ -38,7 +38,7 @@ public class KafkaUserResource implements ResourceType<KafkaUser> {
     }
 
     @Override
-    public void delete(KafkaUser resource) throws Exception {
+    public void delete(KafkaUser resource) {
         kafkaUserClient().inNamespace(resource.getMetadata().getNamespace()).withName(resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleBindingResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleBindingResource.java
@@ -31,7 +31,7 @@ public class ClusterRoleBindingResource implements ResourceType<ClusterRoleBindi
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createOrReplaceClusterRoleBinding(resource);
     }
     @Override
-    public void delete(ClusterRoleBinding resource) throws Exception {
+    public void delete(ClusterRoleBinding resource) {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteClusterRoleBinding(resource);
     }
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/DeploymentResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/DeploymentResource.java
@@ -31,7 +31,7 @@ public class DeploymentResource implements ResourceType<Deployment> {
         ResourceManager.kubeClient().createOrReplaceDeployment(resource);
     }
     @Override
-    public void delete(Deployment resource) throws Exception {
+    public void delete(Deployment resource) {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteDeployment(resource.getMetadata().getNamespace(), resource.getMetadata().getName());
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/JobResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/JobResource.java
@@ -23,7 +23,7 @@ public class JobResource implements ResourceType<Job> {
         ResourceManager.kubeClient().createJob(resource);
     }
     @Override
-    public void delete(Job resource) throws Exception {
+    public void delete(Job resource) {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteJob(resource.getMetadata().getName());
     }
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/NetworkPolicyResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/NetworkPolicyResource.java
@@ -46,7 +46,7 @@ public class NetworkPolicyResource implements ResourceType<NetworkPolicy> {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createNetworkPolicy(resource);
     }
     @Override
-    public void delete(NetworkPolicy resource) throws Exception {
+    public void delete(NetworkPolicy resource) {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteNetworkPolicy(resource.getMetadata().getName());
     }
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleBindingResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleBindingResource.java
@@ -32,7 +32,7 @@ public class RoleBindingResource implements ResourceType<RoleBinding> {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createOrReplaceRoleBinding(resource);
     }
     @Override
-    public void delete(RoleBinding resource) throws Exception {
+    public void delete(RoleBinding resource) {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteRoleBinding(resource.getMetadata().getName());
     }
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ServiceResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ServiceResource.java
@@ -29,7 +29,7 @@ public class ServiceResource implements ResourceType<Service> {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createService(resource);
     }
     @Override
-    public void delete(Service resource) throws Exception {
+    public void delete(Service resource) {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteService(resource);
     }
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
@@ -41,7 +41,7 @@ public class BundleResource implements ResourceType<Deployment> {
         ResourceManager.kubeClient().createOrReplaceDeployment(resource);
     }
     @Override
-    public void delete(Deployment resource) throws Exception {
+    public void delete(Deployment resource) {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteDeployment(resource.getMetadata().getName());
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -767,7 +767,13 @@ class LoggingChangeST extends AbstractST {
         kubeClient().getClient().configMaps().inNamespace(NAMESPACE).createOrReplace(configMap);
 
         ExternalLogging elKafka = new ExternalLoggingBuilder()
-            .withName("external-configmap")
+            .withNewValueFrom()
+            .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder()
+                .withKey("log4j.properties")
+                .withName("external-configmap")
+                .withOptional(false)
+                .build())
+            .endValueFrom()
             .build();
 
         LOGGER.info("Setting log level of kafka INFO");
@@ -1107,7 +1113,7 @@ class LoggingChangeST extends AbstractST {
         LOGGER.info("Checking if Kafka:{} contains error about non-existing CM", clusterName);
         Condition condition = KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(clusterName).get().getStatus().getConditions().get(0);
         assertThat(condition.getType(), is(CustomResourceStatus.NotReady.toString()));
-        assertTrue(condition.getMessage().matches("ConfigMap " + nonExistingCmName + "with external logging configuration does not exist .*"));
+        assertTrue(condition.getMessage().matches("ConfigMap " + nonExistingCmName + " with external logging configuration does not exist .*"));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -16,12 +16,14 @@ import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedTest;
+import io.strimzi.systemtest.enums.CustomResourceStatus;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaBridgeResource;
 import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
@@ -1030,7 +1032,7 @@ class LoggingChangeST extends AbstractST {
     }
 
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
-    void testNotExistingCMSetsDefaultLogging(ExtensionContext extensionContext) {
+    void testNotExistingCMKeepPreviousCMAndPrintsError(ExtensionContext extensionContext) {
         String defaultProps = TestUtils.getFileAsString(TestUtils.USER_PATH + "/../cluster-operator/src/main/resources/kafkaDefaultLoggingProperties");
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -1043,9 +1045,12 @@ class LoggingChangeST extends AbstractST {
             "log4j.logger.kafka=INFO\n" +
             "log4j.logger.org.apache.kafka=INFO";
 
+        String existingCmName = "external-cm";
+        String nonExistingCmName = "non-existing-cm-name";
+
         ConfigMap configMap = new ConfigMapBuilder()
             .withNewMetadata()
-                .withName("external-cm")
+                .withName(existingCmName)
                 .withNamespace(NAMESPACE)
             .endMetadata()
             .withData(Collections.singletonMap("log4j.properties", cmData))
@@ -1061,7 +1066,7 @@ class LoggingChangeST extends AbstractST {
                     .withNewValueFrom()
                         .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder()
                                 .withKey("log4j.properties")
-                                .withName("external-cm")
+                                .withName(existingCmName)
                                 .withOptional(false)
                                 .build())
                     .endValueFrom()
@@ -1083,7 +1088,7 @@ class LoggingChangeST extends AbstractST {
                 .withNewValueFrom()
                     .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder()
                             .withKey("log4j.properties")
-                            .withName("non-existing-cm-name")
+                            .withName(nonExistingCmName)
                             .withOptional(false)
                             .build())
                 .endValueFrom()
@@ -1096,8 +1101,13 @@ class LoggingChangeST extends AbstractST {
             "kafka", "/bin/bash", "-c", "cat custom-config/log4j.properties").out();
 
         assertFalse(log4jFile.isEmpty());
-        assertFalse(log4jFile.contains(cmData));
-        assertTrue(log4jFile.contains(defaultProps));
+        assertTrue(log4jFile.contains(cmData));
+        assertFalse(log4jFile.contains(defaultProps));
+
+        LOGGER.info("Checking if Kafka:{} contains error about non-existing CM", clusterName);
+        Condition condition = KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName(clusterName).get().getStatus().getConditions().get(0);
+        assertThat(condition.getType(), is(CustomResourceStatus.NotReady.toString()));
+        assertTrue(condition.getMessage().matches("ConfigMap " + nonExistingCmName + "with external logging configuration does not exist .*"));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -262,6 +262,10 @@ public class SpecificST extends AbstractST {
             .endSpec()
             .build());
 
+        // we should create topic before KafkaConnect - topic is recreated if we delete it before KafkaConnect
+        String topicName = "rw-" + KafkaTopicUtils.generateRandomNameOfTopic();
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, topicName).build());
+
         resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(false, kafkaClientsName).build());
 
         String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(kafkaClientsName).get(0).getMetadata().getName();
@@ -283,25 +287,19 @@ public class SpecificST extends AbstractST {
 
         NetworkPolicyResource.deployNetworkPolicyForResource(extensionContext, kc, KafkaConnectResources.deploymentName(clusterName));
 
-        String topicName = "topic-test-rack-aware";
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, topicName).build());
+        String connectPodName = kubeClient().listPodNames(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0);
 
-        List<String> connectPods = kubeClient().listPodNames(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND);
-        for (String connectPodName : connectPods) {
-            Affinity connectPodSpecAffinity = kubeClient().getDeployment(KafkaConnectResources.deploymentName(clusterName)).getSpec().getTemplate().getSpec().getAffinity();
-            NodeSelectorRequirement connectPodNodeSelectorRequirement = connectPodSpecAffinity.getNodeAffinity()
-                    .getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().get(0).getMatchExpressions().get(0);
-            Pod connectPod = kubeClient().getPod(connectPodName);
-            NodeAffinity nodeAffinity = connectPod.getSpec().getAffinity().getNodeAffinity();
+        Affinity connectPodSpecAffinity = kubeClient().getDeployment(KafkaConnectResources.deploymentName(clusterName)).getSpec().getTemplate().getSpec().getAffinity();
+        NodeSelectorRequirement connectPodNodeSelectorRequirement = connectPodSpecAffinity.getNodeAffinity()
+                .getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().get(0).getMatchExpressions().get(0);
+        Pod connectPod = kubeClient().getPod(connectPodName);
+        NodeAffinity nodeAffinity = connectPod.getSpec().getAffinity().getNodeAffinity();
 
-            LOGGER.info("PodName: {}\nNodeAffinity: {}", connectPodName, nodeAffinity);
-            assertThat(connectPodNodeSelectorRequirement.getKey(), is(rackKey));
-            assertThat(connectPodNodeSelectorRequirement.getOperator(), is("Exists"));
+        LOGGER.info("PodName: {}\nNodeAffinity: {}", connectPodName, nodeAffinity);
+        assertThat(connectPodNodeSelectorRequirement.getKey(), is(rackKey));
+        assertThat(connectPodNodeSelectorRequirement.getOperator(), is("Exists"));
 
-            topicName = "rw-" + KafkaTopicUtils.generateRandomNameOfTopic();
-            resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, topicName).build());
-            KafkaConnectUtils.sendReceiveMessagesThroughConnect(connectPodName, topicName, kafkaClientsPodName, NAMESPACE, clusterName);
-        }
+        KafkaConnectUtils.sendReceiveMessagesThroughConnect(connectPodName, topicName, kafkaClientsPodName, NAMESPACE, clusterName);
 
         // Revert changes for CO deployment
         resourceManager.createResource(sharedExtensionContext, BundleResource.clusterOperator(NAMESPACE).build());


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Test fixes

### Description

This PR fixes two tests from `LoggingChangeST`, which starts to fail after #4717.
Also I added fix for exception message in `AbstractModel.java`. This exception appears when we set CM (to external logging) which doesn't exist.

Before:
```
    - lastTransitionTime: 2021-04-15T21:22:41.625Z
      message: ConfigMap non-existing-cm-namewith external logging configuration does
        not exist or doesn't contain the configuration under the {} keylog4j.properties.
      reason: InvalidResourceException
      status: "True"
      type: NotReady
```
After:
```
- lastTransitionTime: 2021-04-15T21:33:31.134Z
      message: ConfigMap non-existing-cm-name with external logging configuration
        does not exist or doesn't contain the configuration under the log4j.properties
        key.
      reason: InvalidResourceException
      status: "True"
      type: NotReady
```

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

