### PR TITLE
Fix linux SED command in dev docs

### DIFF
--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -56,6 +56,7 @@ To build Strimzi from a source the operator and Kafka code needs to be compiled 
    sed -Ei -e "s#(image|value): quay.io/strimzi/([a-z0-9-]+):latest#\1: $DOCKER_REGISTRY/$DOCKER_ORG/\2:latest#" \
             -e "s#(image|value): quay.io/strimzi/([a-zA-Z0-9-]+:[0-9.]+)#\1: $DOCKER_REGISTRY/$DOCKER_ORG/\2#" \
             -e "s#([0-9.]+)=quay.io/strimzi/([a-zA-Z0-9-]+:[a-zA-Z0-9.-]+-kafka-[0-9.]+)#\1=$DOCKER_REGISTRY/$DOCKER_ORG/\2#" \
+            packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
     ```
    
     **OS X**


### PR DESCRIPTION
### Type of change

Documentation

### Description

The SED command for Linux in the dev docs is missing the install yaml file reference. This PR adds the file path back in.

