### PR TITLE
Fix leaking HttpClient connections in Cruise Control client

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/HttpClientUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/HttpClientUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+
+import java.util.function.BiConsumer;
+
+public class HttpClientUtils {
+
+    /**
+     * Perform the given operation, which completes the promise, using an HTTP client instance,
+     * after which the client is closed and the future for the promise returned.
+     * @param vertx The vertx instance.
+     * @param options Any client options that should be applied.
+     * @param operation The operation to perform.
+     * @param <T> The type of the result
+     * @return A future which is completed with the result performed by the operation
+     */
+    public static <T> Future<T> withHttpClient(Vertx vertx, HttpClientOptions options, BiConsumer<HttpClient, Promise<T>> operation) {
+        HttpClient httpClient = vertx.createHttpClient(options);
+        Promise<T> promise = Promise.promise();
+        operation.accept(httpClient, promise);
+        return promise.future().compose(
+            result -> {
+                httpClient.close();
+                return Future.succeededFuture(result);
+            },
+            error -> {
+                httpClient.close();
+                return Future.failedFuture(error);
+            });
+    }
+
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.json.Json;
@@ -14,6 +15,7 @@ import io.vertx.core.json.JsonObject;
 
 import java.net.ConnectException;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
 
 public class CruiseControlApiImpl implements CruiseControlApi {
 
@@ -42,17 +44,15 @@ public class CruiseControlApiImpl implements CruiseControlApi {
     @SuppressWarnings("deprecation")
     public Future<CruiseControlResponse> getCruiseControlState(String host, int port, boolean verbose, String userTaskId) {
 
-        Promise<CruiseControlResponse> result = Promise.promise();
-        HttpClientOptions options = new HttpClientOptions().setLogActivity(HTTP_CLIENT_ACTIVITY_LOGGING);
 
         String path = new PathBuilder(CruiseControlEndpoints.STATE)
                 .addParameter(CruiseControlParameters.JSON, "true")
                 .addParameter(CruiseControlParameters.VERBOSE, String.valueOf(verbose))
                 .build();
 
-        HttpClientRequest request = vertx.createHttpClient(options)
-                .get(port, host, path, response -> {
-                    response.exceptionHandler(result::fail);
+        return withHttpClient((httpClient, result) -> {
+                HttpClientRequest request = httpClient.get(port, host, path, response -> {
+                    response.exceptionHandler(result::tryFail);
                     if (response.statusCode() == 200 || response.statusCode() == 201) {
                         String userTaskID = response.getHeader(CC_REST_API_USER_ID_HEADER);
                         response.bodyHandler(buffer -> {
@@ -71,20 +71,19 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                         result.fail(new CruiseControlRestException(
                                 "Unexpected status code " + response.statusCode() + " for request to " + host + ":" + port + path));
                     }
-                })
-                .exceptionHandler(t -> httpExceptionHandler(result, t));
+                }).exceptionHandler(t -> httpExceptionHandler(result, t));
 
-        if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
-            request.setTimeout(idleTimeout * 1000);
-        }
+                if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
+                    request.setTimeout(idleTimeout * 1000);
+                }
 
-        if (userTaskId != null) {
-            request.putHeader(CC_REST_API_USER_ID_HEADER, userTaskId);
-        }
+                if (userTaskId != null) {
+                    request.putHeader(CC_REST_API_USER_ID_HEADER, userTaskId);
+                }
 
-        request.end();
-
-        return result.future();
+                request.end();
+            }
+        );
     }
 
     @Override
@@ -96,88 +95,81 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                     new IllegalArgumentException("Either rebalance options or user task ID should be supplied, both were null"));
         }
 
-        Promise<CruiseControlRebalanceResponse> result = Promise.promise();
-        HttpClientOptions httpOptions = new HttpClientOptions().setLogActivity(HTTP_CLIENT_ACTIVITY_LOGGING);
 
         String path = new PathBuilder(CruiseControlEndpoints.REBALANCE)
                 .addParameter(CruiseControlParameters.JSON, "true")
                 .addRebalanceParameters(rbOptions)
                 .build();
 
-        HttpClientRequest request = vertx.createHttpClient(httpOptions)
-                .post(port, host, path, response -> {
-                    response.exceptionHandler(result::fail);
-                    if (response.statusCode() == 200 || response.statusCode() == 201) {
-                        response.bodyHandler(buffer -> {
-                            String userTaskID = response.getHeader(CC_REST_API_USER_ID_HEADER);
-                            JsonObject json = buffer.toJsonObject();
-                            CruiseControlRebalanceResponse ccResponse = new CruiseControlRebalanceResponse(userTaskID, json);
-                            result.complete(ccResponse);
-                        });
-                    } else if (response.statusCode() == 202) {
-                        response.bodyHandler(buffer -> {
-                            String userTaskID = response.getHeader(CC_REST_API_USER_ID_HEADER);
-                            JsonObject json = buffer.toJsonObject();
-                            CruiseControlRebalanceResponse ccResponse = new CruiseControlRebalanceResponse(userTaskID, json);
-                            if (json.containsKey(CC_REST_API_PROGRESS_KEY)) {
-                                // If the response contains a "progress" key then the rebalance proposal has not yet completed processing
-                                ccResponse.setProposalStillCalaculating(true);
+        return withHttpClient((httpClient, result) -> {
+            HttpClientRequest request = httpClient.post(port, host, path, response -> {
+                response.exceptionHandler(result::tryFail);
+                if (response.statusCode() == 200 || response.statusCode() == 201) {
+                    response.bodyHandler(buffer -> {
+                        String userTaskID = response.getHeader(CC_REST_API_USER_ID_HEADER);
+                        JsonObject json = buffer.toJsonObject();
+                        CruiseControlRebalanceResponse ccResponse = new CruiseControlRebalanceResponse(userTaskID, json);
+                        result.complete(ccResponse);
+                    });
+                } else if (response.statusCode() == 202) {
+                    response.bodyHandler(buffer -> {
+                        String userTaskID = response.getHeader(CC_REST_API_USER_ID_HEADER);
+                        JsonObject json = buffer.toJsonObject();
+                        CruiseControlRebalanceResponse ccResponse = new CruiseControlRebalanceResponse(userTaskID, json);
+                        if (json.containsKey(CC_REST_API_PROGRESS_KEY)) {
+                            // If the response contains a "progress" key then the rebalance proposal has not yet completed processing
+                            ccResponse.setProposalStillCalaculating(true);
+                        } else {
+                            result.fail(new CruiseControlRestException(
+                                    "Error for request: " + host + ":" + port + path +
+                                            ". 202 Status code did not contain progress key. Server returned: " +
+                                            ccResponse.getJson().toString()));
+                        }
+                        result.complete(ccResponse);
+                    });
+                } else if (response.statusCode() == 500) {
+                    response.bodyHandler(buffer -> {
+                        String userTaskID = response.getHeader(CC_REST_API_USER_ID_HEADER);
+                        JsonObject json = buffer.toJsonObject();
+                        if (json.containsKey(CC_REST_API_ERROR_KEY)) {
+                            // If there was a client side error, check whether it was due to not enough data being available
+                            if (json.getString(CC_REST_API_ERROR_KEY).contains("NotEnoughValidWindowsException")) {
+                                CruiseControlRebalanceResponse ccResponse = new CruiseControlRebalanceResponse(userTaskID, json);
+                                ccResponse.setNotEnoughDataForProposal(true);
+                                result.complete(ccResponse);
                             } else {
-                                result.fail(new CruiseControlRestException(
-                                        "Error for request: " + host + ":" + port + path +
-                                        ". 202 Status code did not contain progress key. Server returned: " +
-                                        ccResponse.getJson().toString()));
-                            }
-                            result.complete(ccResponse);
-                        });
-                    } else if (response.statusCode() == 500) {
-                        response.bodyHandler(buffer -> {
-                            String userTaskID = response.getHeader(CC_REST_API_USER_ID_HEADER);
-                            JsonObject json = buffer.toJsonObject();
-                            if (json.containsKey(CC_REST_API_ERROR_KEY)) {
-                                // If there was a client side error, check whether it was due to not enough data being available
-                                if (json.getString(CC_REST_API_ERROR_KEY).contains("NotEnoughValidWindowsException")) {
-                                    CruiseControlRebalanceResponse ccResponse = new CruiseControlRebalanceResponse(userTaskID, json);
-                                    ccResponse.setNotEnoughDataForProposal(true);
-                                    result.complete(ccResponse);
-                                } else {
-                                    // If there was any other kind of error propagate this to the operator
-                                    result.fail(new CruiseControlRestException(
-                                            "Error for request: " + host + ":" + port + path + ". Server returned: " +
-                                            json.getString(CC_REST_API_ERROR_KEY)));
-                                }
-                            } else {
+                                // If there was any other kind of error propagate this to the operator
                                 result.fail(new CruiseControlRestException(
                                         "Error for request: " + host + ":" + port + path + ". Server returned: " +
-                                         json.toString()));
+                                                json.getString(CC_REST_API_ERROR_KEY)));
                             }
-                        });
-                    } else {
-                        result.fail(new CruiseControlRestException(
-                                "Unexpected status code " + response.statusCode() + " for request to " + host + ":" + port + path));
-                    }
-                })
-                .exceptionHandler(t -> httpExceptionHandler(result, t));
+                        } else {
+                            result.fail(new CruiseControlRestException(
+                                    "Error for request: " + host + ":" + port + path + ". Server returned: " +
+                                            json.toString()));
+                        }
+                    });
+                } else {
+                    result.fail(new CruiseControlRestException(
+                            "Unexpected status code " + response.statusCode() + " for request to " + host + ":" + port + path));
+                }
+            }).exceptionHandler(t -> httpExceptionHandler(result, t));
 
-        if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
-            request.setTimeout(idleTimeout * 1000);
-        }
+            if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
+                request.setTimeout(idleTimeout * 1000);
+            }
 
-        if (userTaskId != null) {
-            request.putHeader(CC_REST_API_USER_ID_HEADER, userTaskId);
-        }
+            if (userTaskId != null) {
+                request.putHeader(CC_REST_API_USER_ID_HEADER, userTaskId);
+            }
 
-        request.end();
-
-        return result.future();
+            request.end();
+        });
     }
 
     @Override
     @SuppressWarnings("deprecation")
     public Future<CruiseControlResponse> getUserTaskStatus(String host, int port, String userTaskId) {
-
-        Promise<CruiseControlResponse> result = Promise.promise();
-        HttpClientOptions options = new HttpClientOptions().setLogActivity(HTTP_CLIENT_ACTIVITY_LOGGING);
 
         PathBuilder pathBuilder = new PathBuilder(CruiseControlEndpoints.USER_TASKS)
                         .addParameter(CruiseControlParameters.JSON, "true")
@@ -189,126 +181,141 @@ public class CruiseControlApiImpl implements CruiseControlApi {
 
         String path = pathBuilder.build();
 
-        HttpClientRequest request = vertx.createHttpClient(options)
-                .get(port, host, path, response -> {
-                    response.exceptionHandler(result::fail);
-                    if (response.statusCode() == 200 || response.statusCode() == 201) {
-                        String userTaskID = response.getHeader(CC_REST_API_USER_ID_HEADER);
-                        response.bodyHandler(buffer -> {
-                            JsonObject json = buffer.toJsonObject();
-                            JsonObject jsonUserTask = json.getJsonArray("userTasks").getJsonObject(0);
-                            // This should not be an error with a 200 status but we play it safe
-                            if (jsonUserTask.containsKey(CC_REST_API_ERROR_KEY)) {
-                                result.fail(new CruiseControlRestException(
-                                        "Error for request: " + host + ":" + port + path + ". Server returned: " +
-                                                json.getString(CC_REST_API_ERROR_KEY)));
-                            }
-                            JsonObject statusJson = new JsonObject();
-                            String taskStatusStr = jsonUserTask.getString(STATUS_KEY);
-                            statusJson.put(STATUS_KEY, taskStatusStr);
-                            CruiseControlUserTaskStatus taskStatus = CruiseControlUserTaskStatus.lookup(taskStatusStr);
-                            switch (taskStatus) {
-                                case ACTIVE:
-                                    // If the status is ACTIVE there will not be a "summary" so we skip pulling the summary key
-                                    break;
-                                case IN_EXECUTION:
-                                    // Tasks in execution will be rebalance tasks, so their original response will contain the summary of the rebalance they are executing
-                                    // We handle these in the same way as COMPLETED tasks so we drop down to that case.
-                                case COMPLETED:
-                                    // Completed tasks will have the original rebalance proposal summary in their original response
-                                    statusJson.put(SUMMARY_KEY, ((JsonObject) Json.decodeValue(jsonUserTask.getString("originalResponse"))).getJsonObject(SUMMARY_KEY));
-                                    break;
-                                case COMPLETED_WITH_ERROR:
-                                    // Completed with error tasks will have "CompletedWithError" as their original response, which is not Json.
-                                    statusJson.put(SUMMARY_KEY, jsonUserTask.getString("originalResponse"));
-                                    break;
-                                default:
-                                    throw new IllegalStateException("Unexpected user task status: " + taskStatus);
-                            }
-                            result.complete(new CruiseControlResponse(userTaskID, statusJson));
-                        });
-                    } else if (response.statusCode() == 500) {
-                        response.bodyHandler(buffer -> {
-                            JsonObject json = buffer.toJsonObject();
-                            String errorString;
-                            if (json.containsKey(CC_REST_API_ERROR_KEY)) {
-                                errorString = json.getString(CC_REST_API_ERROR_KEY);
-                            } else {
-                                errorString = json.toString();
-                            }
+        return withHttpClient((httpClient, result) -> {
+            HttpClientRequest request = httpClient.get(port, host, path, response -> {
+                response.exceptionHandler(result::tryFail);
+                if (response.statusCode() == 200 || response.statusCode() == 201) {
+                    String userTaskID = response.getHeader(CC_REST_API_USER_ID_HEADER);
+                    response.bodyHandler(buffer -> {
+                        JsonObject json = buffer.toJsonObject();
+                        JsonObject jsonUserTask = json.getJsonArray("userTasks").getJsonObject(0);
+                        // This should not be an error with a 200 status but we play it safe
+                        if (jsonUserTask.containsKey(CC_REST_API_ERROR_KEY)) {
                             result.fail(new CruiseControlRestException(
-                                    "Error for request: " + host + ":" + port + path + ". Server returned: " + errorString));
-                        });
-                    } else {
+                                    "Error for request: " + host + ":" + port + path + ". Server returned: " +
+                                            json.getString(CC_REST_API_ERROR_KEY)));
+                        }
+                        JsonObject statusJson = new JsonObject();
+                        String taskStatusStr = jsonUserTask.getString(STATUS_KEY);
+                        statusJson.put(STATUS_KEY, taskStatusStr);
+                        CruiseControlUserTaskStatus taskStatus = CruiseControlUserTaskStatus.lookup(taskStatusStr);
+                        switch (taskStatus) {
+                            case ACTIVE:
+                                // If the status is ACTIVE there will not be a "summary" so we skip pulling the summary key
+                                break;
+                            case IN_EXECUTION:
+                                // Tasks in execution will be rebalance tasks, so their original response will contain the summary of the rebalance they are executing
+                                // We handle these in the same way as COMPLETED tasks so we drop down to that case.
+                            case COMPLETED:
+                                // Completed tasks will have the original rebalance proposal summary in their original response
+                                statusJson.put(SUMMARY_KEY, ((JsonObject) Json.decodeValue(jsonUserTask.getString("originalResponse"))).getJsonObject(SUMMARY_KEY));
+                                break;
+                            case COMPLETED_WITH_ERROR:
+                                // Completed with error tasks will have "CompletedWithError" as their original response, which is not Json.
+                                statusJson.put(SUMMARY_KEY, jsonUserTask.getString("originalResponse"));
+                                break;
+                            default:
+                                throw new IllegalStateException("Unexpected user task status: " + taskStatus);
+                        }
+                        result.complete(new CruiseControlResponse(userTaskID, statusJson));
+                    });
+                } else if (response.statusCode() == 500) {
+                    response.bodyHandler(buffer -> {
+                        JsonObject json = buffer.toJsonObject();
+                        String errorString;
+                        if (json.containsKey(CC_REST_API_ERROR_KEY)) {
+                            errorString = json.getString(CC_REST_API_ERROR_KEY);
+                        } else {
+                            errorString = json.toString();
+                        }
                         result.fail(new CruiseControlRestException(
-                                "Unexpected status code " + response.statusCode() + " for GET request to " +
-                                host + ":" + port + path));
-                    }
-                })
-                .exceptionHandler(t -> httpExceptionHandler(result, t));
+                                "Error for request: " + host + ":" + port + path + ". Server returned: " + errorString));
+                    });
+                } else {
+                    result.fail(new CruiseControlRestException(
+                            "Unexpected status code " + response.statusCode() + " for GET request to " +
+                                    host + ":" + port + path));
+                }
+            }).exceptionHandler(t -> httpExceptionHandler(result, t));
 
-        if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
-            request.setTimeout(idleTimeout * 1000);
-        }
+            if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
+                request.setTimeout(idleTimeout * 1000);
+            }
 
-        request.end();
-
-        return result.future();
+            request.end();
+        });
     }
 
     @Override
     @SuppressWarnings("deprecation")
     public Future<CruiseControlResponse> stopExecution(String host, int port) {
 
-        Promise<CruiseControlResponse> result = Promise.promise();
-        HttpClientOptions options = new HttpClientOptions().setLogActivity(HTTP_CLIENT_ACTIVITY_LOGGING);
-
         String path = new PathBuilder(CruiseControlEndpoints.STOP)
                         .addParameter(CruiseControlParameters.JSON, "true").build();
 
-        HttpClientRequest request = vertx.createHttpClient(options)
-                .post(port, host, path, response -> {
-                    response.exceptionHandler(result::fail);
-                    if (response.statusCode() == 200 || response.statusCode() == 201) {
-                        String userTaskID = response.getHeader(CC_REST_API_USER_ID_HEADER);
-                        response.bodyHandler(buffer -> {
-                            JsonObject json = buffer.toJsonObject();
-                            if (json.containsKey(CC_REST_API_ERROR_KEY)) {
-                                result.fail(json.getString(CC_REST_API_ERROR_KEY));
-                            } else {
-                                CruiseControlResponse ccResponse = new CruiseControlResponse(userTaskID, json);
-                                result.complete(ccResponse);
-                            }
-                        });
+        return withHttpClient((httpClient, result) -> {
+            HttpClientRequest request = httpClient.post(port, host, path, response -> {
+                response.exceptionHandler(result::tryFail);
+                if (response.statusCode() == 200 || response.statusCode() == 201) {
+                    String userTaskID = response.getHeader(CC_REST_API_USER_ID_HEADER);
+                    response.bodyHandler(buffer -> {
+                        JsonObject json = buffer.toJsonObject();
+                        if (json.containsKey(CC_REST_API_ERROR_KEY)) {
+                            result.fail(json.getString(CC_REST_API_ERROR_KEY));
+                        } else {
+                            CruiseControlResponse ccResponse = new CruiseControlResponse(userTaskID, json);
+                            result.complete(ccResponse);
+                        }
+                    });
 
-                    } else {
-                        result.fail(new CruiseControlRestException(
-                                "Unexpected status code " + response.statusCode()  + " for GET request to " +
-                                host + ":" + port + path));
-                    }
-                })
-                .exceptionHandler(t -> httpExceptionHandler(result, t));
+                } else {
+                    result.fail(new CruiseControlRestException(
+                            "Unexpected status code " + response.statusCode() + " for GET request to " +
+                                    host + ":" + port + path));
+                }
+            }).exceptionHandler(t -> httpExceptionHandler(result, t));
 
-        if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
-            request.setTimeout(idleTimeout * 1000);
-        }
+            if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
+                request.setTimeout(idleTimeout * 1000);
+            }
 
-        request.end();
-
-        return result.future();
+            request.end();
+        });
     }
 
     private void httpExceptionHandler(Promise<? extends CruiseControlResponse> result, Throwable t) {
         if (t instanceof TimeoutException) {
             // Vert.x throws a NoStackTraceTimeoutException (inherits from TimeoutException) when the request times out
-            // goint to catch and raise a TimeoutException instead
+            // so we catch and raise a TimeoutException instead
             result.fail(new TimeoutException(t.getMessage()));
         } else if (t instanceof ConnectException) {
             // Vert.x throws a AnnotatedConnectException (inherits from ConnectException) when the request times out
-            // goint to catch and raise a ConnectException instead
+            // so we catch and raise a ConnectException instead
             result.fail(new ConnectException(t.getMessage()));
         } else {
             result.fail(t);
         }
+    }
+
+    /**
+     * Perform the given operation, which completes the promise, using an HTTP client instance,
+     * after which the client is closed and the future for the promise returned.
+     * @param operation The operation to perform.
+     * @param <T> The type of the result
+     * @return A future which is completed with the result performed by the operation
+     */
+    private <T> Future<T> withHttpClient(BiConsumer<HttpClient, Promise<T>> operation) {
+        HttpClient httpClient = vertx.createHttpClient(new HttpClientOptions().setLogActivity(HTTP_CLIENT_ACTIVITY_LOGGING));
+        Promise<T> promise = Promise.promise();
+        operation.accept(httpClient, promise);
+        return promise.future().compose(
+            result -> {
+                httpClient.close();
+                return Future.succeededFuture(result);
+            },
+            error -> {
+                httpClient.close();
+                return Future.failedFuture(error);
+            });
     }
 }


### PR DESCRIPTION
### Type of change

Bugfix

### Description

This PR fixes a potential issue with unclosed connections in the cruise control client api. The fix applies the same approach as #3827 so a common `HttpClientUtils` class has been created that is used by both the CC and Kafka Connect client implementations.

### Checklist

- [x] Make sure all tests pass
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
