### PR TITLE
Fix double dots and asciidoc formatting in tables

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
@@ -85,9 +85,9 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
             "* `InternalIP`\n" +
             "* `Hostname`\n" +
             "\n" +
-            "This field can be used to select the address type which will be used as the preferred type and checked first. " +
-            "In case no address will be found for this address type, the other types will be used in the default order." +
-            "This field can be used only with `nodeport` type listener.")
+            "This field is used to select the preferred address type, which is checked first. " +
+            "If no address is found for this address type, the other types are checked in the default order. " +
+            "This field can only be used with `nodeport` type listener.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public NodeAddressType getPreferredNodePortAddressType() {
         return preferredNodePortAddressType;

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
@@ -105,7 +105,7 @@ spec:
                             \ type uses LoadBalancer type services to expose Kafka.\n\
                             * `nodeport` type uses NodePort type services to expose\
                             \ Kafka.\n* `ingress` type uses Kubernetes Nginx Ingress\
-                            \ to expose Kafka.\n."
+                            \ to expose Kafka.\n"
                         tls:
                           type: boolean
                           description: Enables TLS encryption on the listener. This
@@ -506,7 +506,7 @@ spec:
                                 * `InternalIP`
                                 * `Hostname`
 
-                                This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener..
+                                This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener.
                             useServiceDnsDomain:
                               type: boolean
                               description: Configures whether the Kubernetes service
@@ -5972,7 +5972,7 @@ spec:
                               * `loadbalancer` type uses LoadBalancer type services\
                               \ to expose Kafka.\n* `nodeport` type uses NodePort\
                               \ type services to expose Kafka.\n* `ingress` type uses\
-                              \ Kubernetes Nginx Ingress to expose Kafka.\n."
+                              \ Kubernetes Nginx Ingress to expose Kafka.\n"
                           tls:
                             type: boolean
                             description: Enables TLS encryption on the listener. This
@@ -6376,7 +6376,7 @@ spec:
                                   * `InternalIP`
                                   * `Hostname`
 
-                                  This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener..
+                                  This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener.
                               useServiceDnsDomain:
                                 type: boolean
                                 description: Configures whether the Kubernetes service
@@ -7400,7 +7400,7 @@ spec:
                                 \ and `nodeport`. \n\n* `route` type uses OpenShift\
                                 \ Routes to expose Kafka.* `loadbalancer` type uses\
                                 \ LoadBalancer type services to expose Kafka.* `nodeport`\
-                                \ type uses NodePort type services to expose Kafka.."
+                                \ type uses NodePort type services to expose Kafka."
                           required:
                           - type
                           description: Configures external listener on port 9094.
@@ -14378,7 +14378,7 @@ spec:
                               * `loadbalancer` type uses LoadBalancer type services\
                               \ to expose Kafka.\n* `nodeport` type uses NodePort\
                               \ type services to expose Kafka.\n* `ingress` type uses\
-                              \ Kubernetes Nginx Ingress to expose Kafka.\n."
+                              \ Kubernetes Nginx Ingress to expose Kafka.\n"
                           tls:
                             type: boolean
                             description: Enables TLS encryption on the listener. This
@@ -14782,7 +14782,7 @@ spec:
                                   * `InternalIP`
                                   * `Hostname`
 
-                                  This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener..
+                                  This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener.
                               useServiceDnsDomain:
                                 type: boolean
                                 description: Configures whether the Kubernetes service
@@ -15806,7 +15806,7 @@ spec:
                                 \ and `nodeport`. \n\n* `route` type uses OpenShift\
                                 \ Routes to expose Kafka.* `loadbalancer` type uses\
                                 \ LoadBalancer type services to expose Kafka.* `nodeport`\
-                                \ type uses NodePort type services to expose Kafka.."
+                                \ type uses NodePort type services to expose Kafka."
                           required:
                           - type
                           description: Configures external listener on port 9094.

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
@@ -506,7 +506,7 @@ spec:
                                 * `InternalIP`
                                 * `Hostname`
 
-                                This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener.
+                                This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
                             useServiceDnsDomain:
                               type: boolean
                               description: Configures whether the Kubernetes service
@@ -6376,7 +6376,7 @@ spec:
                                   * `InternalIP`
                                   * `Hostname`
 
-                                  This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener.
+                                  This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
                               useServiceDnsDomain:
                                 type: boolean
                                 description: Configures whether the Kubernetes service
@@ -14782,7 +14782,7 @@ spec:
                                   * `InternalIP`
                                   * `Hostname`
 
-                                  This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener.
+                                  This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
                               useServiceDnsDomain:
                                 type: boolean
                                 description: Configures whether the Kubernetes service

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static io.strimzi.crdgenerator.Property.discriminator;
@@ -47,6 +48,7 @@ import static java.util.Collections.singletonList;
 public class DocGenerator {
 
     private static final String NL = System.lineSeparator();
+    private static final Pattern DOT_AT_THE_END = Pattern.compile(".*[.!?]$", Pattern.DOTALL);
 
     private final int headerDepth;
     private final Appendable out;
@@ -165,7 +167,7 @@ public class DocGenerator {
             appendRepeated(' ', maxLen - propertyName.length() - gunk.length());
             out.append(' ');
             out.append(gunk);
-            out.append("|");
+            out.append("a|");
 
             // Set warning message for deprecated fields
             addDeprecationWarning(property);
@@ -308,7 +310,7 @@ public class DocGenerator {
 
     static String getDescription(Description description) {
         String doc = description.value();
-        if (!doc.trim().matches(".*[.!?]$")) {
+        if (!DOT_AT_THE_END.matcher(doc.trim()).matches())  {
             doc = doc + ".";
         }
         doc = doc.replaceAll("[|]", "\\\\|");

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
@@ -5,81 +5,81 @@
 [options="header"]
 |====
 |Property                       |Description
-|affinity                1.2+<.<| For more information, see the {KubeApiReferenceBase}#affinity-v1-core[external documentation for core/v1 affinity].
+|affinity                1.2+<.<a| For more information, see the {KubeApiReferenceBase}#affinity-v1-core[external documentation for core/v1 affinity].
 
 
 |{KubeApiReferenceBase}#affinity-v1-core[Affinity]
-|alternatives            1.2+<.<|
+|alternatives            1.2+<.<a|
 |string array or map
-|arrayOfBoundTypeVar     1.2+<.<|
+|arrayOfBoundTypeVar     1.2+<.<a|
 |xref:type-Number-{context}[`Number`] array
-|arrayOfBoundTypeVar2    1.2+<.<|
+|arrayOfBoundTypeVar2    1.2+<.<a|
 |xref:type-Number-{context}[`Number`] array
-|arrayOfList             1.2+<.<|
+|arrayOfList             1.2+<.<a|
 |string array of dimension 2
-|arrayOfRawList          1.2+<.<|
+|arrayOfRawList          1.2+<.<a|
 |object array of dimension 2
-|arrayOfTypeVar          1.2+<.<|
+|arrayOfTypeVar          1.2+<.<a|
 |object array
-|arrayProperty           1.2+<.<|
+|arrayProperty           1.2+<.<a|
 |string array
-|arrayProperty2          1.2+<.<|
+|arrayProperty2          1.2+<.<a|
 |string array of dimension 2
-|booleanProperty         1.2+<.<|
+|booleanProperty         1.2+<.<a|
 |boolean
-|customisedEnum          1.2+<.<|
+|customisedEnum          1.2+<.<a|
 |string (one of [one, two])
-|fieldProperty           1.2+<.<|Example of field property.
+|fieldProperty           1.2+<.<a|Example of field property.
 |string
-|intProperty             1.2+<.<|An example int property.
+|intProperty             1.2+<.<a|An example int property.
 |integer
-|listOfArray             1.2+<.<|
+|listOfArray             1.2+<.<a|
 |string array of dimension 2
-|listOfBoundTypeVar      1.2+<.<|
+|listOfBoundTypeVar      1.2+<.<a|
 |xref:type-Number-{context}[`Number`] array
-|listOfBoundTypeVar2     1.2+<.<|
+|listOfBoundTypeVar2     1.2+<.<a|
 |xref:type-Number-{context}[`Number`] array
-|listOfInts              1.2+<.<|
+|listOfInts              1.2+<.<a|
 |integer array
-|listOfInts2             1.2+<.<|
+|listOfInts2             1.2+<.<a|
 |integer array of dimension 2
-|listOfMaps              1.2+<.<|
+|listOfMaps              1.2+<.<a|
 |map array
-|listOfObjects           1.2+<.<|
+|listOfObjects           1.2+<.<a|
 |xref:type-ObjectProperty-{context}[`ObjectProperty`] array
-|listOfPolymorphic       1.2+<.<|
+|listOfPolymorphic       1.2+<.<a|
 |xref:type-PolymorphicLeft-{context}[`PolymorphicLeft`], xref:type-PolymorphicRight-{context}[`PolymorphicRight`] array
-|listOfRawList           1.2+<.<|
+|listOfRawList           1.2+<.<a|
 |object array of dimension 2
-|listOfTypeVar           1.2+<.<|
+|listOfTypeVar           1.2+<.<a|
 |object array
-|listOfWildcardTypeVar1  1.2+<.<|
+|listOfWildcardTypeVar1  1.2+<.<a|
 |string array
-|listOfWildcardTypeVar2  1.2+<.<|
+|listOfWildcardTypeVar2  1.2+<.<a|
 |xref:type-Number-{context}[`Number`] array
-|listOfWildcardTypeVar3  1.2+<.<|
+|listOfWildcardTypeVar3  1.2+<.<a|
 |xref:type-Number-{context}[`Number`] array
-|listOfWildcardTypeVar4  1.2+<.<|
+|listOfWildcardTypeVar4  1.2+<.<a|
 |xref:type-Number-{context}[`Number`] array of dimension 2
-|longProperty            1.2+<.<|An example long property.
+|longProperty            1.2+<.<a|An example long property.
 |integer
-|mapProperty             1.2+<.<|
+|mapProperty             1.2+<.<a|
 |map
-|normalEnum              1.2+<.<|
+|normalEnum              1.2+<.<a|
 |string (one of [BAR, FOO])
-|objectProperty          1.2+<.<|
+|objectProperty          1.2+<.<a|
 |xref:type-ObjectProperty-{context}[`ObjectProperty`]
-|polymorphicProperty     1.2+<.<| The type depends on the value of the `polymorphicProperty.discrim` property within the given object, which must be one of [left, right].
+|polymorphicProperty     1.2+<.<a| The type depends on the value of the `polymorphicProperty.discrim` property within the given object, which must be one of [left, right].
 |xref:type-PolymorphicLeft-{context}[`PolymorphicLeft`], xref:type-PolymorphicRight-{context}[`PolymorphicRight`]
-|rawList                 1.2+<.<|
+|rawList                 1.2+<.<a|
 |object array
-|spec                    1.2+<.<|
+|spec                    1.2+<.<a|
 |object
-|status                  1.2+<.<|
+|status                  1.2+<.<a|
 |object
-|stringProperty          1.2+<.<|
+|stringProperty          1.2+<.<a|
 |string
-|typedAlternatives       1.2+<.<|
+|typedAlternatives       1.2+<.<a|
 |xref:type-Type2-{context}[`Type2`] or xref:type-Type1-{context}[`Type1`]
 |====
 
@@ -104,9 +104,9 @@ Example of complex type.
 [options="header"]
 |====
 |Property    |Description
-|bar  1.2+<.<|
+|bar  1.2+<.<a|
 |string
-|foo  1.2+<.<|
+|foo  1.2+<.<a|
 |string
 |====
 
@@ -121,11 +121,11 @@ It must have the value `left` for the type `PolymorphicLeft`.
 [options="header"]
 |====
 |Property               |Description
-|commonProperty  1.2+<.<|
+|commonProperty  1.2+<.<a|
 |string
-|discrim         1.2+<.<|
+|discrim         1.2+<.<a|
 |string
-|leftProperty    1.2+<.<|when descrim=left, the left-hand property.
+|leftProperty    1.2+<.<a|when descrim=left, the left-hand property.
 |string
 |====
 
@@ -140,11 +140,11 @@ It must have the value `right` for the type `PolymorphicRight`.
 [options="header"]
 |====
 |Property               |Description
-|commonProperty  1.2+<.<|
+|commonProperty  1.2+<.<a|
 |string
-|discrim         1.2+<.<|
+|discrim         1.2+<.<a|
 |string
-|rightProperty   1.2+<.<|when descrim=right, the right-hand property.
+|rightProperty   1.2+<.<a|when descrim=right, the right-hand property.
 |string
 |====
 
@@ -157,7 +157,7 @@ Used in: xref:type-ExampleCrd-{context}[`ExampleCrd`]
 [options="header"]
 |====
 |Property     |Description
-|key2  1.2+<.<|
+|key2  1.2+<.<a|
 |string
 |====
 
@@ -173,7 +173,7 @@ Used in: xref:type-ExampleCrd-{context}[`ExampleCrd`]
 [options="header"]
 |====
 |Property     |Description
-|key1  1.2+<.<|
+|key1  1.2+<.<a|
 |string
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -8,9 +8,9 @@
 [options="header"]
 |====
 |Property       |Description
-|spec    1.2+<.<|The specification of the Kafka and ZooKeeper clusters, and Topic Operator.
+|spec    1.2+<.<a|The specification of the Kafka and ZooKeeper clusters, and Topic Operator.
 |xref:type-KafkaSpec-{context}[`KafkaSpec`]
-|status  1.2+<.<|The status of the Kafka and ZooKeeper clusters, and Topic Operator.
+|status  1.2+<.<a|The status of the Kafka and ZooKeeper clusters, and Topic Operator.
 |xref:type-KafkaStatus-{context}[`KafkaStatus`]
 |====
 
@@ -23,23 +23,23 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 [options="header"]
 |====
 |Property                       |Description
-|kafka                   1.2+<.<|Configuration of the Kafka cluster.
+|kafka                   1.2+<.<a|Configuration of the Kafka cluster.
 |xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
-|zookeeper               1.2+<.<|Configuration of the ZooKeeper cluster.
+|zookeeper               1.2+<.<a|Configuration of the ZooKeeper cluster.
 |xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
-|entityOperator          1.2+<.<|Configuration of the Entity Operator.
+|entityOperator          1.2+<.<a|Configuration of the Entity Operator.
 |xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
-|clusterCa               1.2+<.<|Configuration of the cluster certificate authority.
+|clusterCa               1.2+<.<a|Configuration of the cluster certificate authority.
 |xref:type-CertificateAuthority-{context}[`CertificateAuthority`]
-|clientsCa               1.2+<.<|Configuration of the clients certificate authority.
+|clientsCa               1.2+<.<a|Configuration of the clients certificate authority.
 |xref:type-CertificateAuthority-{context}[`CertificateAuthority`]
-|cruiseControl           1.2+<.<|Configuration for Cruise Control deployment. Deploys a Cruise Control instance when specified.
+|cruiseControl           1.2+<.<a|Configuration for Cruise Control deployment. Deploys a Cruise Control instance when specified.
 |xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`]
-|jmxTrans                1.2+<.<|Configuration for JmxTrans. When the property is present a JmxTrans deployment is created for gathering JMX metrics from each Kafka broker. For more information see https://github.com/jmxtrans/jmxtrans[JmxTrans GitHub].
+|jmxTrans                1.2+<.<a|Configuration for JmxTrans. When the property is present a JmxTrans deployment is created for gathering JMX metrics from each Kafka broker. For more information see https://github.com/jmxtrans/jmxtrans[JmxTrans GitHub].
 |xref:type-JmxTransSpec-{context}[`JmxTransSpec`]
-|kafkaExporter           1.2+<.<|Configuration of the Kafka Exporter. Kafka Exporter can provide additional metrics, for example lag of consumer group at topic/partition.
+|kafkaExporter           1.2+<.<a|Configuration of the Kafka Exporter. Kafka Exporter can provide additional metrics, for example lag of consumer group at topic/partition.
 |xref:type-KafkaExporterSpec-{context}[`KafkaExporterSpec`]
-|maintenanceTimeWindows  1.2+<.<|A list of time windows for maintenance tasks (that is, certificates renewal). Each time window is defined by a cron expression.
+|maintenanceTimeWindows  1.2+<.<a|A list of time windows for maintenance tasks (that is, certificates renewal). Each time window is defined by a cron expression.
 |string array
 |====
 
@@ -59,41 +59,41 @@ include::../api/io.strimzi.api.kafka.model.KafkaClusterSpec.adoc[leveloffset=+1]
 [options="header"]
 |====
 |Property                    |Description
-|version              1.2+<.<|The kafka broker version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
+|version              1.2+<.<a|The kafka broker version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
 |string
-|replicas             1.2+<.<|The number of pods in the cluster.
+|replicas             1.2+<.<a|The number of pods in the cluster.
 |integer
-|image                1.2+<.<|The docker image for the pods. The default value depends on the configured `Kafka.spec.kafka.version`.
+|image                1.2+<.<a|The docker image for the pods. The default value depends on the configured `Kafka.spec.kafka.version`.
 |string
-|listeners            1.2+<.<|Configures listeners of Kafka brokers.
+|listeners            1.2+<.<a|Configures listeners of Kafka brokers.
 |xref:type-GenericKafkaListener-{context}[`GenericKafkaListener`] array
-|config               1.2+<.<|Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers (with the exception of: zookeeper.connection.timeout.ms, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols,cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms,cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms,cruise.control.metrics.topic.min.insync.replicas).
+|config               1.2+<.<a|Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers (with the exception of: zookeeper.connection.timeout.ms, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols,cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms,cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms,cruise.control.metrics.topic.min.insync.replicas).
 |map
-|storage              1.2+<.<|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim, jbod].
+|storage              1.2+<.<a|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim, jbod].
 |xref:type-EphemeralStorage-{context}[`EphemeralStorage`], xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`], xref:type-JbodStorage-{context}[`JbodStorage`]
-|authorization        1.2+<.<|Authorization configuration for Kafka brokers. The type depends on the value of the `authorization.type` property within the given object, which must be one of [simple, opa, keycloak, custom].
+|authorization        1.2+<.<a|Authorization configuration for Kafka brokers. The type depends on the value of the `authorization.type` property within the given object, which must be one of [simple, opa, keycloak, custom].
 |xref:type-KafkaAuthorizationSimple-{context}[`KafkaAuthorizationSimple`], xref:type-KafkaAuthorizationOpa-{context}[`KafkaAuthorizationOpa`], xref:type-KafkaAuthorizationKeycloak-{context}[`KafkaAuthorizationKeycloak`], xref:type-KafkaAuthorizationCustom-{context}[`KafkaAuthorizationCustom`]
-|rack                 1.2+<.<|Configuration of the `broker.rack` broker config.
+|rack                 1.2+<.<a|Configuration of the `broker.rack` broker config.
 |xref:type-Rack-{context}[`Rack`]
-|brokerRackInitImage  1.2+<.<|The image of the init container used for initializing the `broker.rack`.
+|brokerRackInitImage  1.2+<.<a|The image of the init container used for initializing the `broker.rack`.
 |string
-|livenessProbe        1.2+<.<|Pod liveness checking.
+|livenessProbe        1.2+<.<a|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe       1.2+<.<|Pod readiness checking.
+|readinessProbe       1.2+<.<a|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|jvmOptions           1.2+<.<|JVM Options for pods.
+|jvmOptions           1.2+<.<a|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|jmxOptions           1.2+<.<|JMX Options for Kafka brokers.
+|jmxOptions           1.2+<.<a|JMX Options for Kafka brokers.
 |xref:type-KafkaJmxOptions-{context}[`KafkaJmxOptions`]
-|resources            1.2+<.<|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources            1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
-|metricsConfig        1.2+<.<|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
+|metricsConfig        1.2+<.<a|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
 |xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`]
-|logging              1.2+<.<|Logging configuration for Kafka. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging              1.2+<.<a|Logging configuration for Kafka. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|template             1.2+<.<|Template for Kafka cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
+|template             1.2+<.<a|Template for Kafka cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
 |xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`]
 |====
 
@@ -113,26 +113,26 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 [options="header"]
 |====
 |Property                   |Description
-|name                1.2+<.<|Name of the listener. The name will be used to identify the listener and the related Kubernetes objects. The name has to be unique within given a Kafka cluster. The name can consist of lowercase characters and numbers and be up to 11 characters long.
+|name                1.2+<.<a|Name of the listener. The name will be used to identify the listener and the related Kubernetes objects. The name has to be unique within given a Kafka cluster. The name can consist of lowercase characters and numbers and be up to 11 characters long.
 |string
-|port                1.2+<.<|Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
+|port                1.2+<.<a|Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
 |integer
-|type                1.2+<.<|Type of the listener. Currently the supported types are `internal`, `route`, `loadbalancer`, `nodeport` and `ingress`. 
+|type                1.2+<.<a|Type of the listener. Currently the supported types are `internal`, `route`, `loadbalancer`, `nodeport` and `ingress`. 
 
 * `internal` type exposes Kafka internally only within the Kubernetes cluster.
 * `route` type uses OpenShift Routes to expose Kafka.
 * `loadbalancer` type uses LoadBalancer type services to expose Kafka.
 * `nodeport` type uses NodePort type services to expose Kafka.
 * `ingress` type uses Kubernetes Nginx Ingress to expose Kafka.
-.
+
 |string (one of [ingress, internal, route, loadbalancer, nodeport])
-|tls                 1.2+<.<|Enables TLS encryption on the listener. This is a required property.
+|tls                 1.2+<.<a|Enables TLS encryption on the listener. This is a required property.
 |boolean
-|authentication      1.2+<.<|Authentication configuration for this listener. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, oauth].
+|authentication      1.2+<.<a|Authentication configuration for this listener. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, oauth].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`]
-|configuration       1.2+<.<|Additional listener configuration.
+|configuration       1.2+<.<a|Additional listener configuration.
 |xref:type-GenericKafkaListenerConfiguration-{context}[`GenericKafkaListenerConfiguration`]
-|networkPolicyPeers  1.2+<.<|List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#networkpolicypeer-v1-networking-k8s-io[external documentation for networking.k8s.io/v1 networkpolicypeer].
+|networkPolicyPeers  1.2+<.<a|List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#networkpolicypeer-v1-networking-k8s-io[external documentation for networking.k8s.io/v1 networkpolicypeer].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#networkpolicypeer-v1-networking-k8s-io[NetworkPolicyPeer] array
@@ -149,7 +149,7 @@ It must have the value `tls` for the type `KafkaListenerAuthenticationTls`.
 [options="header"]
 |====
 |Property     |Description
-|type  1.2+<.<|Must be `tls`.
+|type  1.2+<.<a|Must be `tls`.
 |string
 |====
 
@@ -164,7 +164,7 @@ It must have the value `scram-sha-512` for the type `KafkaListenerAuthentication
 [options="header"]
 |====
 |Property     |Description
-|type  1.2+<.<|Must be `scram-sha-512`.
+|type  1.2+<.<a|Must be `scram-sha-512`.
 |string
 |====
 
@@ -179,57 +179,57 @@ It must have the value `oauth` for the type `KafkaListenerAuthenticationOAuth`.
 [options="header"]
 |====
 |Property                                  |Description
-|accessTokenIsJwt                   1.2+<.<|Configure whether the access token is treated as JWT. This must be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+|accessTokenIsJwt                   1.2+<.<a|Configure whether the access token is treated as JWT. This must be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
 |boolean
-|checkAccessTokenType               1.2+<.<|Configure whether the access token type check is performed or not. This should be set to `false` if the authorization server does not include 'typ' claim in JWT token. Defaults to `true`.
+|checkAccessTokenType               1.2+<.<a|Configure whether the access token type check is performed or not. This should be set to `false` if the authorization server does not include 'typ' claim in JWT token. Defaults to `true`.
 |boolean
-|checkAudience                      1.2+<.<|Enable or disable audience checking. Audience checks identify the recipients of tokens. If audience checking is enabled, the OAuth Client ID also has to be configured using the `clientId` property. The Kafka broker will reject tokens that do not have its `clientId` in their `aud` (audience) claim.Default value is `false`.
+|checkAudience                      1.2+<.<a|Enable or disable audience checking. Audience checks identify the recipients of tokens. If audience checking is enabled, the OAuth Client ID also has to be configured using the `clientId` property. The Kafka broker will reject tokens that do not have its `clientId` in their `aud` (audience) claim.Default value is `false`.
 |boolean
-|checkIssuer                        1.2+<.<|Enable or disable issuer checking. By default issuer is checked using the value configured by `validIssuerUri`. Default value is `true`.
+|checkIssuer                        1.2+<.<a|Enable or disable issuer checking. By default issuer is checked using the value configured by `validIssuerUri`. Default value is `true`.
 |boolean
-|clientId                           1.2+<.<|OAuth Client ID which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
+|clientId                           1.2+<.<a|OAuth Client ID which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
 |string
-|clientSecret                       1.2+<.<|Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
+|clientSecret                       1.2+<.<a|Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
 |xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
-|customClaimCheck                   1.2+<.<|JsonPath filter query to be applied to the JWT token or to the response of the introspection endpoint for additional token validation. Not set by default.
+|customClaimCheck                   1.2+<.<a|JsonPath filter query to be applied to the JWT token or to the response of the introspection endpoint for additional token validation. Not set by default.
 |string
-|disableTlsHostnameVerification     1.2+<.<|Enable or disable TLS hostname verification. Default value is `false`.
+|disableTlsHostnameVerification     1.2+<.<a|Enable or disable TLS hostname verification. Default value is `false`.
 |boolean
-|enableECDSA                        1.2+<.<|Enable or disable ECDSA support by installing BouncyCastle crypto provider. Default value is `false`.
+|enableECDSA                        1.2+<.<a|Enable or disable ECDSA support by installing BouncyCastle crypto provider. Default value is `false`.
 |boolean
-|enableOauthBearer                  1.2+<.<|Enable or disable OAuth authentication over SASL_OAUTHBEARER. Default value is `true`.
+|enableOauthBearer                  1.2+<.<a|Enable or disable OAuth authentication over SASL_OAUTHBEARER. Default value is `true`.
 |boolean
-|enablePlain                        1.2+<.<|Enable or disable OAuth authentication over SASL_PLAIN. There is no re-authentication support when this mechanism is used. Default value is `false`.
+|enablePlain                        1.2+<.<a|Enable or disable OAuth authentication over SASL_PLAIN. There is no re-authentication support when this mechanism is used. Default value is `false`.
 |boolean
-|fallbackUserNameClaim              1.2+<.<|The fallback username claim to be used for the user id if the claim specified by `userNameClaim` is not present. This is useful when `client_credentials` authentication only results in the client id being provided in another claim. It only takes effect if `userNameClaim` is set.
+|fallbackUserNameClaim              1.2+<.<a|The fallback username claim to be used for the user id if the claim specified by `userNameClaim` is not present. This is useful when `client_credentials` authentication only results in the client id being provided in another claim. It only takes effect if `userNameClaim` is set.
 |string
-|fallbackUserNamePrefix             1.2+<.<|The prefix to use with the value of `fallbackUserNameClaim` to construct the user id. This only takes effect if `fallbackUserNameClaim` is true, and the value is present for the claim. Mapping usernames and client ids into the same user id space is useful in preventing name collisions.
+|fallbackUserNamePrefix             1.2+<.<a|The prefix to use with the value of `fallbackUserNameClaim` to construct the user id. This only takes effect if `fallbackUserNameClaim` is true, and the value is present for the claim. Mapping usernames and client ids into the same user id space is useful in preventing name collisions.
 |string
-|introspectionEndpointUri           1.2+<.<|URI of the token introspection endpoint which can be used to validate opaque non-JWT tokens.
+|introspectionEndpointUri           1.2+<.<a|URI of the token introspection endpoint which can be used to validate opaque non-JWT tokens.
 |string
-|jwksEndpointUri                    1.2+<.<|URI of the JWKS certificate endpoint, which can be used for local JWT validation.
+|jwksEndpointUri                    1.2+<.<a|URI of the JWKS certificate endpoint, which can be used for local JWT validation.
 |string
-|jwksExpirySeconds                  1.2+<.<|Configures how often are the JWKS certificates considered valid. The expiry interval has to be at least 60 seconds longer then the refresh interval specified in `jwksRefreshSeconds`. Defaults to 360 seconds.
+|jwksExpirySeconds                  1.2+<.<a|Configures how often are the JWKS certificates considered valid. The expiry interval has to be at least 60 seconds longer then the refresh interval specified in `jwksRefreshSeconds`. Defaults to 360 seconds.
 |integer
-|jwksMinRefreshPauseSeconds         1.2+<.<|The minimum pause between two consecutive refreshes. When an unknown signing key is encountered the refresh is scheduled immediately, but will always wait for this minimum pause. Defaults to 1 second.
+|jwksMinRefreshPauseSeconds         1.2+<.<a|The minimum pause between two consecutive refreshes. When an unknown signing key is encountered the refresh is scheduled immediately, but will always wait for this minimum pause. Defaults to 1 second.
 |integer
-|jwksRefreshSeconds                 1.2+<.<|Configures how often are the JWKS certificates refreshed. The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in `jwksExpirySeconds`. Defaults to 300 seconds.
+|jwksRefreshSeconds                 1.2+<.<a|Configures how often are the JWKS certificates refreshed. The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in `jwksExpirySeconds`. Defaults to 300 seconds.
 |integer
-|maxSecondsWithoutReauthentication  1.2+<.<|Maximum number of seconds the authenticated session remains valid without re-authentication. This enables Apache Kafka re-authentication feature, and causes sessions to expire when the access token expires. If the access token expires before max time or if max time is reached, the client has to re-authenticate, otherwise the server will drop the connection. Not set by default - the authenticated session does not expire when the access token expires. This option only applies to SASL_OAUTHBEARER authentication mechanism (when `enableOauthBearer` is `true`).
+|maxSecondsWithoutReauthentication  1.2+<.<a|Maximum number of seconds the authenticated session remains valid without re-authentication. This enables Apache Kafka re-authentication feature, and causes sessions to expire when the access token expires. If the access token expires before max time or if max time is reached, the client has to re-authenticate, otherwise the server will drop the connection. Not set by default - the authenticated session does not expire when the access token expires. This option only applies to SASL_OAUTHBEARER authentication mechanism (when `enableOauthBearer` is `true`).
 |integer
-|tlsTrustedCertificates             1.2+<.<|Trusted certificates for TLS connection to the OAuth server.
+|tlsTrustedCertificates             1.2+<.<a|Trusted certificates for TLS connection to the OAuth server.
 |xref:type-CertSecretSource-{context}[`CertSecretSource`] array
-|tokenEndpointUri                   1.2+<.<|URI of the Token Endpoint to use with SASL_PLAIN mechanism when the client authenticates with clientId and a secret. 
+|tokenEndpointUri                   1.2+<.<a|URI of the Token Endpoint to use with SASL_PLAIN mechanism when the client authenticates with clientId and a secret. 
 |string
-|type                               1.2+<.<|Must be `oauth`.
+|type                               1.2+<.<a|Must be `oauth`.
 |string
-|userInfoEndpointUri                1.2+<.<|URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. 
+|userInfoEndpointUri                1.2+<.<a|URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. 
 |string
-|userNameClaim                      1.2+<.<|Name of the claim from the JWT authentication token, Introspection Endpoint response or User Info Endpoint response which will be used to extract the user id. Defaults to `sub`.
+|userNameClaim                      1.2+<.<a|Name of the claim from the JWT authentication token, Introspection Endpoint response or User Info Endpoint response which will be used to extract the user id. Defaults to `sub`.
 |string
-|validIssuerUri                     1.2+<.<|URI of the token issuer used for authentication.
+|validIssuerUri                     1.2+<.<a|URI of the token issuer used for authentication.
 |string
-|validTokenType                     1.2+<.<|Valid value for the `token_type` attribute returned by the Introspection Endpoint. No default value, and not checked by default.
+|validTokenType                     1.2+<.<a|Valid value for the `token_type` attribute returned by the Introspection Endpoint. No default value, and not checked by default.
 |string
 |====
 
@@ -242,9 +242,9 @@ Used in: xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenti
 [options="header"]
 |====
 |Property           |Description
-|key         1.2+<.<|The key under which the secret value is stored in the Kubernetes Secret.
+|key         1.2+<.<a|The key under which the secret value is stored in the Kubernetes Secret.
 |string
-|secretName  1.2+<.<|The name of the Kubernetes Secret containing the secret value.
+|secretName  1.2+<.<a|The name of the Kubernetes Secret containing the secret value.
 |string
 |====
 
@@ -257,9 +257,9 @@ Used in: xref:type-KafkaAuthorizationKeycloak-{context}[`KafkaAuthorizationKeycl
 [options="header"]
 |====
 |Property            |Description
-|certificate  1.2+<.<|The name of the file certificate in the Secret.
+|certificate  1.2+<.<a|The name of the file certificate in the Secret.
 |string
-|secretName   1.2+<.<|The name of the Secret containing the certificate.
+|secretName   1.2+<.<a|The name of the Secret containing the certificate.
 |string
 |====
 
@@ -279,34 +279,34 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 [options="header"]
 |====
 |Property                             |Description
-|brokerCertChainAndKey         1.2+<.<|Reference to the `Secret` which holds the certificate and private key pair which will be used for this listener. The certificate can optionally contain the whole chain. This field can be used only with listeners with enabled TLS encryption.
+|brokerCertChainAndKey         1.2+<.<a|Reference to the `Secret` which holds the certificate and private key pair which will be used for this listener. The certificate can optionally contain the whole chain. This field can be used only with listeners with enabled TLS encryption.
 |xref:type-CertAndKeySecretSource-{context}[`CertAndKeySecretSource`]
-|externalTrafficPolicy         1.2+<.<|Specifies whether the service routes external traffic to node-local or cluster-wide endpoints. `Cluster` may cause a second hop to another node and obscures the client source IP. `Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure). If unspecified, Kubernetes will use `Cluster` as the default.This field can be used only with `loadbalancer` or `nodeport` type listener.
+|externalTrafficPolicy         1.2+<.<a|Specifies whether the service routes external traffic to node-local or cluster-wide endpoints. `Cluster` may cause a second hop to another node and obscures the client source IP. `Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure). If unspecified, Kubernetes will use `Cluster` as the default.This field can be used only with `loadbalancer` or `nodeport` type listener.
 |string (one of [Local, Cluster])
-|loadBalancerSourceRanges      1.2+<.<|A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients can connect to load balancer type listeners. If supported by the platform, traffic through the loadbalancer is restricted to the specified CIDR ranges. This field is applicable only for loadbalancer type services and is ignored if the cloud provider does not support the feature. For more information, see https://v1-17.docs.kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/. This field can be used only with `loadbalancer` type listener.
+|loadBalancerSourceRanges      1.2+<.<a|A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients can connect to load balancer type listeners. If supported by the platform, traffic through the loadbalancer is restricted to the specified CIDR ranges. This field is applicable only for loadbalancer type services and is ignored if the cloud provider does not support the feature. For more information, see https://v1-17.docs.kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/. This field can be used only with `loadbalancer` type listener.
 |string array
-|bootstrap                     1.2+<.<|Bootstrap configuration.
+|bootstrap                     1.2+<.<a|Bootstrap configuration.
 |xref:type-GenericKafkaListenerConfigurationBootstrap-{context}[`GenericKafkaListenerConfigurationBootstrap`]
-|brokers                       1.2+<.<|Per-broker configurations.
+|brokers                       1.2+<.<a|Per-broker configurations.
 |xref:type-GenericKafkaListenerConfigurationBroker-{context}[`GenericKafkaListenerConfigurationBroker`] array
-|class                         1.2+<.<|Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener. If not specified, the default Ingress controller will be used.
+|class                         1.2+<.<a|Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener. If not specified, the default Ingress controller will be used.
 |string
-|finalizers                    1.2+<.<|A list of finalizers which will be configured for the `LoadBalancer` type Services created for this listener. If supported by the platform, the finalizer `service.kubernetes.io/load-balancer-cleanup` to make sure that the external load balancer is deleted together with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers. This field can be used only with `loadbalancer` type listeners.
+|finalizers                    1.2+<.<a|A list of finalizers which will be configured for the `LoadBalancer` type Services created for this listener. If supported by the platform, the finalizer `service.kubernetes.io/load-balancer-cleanup` to make sure that the external load balancer is deleted together with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers. This field can be used only with `loadbalancer` type listeners.
 |string array
-|maxConnectionCreationRate     1.2+<.<|The maximum connection creation rate we allow in this listener at any time. New connections will be throttled if the limit is reached.Supported only on Kafka 2.7.0 and newer.
+|maxConnectionCreationRate     1.2+<.<a|The maximum connection creation rate we allow in this listener at any time. New connections will be throttled if the limit is reached.Supported only on Kafka 2.7.0 and newer.
 |integer
-|maxConnections                1.2+<.<|The maximum number of connections we allow for this listener in the broker at any time. New connections are blocked if the limit is reached.
+|maxConnections                1.2+<.<a|The maximum number of connections we allow for this listener in the broker at any time. New connections are blocked if the limit is reached.
 |integer
-|preferredNodePortAddressType  1.2+<.<|Defines which address type should be used as the node address. Available types are: `ExternalDNS`, `ExternalIP`, `InternalDNS`, `InternalIP` and `Hostname`. By default, the addresses will be used in the following order (the first one found will be used):
+|preferredNodePortAddressType  1.2+<.<a|Defines which address type should be used as the node address. Available types are: `ExternalDNS`, `ExternalIP`, `InternalDNS`, `InternalIP` and `Hostname`. By default, the addresses will be used in the following order (the first one found will be used):
 * `ExternalDNS`
 * `ExternalIP`
 * `InternalDNS`
 * `InternalIP`
 * `Hostname`
 
-This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener..
+This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener.
 |string (one of [ExternalDNS, ExternalIP, Hostname, InternalIP, InternalDNS])
-|useServiceDnsDomain           1.2+<.<|Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` type listener.
+|useServiceDnsDomain           1.2+<.<a|Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` type listener.
 |boolean
 |====
 
@@ -319,11 +319,11 @@ Used in: xref:type-GenericKafkaListenerConfiguration-{context}[`GenericKafkaList
 [options="header"]
 |====
 |Property            |Description
-|certificate  1.2+<.<|The name of the file certificate in the Secret.
+|certificate  1.2+<.<a|The name of the file certificate in the Secret.
 |string
-|key          1.2+<.<|The name of the private key in the Secret.
+|key          1.2+<.<a|The name of the private key in the Secret.
 |string
-|secretName   1.2+<.<|The name of the Secret containing the certificate.
+|secretName   1.2+<.<a|The name of the Secret containing the certificate.
 |string
 |====
 
@@ -343,17 +343,17 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 [options="header"]
 |====
 |Property                 |Description
-|alternativeNames  1.2+<.<|Additional alternative names for the bootstrap service. The alternative names will be added to the list of subject alternative names of the TLS certificates.
+|alternativeNames  1.2+<.<a|Additional alternative names for the bootstrap service. The alternative names will be added to the list of subject alternative names of the TLS certificates.
 |string array
-|host              1.2+<.<|The bootstrap host. This field will be used in the Ingress resource or in the Route resource to specify the desired hostname. This field can be used only with `route` (optional) or `ingress` (required) type listeners.
+|host              1.2+<.<a|The bootstrap host. This field will be used in the Ingress resource or in the Route resource to specify the desired hostname. This field can be used only with `route` (optional) or `ingress` (required) type listeners.
 |string
-|nodePort          1.2+<.<|Node port for the bootstrap service. This field can be used only with `nodeport` type listener.
+|nodePort          1.2+<.<a|Node port for the bootstrap service. This field can be used only with `nodeport` type listener.
 |integer
-|loadBalancerIP    1.2+<.<|The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This field is ignored if the cloud provider does not support the feature.This field can be used only with `loadbalancer` type listener.
+|loadBalancerIP    1.2+<.<a|The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This field is ignored if the cloud provider does not support the feature.This field can be used only with `loadbalancer` type listener.
 |string
-|annotations       1.2+<.<|Annotations that will be added to the `Ingress`, `Route`, or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
+|annotations       1.2+<.<a|Annotations that will be added to the `Ingress`, `Route`, or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
 |map
-|labels            1.2+<.<|Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
+|labels            1.2+<.<a|Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
 |map
 |====
 
@@ -373,21 +373,21 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 [options="header"]
 |====
 |Property               |Description
-|broker          1.2+<.<|ID of the kafka broker (broker identifier). Broker IDs start from 0 and correspond to the number of broker replicas.
+|broker          1.2+<.<a|ID of the kafka broker (broker identifier). Broker IDs start from 0 and correspond to the number of broker replicas.
 |integer
-|advertisedHost  1.2+<.<|The host name which will be used in the brokers' `advertised.brokers`.
+|advertisedHost  1.2+<.<a|The host name which will be used in the brokers' `advertised.brokers`.
 |string
-|advertisedPort  1.2+<.<|The port number which will be used in the brokers' `advertised.brokers`.
+|advertisedPort  1.2+<.<a|The port number which will be used in the brokers' `advertised.brokers`.
 |integer
-|host            1.2+<.<|The broker host. This field will be used in the Ingress resource or in the Route resource to specify the desired hostname. This field can be used only with `route` (optional) or `ingress` (required) type listeners.
+|host            1.2+<.<a|The broker host. This field will be used in the Ingress resource or in the Route resource to specify the desired hostname. This field can be used only with `route` (optional) or `ingress` (required) type listeners.
 |string
-|nodePort        1.2+<.<|Node port for the per-broker service. This field can be used only with `nodeport` type listener.
+|nodePort        1.2+<.<a|Node port for the per-broker service. This field can be used only with `nodeport` type listener.
 |integer
-|loadBalancerIP  1.2+<.<|The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This field is ignored if the cloud provider does not support the feature.This field can be used only with `loadbalancer` type listener.
+|loadBalancerIP  1.2+<.<a|The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This field is ignored if the cloud provider does not support the feature.This field can be used only with `loadbalancer` type listener.
 |string
-|annotations     1.2+<.<|Annotations that will be added to the `Ingress` or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, or `ingress` type listeners.
+|annotations     1.2+<.<a|Annotations that will be added to the `Ingress` or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, or `ingress` type listeners.
 |map
-|labels          1.2+<.<|Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
+|labels          1.2+<.<a|Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
 |map
 |====
 
@@ -402,11 +402,11 @@ It must have the value `ephemeral` for the type `EphemeralStorage`.
 [options="header"]
 |====
 |Property          |Description
-|id         1.2+<.<|Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
+|id         1.2+<.<a|Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
 |integer
-|sizeLimit  1.2+<.<|When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi).
+|sizeLimit  1.2+<.<a|When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi).
 |string
-|type       1.2+<.<|Must be `ephemeral`.
+|type       1.2+<.<a|Must be `ephemeral`.
 |string
 |====
 
@@ -421,19 +421,19 @@ It must have the value `persistent-claim` for the type `PersistentClaimStorage`.
 [options="header"]
 |====
 |Property            |Description
-|type         1.2+<.<|Must be `persistent-claim`.
+|type         1.2+<.<a|Must be `persistent-claim`.
 |string
-|size         1.2+<.<|When type=persistent-claim, defines the size of the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
+|size         1.2+<.<a|When type=persistent-claim, defines the size of the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
 |string
-|selector     1.2+<.<|Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
+|selector     1.2+<.<a|Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
 |map
-|deleteClaim  1.2+<.<|Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
+|deleteClaim  1.2+<.<a|Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
 |boolean
-|class        1.2+<.<|The storage class to use for dynamic volume allocation.
+|class        1.2+<.<a|The storage class to use for dynamic volume allocation.
 |string
-|id           1.2+<.<|Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
+|id           1.2+<.<a|Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
 |integer
-|overrides    1.2+<.<|Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+|overrides    1.2+<.<a|Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
 |xref:type-PersistentClaimStorageOverride-{context}[`PersistentClaimStorageOverride`] array
 |====
 
@@ -446,9 +446,9 @@ Used in: xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`]
 [options="header"]
 |====
 |Property       |Description
-|class   1.2+<.<|The storage class to use for dynamic volume allocation for this broker.
+|class   1.2+<.<a|The storage class to use for dynamic volume allocation for this broker.
 |string
-|broker  1.2+<.<|Id of the kafka broker (broker identifier).
+|broker  1.2+<.<a|Id of the kafka broker (broker identifier).
 |integer
 |====
 
@@ -463,9 +463,9 @@ It must have the value `jbod` for the type `JbodStorage`.
 [options="header"]
 |====
 |Property        |Description
-|type     1.2+<.<|Must be `jbod`.
+|type     1.2+<.<a|Must be `jbod`.
 |string
-|volumes  1.2+<.<|List of volumes as Storage objects representing the JBOD disks array.
+|volumes  1.2+<.<a|List of volumes as Storage objects representing the JBOD disks array.
 |xref:type-EphemeralStorage-{context}[`EphemeralStorage`], xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`] array
 |====
 
@@ -487,9 +487,9 @@ It must have the value `simple` for the type `KafkaAuthorizationSimple`.
 [options="header"]
 |====
 |Property           |Description
-|type        1.2+<.<|Must be `simple`.
+|type        1.2+<.<a|Must be `simple`.
 |string
-|superUsers  1.2+<.<|List of super users. Should contain list of user principals which should get unlimited access rights.
+|superUsers  1.2+<.<a|List of super users. Should contain list of user principals which should get unlimited access rights.
 |string array
 |====
 
@@ -511,19 +511,19 @@ It must have the value `opa` for the type `KafkaAuthorizationOpa`.
 [options="header"]
 |====
 |Property                     |Description
-|type                  1.2+<.<|Must be `opa`.
+|type                  1.2+<.<a|Must be `opa`.
 |string
-|url                   1.2+<.<|The URL used to connect to the Open Policy Agent server. The URL has to include the policy which will be queried by the authorizer. This option is required.
+|url                   1.2+<.<a|The URL used to connect to the Open Policy Agent server. The URL has to include the policy which will be queried by the authorizer. This option is required.
 |string
-|allowOnError          1.2+<.<|Defines whether a Kafka client should be allowed or denied by default when the authorizer fails to query the Open Policy Agent, for example, when it is temporarily unavailable). Defaults to `false` - all actions will be denied.
+|allowOnError          1.2+<.<a|Defines whether a Kafka client should be allowed or denied by default when the authorizer fails to query the Open Policy Agent, for example, when it is temporarily unavailable). Defaults to `false` - all actions will be denied.
 |boolean
-|initialCacheCapacity  1.2+<.<|Initial capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request Defaults to `5000`.
+|initialCacheCapacity  1.2+<.<a|Initial capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request Defaults to `5000`.
 |integer
-|maximumCacheSize      1.2+<.<|Maximum capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request. Defaults to `50000`.
+|maximumCacheSize      1.2+<.<a|Maximum capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request. Defaults to `50000`.
 |integer
-|expireAfterMs         1.2+<.<|The expiration of the records kept in the local cache to avoid querying the Open Policy Agent for every request. Defines how often the cached authorization decisions are reloaded from the Open Policy Agent server. In milliseconds. Defaults to `3600000`.
+|expireAfterMs         1.2+<.<a|The expiration of the records kept in the local cache to avoid querying the Open Policy Agent for every request. Defines how often the cached authorization decisions are reloaded from the Open Policy Agent server. In milliseconds. Defaults to `3600000`.
 |integer
-|superUsers            1.2+<.<|List of super users, which is specifically a list of user principals that have unlimited access rights.
+|superUsers            1.2+<.<a|List of super users, which is specifically a list of user principals that have unlimited access rights.
 |string array
 |====
 
@@ -538,23 +538,23 @@ It must have the value `keycloak` for the type `KafkaAuthorizationKeycloak`.
 [options="header"]
 |====
 |Property                               |Description
-|type                            1.2+<.<|Must be `keycloak`.
+|type                            1.2+<.<a|Must be `keycloak`.
 |string
-|clientId                        1.2+<.<|OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+|clientId                        1.2+<.<a|OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
 |string
-|tokenEndpointUri                1.2+<.<|Authorization server token endpoint URI.
+|tokenEndpointUri                1.2+<.<a|Authorization server token endpoint URI.
 |string
-|tlsTrustedCertificates          1.2+<.<|Trusted certificates for TLS connection to the OAuth server.
+|tlsTrustedCertificates          1.2+<.<a|Trusted certificates for TLS connection to the OAuth server.
 |xref:type-CertSecretSource-{context}[`CertSecretSource`] array
-|disableTlsHostnameVerification  1.2+<.<|Enable or disable TLS hostname verification. Default value is `false`.
+|disableTlsHostnameVerification  1.2+<.<a|Enable or disable TLS hostname verification. Default value is `false`.
 |boolean
-|delegateToKafkaAcls             1.2+<.<|Whether authorization decision should be delegated to the 'Simple' authorizer if DENIED by Keycloak Authorization Services policies. Default value is `false`.
+|delegateToKafkaAcls             1.2+<.<a|Whether authorization decision should be delegated to the 'Simple' authorizer if DENIED by Keycloak Authorization Services policies. Default value is `false`.
 |boolean
-|grantsRefreshPeriodSeconds      1.2+<.<|The time between two consecutive grants refresh runs in seconds. The default value is 60.
+|grantsRefreshPeriodSeconds      1.2+<.<a|The time between two consecutive grants refresh runs in seconds. The default value is 60.
 |integer
-|grantsRefreshPoolSize           1.2+<.<|The number of threads to use to refresh grants for active sessions. The more threads, the more parallelism, so the sooner the job completes. However, using more threads places a heavier load on the authorization server. The default value is 5.
+|grantsRefreshPoolSize           1.2+<.<a|The number of threads to use to refresh grants for active sessions. The more threads, the more parallelism, so the sooner the job completes. However, using more threads places a heavier load on the authorization server. The default value is 5.
 |integer
-|superUsers                      1.2+<.<|List of super users. Should contain list of user principals which should get unlimited access rights.
+|superUsers                      1.2+<.<a|List of super users. Should contain list of user principals which should get unlimited access rights.
 |string array
 |====
 
@@ -576,11 +576,11 @@ It must have the value `custom` for the type `KafkaAuthorizationCustom`.
 [options="header"]
 |====
 |Property                |Description
-|type             1.2+<.<|Must be `custom`.
+|type             1.2+<.<a|Must be `custom`.
 |string
-|authorizerClass  1.2+<.<|Authorization implementation class, which must be available in classpath.
+|authorizerClass  1.2+<.<a|Authorization implementation class, which must be available in classpath.
 |string
-|superUsers       1.2+<.<|List of super users, which are user principals with unlimited access rights.
+|superUsers       1.2+<.<a|List of super users, which are user principals with unlimited access rights.
 |string array
 |====
 
@@ -600,7 +600,7 @@ include::../api/io.strimzi.api.kafka.model.Rack.adoc[leveloffset=+1]
 [options="header"]
 |====
 |Property            |Description
-|topologyKey  1.2+<.<|A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config and `client.rack` in Kafka Connect.
+|topologyKey  1.2+<.<a|A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set the broker's `broker.rack` config and `client.rack` in Kafka Connect.
 |string
 |====
 
@@ -613,15 +613,15 @@ Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`], xref:type-E
 [options="header"]
 |====
 |Property                    |Description
-|failureThreshold     1.2+<.<|Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+|failureThreshold     1.2+<.<a|Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
 |integer
-|initialDelaySeconds  1.2+<.<|The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+|initialDelaySeconds  1.2+<.<a|The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
 |integer
-|periodSeconds        1.2+<.<|How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+|periodSeconds        1.2+<.<a|How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
 |integer
-|successThreshold     1.2+<.<|Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+|successThreshold     1.2+<.<a|Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
 |integer
-|timeoutSeconds       1.2+<.<|The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+|timeoutSeconds       1.2+<.<a|The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
 |integer
 |====
 
@@ -634,15 +634,15 @@ Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`], xref:type-E
 [options="header"]
 |====
 |Property                     |Description
-|-XX                   1.2+<.<|A map of -XX options to the JVM.
+|-XX                   1.2+<.<a|A map of -XX options to the JVM.
 |map
-|-Xms                  1.2+<.<|-Xms option to to the JVM.
+|-Xms                  1.2+<.<a|-Xms option to to the JVM.
 |string
-|-Xmx                  1.2+<.<|-Xmx option to to the JVM.
+|-Xmx                  1.2+<.<a|-Xmx option to to the JVM.
 |string
-|gcLoggingEnabled      1.2+<.<|Specifies whether the Garbage Collection logging is enabled. The default is false.
+|gcLoggingEnabled      1.2+<.<a|Specifies whether the Garbage Collection logging is enabled. The default is false.
 |boolean
-|javaSystemProperties  1.2+<.<|A map of additional system properties which will be passed using the `-D` option to the JVM.
+|javaSystemProperties  1.2+<.<a|A map of additional system properties which will be passed using the `-D` option to the JVM.
 |xref:type-SystemProperty-{context}[`SystemProperty`] array
 |====
 
@@ -655,9 +655,9 @@ Used in: xref:type-JvmOptions-{context}[`JvmOptions`]
 [options="header"]
 |====
 |Property      |Description
-|name   1.2+<.<|The system property name.
+|name   1.2+<.<a|The system property name.
 |string
-|value  1.2+<.<|The system property value.
+|value  1.2+<.<a|The system property value.
 |string
 |====
 
@@ -677,7 +677,7 @@ include::../api/io.strimzi.api.kafka.model.KafkaJmxOptions.adoc[leveloffset=+1]
 [options="header"]
 |====
 |Property               |Description
-|authentication  1.2+<.<|Authentication configuration for connecting to the JMX port. The type depends on the value of the `authentication.type` property within the given object, which must be one of [password].
+|authentication  1.2+<.<a|Authentication configuration for connecting to the JMX port. The type depends on the value of the `authentication.type` property within the given object, which must be one of [password].
 |xref:type-KafkaJmxAuthenticationPassword-{context}[`KafkaJmxAuthenticationPassword`]
 |====
 
@@ -692,7 +692,7 @@ It must have the value `password` for the type `KafkaJmxAuthenticationPassword`.
 [options="header"]
 |====
 |Property     |Description
-|type  1.2+<.<|Must be `password`.
+|type  1.2+<.<a|Must be `password`.
 |string
 |====
 
@@ -707,9 +707,9 @@ It must have the value `jmxPrometheusExporter` for the type `JmxPrometheusExport
 [options="header"]
 |====
 |Property          |Description
-|type       1.2+<.<|Must be `jmxPrometheusExporter`.
+|type       1.2+<.<a|Must be `jmxPrometheusExporter`.
 |string
-|valueFrom  1.2+<.<|ConfigMap entry where the Prometheus JMX Exporter configuration is stored. For details of the structure of this configuration, see the {JMXExporter}.
+|valueFrom  1.2+<.<a|ConfigMap entry where the Prometheus JMX Exporter configuration is stored. For details of the structure of this configuration, see the {JMXExporter}.
 |xref:type-ExternalConfigurationReference-{context}[`ExternalConfigurationReference`]
 |====
 
@@ -722,7 +722,7 @@ Used in: xref:type-ExternalLogging-{context}[`ExternalLogging`], xref:type-JmxPr
 [options="header"]
 |====
 |Property                |Description
-|configMapKeyRef  1.2+<.<|Reference to the key in the ConfigMap containing the configuration. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#configmapkeyselector-v1-core[external documentation for core/v1 configmapkeyselector].
+|configMapKeyRef  1.2+<.<a|Reference to the key in the ConfigMap containing the configuration. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#configmapkeyselector-v1-core[external documentation for core/v1 configmapkeyselector].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#configmapkeyselector-v1-core[ConfigMapKeySelector]
@@ -739,9 +739,9 @@ It must have the value `inline` for the type `InlineLogging`.
 [options="header"]
 |====
 |Property        |Description
-|type     1.2+<.<|Must be `inline`.
+|type     1.2+<.<a|Must be `inline`.
 |string
-|loggers  1.2+<.<|A Map from logger name to logger level.
+|loggers  1.2+<.<a|A Map from logger name to logger level.
 |map
 |====
 
@@ -756,9 +756,9 @@ It must have the value `external` for the type `ExternalLogging`.
 [options="header"]
 |====
 |Property          |Description
-|type       1.2+<.<|Must be `external`.
+|type       1.2+<.<a|Must be `external`.
 |string
-|valueFrom  1.2+<.<|`ConfigMap` entry where the logging configuration is stored. 
+|valueFrom  1.2+<.<a|`ConfigMap` entry where the logging configuration is stored. 
 |xref:type-ExternalConfigurationReference-{context}[`ExternalConfigurationReference`]
 |====
 
@@ -771,37 +771,37 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 [options="header"]
 |====
 |Property                         |Description
-|statefulset               1.2+<.<|Template for Kafka `StatefulSet`.
+|statefulset               1.2+<.<a|Template for Kafka `StatefulSet`.
 |xref:type-StatefulSetTemplate-{context}[`StatefulSetTemplate`]
-|pod                       1.2+<.<|Template for Kafka `Pods`.
+|pod                       1.2+<.<a|Template for Kafka `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|bootstrapService          1.2+<.<|Template for Kafka bootstrap `Service`.
+|bootstrapService          1.2+<.<a|Template for Kafka bootstrap `Service`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|brokersService            1.2+<.<|Template for Kafka broker `Service`.
+|brokersService            1.2+<.<a|Template for Kafka broker `Service`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|externalBootstrapService  1.2+<.<|Template for Kafka external bootstrap `Service`.
+|externalBootstrapService  1.2+<.<a|Template for Kafka external bootstrap `Service`.
 |xref:type-ExternalServiceTemplate-{context}[`ExternalServiceTemplate`]
-|perPodService             1.2+<.<|Template for Kafka per-pod `Services` used for access from outside of Kubernetes.
+|perPodService             1.2+<.<a|Template for Kafka per-pod `Services` used for access from outside of Kubernetes.
 |xref:type-ExternalServiceTemplate-{context}[`ExternalServiceTemplate`]
-|externalBootstrapRoute    1.2+<.<|Template for Kafka external bootstrap `Route`.
+|externalBootstrapRoute    1.2+<.<a|Template for Kafka external bootstrap `Route`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|perPodRoute               1.2+<.<|Template for Kafka per-pod `Routes` used for access from outside of OpenShift.
+|perPodRoute               1.2+<.<a|Template for Kafka per-pod `Routes` used for access from outside of OpenShift.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|externalBootstrapIngress  1.2+<.<|Template for Kafka external bootstrap `Ingress`.
+|externalBootstrapIngress  1.2+<.<a|Template for Kafka external bootstrap `Ingress`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|perPodIngress             1.2+<.<|Template for Kafka per-pod `Ingress` used for access from outside of Kubernetes.
+|perPodIngress             1.2+<.<a|Template for Kafka per-pod `Ingress` used for access from outside of Kubernetes.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|persistentVolumeClaim     1.2+<.<|Template for all Kafka `PersistentVolumeClaims`.
+|persistentVolumeClaim     1.2+<.<a|Template for all Kafka `PersistentVolumeClaims`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|podDisruptionBudget       1.2+<.<|Template for Kafka `PodDisruptionBudget`.
+|podDisruptionBudget       1.2+<.<a|Template for Kafka `PodDisruptionBudget`.
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
-|kafkaContainer            1.2+<.<|Template for the Kafka broker container.
+|kafkaContainer            1.2+<.<a|Template for the Kafka broker container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|initContainer             1.2+<.<|Template for the Kafka init container.
+|initContainer             1.2+<.<a|Template for the Kafka init container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|clusterCaCert             1.2+<.<|Template for Secret with Kafka Cluster certificate public key.
+|clusterCaCert             1.2+<.<a|Template for Secret with Kafka Cluster certificate public key.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|clusterRoleBinding        1.2+<.<|Template for the Kafka ClusterRoleBinding.
+|clusterRoleBinding        1.2+<.<a|Template for the Kafka ClusterRoleBinding.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |====
 
@@ -814,9 +814,9 @@ Used in: xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`], xref:
 [options="header"]
 |====
 |Property                    |Description
-|metadata             1.2+<.<|Metadata applied to the resource.
+|metadata             1.2+<.<a|Metadata applied to the resource.
 |xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
-|podManagementPolicy  1.2+<.<|PodManagementPolicy which will be used for this StatefulSet. Valid values are `Parallel` and `OrderedReady`. Defaults to `Parallel`.
+|podManagementPolicy  1.2+<.<a|PodManagementPolicy which will be used for this StatefulSet. Valid values are `Parallel` and `OrderedReady`. Defaults to `Parallel`.
 |string (one of [OrderedReady, Parallel])
 |====
 
@@ -836,9 +836,9 @@ include::../api/io.strimzi.api.kafka.model.template.MetadataTemplate.adoc[levelo
 [options="header"]
 |====
 |Property            |Description
-|labels       1.2+<.<|Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+|labels       1.2+<.<a|Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
 |map
-|annotations  1.2+<.<|Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+|annotations  1.2+<.<a|Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
 |map
 |====
 
@@ -858,35 +858,35 @@ include::../api/io.strimzi.api.kafka.model.template.PodTemplate.adoc[leveloffset
 [options="header"]
 |====
 |Property                              |Description
-|metadata                       1.2+<.<|Metadata applied to the resource.
+|metadata                       1.2+<.<a|Metadata applied to the resource.
 |xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
-|imagePullSecrets               1.2+<.<|List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core[external documentation for core/v1 localobjectreference].
+|imagePullSecrets               1.2+<.<a|List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core[external documentation for core/v1 localobjectreference].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core[LocalObjectReference] array
-|securityContext                1.2+<.<|Configures pod-level security attributes and common container settings. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podsecuritycontext-v1-core[external documentation for core/v1 podsecuritycontext].
+|securityContext                1.2+<.<a|Configures pod-level security attributes and common container settings. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podsecuritycontext-v1-core[external documentation for core/v1 podsecuritycontext].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podsecuritycontext-v1-core[PodSecurityContext]
-|terminationGracePeriodSeconds  1.2+<.<|The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds.
+|terminationGracePeriodSeconds  1.2+<.<a|The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds.
 |integer
-|affinity                       1.2+<.<|The pod's affinity rules. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core[external documentation for core/v1 affinity].
+|affinity                       1.2+<.<a|The pod's affinity rules. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core[external documentation for core/v1 affinity].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core[Affinity]
-|tolerations                    1.2+<.<|The pod's tolerations. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core[external documentation for core/v1 toleration].
+|tolerations                    1.2+<.<a|The pod's tolerations. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core[external documentation for core/v1 toleration].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core[Toleration] array
-|priorityClassName              1.2+<.<|The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
+|priorityClassName              1.2+<.<a|The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
 |string
-|schedulerName                  1.2+<.<|The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+|schedulerName                  1.2+<.<a|The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
 |string
-|hostAliases                    1.2+<.<|The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#HostAlias-v1-core[external documentation for core/v1 HostAlias].
+|hostAliases                    1.2+<.<a|The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#HostAlias-v1-core[external documentation for core/v1 HostAlias].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#HostAlias-v1-core[HostAlias] array
-|topologySpreadConstraints      1.2+<.<|The pod's topology spread constraints. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#topologyspreadconstraint-v1-core[external documentation for core/v1 topologyspreadconstraint].
+|topologySpreadConstraints      1.2+<.<a|The pod's topology spread constraints. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#topologyspreadconstraint-v1-core[external documentation for core/v1 topologyspreadconstraint].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#topologyspreadconstraint-v1-core[TopologySpreadConstraint] array
@@ -901,7 +901,7 @@ Used in: xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`], xre
 [options="header"]
 |====
 |Property         |Description
-|metadata  1.2+<.<|Metadata applied to the resource.
+|metadata  1.2+<.<a|Metadata applied to the resource.
 |xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
 |====
 
@@ -921,7 +921,7 @@ include::../api/io.strimzi.api.kafka.model.template.ExternalServiceTemplate.adoc
 [options="header"]
 |====
 |Property         |Description
-|metadata  1.2+<.<|Metadata applied to the resource.
+|metadata  1.2+<.<a|Metadata applied to the resource.
 |xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
 |====
 
@@ -941,9 +941,9 @@ include::../api/io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate.
 [options="header"]
 |====
 |Property               |Description
-|metadata        1.2+<.<|Metadata to apply to the `PodDistruptionBugetTemplate` resource.
+|metadata        1.2+<.<a|Metadata to apply to the `PodDistruptionBugetTemplate` resource.
 |xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
-|maxUnavailable  1.2+<.<|Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
+|maxUnavailable  1.2+<.<a|Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1.
 |integer
 |====
 
@@ -963,9 +963,9 @@ include::../api/io.strimzi.api.kafka.model.template.ContainerTemplate.adoc[level
 [options="header"]
 |====
 |Property                |Description
-|env              1.2+<.<|Environment variables which should be applied to the container.
+|env              1.2+<.<a|Environment variables which should be applied to the container.
 |xref:type-ContainerEnvVar-{context}[`ContainerEnvVar`] array
-|securityContext  1.2+<.<|Security context for the container. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core[external documentation for core/v1 securitycontext].
+|securityContext  1.2+<.<a|Security context for the container. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core[external documentation for core/v1 securitycontext].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core[SecurityContext]
@@ -980,9 +980,9 @@ Used in: xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 [options="header"]
 |====
 |Property      |Description
-|name   1.2+<.<|The environment variable key.
+|name   1.2+<.<a|The environment variable key.
 |string
-|value  1.2+<.<|The environment variable value.
+|value  1.2+<.<a|The environment variable value.
 |string
 |====
 
@@ -1002,29 +1002,29 @@ include::../api/io.strimzi.api.kafka.model.ZookeeperClusterSpec.adoc[leveloffset
 [options="header"]
 |====
 |Property               |Description
-|replicas        1.2+<.<|The number of pods in the cluster.
+|replicas        1.2+<.<a|The number of pods in the cluster.
 |integer
-|image           1.2+<.<|The docker image for the pods.
+|image           1.2+<.<a|The docker image for the pods.
 |string
-|storage         1.2+<.<|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim].
+|storage         1.2+<.<a|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim].
 |xref:type-EphemeralStorage-{context}[`EphemeralStorage`], xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`]
-|config          1.2+<.<|The ZooKeeper broker config. Properties with the following prefixes cannot be set: server., dataDir, dataLogDir, clientPort, authProvider, quorum.auth, requireClientAuthScheme, snapshot.trust.empty, standaloneEnabled, reconfigEnabled, 4lw.commands.whitelist, secureClientPort, ssl., serverCnxnFactory, sslQuorum (with the exception of: ssl.protocol, ssl.quorum.protocol, ssl.enabledProtocols, ssl.quorum.enabledProtocols, ssl.ciphersuites, ssl.quorum.ciphersuites, ssl.hostnameVerification, ssl.quorum.hostnameVerification).
+|config          1.2+<.<a|The ZooKeeper broker config. Properties with the following prefixes cannot be set: server., dataDir, dataLogDir, clientPort, authProvider, quorum.auth, requireClientAuthScheme, snapshot.trust.empty, standaloneEnabled, reconfigEnabled, 4lw.commands.whitelist, secureClientPort, ssl., serverCnxnFactory, sslQuorum (with the exception of: ssl.protocol, ssl.quorum.protocol, ssl.enabledProtocols, ssl.quorum.enabledProtocols, ssl.ciphersuites, ssl.quorum.ciphersuites, ssl.hostnameVerification, ssl.quorum.hostnameVerification).
 |map
-|livenessProbe   1.2+<.<|Pod liveness checking.
+|livenessProbe   1.2+<.<a|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe  1.2+<.<|Pod readiness checking.
+|readinessProbe  1.2+<.<a|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|jvmOptions      1.2+<.<|JVM Options for pods.
+|jvmOptions      1.2+<.<a|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|resources       1.2+<.<|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources       1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
-|metricsConfig   1.2+<.<|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
+|metricsConfig   1.2+<.<a|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
 |xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`]
-|logging         1.2+<.<|Logging configuration for ZooKeeper. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging         1.2+<.<a|Logging configuration for ZooKeeper. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|template        1.2+<.<|Template for ZooKeeper cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
+|template        1.2+<.<a|Template for ZooKeeper cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
 |xref:type-ZookeeperClusterTemplate-{context}[`ZookeeperClusterTemplate`]
 |====
 
@@ -1037,19 +1037,19 @@ Used in: xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 [options="header"]
 |====
 |Property                      |Description
-|statefulset            1.2+<.<|Template for ZooKeeper `StatefulSet`.
+|statefulset            1.2+<.<a|Template for ZooKeeper `StatefulSet`.
 |xref:type-StatefulSetTemplate-{context}[`StatefulSetTemplate`]
-|pod                    1.2+<.<|Template for ZooKeeper `Pods`.
+|pod                    1.2+<.<a|Template for ZooKeeper `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|clientService          1.2+<.<|Template for ZooKeeper client `Service`.
+|clientService          1.2+<.<a|Template for ZooKeeper client `Service`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|nodesService           1.2+<.<|Template for ZooKeeper nodes `Service`.
+|nodesService           1.2+<.<a|Template for ZooKeeper nodes `Service`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|persistentVolumeClaim  1.2+<.<|Template for all ZooKeeper `PersistentVolumeClaims`.
+|persistentVolumeClaim  1.2+<.<a|Template for all ZooKeeper `PersistentVolumeClaims`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|podDisruptionBudget    1.2+<.<|Template for ZooKeeper `PodDisruptionBudget`.
+|podDisruptionBudget    1.2+<.<a|Template for ZooKeeper `PodDisruptionBudget`.
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
-|zookeeperContainer     1.2+<.<|Template for the ZooKeeper container.
+|zookeeperContainer     1.2+<.<a|Template for the ZooKeeper container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |====
 
@@ -1062,13 +1062,13 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 [options="header"]
 |====
 |Property              |Description
-|topicOperator  1.2+<.<|Configuration of the Topic Operator.
+|topicOperator  1.2+<.<a|Configuration of the Topic Operator.
 |xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`]
-|userOperator   1.2+<.<|Configuration of the User Operator.
+|userOperator   1.2+<.<a|Configuration of the User Operator.
 |xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`]
-|tlsSidecar     1.2+<.<|TLS sidecar configuration.
+|tlsSidecar     1.2+<.<a|TLS sidecar configuration.
 |xref:type-TlsSidecar-{context}[`TlsSidecar`]
-|template       1.2+<.<|Template for Entity Operator resources. The template allows users to specify how is the `Deployment` and `Pods` generated.
+|template       1.2+<.<a|Template for Entity Operator resources. The template allows users to specify how is the `Deployment` and `Pods` generated.
 |xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`]
 |====
 
@@ -1088,29 +1088,29 @@ include::../api/io.strimzi.api.kafka.model.EntityTopicOperatorSpec.adoc[leveloff
 [options="header"]
 |====
 |Property                               |Description
-|watchedNamespace                1.2+<.<|The namespace the Topic Operator should watch.
+|watchedNamespace                1.2+<.<a|The namespace the Topic Operator should watch.
 |string
-|image                           1.2+<.<|The image to use for the Topic Operator.
+|image                           1.2+<.<a|The image to use for the Topic Operator.
 |string
-|reconciliationIntervalSeconds   1.2+<.<|Interval between periodic reconciliations.
+|reconciliationIntervalSeconds   1.2+<.<a|Interval between periodic reconciliations.
 |integer
-|zookeeperSessionTimeoutSeconds  1.2+<.<|Timeout for the ZooKeeper session.
+|zookeeperSessionTimeoutSeconds  1.2+<.<a|Timeout for the ZooKeeper session.
 |integer
-|startupProbe                    1.2+<.<|Pod startup checking.
+|startupProbe                    1.2+<.<a|Pod startup checking.
 |xref:type-Probe-{context}[`Probe`]
-|livenessProbe                   1.2+<.<|Pod liveness checking.
+|livenessProbe                   1.2+<.<a|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe                  1.2+<.<|Pod readiness checking.
+|readinessProbe                  1.2+<.<a|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|resources                       1.2+<.<|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources                       1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
-|topicMetadataMaxAttempts        1.2+<.<|The number of attempts at getting topic metadata.
+|topicMetadataMaxAttempts        1.2+<.<a|The number of attempts at getting topic metadata.
 |integer
-|logging                         1.2+<.<|Logging configuration. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging                         1.2+<.<a|Logging configuration. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|jvmOptions                      1.2+<.<|JVM Options for pods.
+|jvmOptions                      1.2+<.<a|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
 |====
 
@@ -1130,27 +1130,27 @@ include::../api/io.strimzi.api.kafka.model.EntityUserOperatorSpec.adoc[leveloffs
 [options="header"]
 |====
 |Property                               |Description
-|watchedNamespace                1.2+<.<|The namespace the User Operator should watch.
+|watchedNamespace                1.2+<.<a|The namespace the User Operator should watch.
 |string
-|image                           1.2+<.<|The image to use for the User Operator.
+|image                           1.2+<.<a|The image to use for the User Operator.
 |string
-|reconciliationIntervalSeconds   1.2+<.<|Interval between periodic reconciliations.
+|reconciliationIntervalSeconds   1.2+<.<a|Interval between periodic reconciliations.
 |integer
-|zookeeperSessionTimeoutSeconds  1.2+<.<|Timeout for the ZooKeeper session.
+|zookeeperSessionTimeoutSeconds  1.2+<.<a|Timeout for the ZooKeeper session.
 |integer
-|secretPrefix                    1.2+<.<|The prefix that will be added to the KafkaUser name to be used as the Secret name.
+|secretPrefix                    1.2+<.<a|The prefix that will be added to the KafkaUser name to be used as the Secret name.
 |string
-|livenessProbe                   1.2+<.<|Pod liveness checking.
+|livenessProbe                   1.2+<.<a|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe                  1.2+<.<|Pod readiness checking.
+|readinessProbe                  1.2+<.<a|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|resources                       1.2+<.<|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources                       1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
-|logging                         1.2+<.<|Logging configuration. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging                         1.2+<.<a|Logging configuration. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|jvmOptions                      1.2+<.<|JVM Options for pods.
+|jvmOptions                      1.2+<.<a|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
 |====
 
@@ -1170,15 +1170,15 @@ include::../api/io.strimzi.api.kafka.model.TlsSidecar.adoc[leveloffset=+1]
 [options="header"]
 |====
 |Property               |Description
-|image           1.2+<.<|The docker image for the container.
+|image           1.2+<.<a|The docker image for the container.
 |string
-|livenessProbe   1.2+<.<|Pod liveness checking.
+|livenessProbe   1.2+<.<a|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|logLevel        1.2+<.<|The log level for the TLS sidecar. Default value is `notice`.
+|logLevel        1.2+<.<a|The log level for the TLS sidecar. Default value is `notice`.
 |string (one of [emerg, debug, crit, err, alert, warning, notice, info])
-|readinessProbe  1.2+<.<|Pod readiness checking.
+|readinessProbe  1.2+<.<a|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|resources       1.2+<.<|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources       1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
@@ -1193,15 +1193,15 @@ Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
 [options="header"]
 |====
 |Property                       |Description
-|deployment              1.2+<.<|Template for Entity Operator `Deployment`.
+|deployment              1.2+<.<a|Template for Entity Operator `Deployment`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|pod                     1.2+<.<|Template for Entity Operator `Pods`.
+|pod                     1.2+<.<a|Template for Entity Operator `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|tlsSidecarContainer     1.2+<.<|Template for the Entity Operator TLS sidecar container.
+|tlsSidecarContainer     1.2+<.<a|Template for the Entity Operator TLS sidecar container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|topicOperatorContainer  1.2+<.<|Template for the Entity Topic Operator container.
+|topicOperatorContainer  1.2+<.<a|Template for the Entity Topic Operator container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|userOperatorContainer   1.2+<.<|Template for the Entity User Operator container.
+|userOperatorContainer   1.2+<.<a|Template for the Entity User Operator container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |====
 
@@ -1215,15 +1215,15 @@ Configuration of how TLS certificates are used within the cluster. This applies 
 [options="header"]
 |====
 |Property                             |Description
-|generateCertificateAuthority  1.2+<.<|If true then Certificate Authority certificates will be generated automatically. Otherwise the user will need to provide a Secret with the CA certificate. Default is true.
+|generateCertificateAuthority  1.2+<.<a|If true then Certificate Authority certificates will be generated automatically. Otherwise the user will need to provide a Secret with the CA certificate. Default is true.
 |boolean
-|generateSecretOwnerReference  1.2+<.<|If `true`, the Cluster and Client CA Secrets are configured with the `ownerReference` set to the `Kafka` resource. If the `Kafka` resource is deleted when `true`, the CA Secrets are also deleted. If `false`, the `ownerReference` is disabled. If the `Kafka` resource is deleted when `false`, the CA Secrets are retained and available for reuse. Default is `true`.
+|generateSecretOwnerReference  1.2+<.<a|If `true`, the Cluster and Client CA Secrets are configured with the `ownerReference` set to the `Kafka` resource. If the `Kafka` resource is deleted when `true`, the CA Secrets are also deleted. If `false`, the `ownerReference` is disabled. If the `Kafka` resource is deleted when `false`, the CA Secrets are retained and available for reuse. Default is `true`.
 |boolean
-|validityDays                  1.2+<.<|The number of days generated certificates should be valid for. The default is 365.
+|validityDays                  1.2+<.<a|The number of days generated certificates should be valid for. The default is 365.
 |integer
-|renewalDays                   1.2+<.<|The number of days in the certificate renewal period. This is the number of days before the a certificate expires during which renewal actions may be performed. When `generateCertificateAuthority` is true, this will cause the generation of a new certificate. When `generateCertificateAuthority` is true, this will cause extra logging at WARN level about the pending certificate expiry. Default is 30.
+|renewalDays                   1.2+<.<a|The number of days in the certificate renewal period. This is the number of days before the a certificate expires during which renewal actions may be performed. When `generateCertificateAuthority` is true, this will cause the generation of a new certificate. When `generateCertificateAuthority` is true, this will cause extra logging at WARN level about the pending certificate expiry. Default is 30.
 |integer
-|certificateExpirationPolicy   1.2+<.<|How should CA certificate expiration be handled when `generateCertificateAuthority=true`. The default is for a new CA certificate to be generated reusing the existing private key.
+|certificateExpirationPolicy   1.2+<.<a|How should CA certificate expiration be handled when `generateCertificateAuthority=true`. The default is for a new CA certificate to be generated reusing the existing private key.
 |string (one of [replace-key, renew-certificate])
 |====
 
@@ -1236,29 +1236,29 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 [options="header"]
 |====
 |Property               |Description
-|image           1.2+<.<|The docker image for the pods.
+|image           1.2+<.<a|The docker image for the pods.
 |string
-|tlsSidecar      1.2+<.<|TLS sidecar configuration.
+|tlsSidecar      1.2+<.<a|TLS sidecar configuration.
 |xref:type-TlsSidecar-{context}[`TlsSidecar`]
-|resources       1.2+<.<|CPU and memory resources to reserve for the Cruise Control container. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources       1.2+<.<a|CPU and memory resources to reserve for the Cruise Control container. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
-|livenessProbe   1.2+<.<|Pod liveness checking for the Cruise Control container.
+|livenessProbe   1.2+<.<a|Pod liveness checking for the Cruise Control container.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe  1.2+<.<|Pod readiness checking for the Cruise Control container.
+|readinessProbe  1.2+<.<a|Pod readiness checking for the Cruise Control container.
 |xref:type-Probe-{context}[`Probe`]
-|jvmOptions      1.2+<.<|JVM Options for the Cruise Control container.
+|jvmOptions      1.2+<.<a|JVM Options for the Cruise Control container.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|logging         1.2+<.<|Logging configuration (Log4j 2) for Cruise Control. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging         1.2+<.<a|Logging configuration (Log4j 2) for Cruise Control. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|template        1.2+<.<|Template to specify how Cruise Control resources, `Deployments` and `Pods`, are generated.
+|template        1.2+<.<a|Template to specify how Cruise Control resources, `Deployments` and `Pods`, are generated.
 |xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`]
-|brokerCapacity  1.2+<.<|The Cruise Control `brokerCapacity` configuration.
+|brokerCapacity  1.2+<.<a|The Cruise Control `brokerCapacity` configuration.
 |xref:type-BrokerCapacity-{context}[`BrokerCapacity`]
-|config          1.2+<.<|The Cruise Control configuration. For a full list of configuration options refer to https://github.com/linkedin/cruise-control/wiki/Configurations. Note that properties with the following prefixes cannot be set: bootstrap.servers, client.id, zookeeper., network., security., failed.brokers.zk.path,webserver.http., webserver.api.urlprefix, webserver.session.path, webserver.accesslog., two.step., request.reason.required,metric.reporter.sampler.bootstrap.servers, metric.reporter.topic, partition.metric.sample.store.topic, broker.metric.sample.store.topic,capacity.config.file, self.healing., anomaly.detection., ssl. (with the exception of: ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, webserver.http.cors.enabled,webserver.http.cors.origin, webserver.http.cors.exposeheaders).
+|config          1.2+<.<a|The Cruise Control configuration. For a full list of configuration options refer to https://github.com/linkedin/cruise-control/wiki/Configurations. Note that properties with the following prefixes cannot be set: bootstrap.servers, client.id, zookeeper., network., security., failed.brokers.zk.path,webserver.http., webserver.api.urlprefix, webserver.session.path, webserver.accesslog., two.step., request.reason.required,metric.reporter.sampler.bootstrap.servers, metric.reporter.topic, partition.metric.sample.store.topic, broker.metric.sample.store.topic,capacity.config.file, self.healing., anomaly.detection., ssl. (with the exception of: ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, webserver.http.cors.enabled,webserver.http.cors.origin, webserver.http.cors.exposeheaders).
 |map
-|metricsConfig   1.2+<.<|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
+|metricsConfig   1.2+<.<a|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
 |xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`]
 |====
 
@@ -1271,17 +1271,17 @@ Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`]
 [options="header"]
 |====
 |Property                       |Description
-|deployment              1.2+<.<|Template for Cruise Control `Deployment`.
+|deployment              1.2+<.<a|Template for Cruise Control `Deployment`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|pod                     1.2+<.<|Template for Cruise Control `Pods`.
+|pod                     1.2+<.<a|Template for Cruise Control `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|apiService              1.2+<.<|Template for Cruise Control API `Service`.
+|apiService              1.2+<.<a|Template for Cruise Control API `Service`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|podDisruptionBudget     1.2+<.<|Template for Cruise Control `PodDisruptionBudget`.
+|podDisruptionBudget     1.2+<.<a|Template for Cruise Control `PodDisruptionBudget`.
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
-|cruiseControlContainer  1.2+<.<|Template for the Cruise Control container.
+|cruiseControlContainer  1.2+<.<a|Template for the Cruise Control container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|tlsSidecarContainer     1.2+<.<|Template for the Cruise Control TLS sidecar container.
+|tlsSidecarContainer     1.2+<.<a|Template for the Cruise Control TLS sidecar container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |====
 
@@ -1294,13 +1294,13 @@ Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`]
 [options="header"]
 |====
 |Property                |Description
-|disk             1.2+<.<|Broker capacity for disk in bytes, for example, 100Gi.
+|disk             1.2+<.<a|Broker capacity for disk in bytes, for example, 100Gi.
 |string
-|cpuUtilization   1.2+<.<|Broker capacity for CPU resource utilization as a percentage (0 - 100).
+|cpuUtilization   1.2+<.<a|Broker capacity for CPU resource utilization as a percentage (0 - 100).
 |integer
-|inboundNetwork   1.2+<.<|Broker capacity for inbound network throughput in bytes per second, for example, 10000KB/s.
+|inboundNetwork   1.2+<.<a|Broker capacity for inbound network throughput in bytes per second, for example, 10000KB/s.
 |string
-|outboundNetwork  1.2+<.<|Broker capacity for outbound network throughput in bytes per second, for example 10000KB/s.
+|outboundNetwork  1.2+<.<a|Broker capacity for outbound network throughput in bytes per second, for example 10000KB/s.
 |string
 |====
 
@@ -1313,19 +1313,19 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 [options="header"]
 |====
 |Property                  |Description
-|image              1.2+<.<|The image to use for the JmxTrans.
+|image              1.2+<.<a|The image to use for the JmxTrans.
 |string
-|outputDefinitions  1.2+<.<|Defines the output hosts that will be referenced later on. For more information on these properties see, xref:type-JmxTransOutputDefinitionTemplate-reference[`JmxTransOutputDefinitionTemplate` schema reference].
+|outputDefinitions  1.2+<.<a|Defines the output hosts that will be referenced later on. For more information on these properties see, xref:type-JmxTransOutputDefinitionTemplate-reference[`JmxTransOutputDefinitionTemplate` schema reference].
 |xref:type-JmxTransOutputDefinitionTemplate-{context}[`JmxTransOutputDefinitionTemplate`] array
-|logLevel           1.2+<.<|Sets the logging level of the JmxTrans deployment.For more information see, https://github.com/jmxtrans/jmxtrans-agent/wiki/Troubleshooting[JmxTrans Logging Level].
+|logLevel           1.2+<.<a|Sets the logging level of the JmxTrans deployment.For more information see, https://github.com/jmxtrans/jmxtrans-agent/wiki/Troubleshooting[JmxTrans Logging Level].
 |string
-|kafkaQueries       1.2+<.<|Queries to send to the Kafka brokers to define what data should be read from each broker. For more information on these properties see, xref:type-JmxTransQueryTemplate-reference[`JmxTransQueryTemplate` schema reference].
+|kafkaQueries       1.2+<.<a|Queries to send to the Kafka brokers to define what data should be read from each broker. For more information on these properties see, xref:type-JmxTransQueryTemplate-reference[`JmxTransQueryTemplate` schema reference].
 |xref:type-JmxTransQueryTemplate-{context}[`JmxTransQueryTemplate`] array
-|resources          1.2+<.<|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources          1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
-|template           1.2+<.<|Template for JmxTrans resources.
+|template           1.2+<.<a|Template for JmxTrans resources.
 |xref:type-JmxTransTemplate-{context}[`JmxTransTemplate`]
 |====
 
@@ -1338,17 +1338,17 @@ Used in: xref:type-JmxTransSpec-{context}[`JmxTransSpec`]
 [options="header"]
 |====
 |Property                    |Description
-|outputType           1.2+<.<|Template for setting the format of the data that will be pushed.For more information see https://github.com/jmxtrans/jmxtrans/wiki/OutputWriters[JmxTrans OutputWriters].
+|outputType           1.2+<.<a|Template for setting the format of the data that will be pushed.For more information see https://github.com/jmxtrans/jmxtrans/wiki/OutputWriters[JmxTrans OutputWriters].
 |string
-|host                 1.2+<.<|The DNS/hostname of the remote host that the data is pushed to.
+|host                 1.2+<.<a|The DNS/hostname of the remote host that the data is pushed to.
 |string
-|port                 1.2+<.<|The port of the remote host that the data is pushed to.
+|port                 1.2+<.<a|The port of the remote host that the data is pushed to.
 |integer
-|flushDelayInSeconds  1.2+<.<|How many seconds the JmxTrans waits before pushing a new set of data out.
+|flushDelayInSeconds  1.2+<.<a|How many seconds the JmxTrans waits before pushing a new set of data out.
 |integer
-|typeNames            1.2+<.<|Template for filtering data to be included in response to a wildcard query. For more information see https://github.com/jmxtrans/jmxtrans/wiki/Queries[JmxTrans queries].
+|typeNames            1.2+<.<a|Template for filtering data to be included in response to a wildcard query. For more information see https://github.com/jmxtrans/jmxtrans/wiki/Queries[JmxTrans queries].
 |string array
-|name                 1.2+<.<|Template for setting the name of the output definition. This is used to identify where to send the results of queries should be sent.
+|name                 1.2+<.<a|Template for setting the name of the output definition. This is used to identify where to send the results of queries should be sent.
 |string
 |====
 
@@ -1361,11 +1361,11 @@ Used in: xref:type-JmxTransSpec-{context}[`JmxTransSpec`]
 [options="header"]
 |====
 |Property            |Description
-|targetMBean  1.2+<.<|If using wildcards instead of a specific MBean then the data is gathered from multiple MBeans. Otherwise if specifying an MBean then data is gathered from that specified MBean.
+|targetMBean  1.2+<.<a|If using wildcards instead of a specific MBean then the data is gathered from multiple MBeans. Otherwise if specifying an MBean then data is gathered from that specified MBean.
 |string
-|attributes   1.2+<.<|Determine which attributes of the targeted MBean should be included.
+|attributes   1.2+<.<a|Determine which attributes of the targeted MBean should be included.
 |string array
-|outputs      1.2+<.<|List of the names of output definitions specified in the spec.kafka.jmxTrans.outputDefinitions that have defined where JMX metrics are pushed to, and in which data format.
+|outputs      1.2+<.<a|List of the names of output definitions specified in the spec.kafka.jmxTrans.outputDefinitions that have defined where JMX metrics are pushed to, and in which data format.
 |string array
 |====
 
@@ -1378,11 +1378,11 @@ Used in: xref:type-JmxTransSpec-{context}[`JmxTransSpec`]
 [options="header"]
 |====
 |Property           |Description
-|deployment  1.2+<.<|Template for JmxTrans `Deployment`.
+|deployment  1.2+<.<a|Template for JmxTrans `Deployment`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|pod         1.2+<.<|Template for JmxTrans `Pods`.
+|pod         1.2+<.<a|Template for JmxTrans `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|container   1.2+<.<|Template for JmxTrans container.
+|container   1.2+<.<a|Template for JmxTrans container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |====
 
@@ -1395,25 +1395,25 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 [options="header"]
 |====
 |Property                    |Description
-|image                1.2+<.<|The docker image for the pods.
+|image                1.2+<.<a|The docker image for the pods.
 |string
-|groupRegex           1.2+<.<|Regular expression to specify which consumer groups to collect. Default value is `.*`.
+|groupRegex           1.2+<.<a|Regular expression to specify which consumer groups to collect. Default value is `.*`.
 |string
-|topicRegex           1.2+<.<|Regular expression to specify which topics to collect. Default value is `.*`.
+|topicRegex           1.2+<.<a|Regular expression to specify which topics to collect. Default value is `.*`.
 |string
-|resources            1.2+<.<|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources            1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
-|logging              1.2+<.<|Only log messages with the given severity or above. Valid levels: [`debug`, `info`, `warn`, `error`, `fatal`]. Default log level is `info`.
+|logging              1.2+<.<a|Only log messages with the given severity or above. Valid levels: [`debug`, `info`, `warn`, `error`, `fatal`]. Default log level is `info`.
 |string
-|enableSaramaLogging  1.2+<.<|Enable Sarama logging, a Go client library used by the Kafka Exporter.
+|enableSaramaLogging  1.2+<.<a|Enable Sarama logging, a Go client library used by the Kafka Exporter.
 |boolean
-|template             1.2+<.<|Customization of deployment templates and pods.
+|template             1.2+<.<a|Customization of deployment templates and pods.
 |xref:type-KafkaExporterTemplate-{context}[`KafkaExporterTemplate`]
-|livenessProbe        1.2+<.<|Pod liveness check.
+|livenessProbe        1.2+<.<a|Pod liveness check.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe       1.2+<.<|Pod readiness check.
+|readinessProbe       1.2+<.<a|Pod readiness check.
 |xref:type-Probe-{context}[`Probe`]
 |====
 
@@ -1426,13 +1426,13 @@ Used in: xref:type-KafkaExporterSpec-{context}[`KafkaExporterSpec`]
 [options="header"]
 |====
 |Property           |Description
-|deployment  1.2+<.<|Template for Kafka Exporter `Deployment`.
+|deployment  1.2+<.<a|Template for Kafka Exporter `Deployment`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|pod         1.2+<.<|Template for Kafka Exporter `Pods`.
+|pod         1.2+<.<a|Template for Kafka Exporter `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|service     1.2+<.<|Template for Kafka Exporter `Service`.
+|service     1.2+<.<a|Template for Kafka Exporter `Service`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|container   1.2+<.<|Template for the Kafka Exporter container.
+|container   1.2+<.<a|Template for the Kafka Exporter container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |====
 
@@ -1445,13 +1445,13 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 [options="header"]
 |====
 |Property                   |Description
-|conditions          1.2+<.<|List of status conditions.
+|conditions          1.2+<.<a|List of status conditions.
 |xref:type-Condition-{context}[`Condition`] array
-|observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
+|observedGeneration  1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
 |integer
-|listeners           1.2+<.<|Addresses of the internal and external listeners.
+|listeners           1.2+<.<a|Addresses of the internal and external listeners.
 |xref:type-ListenerStatus-{context}[`ListenerStatus`] array
-|clusterId           1.2+<.<|Kafka cluster Id.
+|clusterId           1.2+<.<a|Kafka cluster Id.
 |string
 |====
 
@@ -1464,15 +1464,15 @@ Used in: xref:type-KafkaBridgeStatus-{context}[`KafkaBridgeStatus`], xref:type-K
 [options="header"]
 |====
 |Property                   |Description
-|type                1.2+<.<|The unique identifier of a condition, used to distinguish between other conditions in the resource.
+|type                1.2+<.<a|The unique identifier of a condition, used to distinguish between other conditions in the resource.
 |string
-|status              1.2+<.<|The status of the condition, either True, False or Unknown.
+|status              1.2+<.<a|The status of the condition, either True, False or Unknown.
 |string
-|lastTransitionTime  1.2+<.<|Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
+|lastTransitionTime  1.2+<.<a|Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
 |string
-|reason              1.2+<.<|The reason for the condition's last transition (a single word in CamelCase).
+|reason              1.2+<.<a|The reason for the condition's last transition (a single word in CamelCase).
 |string
-|message             1.2+<.<|Human-readable message indicating details about the condition's last transition.
+|message             1.2+<.<a|Human-readable message indicating details about the condition's last transition.
 |string
 |====
 
@@ -1485,13 +1485,13 @@ Used in: xref:type-KafkaStatus-{context}[`KafkaStatus`]
 [options="header"]
 |====
 |Property                 |Description
-|type              1.2+<.<|The type of the listener. Can be one of the following three types: `plain`, `tls`, and `external`.
+|type              1.2+<.<a|The type of the listener. Can be one of the following three types: `plain`, `tls`, and `external`.
 |string
-|addresses         1.2+<.<|A list of the addresses for this listener.
+|addresses         1.2+<.<a|A list of the addresses for this listener.
 |xref:type-ListenerAddress-{context}[`ListenerAddress`] array
-|bootstrapServers  1.2+<.<|A comma-separated list of `host:port` pairs for connecting to the Kafka cluster using this listener.
+|bootstrapServers  1.2+<.<a|A comma-separated list of `host:port` pairs for connecting to the Kafka cluster using this listener.
 |string
-|certificates      1.2+<.<|A list of TLS certificates which can be used to verify the identity of the server when connecting to the given listener. Set only for `tls` and `external` listeners.
+|certificates      1.2+<.<a|A list of TLS certificates which can be used to verify the identity of the server when connecting to the given listener. Set only for `tls` and `external` listeners.
 |string array
 |====
 
@@ -1504,9 +1504,9 @@ Used in: xref:type-ListenerStatus-{context}[`ListenerStatus`]
 [options="header"]
 |====
 |Property     |Description
-|host  1.2+<.<|The DNS name or IP address of the Kafka bootstrap service.
+|host  1.2+<.<a|The DNS name or IP address of the Kafka bootstrap service.
 |string
-|port  1.2+<.<|The port of the Kafka bootstrap service.
+|port  1.2+<.<a|The port of the Kafka bootstrap service.
 |integer
 |====
 
@@ -1517,9 +1517,9 @@ Used in: xref:type-ListenerStatus-{context}[`ListenerStatus`]
 [options="header"]
 |====
 |Property       |Description
-|spec    1.2+<.<|The specification of the Kafka Connect cluster.
+|spec    1.2+<.<a|The specification of the Kafka Connect cluster.
 |xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`]
-|status  1.2+<.<|The status of the Kafka Connect cluster.
+|status  1.2+<.<a|The status of the Kafka Connect cluster.
 |xref:type-KafkaConnectStatus-{context}[`KafkaConnectStatus`]
 |====
 
@@ -1539,47 +1539,47 @@ include::../api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc[leveloffset=+1]
 [options="header"]
 |====
 |Property                      |Description
-|version                1.2+<.<|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
+|version                1.2+<.<a|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
 |string
-|replicas               1.2+<.<|The number of pods in the Kafka Connect group.
+|replicas               1.2+<.<a|The number of pods in the Kafka Connect group.
 |integer
-|image                  1.2+<.<|The docker image for the pods.
+|image                  1.2+<.<a|The docker image for the pods.
 |string
-|bootstrapServers       1.2+<.<|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
+|bootstrapServers       1.2+<.<a|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
 |string
-|tls                    1.2+<.<|TLS configuration.
+|tls                    1.2+<.<a|TLS configuration.
 |xref:type-KafkaConnectTls-{context}[`KafkaConnectTls`]
-|authentication         1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
+|authentication         1.2+<.<a|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
-|config                 1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
+|config                 1.2+<.<a|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
-|resources              1.2+<.<|The maximum limits for CPU and memory resources and the requested initial resources. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources              1.2+<.<a|The maximum limits for CPU and memory resources and the requested initial resources. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
-|livenessProbe          1.2+<.<|Pod liveness checking.
+|livenessProbe          1.2+<.<a|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe         1.2+<.<|Pod readiness checking.
+|readinessProbe         1.2+<.<a|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|jvmOptions             1.2+<.<|JVM Options for pods.
+|jvmOptions             1.2+<.<a|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|jmxOptions             1.2+<.<|JMX Options.
+|jmxOptions             1.2+<.<a|JMX Options.
 |xref:type-KafkaJmxOptions-{context}[`KafkaJmxOptions`]
-|logging                1.2+<.<|Logging configuration for Kafka Connect. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging                1.2+<.<a|Logging configuration for Kafka Connect. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|tracing                1.2+<.<|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
+|tracing                1.2+<.<a|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
 |xref:type-JaegerTracing-{context}[`JaegerTracing`]
-|template               1.2+<.<|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
+|template               1.2+<.<a|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
-|externalConfiguration  1.2+<.<|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
+|externalConfiguration  1.2+<.<a|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
-|build                  1.2+<.<|Configures how the Connect container image should be built. Optional.
+|build                  1.2+<.<a|Configures how the Connect container image should be built. Optional.
 |xref:type-Build-{context}[`Build`]
-|clientRackInitImage    1.2+<.<|The image of the init container used for initializing the `client.rack`.
+|clientRackInitImage    1.2+<.<a|The image of the init container used for initializing the `client.rack`.
 |string
-|metricsConfig          1.2+<.<|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
+|metricsConfig          1.2+<.<a|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
 |xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`]
-|rack                   1.2+<.<|Configuration of the node label which will be used as the client.rack consumer configuration.
+|rack                   1.2+<.<a|Configuration of the node label which will be used as the client.rack consumer configuration.
 |xref:type-Rack-{context}[`Rack`]
 |====
 
@@ -1599,7 +1599,7 @@ include::../api/io.strimzi.api.kafka.model.KafkaConnectTls.adoc[leveloffset=+1]
 [options="header"]
 |====
 |Property                    |Description
-|trustedCertificates  1.2+<.<|Trusted certificates for TLS connection.
+|trustedCertificates  1.2+<.<a|Trusted certificates for TLS connection.
 |xref:type-CertSecretSource-{context}[`CertSecretSource`] array
 |====
 
@@ -1621,9 +1621,9 @@ It must have the value `tls` for the type `KafkaClientAuthenticationTls`.
 [options="header"]
 |====
 |Property                  |Description
-|certificateAndKey  1.2+<.<|Reference to the `Secret` which holds the certificate and private key pair.
+|certificateAndKey  1.2+<.<a|Reference to the `Secret` which holds the certificate and private key pair.
 |xref:type-CertAndKeySecretSource-{context}[`CertAndKeySecretSource`]
-|type               1.2+<.<|Must be `tls`.
+|type               1.2+<.<a|Must be `tls`.
 |string
 |====
 
@@ -1645,11 +1645,11 @@ It must have the value `scram-sha-512` for the type `KafkaClientAuthenticationSc
 [options="header"]
 |====
 |Property               |Description
-|passwordSecret  1.2+<.<|Reference to the `Secret` which holds the password.
+|passwordSecret  1.2+<.<a|Reference to the `Secret` which holds the password.
 |xref:type-PasswordSecretSource-{context}[`PasswordSecretSource`]
-|type            1.2+<.<|Must be `scram-sha-512`.
+|type            1.2+<.<a|Must be `scram-sha-512`.
 |string
-|username        1.2+<.<|Username used for the authentication.
+|username        1.2+<.<a|Username used for the authentication.
 |string
 |====
 
@@ -1662,9 +1662,9 @@ Used in: xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenti
 [options="header"]
 |====
 |Property           |Description
-|password    1.2+<.<|The name of the key in the Secret under which the password is stored.
+|password    1.2+<.<a|The name of the key in the Secret under which the password is stored.
 |string
-|secretName  1.2+<.<|The name of the Secret containing the password.
+|secretName  1.2+<.<a|The name of the Secret containing the password.
 |string
 |====
 
@@ -1686,11 +1686,11 @@ It must have the value `plain` for the type `KafkaClientAuthenticationPlain`.
 [options="header"]
 |====
 |Property               |Description
-|passwordSecret  1.2+<.<|Reference to the `Secret` which holds the password.
+|passwordSecret  1.2+<.<a|Reference to the `Secret` which holds the password.
 |xref:type-PasswordSecretSource-{context}[`PasswordSecretSource`]
-|type            1.2+<.<|Must be `plain`.
+|type            1.2+<.<a|Must be `plain`.
 |string
-|username        1.2+<.<|Username used for the authentication.
+|username        1.2+<.<a|Username used for the authentication.
 |string
 |====
 
@@ -1712,27 +1712,27 @@ It must have the value `oauth` for the type `KafkaClientAuthenticationOAuth`.
 [options="header"]
 |====
 |Property                               |Description
-|accessToken                     1.2+<.<|Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
+|accessToken                     1.2+<.<a|Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
 |xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
-|accessTokenIsJwt                1.2+<.<|Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+|accessTokenIsJwt                1.2+<.<a|Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
 |boolean
-|clientId                        1.2+<.<|OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+|clientId                        1.2+<.<a|OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
 |string
-|clientSecret                    1.2+<.<|Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+|clientSecret                    1.2+<.<a|Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
 |xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
-|disableTlsHostnameVerification  1.2+<.<|Enable or disable TLS hostname verification. Default value is `false`.
+|disableTlsHostnameVerification  1.2+<.<a|Enable or disable TLS hostname verification. Default value is `false`.
 |boolean
-|maxTokenExpirySeconds           1.2+<.<|Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
+|maxTokenExpirySeconds           1.2+<.<a|Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
 |integer
-|refreshToken                    1.2+<.<|Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
+|refreshToken                    1.2+<.<a|Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
 |xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
-|scope                           1.2+<.<|OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
+|scope                           1.2+<.<a|OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
 |string
-|tlsTrustedCertificates          1.2+<.<|Trusted certificates for TLS connection to the OAuth server.
+|tlsTrustedCertificates          1.2+<.<a|Trusted certificates for TLS connection to the OAuth server.
 |xref:type-CertSecretSource-{context}[`CertSecretSource`] array
-|tokenEndpointUri                1.2+<.<|Authorization server token endpoint URI.
+|tokenEndpointUri                1.2+<.<a|Authorization server token endpoint URI.
 |string
-|type                            1.2+<.<|Must be `oauth`.
+|type                            1.2+<.<a|Must be `oauth`.
 |string
 |====
 
@@ -1747,7 +1747,7 @@ It must have the value `jaeger` for the type `JaegerTracing`.
 [options="header"]
 |====
 |Property     |Description
-|type  1.2+<.<|Must be `jaeger`.
+|type  1.2+<.<a|Must be `jaeger`.
 |string
 |====
 
@@ -1760,25 +1760,25 @@ Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:ty
 [options="header"]
 |====
 |Property                    |Description
-|deployment           1.2+<.<|Template for Kafka Connect `Deployment`.
+|deployment           1.2+<.<a|Template for Kafka Connect `Deployment`.
 |xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`]
-|pod                  1.2+<.<|Template for Kafka Connect `Pods`.
+|pod                  1.2+<.<a|Template for Kafka Connect `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|apiService           1.2+<.<|Template for Kafka Connect API `Service`.
+|apiService           1.2+<.<a|Template for Kafka Connect API `Service`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|buildConfig          1.2+<.<|Template for the Kafka Connect BuildConfig used to build new container images. The BuildConfig is used only on OpenShift.
+|buildConfig          1.2+<.<a|Template for the Kafka Connect BuildConfig used to build new container images. The BuildConfig is used only on OpenShift.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|buildContainer       1.2+<.<|Template for the Kafka Connect Build container. The build container is used only on Kubernetes.
+|buildContainer       1.2+<.<a|Template for the Kafka Connect Build container. The build container is used only on Kubernetes.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|buildPod             1.2+<.<|Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
+|buildPod             1.2+<.<a|Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|clusterRoleBinding   1.2+<.<|Template for the Kafka Connect ClusterRoleBinding.
+|clusterRoleBinding   1.2+<.<a|Template for the Kafka Connect ClusterRoleBinding.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|connectContainer     1.2+<.<|Template for the Kafka Connect container.
+|connectContainer     1.2+<.<a|Template for the Kafka Connect container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|initContainer        1.2+<.<|Template for the Kafka init container.
+|initContainer        1.2+<.<a|Template for the Kafka init container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|podDisruptionBudget  1.2+<.<|Template for Kafka Connect `PodDisruptionBudget`.
+|podDisruptionBudget  1.2+<.<a|Template for Kafka Connect `PodDisruptionBudget`.
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
 |====
 
@@ -1791,9 +1791,9 @@ Used in: xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`], xref:ty
 [options="header"]
 |====
 |Property                   |Description
-|metadata            1.2+<.<|Metadata applied to the resource.
+|metadata            1.2+<.<a|Metadata applied to the resource.
 |xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
-|deploymentStrategy  1.2+<.<|DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
+|deploymentStrategy  1.2+<.<a|DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
 |string (one of [RollingUpdate, Recreate])
 |====
 
@@ -1813,9 +1813,9 @@ include::../api/io.strimzi.api.kafka.model.connect.ExternalConfiguration.adoc[le
 [options="header"]
 |====
 |Property        |Description
-|env      1.2+<.<|Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as environment variables.
+|env      1.2+<.<a|Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as environment variables.
 |xref:type-ExternalConfigurationEnv-{context}[`ExternalConfigurationEnv`] array
-|volumes  1.2+<.<|Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as volumes.
+|volumes  1.2+<.<a|Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as volumes.
 |xref:type-ExternalConfigurationVolumeSource-{context}[`ExternalConfigurationVolumeSource`] array
 |====
 
@@ -1828,9 +1828,9 @@ Used in: xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
 [options="header"]
 |====
 |Property          |Description
-|name       1.2+<.<|Name of the environment variable which will be passed to the Kafka Connect pods. The name of the environment variable cannot start with `KAFKA_` or `STRIMZI_`.
+|name       1.2+<.<a|Name of the environment variable which will be passed to the Kafka Connect pods. The name of the environment variable cannot start with `KAFKA_` or `STRIMZI_`.
 |string
-|valueFrom  1.2+<.<|Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
+|valueFrom  1.2+<.<a|Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
 |xref:type-ExternalConfigurationEnvVarSource-{context}[`ExternalConfigurationEnvVarSource`]
 |====
 
@@ -1843,11 +1843,11 @@ Used in: xref:type-ExternalConfigurationEnv-{context}[`ExternalConfigurationEnv`
 [options="header"]
 |====
 |Property                |Description
-|configMapKeyRef  1.2+<.<|Reference to a key in a ConfigMap. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#configmapkeyselector-v1-core[external documentation for core/v1 configmapkeyselector].
+|configMapKeyRef  1.2+<.<a|Reference to a key in a ConfigMap. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#configmapkeyselector-v1-core[external documentation for core/v1 configmapkeyselector].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#configmapkeyselector-v1-core[ConfigMapKeySelector]
-|secretKeyRef     1.2+<.<|Reference to a key in a Secret. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core[external documentation for core/v1 secretkeyselector].
+|secretKeyRef     1.2+<.<a|Reference to a key in a Secret. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core[external documentation for core/v1 secretkeyselector].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core[SecretKeySelector]
@@ -1862,13 +1862,13 @@ Used in: xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
 [options="header"]
 |====
 |Property          |Description
-|configMap  1.2+<.<|Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#configmapvolumesource-v1-core[external documentation for core/v1 configmapvolumesource].
+|configMap  1.2+<.<a|Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#configmapvolumesource-v1-core[external documentation for core/v1 configmapvolumesource].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#configmapvolumesource-v1-core[ConfigMapVolumeSource]
-|name       1.2+<.<|Name of the volume which will be added to the Kafka Connect pods.
+|name       1.2+<.<a|Name of the volume which will be added to the Kafka Connect pods.
 |string
-|secret     1.2+<.<|Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretvolumesource-v1-core[external documentation for core/v1 secretvolumesource].
+|secret     1.2+<.<a|Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretvolumesource-v1-core[external documentation for core/v1 secretvolumesource].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretvolumesource-v1-core[SecretVolumeSource]
@@ -1890,13 +1890,13 @@ include::../api/io.strimzi.api.kafka.model.connect.build.Build.adoc[leveloffset=
 [options="header"]
 |====
 |Property          |Description
-|output     1.2+<.<|Configures where should the newly built image be stored. Required. The type depends on the value of the `output.type` property within the given object, which must be one of [docker, imagestream].
+|output     1.2+<.<a|Configures where should the newly built image be stored. Required. The type depends on the value of the `output.type` property within the given object, which must be one of [docker, imagestream].
 |xref:type-DockerOutput-{context}[`DockerOutput`], xref:type-ImageStreamOutput-{context}[`ImageStreamOutput`]
-|resources  1.2+<.<|CPU and memory resources to reserve for the build. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources  1.2+<.<a|CPU and memory resources to reserve for the build. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
-|plugins    1.2+<.<|List of connector plugins which should be added to the Kafka Connect. Required.
+|plugins    1.2+<.<a|List of connector plugins which should be added to the Kafka Connect. Required.
 |xref:type-Plugin-{context}[`Plugin`] array
 |====
 
@@ -1911,13 +1911,13 @@ It must have the value `docker` for the type `DockerOutput`.
 [options="header"]
 |====
 |Property                        |Description
-|image                    1.2+<.<|The full name which should be used for tagging and pushing the newly built image. For example `quay.io/my-organization/my-custom-connect:latest`. Required.
+|image                    1.2+<.<a|The full name which should be used for tagging and pushing the newly built image. For example `quay.io/my-organization/my-custom-connect:latest`. Required.
 |string
-|pushSecret               1.2+<.<|Container Registry Secret with the credentials for pushing the newly built image.
+|pushSecret               1.2+<.<a|Container Registry Secret with the credentials for pushing the newly built image.
 |string
-|additionalKanikoOptions  1.2+<.<|Configures additional options which will be passed to the Kaniko executor when building the new Connect image. Allowed options are: --customPlatform, --insecure, --insecure-pull, --insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run. These options will be used only on Kubernetes where the Kaniko executor is used. They will be ignored on OpenShift. The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. Changing this field does not trigger new build of the Kafka Connect image.
+|additionalKanikoOptions  1.2+<.<a|Configures additional options which will be passed to the Kaniko executor when building the new Connect image. Allowed options are: --customPlatform, --insecure, --insecure-pull, --insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run. These options will be used only on Kubernetes where the Kaniko executor is used. They will be ignored on OpenShift. The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. Changing this field does not trigger new build of the Kafka Connect image.
 |string array
-|type                     1.2+<.<|Must be `docker`.
+|type                     1.2+<.<a|Must be `docker`.
 |string
 |====
 
@@ -1932,9 +1932,9 @@ It must have the value `imagestream` for the type `ImageStreamOutput`.
 [options="header"]
 |====
 |Property      |Description
-|image  1.2+<.<|The name and tag of the ImageStream where the newly built image will be pushed. For example `my-custom-connect:latest`. Required.
+|image  1.2+<.<a|The name and tag of the ImageStream where the newly built image will be pushed. For example `my-custom-connect:latest`. Required.
 |string
-|type   1.2+<.<|Must be `imagestream`.
+|type   1.2+<.<a|Must be `imagestream`.
 |string
 |====
 
@@ -1947,9 +1947,9 @@ Used in: xref:type-Build-{context}[`Build`]
 [options="header"]
 |====
 |Property          |Description
-|name       1.2+<.<|The unique name of the connector plugin. Will be used to generate the path where the connector artifacts will be stored. The name has to be unique within the KafkaConnect resource. The name has to follow the following pattern: `^[a-z][-_a-z0-9]*[a-z]$`. Required.
+|name       1.2+<.<a|The unique name of the connector plugin. Will be used to generate the path where the connector artifacts will be stored. The name has to be unique within the KafkaConnect resource. The name has to follow the following pattern: `^[a-z][-_a-z0-9]*[a-z]$`. Required.
 |string
-|artifacts  1.2+<.<|List of artifacts which belong to this connector plugin. Required.
+|artifacts  1.2+<.<a|List of artifacts which belong to this connector plugin. Required.
 |xref:type-JarArtifact-{context}[`JarArtifact`], xref:type-TgzArtifact-{context}[`TgzArtifact`], xref:type-ZipArtifact-{context}[`ZipArtifact`] array
 |====
 
@@ -1962,11 +1962,11 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 [options="header"]
 |====
 |Property          |Description
-|url        1.2+<.<|URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required.
+|url        1.2+<.<a|URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required.
 |string
-|sha512sum  1.2+<.<|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified.
+|sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified.
 |string
-|type       1.2+<.<|Must be `jar`.
+|type       1.2+<.<a|Must be `jar`.
 |string
 |====
 
@@ -1979,11 +1979,11 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 [options="header"]
 |====
 |Property          |Description
-|url        1.2+<.<|URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required.
+|url        1.2+<.<a|URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required.
 |string
-|sha512sum  1.2+<.<|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified.
+|sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified.
 |string
-|type       1.2+<.<|Must be `tgz`.
+|type       1.2+<.<a|Must be `tgz`.
 |string
 |====
 
@@ -1996,11 +1996,11 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 [options="header"]
 |====
 |Property          |Description
-|url        1.2+<.<|URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required.
+|url        1.2+<.<a|URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required.
 |string
-|sha512sum  1.2+<.<|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified.
+|sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified.
 |string
-|type       1.2+<.<|Must be `zip`.
+|type       1.2+<.<a|Must be `zip`.
 |string
 |====
 
@@ -2013,17 +2013,17 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 [options="header"]
 |====
 |Property                   |Description
-|conditions          1.2+<.<|List of status conditions.
+|conditions          1.2+<.<a|List of status conditions.
 |xref:type-Condition-{context}[`Condition`] array
-|observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
+|observedGeneration  1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
 |integer
-|url                 1.2+<.<|The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
+|url                 1.2+<.<a|The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
 |string
-|connectorPlugins    1.2+<.<|The list of connector plugins available in this Kafka Connect deployment.
+|connectorPlugins    1.2+<.<a|The list of connector plugins available in this Kafka Connect deployment.
 |xref:type-ConnectorPlugin-{context}[`ConnectorPlugin`] array
-|labelSelector       1.2+<.<|Label selector for pods providing this resource.
+|labelSelector       1.2+<.<a|Label selector for pods providing this resource.
 |string
-|replicas            1.2+<.<|The current number of pods being used to provide this resource.
+|replicas            1.2+<.<a|The current number of pods being used to provide this resource.
 |integer
 |====
 
@@ -2036,11 +2036,11 @@ Used in: xref:type-KafkaConnectS2IStatus-{context}[`KafkaConnectS2IStatus`], xre
 [options="header"]
 |====
 |Property        |Description
-|type     1.2+<.<|The type of the connector plugin. The available types are `sink` and `source`.
+|type     1.2+<.<a|The type of the connector plugin. The available types are `sink` and `source`.
 |string
-|version  1.2+<.<|The version of the connector plugin.
+|version  1.2+<.<a|The version of the connector plugin.
 |string
-|class    1.2+<.<|The class of the connector plugin.
+|class    1.2+<.<a|The class of the connector plugin.
 |string
 |====
 
@@ -2054,9 +2054,9 @@ Please use xref:type-Build-{context}[`Build`] instead.
 [options="header"]
 |====
 |Property       |Description
-|spec    1.2+<.<|The specification of the Kafka Connect Source-to-Image (S2I) cluster.
+|spec    1.2+<.<a|The specification of the Kafka Connect Source-to-Image (S2I) cluster.
 |xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`]
-|status  1.2+<.<|The status of the Kafka Connect Source-to-Image (S2I) cluster.
+|status  1.2+<.<a|The status of the Kafka Connect Source-to-Image (S2I) cluster.
 |xref:type-KafkaConnectS2IStatus-{context}[`KafkaConnectS2IStatus`]
 |====
 
@@ -2076,53 +2076,53 @@ include::../api/io.strimzi.api.kafka.model.KafkaConnectS2ISpec.adoc[leveloffset=
 [options="header"]
 |====
 |Property                         |Description
-|version                   1.2+<.<|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
+|version                   1.2+<.<a|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
 |string
-|replicas                  1.2+<.<|The number of pods in the Kafka Connect group.
+|replicas                  1.2+<.<a|The number of pods in the Kafka Connect group.
 |integer
-|image                     1.2+<.<|The docker image for the pods.
+|image                     1.2+<.<a|The docker image for the pods.
 |string
-|buildResources            1.2+<.<|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|buildResources            1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
-|bootstrapServers          1.2+<.<|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
+|bootstrapServers          1.2+<.<a|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
 |string
-|tls                       1.2+<.<|TLS configuration.
+|tls                       1.2+<.<a|TLS configuration.
 |xref:type-KafkaConnectTls-{context}[`KafkaConnectTls`]
-|authentication            1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
+|authentication            1.2+<.<a|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
-|config                    1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
+|config                    1.2+<.<a|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
-|resources                 1.2+<.<|The maximum limits for CPU and memory resources and the requested initial resources. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources                 1.2+<.<a|The maximum limits for CPU and memory resources and the requested initial resources. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
-|livenessProbe             1.2+<.<|Pod liveness checking.
+|livenessProbe             1.2+<.<a|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe            1.2+<.<|Pod readiness checking.
+|readinessProbe            1.2+<.<a|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|jvmOptions                1.2+<.<|JVM Options for pods.
+|jvmOptions                1.2+<.<a|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|jmxOptions                1.2+<.<|JMX Options.
+|jmxOptions                1.2+<.<a|JMX Options.
 |xref:type-KafkaJmxOptions-{context}[`KafkaJmxOptions`]
-|logging                   1.2+<.<|Logging configuration for Kafka Connect. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging                   1.2+<.<a|Logging configuration for Kafka Connect. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|tracing                   1.2+<.<|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
+|tracing                   1.2+<.<a|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
 |xref:type-JaegerTracing-{context}[`JaegerTracing`]
-|template                  1.2+<.<|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
+|template                  1.2+<.<a|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
-|externalConfiguration     1.2+<.<|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
+|externalConfiguration     1.2+<.<a|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
-|build                     1.2+<.<|Configures how the Connect container image should be built. Optional.
+|build                     1.2+<.<a|Configures how the Connect container image should be built. Optional.
 |xref:type-Build-{context}[`Build`]
-|clientRackInitImage       1.2+<.<|The image of the init container used for initializing the `client.rack`.
+|clientRackInitImage       1.2+<.<a|The image of the init container used for initializing the `client.rack`.
 |string
-|insecureSourceRepository  1.2+<.<|When true this configures the source repository with the 'Local' reference policy and an import policy that accepts insecure source tags.
+|insecureSourceRepository  1.2+<.<a|When true this configures the source repository with the 'Local' reference policy and an import policy that accepts insecure source tags.
 |boolean
-|metricsConfig             1.2+<.<|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
+|metricsConfig             1.2+<.<a|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
 |xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`]
-|rack                      1.2+<.<|Configuration of the node label which will be used as the client.rack consumer configuration.
+|rack                      1.2+<.<a|Configuration of the node label which will be used as the client.rack consumer configuration.
 |xref:type-Rack-{context}[`Rack`]
 |====
 
@@ -2135,19 +2135,19 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 [options="header"]
 |====
 |Property                   |Description
-|conditions          1.2+<.<|List of status conditions.
+|conditions          1.2+<.<a|List of status conditions.
 |xref:type-Condition-{context}[`Condition`] array
-|observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
+|observedGeneration  1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
 |integer
-|url                 1.2+<.<|The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
+|url                 1.2+<.<a|The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
 |string
-|connectorPlugins    1.2+<.<|The list of connector plugins available in this Kafka Connect deployment.
+|connectorPlugins    1.2+<.<a|The list of connector plugins available in this Kafka Connect deployment.
 |xref:type-ConnectorPlugin-{context}[`ConnectorPlugin`] array
-|buildConfigName     1.2+<.<|The name of the build configuration.
+|buildConfigName     1.2+<.<a|The name of the build configuration.
 |string
-|labelSelector       1.2+<.<|Label selector for pods providing this resource.
+|labelSelector       1.2+<.<a|Label selector for pods providing this resource.
 |string
-|replicas            1.2+<.<|The current number of pods being used to provide this resource.
+|replicas            1.2+<.<a|The current number of pods being used to provide this resource.
 |integer
 |====
 
@@ -2158,9 +2158,9 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 [options="header"]
 |====
 |Property       |Description
-|spec    1.2+<.<|The specification of the topic.
+|spec    1.2+<.<a|The specification of the topic.
 |xref:type-KafkaTopicSpec-{context}[`KafkaTopicSpec`]
-|status  1.2+<.<|The status of the topic.
+|status  1.2+<.<a|The status of the topic.
 |xref:type-KafkaTopicStatus-{context}[`KafkaTopicStatus`]
 |====
 
@@ -2173,13 +2173,13 @@ Used in: xref:type-KafkaTopic-{context}[`KafkaTopic`]
 [options="header"]
 |====
 |Property           |Description
-|partitions  1.2+<.<|The number of partitions the topic should have. This cannot be decreased after topic creation. It can be increased after topic creation, but it is important to understand the consequences that has, especially for topics with semantic partitioning. When absent this will default to the broker configuration for `num.partitions`.
+|partitions  1.2+<.<a|The number of partitions the topic should have. This cannot be decreased after topic creation. It can be increased after topic creation, but it is important to understand the consequences that has, especially for topics with semantic partitioning. When absent this will default to the broker configuration for `num.partitions`.
 |integer
-|replicas    1.2+<.<|The number of replicas the topic should have. When absent this will default to the broker configuration for `default.replication.factor`.
+|replicas    1.2+<.<a|The number of replicas the topic should have. When absent this will default to the broker configuration for `default.replication.factor`.
 |integer
-|config      1.2+<.<|The topic configuration.
+|config      1.2+<.<a|The topic configuration.
 |map
-|topicName   1.2+<.<|The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
+|topicName   1.2+<.<a|The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
 |string
 |====
 
@@ -2192,11 +2192,11 @@ Used in: xref:type-KafkaTopic-{context}[`KafkaTopic`]
 [options="header"]
 |====
 |Property                   |Description
-|conditions          1.2+<.<|List of status conditions.
+|conditions          1.2+<.<a|List of status conditions.
 |xref:type-Condition-{context}[`Condition`] array
-|observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
+|observedGeneration  1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
 |integer
-|topicName           1.2+<.<|Topic name.
+|topicName           1.2+<.<a|Topic name.
 |string
 |====
 
@@ -2207,9 +2207,9 @@ Used in: xref:type-KafkaTopic-{context}[`KafkaTopic`]
 [options="header"]
 |====
 |Property       |Description
-|spec    1.2+<.<|The specification of the user.
+|spec    1.2+<.<a|The specification of the user.
 |xref:type-KafkaUserSpec-{context}[`KafkaUserSpec`]
-|status  1.2+<.<|The status of the Kafka User.
+|status  1.2+<.<a|The status of the Kafka User.
 |xref:type-KafkaUserStatus-{context}[`KafkaUserStatus`]
 |====
 
@@ -2222,13 +2222,13 @@ Used in: xref:type-KafkaUser-{context}[`KafkaUser`]
 [options="header"]
 |====
 |Property               |Description
-|authentication  1.2+<.<|Authentication mechanism enabled for this Kafka user. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
+|authentication  1.2+<.<a|Authentication mechanism enabled for this Kafka user. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaUserTlsClientAuthentication-{context}[`KafkaUserTlsClientAuthentication`], xref:type-KafkaUserScramSha512ClientAuthentication-{context}[`KafkaUserScramSha512ClientAuthentication`]
-|authorization   1.2+<.<|Authorization rules for this Kafka user. The type depends on the value of the `authorization.type` property within the given object, which must be one of [simple].
+|authorization   1.2+<.<a|Authorization rules for this Kafka user. The type depends on the value of the `authorization.type` property within the given object, which must be one of [simple].
 |xref:type-KafkaUserAuthorizationSimple-{context}[`KafkaUserAuthorizationSimple`]
-|quotas          1.2+<.<|Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
+|quotas          1.2+<.<a|Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
 |xref:type-KafkaUserQuotas-{context}[`KafkaUserQuotas`]
-|template        1.2+<.<|Template to specify how Kafka User `Secrets` are generated.
+|template        1.2+<.<a|Template to specify how Kafka User `Secrets` are generated.
 |xref:type-KafkaUserTemplate-{context}[`KafkaUserTemplate`]
 |====
 
@@ -2243,7 +2243,7 @@ It must have the value `tls` for the type `KafkaUserTlsClientAuthentication`.
 [options="header"]
 |====
 |Property     |Description
-|type  1.2+<.<|Must be `tls`.
+|type  1.2+<.<a|Must be `tls`.
 |string
 |====
 
@@ -2258,7 +2258,7 @@ It must have the value `scram-sha-512` for the type `KafkaUserScramSha512ClientA
 [options="header"]
 |====
 |Property     |Description
-|type  1.2+<.<|Must be `scram-sha-512`.
+|type  1.2+<.<a|Must be `scram-sha-512`.
 |string
 |====
 
@@ -2273,9 +2273,9 @@ It must have the value `simple` for the type `KafkaUserAuthorizationSimple`.
 [options="header"]
 |====
 |Property     |Description
-|type  1.2+<.<|Must be `simple`.
+|type  1.2+<.<a|Must be `simple`.
 |string
-|acls  1.2+<.<|List of ACL rules which should be applied to this user.
+|acls  1.2+<.<a|List of ACL rules which should be applied to this user.
 |xref:type-AclRule-{context}[`AclRule`] array
 |====
 
@@ -2295,13 +2295,13 @@ include::../api/io.strimzi.api.kafka.model.AclRule.adoc[leveloffset=+1]
 [options="header"]
 |====
 |Property          |Description
-|host       1.2+<.<|The host from which the action described in the ACL rule is allowed or denied.
+|host       1.2+<.<a|The host from which the action described in the ACL rule is allowed or denied.
 |string
-|operation  1.2+<.<|Operation which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All.
+|operation  1.2+<.<a|Operation which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All.
 |string (one of [Read, Write, Delete, Alter, Describe, All, IdempotentWrite, ClusterAction, Create, AlterConfigs, DescribeConfigs])
-|resource   1.2+<.<|Indicates the resource for which given ACL rule applies. The type depends on the value of the `resource.type` property within the given object, which must be one of [topic, group, cluster, transactionalId].
+|resource   1.2+<.<a|Indicates the resource for which given ACL rule applies. The type depends on the value of the `resource.type` property within the given object, which must be one of [topic, group, cluster, transactionalId].
 |xref:type-AclRuleTopicResource-{context}[`AclRuleTopicResource`], xref:type-AclRuleGroupResource-{context}[`AclRuleGroupResource`], xref:type-AclRuleClusterResource-{context}[`AclRuleClusterResource`], xref:type-AclRuleTransactionalIdResource-{context}[`AclRuleTransactionalIdResource`]
-|type       1.2+<.<|The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+|type       1.2+<.<a|The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
 |string (one of [allow, deny])
 |====
 
@@ -2316,11 +2316,11 @@ It must have the value `topic` for the type `AclRuleTopicResource`.
 [options="header"]
 |====
 |Property            |Description
-|type         1.2+<.<|Must be `topic`.
+|type         1.2+<.<a|Must be `topic`.
 |string
-|name         1.2+<.<|Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
+|name         1.2+<.<a|Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
 |string
-|patternType  1.2+<.<|Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full topic name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`.
+|patternType  1.2+<.<a|Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full topic name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`.
 |string (one of [prefix, literal])
 |====
 
@@ -2335,11 +2335,11 @@ It must have the value `group` for the type `AclRuleGroupResource`.
 [options="header"]
 |====
 |Property            |Description
-|type         1.2+<.<|Must be `group`.
+|type         1.2+<.<a|Must be `group`.
 |string
-|name         1.2+<.<|Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
+|name         1.2+<.<a|Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
 |string
-|patternType  1.2+<.<|Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full topic name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`.
+|patternType  1.2+<.<a|Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full topic name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`.
 |string (one of [prefix, literal])
 |====
 
@@ -2354,7 +2354,7 @@ It must have the value `cluster` for the type `AclRuleClusterResource`.
 [options="header"]
 |====
 |Property     |Description
-|type  1.2+<.<|Must be `cluster`.
+|type  1.2+<.<a|Must be `cluster`.
 |string
 |====
 
@@ -2369,11 +2369,11 @@ It must have the value `transactionalId` for the type `AclRuleTransactionalIdRes
 [options="header"]
 |====
 |Property            |Description
-|type         1.2+<.<|Must be `transactionalId`.
+|type         1.2+<.<a|Must be `transactionalId`.
 |string
-|name         1.2+<.<|Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
+|name         1.2+<.<a|Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
 |string
-|patternType  1.2+<.<|Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`.
+|patternType  1.2+<.<a|Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`.
 |string (one of [prefix, literal])
 |====
 
@@ -2393,11 +2393,11 @@ include::../api/io.strimzi.api.kafka.model.KafkaUserQuotas.adoc[leveloffset=+1]
 [options="header"]
 |====
 |Property                  |Description
-|consumerByteRate   1.2+<.<|A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
+|consumerByteRate   1.2+<.<a|A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
 |integer
-|producerByteRate   1.2+<.<|A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
+|producerByteRate   1.2+<.<a|A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
 |integer
-|requestPercentage  1.2+<.<|A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
+|requestPercentage  1.2+<.<a|A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
 |integer
 |====
 
@@ -2417,7 +2417,7 @@ include::../api/io.strimzi.api.kafka.model.template.KafkaUserTemplate.adoc[level
 [options="header"]
 |====
 |Property       |Description
-|secret  1.2+<.<|Template for KafkaUser resources. The template allows users to specify how the `Secret` with password or TLS certificates is generated.
+|secret  1.2+<.<a|Template for KafkaUser resources. The template allows users to specify how the `Secret` with password or TLS certificates is generated.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |====
 
@@ -2430,13 +2430,13 @@ Used in: xref:type-KafkaUser-{context}[`KafkaUser`]
 [options="header"]
 |====
 |Property                   |Description
-|conditions          1.2+<.<|List of status conditions.
+|conditions          1.2+<.<a|List of status conditions.
 |xref:type-Condition-{context}[`Condition`] array
-|observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
+|observedGeneration  1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
 |integer
-|username            1.2+<.<|Username.
+|username            1.2+<.<a|Username.
 |string
-|secret              1.2+<.<|The name of `Secret` where the credentials are stored.
+|secret              1.2+<.<a|The name of `Secret` where the credentials are stored.
 |string
 |====
 
@@ -2447,9 +2447,9 @@ Used in: xref:type-KafkaUser-{context}[`KafkaUser`]
 [options="header"]
 |====
 |Property       |Description
-|spec    1.2+<.<|The specification of Kafka MirrorMaker.
+|spec    1.2+<.<a|The specification of Kafka MirrorMaker.
 |xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
-|status  1.2+<.<|The status of Kafka MirrorMaker.
+|status  1.2+<.<a|The status of Kafka MirrorMaker.
 |xref:type-KafkaMirrorMakerStatus-{context}[`KafkaMirrorMakerStatus`]
 |====
 
@@ -2469,35 +2469,35 @@ include::../api/io.strimzi.api.kafka.model.KafkaMirrorMakerSpec.adoc[leveloffset
 [options="header"]
 |====
 |Property               |Description
-|version         1.2+<.<|The Kafka MirrorMaker version. Defaults to {DefaultKafkaVersion}. Consult the documentation to understand the process required to upgrade or downgrade the version.
+|version         1.2+<.<a|The Kafka MirrorMaker version. Defaults to {DefaultKafkaVersion}. Consult the documentation to understand the process required to upgrade or downgrade the version.
 |string
-|replicas        1.2+<.<|The number of pods in the `Deployment`.
+|replicas        1.2+<.<a|The number of pods in the `Deployment`.
 |integer
-|image           1.2+<.<|The docker image for the pods.
+|image           1.2+<.<a|The docker image for the pods.
 |string
-|consumer        1.2+<.<|Configuration of source cluster.
+|consumer        1.2+<.<a|Configuration of source cluster.
 |xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`]
-|producer        1.2+<.<|Configuration of target cluster.
+|producer        1.2+<.<a|Configuration of target cluster.
 |xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
-|resources       1.2+<.<|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources       1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
-|whitelist       1.2+<.<|List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the whitelist `'A\|B'`. Or, as a special case, you can mirror all topics using the whitelist '*'. You can also specify multiple regular expressions separated by commas.
+|whitelist       1.2+<.<a|List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the whitelist `'A\|B'`. Or, as a special case, you can mirror all topics using the whitelist '*'. You can also specify multiple regular expressions separated by commas.
 |string
-|jvmOptions      1.2+<.<|JVM Options for pods.
+|jvmOptions      1.2+<.<a|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|logging         1.2+<.<|Logging configuration for MirrorMaker. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging         1.2+<.<a|Logging configuration for MirrorMaker. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|metricsConfig   1.2+<.<|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
+|metricsConfig   1.2+<.<a|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
 |xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`]
-|tracing         1.2+<.<|The configuration of tracing in Kafka MirrorMaker. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
+|tracing         1.2+<.<a|The configuration of tracing in Kafka MirrorMaker. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
 |xref:type-JaegerTracing-{context}[`JaegerTracing`]
-|template        1.2+<.<|Template to specify how Kafka MirrorMaker resources, `Deployments` and `Pods`, are generated.
+|template        1.2+<.<a|Template to specify how Kafka MirrorMaker resources, `Deployments` and `Pods`, are generated.
 |xref:type-KafkaMirrorMakerTemplate-{context}[`KafkaMirrorMakerTemplate`]
-|livenessProbe   1.2+<.<|Pod liveness checking.
+|livenessProbe   1.2+<.<a|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe  1.2+<.<|Pod readiness checking.
+|readinessProbe  1.2+<.<a|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
 |====
 
@@ -2517,19 +2517,19 @@ include::../api/io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec.adoc[lev
 [options="header"]
 |====
 |Property                     |Description
-|numStreams            1.2+<.<|Specifies the number of consumer stream threads to create.
+|numStreams            1.2+<.<a|Specifies the number of consumer stream threads to create.
 |integer
-|offsetCommitInterval  1.2+<.<|Specifies the offset auto-commit interval in ms. Default value is 60000.
+|offsetCommitInterval  1.2+<.<a|Specifies the offset auto-commit interval in ms. Default value is 60000.
 |integer
-|bootstrapServers      1.2+<.<|A list of host:port pairs for establishing the initial connection to the Kafka cluster.
+|bootstrapServers      1.2+<.<a|A list of host:port pairs for establishing the initial connection to the Kafka cluster.
 |string
-|groupId               1.2+<.<|A unique string that identifies the consumer group this consumer belongs to.
+|groupId               1.2+<.<a|A unique string that identifies the consumer group this consumer belongs to.
 |string
-|authentication        1.2+<.<|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
+|authentication        1.2+<.<a|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
-|config                1.2+<.<|The MirrorMaker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
+|config                1.2+<.<a|The MirrorMaker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
-|tls                   1.2+<.<|TLS configuration for connecting MirrorMaker to the cluster.
+|tls                   1.2+<.<a|TLS configuration for connecting MirrorMaker to the cluster.
 |xref:type-KafkaMirrorMakerTls-{context}[`KafkaMirrorMakerTls`]
 |====
 
@@ -2549,7 +2549,7 @@ include::../api/io.strimzi.api.kafka.model.KafkaMirrorMakerTls.adoc[leveloffset=
 [options="header"]
 |====
 |Property                    |Description
-|trustedCertificates  1.2+<.<|Trusted certificates for TLS connection.
+|trustedCertificates  1.2+<.<a|Trusted certificates for TLS connection.
 |xref:type-CertSecretSource-{context}[`CertSecretSource`] array
 |====
 
@@ -2569,15 +2569,15 @@ include::../api/io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec.adoc[lev
 [options="header"]
 |====
 |Property                   |Description
-|bootstrapServers    1.2+<.<|A list of host:port pairs for establishing the initial connection to the Kafka cluster.
+|bootstrapServers    1.2+<.<a|A list of host:port pairs for establishing the initial connection to the Kafka cluster.
 |string
-|abortOnSendFailure  1.2+<.<|Flag to set the MirrorMaker to exit on a failed send. Default value is `true`.
+|abortOnSendFailure  1.2+<.<a|Flag to set the MirrorMaker to exit on a failed send. Default value is `true`.
 |boolean
-|authentication      1.2+<.<|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
+|authentication      1.2+<.<a|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
-|config              1.2+<.<|The MirrorMaker producer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
+|config              1.2+<.<a|The MirrorMaker producer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
-|tls                 1.2+<.<|TLS configuration for connecting MirrorMaker to the cluster.
+|tls                 1.2+<.<a|TLS configuration for connecting MirrorMaker to the cluster.
 |xref:type-KafkaMirrorMakerTls-{context}[`KafkaMirrorMakerTls`]
 |====
 
@@ -2590,13 +2590,13 @@ Used in: xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
 [options="header"]
 |====
 |Property                     |Description
-|deployment            1.2+<.<|Template for Kafka MirrorMaker `Deployment`.
+|deployment            1.2+<.<a|Template for Kafka MirrorMaker `Deployment`.
 |xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`]
-|pod                   1.2+<.<|Template for Kafka MirrorMaker `Pods`.
+|pod                   1.2+<.<a|Template for Kafka MirrorMaker `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|mirrorMakerContainer  1.2+<.<|Template for Kafka MirrorMaker container.
+|mirrorMakerContainer  1.2+<.<a|Template for Kafka MirrorMaker container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|podDisruptionBudget   1.2+<.<|Template for Kafka MirrorMaker `PodDisruptionBudget`.
+|podDisruptionBudget   1.2+<.<a|Template for Kafka MirrorMaker `PodDisruptionBudget`.
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
 |====
 
@@ -2609,13 +2609,13 @@ Used in: xref:type-KafkaMirrorMaker-{context}[`KafkaMirrorMaker`]
 [options="header"]
 |====
 |Property                   |Description
-|conditions          1.2+<.<|List of status conditions.
+|conditions          1.2+<.<a|List of status conditions.
 |xref:type-Condition-{context}[`Condition`] array
-|observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
+|observedGeneration  1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
 |integer
-|labelSelector       1.2+<.<|Label selector for pods providing this resource.
+|labelSelector       1.2+<.<a|Label selector for pods providing this resource.
 |string
-|replicas            1.2+<.<|The current number of pods being used to provide this resource.
+|replicas            1.2+<.<a|The current number of pods being used to provide this resource.
 |integer
 |====
 
@@ -2626,9 +2626,9 @@ Used in: xref:type-KafkaMirrorMaker-{context}[`KafkaMirrorMaker`]
 [options="header"]
 |====
 |Property       |Description
-|spec    1.2+<.<|The specification of the Kafka Bridge.
+|spec    1.2+<.<a|The specification of the Kafka Bridge.
 |xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`]
-|status  1.2+<.<|The status of the Kafka Bridge.
+|status  1.2+<.<a|The status of the Kafka Bridge.
 |xref:type-KafkaBridgeStatus-{context}[`KafkaBridgeStatus`]
 |====
 
@@ -2648,39 +2648,39 @@ include::../api/io.strimzi.api.kafka.model.KafkaBridgeSpec.adoc[leveloffset=+1]
 [options="header"]
 |====
 |Property                 |Description
-|replicas          1.2+<.<|The number of pods in the `Deployment`.
+|replicas          1.2+<.<a|The number of pods in the `Deployment`.
 |integer
-|image             1.2+<.<|The docker image for the pods.
+|image             1.2+<.<a|The docker image for the pods.
 |string
-|bootstrapServers  1.2+<.<|A list of host:port pairs for establishing the initial connection to the Kafka cluster.
+|bootstrapServers  1.2+<.<a|A list of host:port pairs for establishing the initial connection to the Kafka cluster.
 |string
-|tls               1.2+<.<|TLS configuration for connecting Kafka Bridge to the cluster.
+|tls               1.2+<.<a|TLS configuration for connecting Kafka Bridge to the cluster.
 |xref:type-KafkaBridgeTls-{context}[`KafkaBridgeTls`]
-|authentication    1.2+<.<|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
+|authentication    1.2+<.<a|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
-|http              1.2+<.<|The HTTP related configuration.
+|http              1.2+<.<a|The HTTP related configuration.
 |xref:type-KafkaBridgeHttpConfig-{context}[`KafkaBridgeHttpConfig`]
-|consumer          1.2+<.<|Kafka consumer related configuration.
+|consumer          1.2+<.<a|Kafka consumer related configuration.
 |xref:type-KafkaBridgeConsumerSpec-{context}[`KafkaBridgeConsumerSpec`]
-|producer          1.2+<.<|Kafka producer related configuration.
+|producer          1.2+<.<a|Kafka producer related configuration.
 |xref:type-KafkaBridgeProducerSpec-{context}[`KafkaBridgeProducerSpec`]
-|resources         1.2+<.<|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources         1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
-|jvmOptions        1.2+<.<|**Currently not supported** JVM Options for pods.
+|jvmOptions        1.2+<.<a|**Currently not supported** JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|logging           1.2+<.<|Logging configuration for Kafka Bridge. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging           1.2+<.<a|Logging configuration for Kafka Bridge. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|enableMetrics     1.2+<.<|Enable the metrics for the Kafka Bridge. Default is false.
+|enableMetrics     1.2+<.<a|Enable the metrics for the Kafka Bridge. Default is false.
 |boolean
-|livenessProbe     1.2+<.<|Pod liveness checking.
+|livenessProbe     1.2+<.<a|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe    1.2+<.<|Pod readiness checking.
+|readinessProbe    1.2+<.<a|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|template          1.2+<.<|Template for Kafka Bridge resources. The template allows users to specify how is the `Deployment` and `Pods` generated.
+|template          1.2+<.<a|Template for Kafka Bridge resources. The template allows users to specify how is the `Deployment` and `Pods` generated.
 |xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`]
-|tracing           1.2+<.<|The configuration of tracing in Kafka Bridge. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
+|tracing           1.2+<.<a|The configuration of tracing in Kafka Bridge. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
 |xref:type-JaegerTracing-{context}[`JaegerTracing`]
 |====
 
@@ -2693,7 +2693,7 @@ Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`]
 [options="header"]
 |====
 |Property                    |Description
-|trustedCertificates  1.2+<.<|Trusted certificates for TLS connection.
+|trustedCertificates  1.2+<.<a|Trusted certificates for TLS connection.
 |xref:type-CertSecretSource-{context}[`CertSecretSource`] array
 |====
 
@@ -2713,9 +2713,9 @@ include::../api/io.strimzi.api.kafka.model.KafkaBridgeHttpConfig.adoc[leveloffse
 [options="header"]
 |====
 |Property     |Description
-|port  1.2+<.<|The port which is the server listening on.
+|port  1.2+<.<a|The port which is the server listening on.
 |integer
-|cors  1.2+<.<|CORS configuration for the HTTP Bridge.
+|cors  1.2+<.<a|CORS configuration for the HTTP Bridge.
 |xref:type-KafkaBridgeHttpCors-{context}[`KafkaBridgeHttpCors`]
 |====
 
@@ -2728,9 +2728,9 @@ Used in: xref:type-KafkaBridgeHttpConfig-{context}[`KafkaBridgeHttpConfig`]
 [options="header"]
 |====
 |Property               |Description
-|allowedOrigins  1.2+<.<|List of allowed origins. Java regular expressions can be used.
+|allowedOrigins  1.2+<.<a|List of allowed origins. Java regular expressions can be used.
 |string array
-|allowedMethods  1.2+<.<|List of allowed HTTP methods.
+|allowedMethods  1.2+<.<a|List of allowed HTTP methods.
 |string array
 |====
 
@@ -2750,7 +2750,7 @@ include::../api/io.strimzi.api.kafka.model.KafkaBridgeConsumerSpec.adoc[leveloff
 [options="header"]
 |====
 |Property       |Description
-|config  1.2+<.<|The Kafka consumer configuration used for consumer instances created by the bridge. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
+|config  1.2+<.<a|The Kafka consumer configuration used for consumer instances created by the bridge. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
 |====
 
@@ -2770,7 +2770,7 @@ include::../api/io.strimzi.api.kafka.model.KafkaBridgeProducerSpec.adoc[leveloff
 [options="header"]
 |====
 |Property       |Description
-|config  1.2+<.<|The Kafka producer configuration used for producer instances created by the bridge. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
+|config  1.2+<.<a|The Kafka producer configuration used for producer instances created by the bridge. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
 |====
 
@@ -2783,15 +2783,15 @@ Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`]
 [options="header"]
 |====
 |Property                    |Description
-|deployment           1.2+<.<|Template for Kafka Bridge `Deployment`.
+|deployment           1.2+<.<a|Template for Kafka Bridge `Deployment`.
 |xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`]
-|pod                  1.2+<.<|Template for Kafka Bridge `Pods`.
+|pod                  1.2+<.<a|Template for Kafka Bridge `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|apiService           1.2+<.<|Template for Kafka Bridge API `Service`.
+|apiService           1.2+<.<a|Template for Kafka Bridge API `Service`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|bridgeContainer      1.2+<.<|Template for the Kafka Bridge container.
+|bridgeContainer      1.2+<.<a|Template for the Kafka Bridge container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|podDisruptionBudget  1.2+<.<|Template for Kafka Bridge `PodDisruptionBudget`.
+|podDisruptionBudget  1.2+<.<a|Template for Kafka Bridge `PodDisruptionBudget`.
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
 |====
 
@@ -2804,15 +2804,15 @@ Used in: xref:type-KafkaBridge-{context}[`KafkaBridge`]
 [options="header"]
 |====
 |Property                   |Description
-|conditions          1.2+<.<|List of status conditions.
+|conditions          1.2+<.<a|List of status conditions.
 |xref:type-Condition-{context}[`Condition`] array
-|observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
+|observedGeneration  1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
 |integer
-|url                 1.2+<.<|The URL at which external client applications can access the Kafka Bridge.
+|url                 1.2+<.<a|The URL at which external client applications can access the Kafka Bridge.
 |string
-|labelSelector       1.2+<.<|Label selector for pods providing this resource.
+|labelSelector       1.2+<.<a|Label selector for pods providing this resource.
 |string
-|replicas            1.2+<.<|The current number of pods being used to provide this resource.
+|replicas            1.2+<.<a|The current number of pods being used to provide this resource.
 |integer
 |====
 
@@ -2823,9 +2823,9 @@ Used in: xref:type-KafkaBridge-{context}[`KafkaBridge`]
 [options="header"]
 |====
 |Property       |Description
-|spec    1.2+<.<|The specification of the Kafka Connector.
+|spec    1.2+<.<a|The specification of the Kafka Connector.
 |xref:type-KafkaConnectorSpec-{context}[`KafkaConnectorSpec`]
-|status  1.2+<.<|The status of the Kafka Connector.
+|status  1.2+<.<a|The status of the Kafka Connector.
 |xref:type-KafkaConnectorStatus-{context}[`KafkaConnectorStatus`]
 |====
 
@@ -2838,13 +2838,13 @@ Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
 [options="header"]
 |====
 |Property         |Description
-|class     1.2+<.<|The Class for the Kafka Connector.
+|class     1.2+<.<a|The Class for the Kafka Connector.
 |string
-|tasksMax  1.2+<.<|The maximum number of tasks for the Kafka Connector.
+|tasksMax  1.2+<.<a|The maximum number of tasks for the Kafka Connector.
 |integer
-|config    1.2+<.<|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
+|config    1.2+<.<a|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
 |map
-|pause     1.2+<.<|Whether the connector should be paused. Defaults to false.
+|pause     1.2+<.<a|Whether the connector should be paused. Defaults to false.
 |boolean
 |====
 
@@ -2857,15 +2857,15 @@ Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
 [options="header"]
 |====
 |Property                   |Description
-|conditions          1.2+<.<|List of status conditions.
+|conditions          1.2+<.<a|List of status conditions.
 |xref:type-Condition-{context}[`Condition`] array
-|observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
+|observedGeneration  1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
 |integer
-|connectorStatus     1.2+<.<|The connector status, as reported by the Kafka Connect REST API.
+|connectorStatus     1.2+<.<a|The connector status, as reported by the Kafka Connect REST API.
 |map
-|tasksMax            1.2+<.<|The maximum number of tasks for the Kafka Connector.
+|tasksMax            1.2+<.<a|The maximum number of tasks for the Kafka Connector.
 |integer
-|topics              1.2+<.<|The list of topics used by the Kafka Connector.
+|topics              1.2+<.<a|The list of topics used by the Kafka Connector.
 |string array
 |====
 
@@ -2876,9 +2876,9 @@ Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
 [options="header"]
 |====
 |Property       |Description
-|spec    1.2+<.<|The specification of the Kafka MirrorMaker 2.0 cluster.
+|spec    1.2+<.<a|The specification of the Kafka MirrorMaker 2.0 cluster.
 |xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`]
-|status  1.2+<.<|The status of the Kafka MirrorMaker 2.0 cluster.
+|status  1.2+<.<a|The status of the Kafka MirrorMaker 2.0 cluster.
 |xref:type-KafkaMirrorMaker2Status-{context}[`KafkaMirrorMaker2Status`]
 |====
 
@@ -2891,39 +2891,39 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 [options="header"]
 |====
 |Property                      |Description
-|version                1.2+<.<|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
+|version                1.2+<.<a|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
 |string
-|replicas               1.2+<.<|The number of pods in the Kafka Connect group.
+|replicas               1.2+<.<a|The number of pods in the Kafka Connect group.
 |integer
-|image                  1.2+<.<|The docker image for the pods.
+|image                  1.2+<.<a|The docker image for the pods.
 |string
-|connectCluster         1.2+<.<|The cluster alias used for Kafka Connect. The alias must match a cluster in the list at `spec.clusters`.
+|connectCluster         1.2+<.<a|The cluster alias used for Kafka Connect. The alias must match a cluster in the list at `spec.clusters`.
 |string
-|clusters               1.2+<.<|Kafka clusters for mirroring.
+|clusters               1.2+<.<a|Kafka clusters for mirroring.
 |xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`] array
-|mirrors                1.2+<.<|Configuration of the MirrorMaker 2.0 connectors.
+|mirrors                1.2+<.<a|Configuration of the MirrorMaker 2.0 connectors.
 |xref:type-KafkaMirrorMaker2MirrorSpec-{context}[`KafkaMirrorMaker2MirrorSpec`] array
-|resources              1.2+<.<|The maximum limits for CPU and memory resources and the requested initial resources. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources              1.2+<.<a|The maximum limits for CPU and memory resources and the requested initial resources. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
-|livenessProbe          1.2+<.<|Pod liveness checking.
+|livenessProbe          1.2+<.<a|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe         1.2+<.<|Pod readiness checking.
+|readinessProbe         1.2+<.<a|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|jvmOptions             1.2+<.<|JVM Options for pods.
+|jvmOptions             1.2+<.<a|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|jmxOptions             1.2+<.<|JMX Options.
+|jmxOptions             1.2+<.<a|JMX Options.
 |xref:type-KafkaJmxOptions-{context}[`KafkaJmxOptions`]
-|logging                1.2+<.<|Logging configuration for Kafka Connect. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging                1.2+<.<a|Logging configuration for Kafka Connect. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|tracing                1.2+<.<|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
+|tracing                1.2+<.<a|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
 |xref:type-JaegerTracing-{context}[`JaegerTracing`]
-|template               1.2+<.<|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
+|template               1.2+<.<a|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
-|externalConfiguration  1.2+<.<|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
+|externalConfiguration  1.2+<.<a|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
-|metricsConfig          1.2+<.<|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
+|metricsConfig          1.2+<.<a|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
 |xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`]
 |====
 
@@ -2943,15 +2943,15 @@ include::../api/io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpec.adoc[lev
 [options="header"]
 |====
 |Property                 |Description
-|alias             1.2+<.<|Alias used to reference the Kafka cluster.
+|alias             1.2+<.<a|Alias used to reference the Kafka cluster.
 |string
-|bootstrapServers  1.2+<.<|A comma-separated list of `host:port` pairs for establishing the connection to the Kafka cluster.
+|bootstrapServers  1.2+<.<a|A comma-separated list of `host:port` pairs for establishing the connection to the Kafka cluster.
 |string
-|tls               1.2+<.<|TLS configuration for connecting MirrorMaker 2.0 connectors to a cluster.
+|tls               1.2+<.<a|TLS configuration for connecting MirrorMaker 2.0 connectors to a cluster.
 |xref:type-KafkaMirrorMaker2Tls-{context}[`KafkaMirrorMaker2Tls`]
-|authentication    1.2+<.<|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
+|authentication    1.2+<.<a|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
-|config            1.2+<.<|The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
+|config            1.2+<.<a|The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
 |====
 
@@ -2964,7 +2964,7 @@ Used in: xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2Clus
 [options="header"]
 |====
 |Property                    |Description
-|trustedCertificates  1.2+<.<|Trusted certificates for TLS connection.
+|trustedCertificates  1.2+<.<a|Trusted certificates for TLS connection.
 |xref:type-CertSecretSource-{context}[`CertSecretSource`] array
 |====
 
@@ -2977,23 +2977,23 @@ Used in: xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`]
 [options="header"]
 |====
 |Property                       |Description
-|sourceCluster           1.2+<.<|The alias of the source cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
+|sourceCluster           1.2+<.<a|The alias of the source cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
 |string
-|targetCluster           1.2+<.<|The alias of the target cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
+|targetCluster           1.2+<.<a|The alias of the target cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
 |string
-|sourceConnector         1.2+<.<|The specification of the Kafka MirrorMaker 2.0 source connector.
+|sourceConnector         1.2+<.<a|The specification of the Kafka MirrorMaker 2.0 source connector.
 |xref:type-KafkaMirrorMaker2ConnectorSpec-{context}[`KafkaMirrorMaker2ConnectorSpec`]
-|heartbeatConnector      1.2+<.<|The specification of the Kafka MirrorMaker 2.0 heartbeat connector.
+|heartbeatConnector      1.2+<.<a|The specification of the Kafka MirrorMaker 2.0 heartbeat connector.
 |xref:type-KafkaMirrorMaker2ConnectorSpec-{context}[`KafkaMirrorMaker2ConnectorSpec`]
-|checkpointConnector     1.2+<.<|The specification of the Kafka MirrorMaker 2.0 checkpoint connector.
+|checkpointConnector     1.2+<.<a|The specification of the Kafka MirrorMaker 2.0 checkpoint connector.
 |xref:type-KafkaMirrorMaker2ConnectorSpec-{context}[`KafkaMirrorMaker2ConnectorSpec`]
-|topicsPattern           1.2+<.<|A regular expression matching the topics to be mirrored, for example, "topic1\|topic2\|topic3". Comma-separated lists are also supported.
+|topicsPattern           1.2+<.<a|A regular expression matching the topics to be mirrored, for example, "topic1\|topic2\|topic3". Comma-separated lists are also supported.
 |string
-|topicsBlacklistPattern  1.2+<.<|A regular expression matching the topics to exclude from mirroring. Comma-separated lists are also supported.
+|topicsBlacklistPattern  1.2+<.<a|A regular expression matching the topics to exclude from mirroring. Comma-separated lists are also supported.
 |string
-|groupsPattern           1.2+<.<|A regular expression matching the consumer groups to be mirrored. Comma-separated lists are also supported.
+|groupsPattern           1.2+<.<a|A regular expression matching the consumer groups to be mirrored. Comma-separated lists are also supported.
 |string
-|groupsBlacklistPattern  1.2+<.<|A regular expression matching the consumer groups to exclude from mirroring. Comma-separated lists are also supported.
+|groupsBlacklistPattern  1.2+<.<a|A regular expression matching the consumer groups to exclude from mirroring. Comma-separated lists are also supported.
 |string
 |====
 
@@ -3006,11 +3006,11 @@ Used in: xref:type-KafkaMirrorMaker2MirrorSpec-{context}[`KafkaMirrorMaker2Mirro
 [options="header"]
 |====
 |Property         |Description
-|tasksMax  1.2+<.<|The maximum number of tasks for the Kafka Connector.
+|tasksMax  1.2+<.<a|The maximum number of tasks for the Kafka Connector.
 |integer
-|config    1.2+<.<|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
+|config    1.2+<.<a|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
 |map
-|pause     1.2+<.<|Whether the connector should be paused. Defaults to false.
+|pause     1.2+<.<a|Whether the connector should be paused. Defaults to false.
 |boolean
 |====
 
@@ -3023,19 +3023,19 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 [options="header"]
 |====
 |Property                   |Description
-|conditions          1.2+<.<|List of status conditions.
+|conditions          1.2+<.<a|List of status conditions.
 |xref:type-Condition-{context}[`Condition`] array
-|observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
+|observedGeneration  1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
 |integer
-|url                 1.2+<.<|The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
+|url                 1.2+<.<a|The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
 |string
-|connectorPlugins    1.2+<.<|The list of connector plugins available in this Kafka Connect deployment.
+|connectorPlugins    1.2+<.<a|The list of connector plugins available in this Kafka Connect deployment.
 |xref:type-ConnectorPlugin-{context}[`ConnectorPlugin`] array
-|connectors          1.2+<.<|List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.
+|connectors          1.2+<.<a|List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.
 |map array
-|labelSelector       1.2+<.<|Label selector for pods providing this resource.
+|labelSelector       1.2+<.<a|Label selector for pods providing this resource.
 |string
-|replicas            1.2+<.<|The current number of pods being used to provide this resource.
+|replicas            1.2+<.<a|The current number of pods being used to provide this resource.
 |integer
 |====
 
@@ -3046,9 +3046,9 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 [options="header"]
 |====
 |Property       |Description
-|spec    1.2+<.<|The specification of the Kafka rebalance.
+|spec    1.2+<.<a|The specification of the Kafka rebalance.
 |xref:type-KafkaRebalanceSpec-{context}[`KafkaRebalanceSpec`]
-|status  1.2+<.<|The status of the Kafka rebalance.
+|status  1.2+<.<a|The status of the Kafka rebalance.
 |xref:type-KafkaRebalanceStatus-{context}[`KafkaRebalanceStatus`]
 |====
 
@@ -3061,21 +3061,21 @@ Used in: xref:type-KafkaRebalance-{context}[`KafkaRebalance`]
 [options="header"]
 |====
 |Property                                        |Description
-|goals                                    1.2+<.<|A list of goals, ordered by decreasing priority, to use for generating and executing the rebalance proposal. The supported goals are available at https://github.com/linkedin/cruise-control#goals. If an empty goals list is provided, the goals declared in the default.goals Cruise Control configuration parameter are used.
+|goals                                    1.2+<.<a|A list of goals, ordered by decreasing priority, to use for generating and executing the rebalance proposal. The supported goals are available at https://github.com/linkedin/cruise-control#goals. If an empty goals list is provided, the goals declared in the default.goals Cruise Control configuration parameter are used.
 |string array
-|skipHardGoalCheck                        1.2+<.<|Whether to allow the hard goals specified in the Kafka CR to be skipped in optimization proposal generation. This can be useful when some of those hard goals are preventing a balance solution being found. Default is false.
+|skipHardGoalCheck                        1.2+<.<a|Whether to allow the hard goals specified in the Kafka CR to be skipped in optimization proposal generation. This can be useful when some of those hard goals are preventing a balance solution being found. Default is false.
 |boolean
-|excludedTopics                           1.2+<.<|A regular expression where any matching topics will be excluded from the calculation of optimization proposals. This expression will be parsed by the java.util.regex.Pattern class; for more information on the supported formar consult the documentation for that class.
+|excludedTopics                           1.2+<.<a|A regular expression where any matching topics will be excluded from the calculation of optimization proposals. This expression will be parsed by the java.util.regex.Pattern class; for more information on the supported formar consult the documentation for that class.
 |string
-|concurrentPartitionMovementsPerBroker    1.2+<.<|The upper bound of ongoing partition replica movements going into/out of each broker. Default is 5.
+|concurrentPartitionMovementsPerBroker    1.2+<.<a|The upper bound of ongoing partition replica movements going into/out of each broker. Default is 5.
 |integer
-|concurrentIntraBrokerPartitionMovements  1.2+<.<|The upper bound of ongoing partition replica movements between disks within each broker. Default is 2.
+|concurrentIntraBrokerPartitionMovements  1.2+<.<a|The upper bound of ongoing partition replica movements between disks within each broker. Default is 2.
 |integer
-|concurrentLeaderMovements                1.2+<.<|The upper bound of ongoing partition leadership movements. Default is 1000.
+|concurrentLeaderMovements                1.2+<.<a|The upper bound of ongoing partition leadership movements. Default is 1000.
 |integer
-|replicationThrottle                      1.2+<.<|The upper bound, in bytes per second, on the bandwidth used to move replicas. There is no limit by default.
+|replicationThrottle                      1.2+<.<a|The upper bound, in bytes per second, on the bandwidth used to move replicas. There is no limit by default.
 |integer
-|replicaMovementStrategies                1.2+<.<|A list of strategy class names used to determine the execution order for the replica movements in the generated optimization proposal. By default BaseReplicaMovementStrategy is used, which will execute the replica movements in the order that they were generated.
+|replicaMovementStrategies                1.2+<.<a|A list of strategy class names used to determine the execution order for the replica movements in the generated optimization proposal. By default BaseReplicaMovementStrategy is used, which will execute the replica movements in the order that they were generated.
 |string array
 |====
 
@@ -3088,13 +3088,13 @@ Used in: xref:type-KafkaRebalance-{context}[`KafkaRebalance`]
 [options="header"]
 |====
 |Property                   |Description
-|conditions          1.2+<.<|List of status conditions.
+|conditions          1.2+<.<a|List of status conditions.
 |xref:type-Condition-{context}[`Condition`] array
-|observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
+|observedGeneration  1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
 |integer
-|sessionId           1.2+<.<|The session identifier for requests to Cruise Control pertaining to this KafkaRebalance resource. This is used by the Kafka Rebalance operator to track the status of ongoing rebalancing operations.
+|sessionId           1.2+<.<a|The session identifier for requests to Cruise Control pertaining to this KafkaRebalance resource. This is used by the Kafka Rebalance operator to track the status of ongoing rebalancing operations.
 |string
-|optimizationResult  1.2+<.<|A JSON object describing the optimization result.
+|optimizationResult  1.2+<.<a|A JSON object describing the optimization result.
 |map
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -304,7 +304,7 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 * `InternalIP`
 * `Hostname`
 
-This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener.
+This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
 |string (one of [ExternalDNS, ExternalIP, Hostname, InternalIP, InternalDNS])
 |useServiceDnsDomain           1.2+<.<a|Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` type listener.
 |boolean

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -85,7 +85,7 @@ spec:
                               - loadbalancer
                               - nodeport
                               - ingress
-                            description: "Type of the listener. Currently the supported types are `internal`, `route`, `loadbalancer`, `nodeport` and `ingress`. \n\n* `internal` type exposes Kafka internally only within the Kubernetes cluster.\n* `route` type uses OpenShift Routes to expose Kafka.\n* `loadbalancer` type uses LoadBalancer type services to expose Kafka.\n* `nodeport` type uses NodePort type services to expose Kafka.\n* `ingress` type uses Kubernetes Nginx Ingress to expose Kafka.\n."
+                            description: "Type of the listener. Currently the supported types are `internal`, `route`, `loadbalancer`, `nodeport` and `ingress`. \n\n* `internal` type exposes Kafka internally only within the Kubernetes cluster.\n* `route` type uses OpenShift Routes to expose Kafka.\n* `loadbalancer` type uses LoadBalancer type services to expose Kafka.\n* `nodeport` type uses NodePort type services to expose Kafka.\n* `ingress` type uses Kubernetes Nginx Ingress to expose Kafka.\n"
                           tls:
                             type: boolean
                             description: Enables TLS encryption on the listener. This is a required property.
@@ -323,7 +323,7 @@ spec:
                                   * `InternalIP`
                                   * `Hostname`
 
-                                  This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener..
+                                  This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener.
                               useServiceDnsDomain:
                                 type: boolean
                                 description: Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` type listener.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -323,7 +323,7 @@ spec:
                                   * `InternalIP`
                                   * `Hostname`
 
-                                  This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener.
+                                  This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
                               useServiceDnsDomain:
                                 type: boolean
                                 description: Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` type listener.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -105,7 +105,7 @@ spec:
                             \ type uses LoadBalancer type services to expose Kafka.\n\
                             * `nodeport` type uses NodePort type services to expose\
                             \ Kafka.\n* `ingress` type uses Kubernetes Nginx Ingress\
-                            \ to expose Kafka.\n."
+                            \ to expose Kafka.\n"
                         tls:
                           type: boolean
                           description: Enables TLS encryption on the listener. This
@@ -510,7 +510,7 @@ spec:
                                 * `InternalIP`
                                 * `Hostname`
 
-                                This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener..
+                                This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener.
                             useServiceDnsDomain:
                               type: boolean
                               description: Configures whether the Kubernetes service

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -510,7 +510,7 @@ spec:
                                 * `InternalIP`
                                 * `Hostname`
 
-                                This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order.This field can be used only with `nodeport` type listener.
+                                This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
                             useServiceDnsDomain:
                               type: boolean
                               description: Configures whether the Kubernetes service


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR fixes some issues in the APi reference documentation:

* It fixes the way we check for `.` at the end of the description to work fine with multiline descriptions. In thepast, we had two places where this generated `..` at the end of the description. This should be now fixed by using the `DOTALL` flag in the Java pattern matcher.
* It enabled asciidoc formatting in the schema tables. That was disabled in the past and as result, it was not formatting for example lists properly. See the example of this before this change:
    ![Screenshot 2021-04-16 at 13 52 07](https://user-images.githubusercontent.com/5658439/115020825-6d043f80-9ebb-11eb-8036-d2c12b1f7019.png)
  and after this change:
    ![Screenshot 2021-04-16 at 13 51 33](https://user-images.githubusercontent.com/5658439/115020849-755c7a80-9ebb-11eb-966a-d7a08b7c3506.png)


These are not major issues. But it makes the docs little bit better.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Supply screenshots for visual changes, such as Grafana dashboards