### PR TITLE
Update to Fabric8 Kubernetes Client 5.3.0

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/ApiEvolutionCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/ApiEvolutionCrdIT.java
@@ -11,7 +11,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.V1ApiextensionsAPIGroupClient;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.Crds;
@@ -125,14 +124,14 @@ public class ApiEvolutionCrdIT extends AbstractCrdIT {
             assertIsListListener(v1beta2Get(nameC));
 
             LOGGER.info("Phase 2 : Updating CRD so v1beta1 has served=false");
-            CustomResourceDefinition crdPhase2Part2 = cluster.client().getClient().customResourceDefinitions()
+            CustomResourceDefinition crdPhase2Part2 = cluster.client().getClient().apiextensions().v1beta1().customResourceDefinitions()
                     .createOrReplace(new CustomResourceDefinitionBuilder(crdPhase2).editSpec()
                             .editLastVersion().withServed(false).endVersion().endSpec().build());
 
             CustomResourceDefinition crdPhase2Part3 = waitForCrdUpdate(crdPhase2Part2.getMetadata().getGeneration());
 
             LOGGER.info("Phase 2 : Updating CRD status.stored versions = v1beta2");
-            CustomResourceDefinition crdPhase2Part4 = cluster.client().getClient().customResourceDefinitions()
+            CustomResourceDefinition crdPhase2Part4 = cluster.client().getClient().apiextensions().v1beta1().customResourceDefinitions()
                     .updateStatus(new CustomResourceDefinitionBuilder(crdPhase2Part3).editStatus().withStoredVersions(asList("v1beta2")).endStatus().build());
 
             assertEquals(asList("v1beta2"), crdPhase2Part4.getStatus().getStoredVersions());
@@ -201,10 +200,10 @@ public class ApiEvolutionCrdIT extends AbstractCrdIT {
 
     private CustomResourceDefinition waitForCrdUpdate(long crdGeneration2) {
         TestUtils.waitFor("CRD update", 1000, 30000, () ->
-                crdGeneration2 == cluster.client().getClient().customResourceDefinitions()
+                crdGeneration2 == cluster.client().getClient().apiextensions().v1beta1().customResourceDefinitions()
                         .withName("kafkas.kafka.strimzi.io").get()
                         .getMetadata().getGeneration());
-        return cluster.client().getClient().customResourceDefinitions()
+        return cluster.client().getClient().apiextensions().v1beta1().customResourceDefinitions()
                 .withName("kafkas.kafka.strimzi.io").get();
     }
 
@@ -252,7 +251,7 @@ public class ApiEvolutionCrdIT extends AbstractCrdIT {
         @Override
         public CustomResourceDefinition createOrReplace() throws IOException {
             CustomResourceDefinition build = build();
-            return cluster.client().getClient().customResourceDefinitions()
+            return cluster.client().getClient().apiextensions().v1beta1().customResourceDefinitions()
                     .createOrReplace(build);
         }
 
@@ -275,7 +274,7 @@ public class ApiEvolutionCrdIT extends AbstractCrdIT {
 
         @Override
         public io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition createOrReplace() throws IOException {
-            return cluster.client().getClient().adapt(V1ApiextensionsAPIGroupClient.class).customResourceDefinitions()
+            return cluster.client().getClient().apiextensions().v1().customResourceDefinitions()
                     .createOrReplace(build());
         }
     }
@@ -283,13 +282,13 @@ public class ApiEvolutionCrdIT extends AbstractCrdIT {
     private void deleteCrd() {
         KubernetesClientException ex = null;
         try {
-            cluster.client().getClient().customResourceDefinitions()
+            cluster.client().getClient().apiextensions().v1beta1().customResourceDefinitions()
                     .withName("kafkas.kafka.strimzi.io")
                     .delete();
         } catch (KubernetesClientException e) {
             ex = e;
             try {
-                cluster.client().getClient().adapt(V1ApiextensionsAPIGroupClient.class).customResourceDefinitions()
+                cluster.client().getClient().apiextensions().v1().customResourceDefinitions()
                         .withName("kafkas.kafka.strimzi.io")
                         .delete();
             } catch (KubernetesClientException e2) {

--- a/api/src/test/java/io/strimzi/api/kafka/model/StructuralCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/StructuralCrdIT.java
@@ -73,7 +73,7 @@ public class StructuralCrdIT extends AbstractCrdIT {
 
     private void assertApiVersionsAreStructural(String api, ApiVersion crdApiVersion, VersionRange<ApiVersion> shouldBeStructural) {
         Pattern pattern = Pattern.compile("[^.]spec\\.versions\\[([0-9]+)\\]\\.[^,]*?");
-        CustomResourceDefinition crd = cluster.client().getClient().customResourceDefinitions().withName(api).get();
+        CustomResourceDefinition crd = cluster.client().getClient().apiextensions().v1beta1().customResourceDefinitions().withName(api).get();
         // We can't make the following assertion because the current version of fabric8 always requests
         // the CRD using v1beta1 api version, so the apiserver just replaces it and serves it.
         //assertEquals(crdApiVersion, ApiVersion.parse(crd.getApiVersion().replace("apiextensions.k8s.io/", "")));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -13,7 +13,6 @@ import io.fabric8.kubernetes.client.dsl.FilterWatchListMultiDeletable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
@@ -146,8 +145,7 @@ public class ClusterOperatorTest {
             when(mockResource.get()).thenReturn(null);
         }
         when(mockCrds.withName(KafkaConnectS2I.CRD_NAME)).thenReturn(mockResource);
-        when(client.customResourceDefinitions()).thenReturn(mockCrds);
-        when(client.customResources(any(CustomResourceDefinitionContext.class), any(), any())).thenReturn(mockCms);
+        when(client.customResources(any(), any())).thenReturn(mockCms);
 
         List<String> namespaceList = asList(namespaces.split(" *,+ *"));
         for (String namespace: namespaceList) {
@@ -228,8 +226,7 @@ public class ClusterOperatorTest {
             when(mockResource.get()).thenReturn(null);
         }
         when(mockCrds.withName(KafkaConnectS2I.CRD_NAME)).thenReturn(mockResource);
-        when(client.customResourceDefinitions()).thenReturn(mockCrds);
-        when(client.customResources(any(CustomResourceDefinitionContext.class), any(), any())).thenReturn(mockCms);
+        when(client.customResources(any(), any())).thenReturn(mockCms);
 
         FilterWatchListMultiDeletable mockFilteredCms = mock(FilterWatchListMultiDeletable.class);
         when(mockFilteredCms.withLabels(any())).thenReturn(mockFilteredCms);

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
@@ -295,9 +295,7 @@ class MockBuilder<T extends HasMetadata,
         });
         mockDelete(resourceName, resource);
         mockIsReady(resourceName, resource);
-        //if (Readiness.isReadinessApplicable(resourceTypeClass)) {
-        //    mockIsReady(resourceName, resource);
-        //}
+
         try {
             when(resource.waitUntilCondition(any(), anyLong(), any())).thenAnswer(i -> {
                 Predicate<T> p = i.getArgument(0);

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
@@ -16,7 +16,6 @@ import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.mockito.ArgumentMatchers;
@@ -295,9 +294,10 @@ class MockBuilder<T extends HasMetadata,
             return doPatch(t.getMetadata().getName(), resource, (T) f.apply(t));
         });
         mockDelete(resourceName, resource);
-        if (Readiness.isReadinessApplicable(resourceTypeClass)) {
-            mockIsReady(resourceName, resource);
-        }
+        mockIsReady(resourceName, resource);
+        //if (Readiness.isReadinessApplicable(resourceTypeClass)) {
+        //    mockIsReady(resourceName, resource);
+        //}
         try {
             when(resource.waitUntilCondition(any(), anyLong(), any())).thenAnswer(i -> {
                 Predicate<T> p = i.getArgument(0);

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
@@ -302,7 +302,7 @@ public class MockKube {
                 Resource crdResource = mock(Resource.class);
                 when(crdResource.get()).thenReturn(crd);
                 when(crds.withName(crd.getMetadata().getName())).thenReturn(crdResource);
-                String key = crdKey(CustomResourceDefinitionContext.fromCrd(crd));
+                String key = crdKey(mockedCrd.crClass);
                 CreateOrReplaceable crdMixedOp = crdMixedOps.get(key);
                 if (crdMixedOp == null) {
                     CustomResourceMockBuilder customResourceMockBuilder = addMockBuilder(crd.getSpec().getNames().getPlural(), new CustomResourceMockBuilder<>((MockedCrd) mockedCrd));
@@ -369,8 +369,8 @@ public class MockKube {
         return mockClient;
     }
 
-    public String crdKey(CustomResourceDefinitionContext crdc) {
-        return crdc.getGroup() + "##" + crdc.getVersion() + "##" + crdc.getKind();
+    public <T extends CustomResource> String crdKey(Class<T> crClass) {
+        return crClass.getName();
     }
 
     @SuppressWarnings({"unchecked", "deprecation"})
@@ -378,23 +378,22 @@ public class MockKube {
         when(mockClient.customResources(any(CustomResourceDefinitionContext.class),
                 any(Class.class),
                 any(Class.class))).thenAnswer(invocation -> {
-                    CustomResourceDefinitionContext crdArg = invocation.getArgument(0);
-                    String key = crdKey(crdArg);
+                    Class<CustomResource> crClass = invocation.getArgument(1);
+                    String key = crdKey(crClass);
                     CreateOrReplaceable createOrReplaceable = crdMixedOps.get(key);
                     if (createOrReplaceable == null) {
-                        throw new RuntimeException("Unknown CRD " + invocation.getArgument(0));
+                        throw new RuntimeException("Unknown CRD " + key);
                     }
                     return createOrReplaceable;
                 });
 
-        when(mockClient.customResources(any(CustomResourceDefinition.class),
-                any(Class.class),
-                any(Class.class))).thenAnswer(invocation -> {
-                    CustomResourceDefinition crdArg = invocation.getArgument(0);
-                    String key = crdKey(CustomResourceDefinitionContext.fromCrd(crdArg));
+        when(mockClient.customResources(any(Class.class), any(Class.class)))
+                .thenAnswer(invocation -> {
+                    Class<CustomResource> crClass = invocation.getArgument(0);
+                    String key = crdKey(crClass);
                     CreateOrReplaceable createOrReplaceable = crdMixedOps.get(key);
                     if (createOrReplaceable == null) {
-                        throw new RuntimeException("Unknown CRD " + invocation.getArgument(0));
+                        throw new RuntimeException("Unknown CRD " + key);
                     }
                     return createOrReplaceable;
                 });

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractReadyResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractReadyResourceOperator.java
@@ -52,13 +52,6 @@ public abstract class AbstractReadyResourceOperator<C extends KubernetesClient,
         T resource = resourceOp.get();
         if (resource != null)   {
             return Boolean.TRUE.equals(resourceOp.isReady());
-            /*if (Readiness.isReadinessApplicable(resource.getClass())) {
-                return Boolean.TRUE.equals(resourceOp.isReady());
-            } else {
-                log.warn("Method isReady was called on resource {} of kind {} on which readiness is not applicable.",
-                        resource.getMetadata().getName(), resource.getKind());
-                return true;
-            }*/
         } else {
             return false;
         }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractReadyResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractReadyResourceOperator.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
@@ -52,13 +51,14 @@ public abstract class AbstractReadyResourceOperator<C extends KubernetesClient,
         R resourceOp = operation().inNamespace(namespace).withName(name);
         T resource = resourceOp.get();
         if (resource != null)   {
-            if (Readiness.isReadinessApplicable(resource.getClass())) {
+            return Boolean.TRUE.equals(resourceOp.isReady());
+            /*if (Readiness.isReadinessApplicable(resource.getClass())) {
                 return Boolean.TRUE.equals(resourceOp.isReady());
             } else {
                 log.warn("Method isReady was called on resource {} of kind {} on which readiness is not applicable.",
                         resource.getMetadata().getName(), resource.getKind());
                 return true;
-            }
+            }*/
         } else {
             return false;
         }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -27,7 +27,6 @@ public class CrdOperator<C extends KubernetesClient,
 
     private final Class<T> cls;
     private final Class<L> listCls;
-    protected final CustomResourceDefinition crd;
 
     /**
      * Constructor
@@ -41,7 +40,6 @@ public class CrdOperator<C extends KubernetesClient,
         super(vertx, client, crd.getSpec().getNames().getKind());
         this.cls = cls;
         this.listCls = listCls;
-        this.crd = crd;
     }
 
     @Override

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -12,7 +12,6 @@ import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.strimzi.operator.common.Util;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
@@ -47,7 +46,7 @@ public class CrdOperator<C extends KubernetesClient,
 
     @Override
     protected MixedOperation<T, L, Resource<T>> operation() {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd), cls, listCls);
+        return client.customResources(cls, listCls);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
@@ -147,7 +147,7 @@ public class ServiceOperator extends AbstractResourceOperator<KubernetesClient, 
      * @param desired   Desired Service
      */
     protected void patchIpFamily(Service current, Service desired) {
-        desired.getSpec().setIpFamily(current.getSpec().getIpFamily());
+        desired.getSpec().setIpFamilies(current.getSpec().getIpFamilies());
     }
 
     /**

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractCustomResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractCustomResourceOperatorIT.java
@@ -64,7 +64,6 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
     protected static KubernetesClient client;
     private static KubeClusterResource cluster;
 
-
     protected abstract CrdOperator<C, T, L> operator();
     protected abstract CustomResourceDefinition getCrd();
     protected abstract String getNamespace();
@@ -72,7 +71,6 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
     protected abstract T getResourceWithModifications(T resourceInCluster);
     protected abstract T getResourceWithNewReadyStatus(T resourceInCluster);
     protected abstract void assertReady(VertxTestContext context, T modifiedCustomResource);
-
 
     @BeforeAll
     public void before() {
@@ -95,7 +93,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
         cmdKubeClient().waitForResourceCreation("Namespace", namespace);
 
         log.info("Creating CRD");
-        client.customResourceDefinitions().createOrReplace(getCrd());
+        client.apiextensions().v1beta1().customResourceDefinitions().createOrReplace(getCrd());
         log.info("Created CRD");
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractReadyResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractReadyResourceOperatorTest.java
@@ -10,9 +10,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.internal.readiness.Readiness;
-import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.internal.readiness.OpenShiftReadiness;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxTestContext;
@@ -137,15 +134,16 @@ public abstract class AbstractReadyResourceOperatorTest<C extends KubernetesClie
         Checkpoint async = context.checkpoint();
         op.readiness(NAMESPACE, RESOURCE_NAME, 20, 5_000)
             .onComplete(context.succeeding(v -> {
-                if (clientType() == OpenShiftClient.class)    {
+                /*if (clientType() == OpenShiftClient.class)    {
                     verify(mockResource, times(OpenShiftReadiness.isReadinessApplicable(resource.getClass()) ? unreadyCount + 1 : 1)).get();
                 } else {
                     verify(mockResource, times(Readiness.isReadinessApplicable(resource.getClass()) ? unreadyCount + 1 : 1)).get();
-                }
+                }*/
 
-                if (Readiness.isReadinessApplicable(resource.getClass())) {
+                verify(mockResource, times(unreadyCount + 1)).isReady();
+                /*if (Readiness.isReadinessApplicable(resource.getClass())) {
                     verify(mockResource, times(unreadyCount + 1)).isReady();
-                }
+                }*/
                 async.flag();
             }));
     }
@@ -155,9 +153,9 @@ public abstract class AbstractReadyResourceOperatorTest<C extends KubernetesClie
         T resource = resource();
 
         // This test does not apply to the resource types without the Ready field
-        if (!Readiness.isReadinessApplicable(resource.getClass()))  {
+        /*if (!Readiness.isReadinessApplicable(resource.getClass()))  {
             context.completeNow();
-        }
+        }*/
 
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
@@ -189,9 +187,9 @@ public abstract class AbstractReadyResourceOperatorTest<C extends KubernetesClie
         T resource = resource();
 
         // This test does not apply to the resource types without the Ready field
-        if (!Readiness.isReadinessApplicable(resource.getClass()))  {
+        /*if (!Readiness.isReadinessApplicable(resource.getClass()))  {
             context.completeNow();
-        }
+        }*/
 
         RuntimeException ex = new RuntimeException("This is a test exception");
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractReadyResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractReadyResourceOperatorTest.java
@@ -134,16 +134,7 @@ public abstract class AbstractReadyResourceOperatorTest<C extends KubernetesClie
         Checkpoint async = context.checkpoint();
         op.readiness(NAMESPACE, RESOURCE_NAME, 20, 5_000)
             .onComplete(context.succeeding(v -> {
-                /*if (clientType() == OpenShiftClient.class)    {
-                    verify(mockResource, times(OpenShiftReadiness.isReadinessApplicable(resource.getClass()) ? unreadyCount + 1 : 1)).get();
-                } else {
-                    verify(mockResource, times(Readiness.isReadinessApplicable(resource.getClass()) ? unreadyCount + 1 : 1)).get();
-                }*/
-
                 verify(mockResource, times(unreadyCount + 1)).isReady();
-                /*if (Readiness.isReadinessApplicable(resource.getClass())) {
-                    verify(mockResource, times(unreadyCount + 1)).isReady();
-                }*/
                 async.flag();
             }));
     }
@@ -151,11 +142,6 @@ public abstract class AbstractReadyResourceOperatorTest<C extends KubernetesClie
     @Test
     public void testWaitUntilReadyUnsuccessful(VertxTestContext context) {
         T resource = resource();
-
-        // This test does not apply to the resource types without the Ready field
-        /*if (!Readiness.isReadinessApplicable(resource.getClass()))  {
-            context.completeNow();
-        }*/
 
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
@@ -185,11 +171,6 @@ public abstract class AbstractReadyResourceOperatorTest<C extends KubernetesClie
     @Test
     public void testWaitUntilReadyThrows(VertxTestContext context) {
         T resource = resource();
-
-        // This test does not apply to the resource types without the Ready field
-        /*if (!Readiness.isReadinessApplicable(resource.getClass()))  {
-            context.completeNow();
-        }*/
 
         RuntimeException ex = new RuntimeException("This is a test exception");
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaList;
 import io.strimzi.api.kafka.model.Kafka;
@@ -72,7 +71,7 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
 
     @Override
     protected void mocker(KubernetesClient mockClient, MixedOperation op) {
-        when(mockClient.customResources(any(CustomResourceDefinitionContext.class), any(), any())).thenReturn(op);
+        when(mockClient.customResources(any(), any())).thenReturn(op);
     }
 
     @Override

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
@@ -200,7 +200,7 @@ public class ServiceOperatorTest extends AbstractResourceOperatorTest<Kubernetes
                                     .withTargetPort(new IntOrString(5678))
                                     .build()
                     )
-                    .withNewIpFamily("IPv6")
+                    .withIpFamilies("IPv6")
                 .endSpec()
                 .build();
 
@@ -223,7 +223,7 @@ public class ServiceOperatorTest extends AbstractResourceOperatorTest<Kubernetes
                                     .withTargetPort(new IntOrString(5678))
                                     .build()
                     )
-                    .withNewIpFamily("IPv6")
+                    .withIpFamilies("IPv6")
                 .endSpec()
                 .build();
 
@@ -252,7 +252,7 @@ public class ServiceOperatorTest extends AbstractResourceOperatorTest<Kubernetes
         ServiceOperator op = new ServiceOperator(vertx, client);
         op.patchIpFamily(current, desired);
 
-        assertThat(current.getSpec().getIpFamily(), is(desired.getSpec().getIpFamily()));
-        assertThat(current2.getSpec().getIpFamily(), is(desired.getSpec().getIpFamily()));
+        assertThat(current.getSpec().getIpFamilies(), is(desired.getSpec().getIpFamilies()));
+        assertThat(current2.getSpec().getIpFamilies(), is(desired.getSpec().getIpFamilies()));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -88,10 +88,10 @@
         <jacoco.version>0.7.9</jacoco.version>
         <license.maven.version>2.11</license.maven.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
-        <sundrio.version>0.24.2</sundrio.version>
-        <fabric8.kubernetes-client.version>5.0.2</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>5.0.2</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>5.0.2</fabric8.kubernetes-model.version>
+        <sundrio.version>0.30.0</sundrio.version>
+        <fabric8.kubernetes-client.version>5.3.0</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>5.3.0</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>5.3.0</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <okhttp.version>3.12.6</okhttp.version>
         <okio.version>1.15.0</okio.version>

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -7,8 +7,6 @@ package io.strimzi.test.k8s;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Event;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
@@ -30,6 +28,8 @@ import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.VersionInfo;
@@ -676,12 +676,12 @@ public class KubeClient {
 
     @SuppressWarnings("deprecation")
     public List<Event> listEvents() {
-        return client.events().inNamespace(getNamespace()).list().getItems();
+        return client.v1().events().inNamespace(getNamespace()).list().getItems();
     }
 
     @SuppressWarnings("deprecation")
     public List<Event> listEvents(String resourceType, String resourceName) {
-        return client.events().inNamespace(getNamespace()).list().getItems().stream()
+        return client.v1().events().inNamespace(getNamespace()).list().getItems().stream()
                 .filter(event -> event.getInvolvedObject().getKind().equals(resourceType))
                 .filter(event -> event.getInvolvedObject().getName().equals(resourceName))
                 .collect(Collectors.toList());
@@ -742,8 +742,8 @@ public class KubeClient {
         client.rbac().roleBindings().inNamespace(getNamespace()).withName(name).delete();
     }
 
-    public <T extends HasMetadata, L extends KubernetesResourceList<T>> MixedOperation<T, L, Resource<T>> customResources(CustomResourceDefinitionContext crdContext, Class<T> resourceType, Class<L> listClass) {
-        return client.customResources(crdContext, resourceType, listClass); //TODO namespace here
+    public <T extends CustomResource, L extends CustomResourceList<T>> MixedOperation<T, L, Resource<T>> customResources(CustomResourceDefinitionContext crdContext, Class<T> resourceType, Class<L> listClass) {
+        return client.customResources(resourceType, listClass); //TODO namespace here
     }
 
     // =========================

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -31,10 +31,6 @@
             <artifactId>kubernetes-model-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model-apiextensions</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
@@ -10,7 +10,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.KafkaTopic;
@@ -110,7 +109,7 @@ public class K8sImpl implements K8s {
     }
 
     private MixedOperation<KafkaTopic, KafkaTopicList, Resource<KafkaTopic>> operation() {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(Crds.kafkaTopic()), KafkaTopic.class, KafkaTopicList.class);
+        return client.customResources(KafkaTopic.class, KafkaTopicList.class);
     }
 
     @Override
@@ -126,7 +125,6 @@ public class K8sImpl implements K8s {
     /**
      * Create the given k8s event
      */
-    @SuppressWarnings("deprecation")
     @Override
     public Future<Void> createEvent(Event event) {
         Promise<Void> handler = Promise.promise();
@@ -134,7 +132,7 @@ public class K8sImpl implements K8s {
             try {
                 try {
                     LOGGER.debug("Creating event {}", event);
-                    client.events().inNamespace(namespace).create(event);
+                    client.v1().events().inNamespace(namespace).create(event);
                 } catch (KubernetesClientException e) {
                     LOGGER.error("Error creating event {}", event, e);
                 }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -7,9 +7,7 @@ package io.strimzi.operator.topic;
 import io.apicurio.registry.utils.ConcurrentUtil;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.operator.common.MicrometerMetricsProvider;
@@ -270,7 +268,7 @@ public class Session extends AbstractVerticle {
         try {
             LOGGER.debug("Watching KafkaTopics matching {}", config.get(Config.LABELS).labels());
 
-            Session.this.topicWatch = kubeClient.customResources(CustomResourceDefinitionContext.fromCrd(Crds.kafkaTopic()), KafkaTopic.class, KafkaTopicList.class)
+            Session.this.topicWatch = kubeClient.customResources(KafkaTopic.class, KafkaTopicList.class)
                     .inNamespace(config.get(Config.NAMESPACE)).withLabels(config.get(Config.LABELS).labels()).watch(watcher);
             LOGGER.debug("Watching setup");
             promise.complete();

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
@@ -5,11 +5,9 @@
 package io.strimzi.operator.topic;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
@@ -58,8 +56,8 @@ public class K8sImplTest {
 
         KubernetesClient mockClient = mock(KubernetesClient.class);
         MixedOperation<KafkaTopic, KafkaTopicList, Resource<KafkaTopic>> mockResources = mock(MixedOperation.class);
-        when(mockClient.customResources(any(CustomResourceDefinitionContext.class), any(Class.class), any(Class.class))).thenReturn(mockResources);
-        when(mockClient.customResources(any(CustomResourceDefinition.class), any(Class.class), any(Class.class))).thenReturn(mockResources);
+        when(mockClient.customResources(any(Class.class), any(Class.class))).thenReturn(mockResources);
+        when(mockClient.customResources(any(Class.class), any(Class.class))).thenReturn(mockResources);
         when(mockResources.withLabels(any())).thenReturn(mockResources);
         when(mockResources.inNamespace(any())).thenReturn(mockResources);
         when(mockResources.list()).thenAnswer(invocation -> {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -185,7 +185,7 @@ public abstract class TopicOperatorBaseIT {
 
         // We can't delete events, so record the events which exist at the start of the test
         // and then waitForEvents() can ignore those
-        preExistingEvents = kubeClient.events().inNamespace(NAMESPACE).withLabels(labels.labels()).list().
+        preExistingEvents = kubeClient.v1().events().inNamespace(NAMESPACE).withLabels(labels.labels()).list().
                 getItems().stream().
                 map(evt -> evt.getMetadata().getUid()).
                 collect(Collectors.toSet());
@@ -580,7 +580,7 @@ public abstract class TopicOperatorBaseIT {
 
     protected void waitForEvent(KafkaTopic kafkaTopic, String expectedMessage, TopicOperator.EventType expectedType) throws InterruptedException, ExecutionException, TimeoutException {
         waitFor(() -> {
-            List<Event> items = kubeClient.events().inNamespace(NAMESPACE).withLabels(labels.labels()).list().getItems();
+            List<Event> items = kubeClient.v1().events().inNamespace(NAMESPACE).withLabels(labels.labels()).list().getItems();
             List<Event> filtered = items.stream().
                     filter(evt -> !preExistingEvents.contains(evt.getMetadata().getUid())
                             && "KafkaTopic".equals(evt.getInvolvedObject().getKind())


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR upgrades the Fabric8 Kubernetes Client to 5.3.0 and Sundrio to 0.30 (used also by the Fabric8 5.3.0).

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally