### PR TITLE
Dynamic Config TODO should be closed out

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -360,7 +360,6 @@ public class KafkaRoller {
                             log.debug("{}: Pod {} can be rolled now", reconciliation, podId);
                             restartAndAwaitReadiness(pod, operationTimeoutMs, TimeUnit.MILLISECONDS);
                         } else {
-                            // TODO do we need some check here that the broker is still OK?
                             awaitReadiness(pod, operationTimeoutMs, TimeUnit.MILLISECONDS);
                         }
                     } else {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

After investigation I do not feel this TODO is needed anymore and can be closed out. As we were investigating, we found that the only things that could be Dynamically Configured were the loggers. After testing the functionality with potential configurations aimed to make the loggers unhealthy to trigger a bad broker config, we found the broker object not reporting that the logger was misconfigured but the Cluster Operator would report back with this. Even though it was broken, the Kafka Broker still reported back in a healthy state and seemed to function fine without the logger. So no matter the change that can be applied Dynamically, it all seems to be related to the logger in this context which doesn't seem to be an essential component to the Broker to function and report back healthy. 

This is in response too --> #2389 and #3324

For future it might be a good idea to incorporate some kind of check to the CO for bad logger configuration and stop a dynamic update rather than continue to apply a potential "bad" config.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

