### PR TITLE
[MO] - [checkstyle] -> able to run it via intelij checkstyle plugin

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -3,7 +3,7 @@
         "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
         "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
-<module name = "Checker">
+<module name="Checker">
 
     <property name="localeLanguage" value="en"/>
 
@@ -11,14 +11,18 @@
 
     <!-- header -->
     <module name="RegexpHeader">
-        <property name="headerFile" value="${checkstyle.header.file}"/>
+        <!--
+            /*
+             * Copyright Strimzi authors.
+             * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+             */
+         -->
+        <property name="header" value="^\/\*$\n^\s\*\sCopyright\sStrimzi\sauthors\.$\n^\s\*\sLicense:\sApache\sLicense\s2\.0\s\(see\sthe\sfile\sLICENSE\sor\shttp:\/\/apache\.org\/licenses\/LICENSE-2\.0\.html\)\.$\n^\s\*\/$"/>
         <property name="fileExtensions" value="java"/>
     </module>
 
-    <module name="SuppressWarningsFilter" />
-
+    <module name="SuppressWarningsFilter"/>
     <module name="TreeWalker">
-
         <!-- code cleanup -->
         <module name="UnusedImports">
             <property name="processJavadoc" value="true" />

--- a/.checkstyle/java.header
+++ b/.checkstyle/java.header
@@ -1,4 +1,0 @@
-^/\*
-^ \* Copyright Strimzi authors.
-^ \* License: Apache License 2\.0 \(see the file LICENSE or http://apache\.org/licenses/LICENSE-2\.0\.html\)\.
-^ \*/

--- a/pom.xml
+++ b/pom.xml
@@ -900,7 +900,6 @@
                         <phase>validate</phase>
                         <configuration>
                             <configLocation>.checkstyle/checkstyle.xml</configLocation>
-                            <headerLocation>.checkstyle/java.header</headerLocation>
                             <suppressionsLocation>.checkstyle/suppressions.xml</suppressionsLocation>
                             <includeTestSourceDirectory>true</includeTestSourceDirectory>
                             <encoding>UTF-8</encoding>


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR removing `java.header` file and improving regex for the header. Moreover, everyone is able to set up checkstyle plugin and see problems in a real-time when editing code. 

For instance:
![image](https://user-images.githubusercontent.com/30839163/115055462-be272a00-9ee1-11eb-8026-9fe55a1417f1.png)
![image](https://user-images.githubusercontent.com/30839163/115055502-c8e1bf00-9ee1-11eb-9084-492603fc9671.png)

The problem was that with in that `java.header` file was an issue with parsing regex inside that file. I tried to escape the `\{` and `\}` but it does not work. So I added regex inside value attribute and it works.  

<img width="948" alt="image" src="https://user-images.githubusercontent.com/30839163/115055603-f169b900-9ee1-11eb-95f3-370892f25311.png">.