### PR TITLE
ST: Downgrade Strimzi without upgraded Kafka

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
@@ -30,7 +30,6 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
     private static List<TestKafkaVersion> kafkaVersions;
     private static List<TestKafkaVersion> supportedKafkaVersions;
 
-
     static {
         try {
             kafkaVersions = parseKafkaVersions(TestUtils.USER_PATH + "/../kafka-versions.yaml");
@@ -42,7 +41,7 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
                 throw new Exception("There is no one Kafka version supported inside " + TestUtils.USER_PATH + "/../kafka-versions.yaml file");
             }
 
-            LOGGER.debug("These are following supported Kafka versions:\n{}", kafkaVersions.toString());
+            LOGGER.debug("These are following Kafka versions:\n{}", kafkaVersions.toString());
             LOGGER.debug("These are following supported Kafka versions:\n{}", supportedKafkaVersions.toString());
         } catch (Exception e) {
             e.printStackTrace();

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
@@ -206,6 +206,6 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
 
     public static TestKafkaVersion getSpecificVersion(String kafkaVersion) {
         // One specific version will always be only once in the list
-        return kafkaVersions.stream().filter(it -> it.version == kafkaVersion).collect(Collectors.toList()).get(0);
+        return kafkaVersions.stream().filter(it -> it.version.equals(kafkaVersion)).collect(Collectors.toList()).get(0);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
@@ -28,20 +28,22 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
 
     private static final Logger LOGGER = LogManager.getLogger(TestKafkaVersion.class);
     private static List<TestKafkaVersion> kafkaVersions;
+    private static List<TestKafkaVersion> supportedKafkaVersions;
+
 
     static {
         try {
-            List<TestKafkaVersion> tmpKafkaVersions = parseKafkaVersions(TestUtils.USER_PATH + "/../kafka-versions.yaml");
-            List<TestKafkaVersion> supportedKafkaVersions = tmpKafkaVersions.stream().filter(TestKafkaVersion::isSupported).collect(Collectors.toList());
+            kafkaVersions = parseKafkaVersions(TestUtils.USER_PATH + "/../kafka-versions.yaml");
+            supportedKafkaVersions = kafkaVersions.stream().filter(TestKafkaVersion::isSupported).collect(Collectors.toList());
+            Collections.sort(kafkaVersions);
             Collections.sort(supportedKafkaVersions);
 
-            kafkaVersions = supportedKafkaVersions;
-
-            if (kafkaVersions == null || kafkaVersions.size() == 0) {
+            if (supportedKafkaVersions == null || supportedKafkaVersions.size() == 0) {
                 throw new Exception("There is no one Kafka version supported inside " + TestUtils.USER_PATH + "/../kafka-versions.yaml file");
             }
 
-            LOGGER.info("These are following supported Kafka versions:\n{}", kafkaVersions.toString());
+            LOGGER.debug("These are following supported Kafka versions:\n{}", kafkaVersions.toString());
+            LOGGER.debug("These are following supported Kafka versions:\n{}", supportedKafkaVersions.toString());
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -175,9 +177,14 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
         return kafkaVersions;
     }
 
+    public static List<TestKafkaVersion> getSupportedKafkaVersions() {
+        return supportedKafkaVersions;
+    }
+
     public static List<TestKafkaVersion> getKafkaVersions() {
         return kafkaVersions;
     }
+
 
     /**
      * Parse the version information present in the {@code /kafka-versions} classpath resource and return a map
@@ -195,5 +202,10 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
 
     public static boolean containsVersion(String kafkaVersion) {
         return kafkaVersions.stream().map(item -> item.version()).collect(Collectors.toList()).contains(kafkaVersion);
+    }
+
+    public static TestKafkaVersion getSpecificVersion(String kafkaVersion) {
+        // One specific version will always be only once in the list
+        return kafkaVersions.stream().filter(it -> it.version == kafkaVersion).collect(Collectors.toList()).get(0);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -22,6 +22,7 @@ import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.utils.TestKafkaVersion;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.test.TestUtils;
@@ -449,8 +450,8 @@ public class KafkaUtils {
                 ((ObjectNode) kafkaNode.get("config")).remove("inter.broker.protocol.version");
             } else if (!version.equals("")) {
                 kafkaNode.put("version", version);
-                ((ObjectNode) kafkaNode.get("config")).put("log.message.format.version", version.substring(0, 3));
-                ((ObjectNode) kafkaNode.get("config")).put("inter.broker.protocol.version", version.substring(0, 3));
+                ((ObjectNode) kafkaNode.get("config")).put("log.message.format.version", TestKafkaVersion.getSpecificVersion(version).messageVersion());
+                ((ObjectNode) kafkaNode.get("config")).put("inter.broker.protocol.version", TestKafkaVersion.getSpecificVersion(version).protocolVersion());
             }
             if (logMessageFormat != null) {
                 ((ObjectNode) kafkaNode.get("config")).put("log.message.format.version", logMessageFormat);

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectS2IST.java
@@ -592,7 +592,7 @@ class ConnectS2IST extends AbstractST {
                     .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
                 .endMetadata()
                 .editSpec()
-                    .withVersion(TestKafkaVersion.getKafkaVersions().get(0).version())
+                    .withVersion(TestKafkaVersion.getSupportedKafkaVersions().get(0).version())
                 .endSpec()
                 .build());
 
@@ -647,9 +647,9 @@ class ConnectS2IST extends AbstractST {
 
         LOGGER.info("===== CONNECTS2I VERSION CHANGE =====");
 
-        LOGGER.info("Setting version from {} to {}", TestKafkaVersion.getKafkaVersions().get(0).version(), TestKafkaVersion.getKafkaVersions().get(1).version());
+        LOGGER.info("Setting version from {} to {}", TestKafkaVersion.getSupportedKafkaVersions().get(0).version(), TestKafkaVersion.getSupportedKafkaVersions().get(1).version());
         KafkaConnectS2IResource.replaceConnectS2IResource(connectS2IClusterName,
-            kafkaConnectS2I -> kafkaConnectS2I.getSpec().setVersion(TestKafkaVersion.getKafkaVersions().get(1).version()));
+            kafkaConnectS2I -> kafkaConnectS2I.getSpec().setVersion(TestKafkaVersion.getSupportedKafkaVersions().get(1).version()));
 
         depConfSnapshot = DeploymentConfigUtils.waitTillDepConfigHasRolled(deploymentConfigName, depConfSnapshot);
 
@@ -658,7 +658,7 @@ class ConnectS2IST extends AbstractST {
         String actualVersion = cmdKubeClient().execInPodContainer(kubeClient().listPodNames(Labels.STRIMZI_KIND_LABEL, KafkaConnectS2I.RESOURCE_KIND).get(0),
                 "", "/bin/bash", "-c", versionCommand).out().trim();
 
-        assertThat(actualVersion, is(TestKafkaVersion.getKafkaVersions().get(1).version()));
+        assertThat(actualVersion, is(TestKafkaVersion.getSupportedKafkaVersions().get(1).version()));
 
         LOGGER.info("===== CONNECTS2I CERT CHANGE =====");
         InputStream secretInputStream = getClass().getClassLoader().getResourceAsStream("security-st-certs/expired-cluster-ca.crt");

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -412,7 +412,15 @@ public class AbstractUpgradeST extends AbstractST {
         if (!cmdKubeClient().getResources(getResourceApiVersion(Kafka.RESOURCE_PLURAL, operatorVersion)).contains(clusterName)) {
             // Deploy a Kafka cluster
             if ("HEAD".equals(testParameters.getString("fromVersion"))) {
-                resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, 3, 3).build());
+                resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, 3, 3)
+                    .editSpec()
+                        .editKafka()
+                            .withVersion(kafkaVersion)
+                            .addToConfig("log.message.format.version", kafkaVersion.substring(0, 3))
+                            .addToConfig("inter.broker.protocol.version", kafkaVersion.substring(0, 3))
+                        .endKafka()
+                    .endSpec()
+                    .build());
             } else {
                 kafkaYaml = new File(dir, testParameters.getString("fromExamples") + "/examples/kafka/kafka-persistent.yaml");
                 LOGGER.info("Going to deploy Kafka from: {}", kafkaYaml.getPath());

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -95,7 +95,7 @@ public class AbstractUpgradeST extends AbstractST {
         JsonArray upgradeData = readUpgradeJson(UPGRADE_JSON_FILE);
         List<Arguments> parameters = new LinkedList<>();
 
-        List<TestKafkaVersion> testKafkaVersions = TestKafkaVersion.getKafkaVersions();
+        List<TestKafkaVersion> testKafkaVersions = TestKafkaVersion.getSupportedKafkaVersions();
         TestKafkaVersion testKafkaVersion = testKafkaVersions.get(testKafkaVersions.size() - 1);
 
         upgradeData.forEach(jsonData -> {
@@ -120,7 +120,7 @@ public class AbstractUpgradeST extends AbstractST {
     }
 
     protected static Map<String, JsonObject> buildMidStepUpgradeData(JsonObject jsonData) {
-        List<TestKafkaVersion> testKafkaVersions = TestKafkaVersion.getKafkaVersions();
+        List<TestKafkaVersion> testKafkaVersions = TestKafkaVersion.getSupportedKafkaVersions();
         TestKafkaVersion testKafkaVersion = testKafkaVersions.get(testKafkaVersions.size() - 1);
 
         Map<String, JsonObject> steps = new HashMap<>();
@@ -207,7 +207,7 @@ public class AbstractUpgradeST extends AbstractST {
         kafkaYaml = new File(examplesPath + "/kafka/kafka-persistent.yaml");
         LOGGER.info("Going to deploy Kafka from: {}", kafkaYaml.getPath());
         // Change kafka version of it's empty (null is for remove the version)
-        String defaultValueForVersions = kafkaVersionFromCR == null ? null : kafkaVersionFromCR.substring(0, 3);
+        String defaultValueForVersions = kafkaVersionFromCR == null ? null : TestKafkaVersion.getSpecificVersion(kafkaVersionFromCR).messageVersion();
         cmdKubeClient().applyContent(KafkaUtils.changeOrRemoveKafkaConfiguration(kafkaYaml, kafkaVersionFromCR, defaultValueForVersions, defaultValueForVersions));
 
         kafkaUserYaml = new File(examplesPath + "/user/kafka-user.yaml");
@@ -416,8 +416,8 @@ public class AbstractUpgradeST extends AbstractST {
                     .editSpec()
                         .editKafka()
                             .withVersion(kafkaVersion)
-                            .addToConfig("log.message.format.version", kafkaVersion.substring(0, 3))
-                            .addToConfig("inter.broker.protocol.version", kafkaVersion.substring(0, 3))
+                            .addToConfig("log.message.format.version", TestKafkaVersion.getSpecificVersion(kafkaVersion).messageVersion())
+                            .addToConfig("inter.broker.protocol.version", TestKafkaVersion.getSpecificVersion(kafkaVersion).protocolVersion())
                         .endKafka()
                     .endSpec()
                     .build());

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
@@ -52,7 +52,7 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
 
     @IsolatedTest
     void testKafkaClusterUpgrade(ExtensionContext testContext) {
-        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getKafkaVersions();
+        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
 
         String clusterName = mapWithClusterNames.get(testContext.getDisplayName());
         String producerName = clusterName + "-producer";
@@ -77,7 +77,7 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
 
     @IsolatedTest
     void testKafkaClusterDowngrade(ExtensionContext testContext) {
-        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getKafkaVersions();
+        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
 
         String clusterName = mapWithClusterNames.get(testContext.getDisplayName());
         String producerName = clusterName + "-producer";
@@ -102,7 +102,7 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
 
     @IsolatedTest
     void testKafkaClusterDowngradeToOlderMessageFormat(ExtensionContext testContext) {
-        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getKafkaVersions();
+        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
 
         String clusterName = mapWithClusterNames.get(testContext.getDisplayName());
         String producerName = clusterName + "-producer";
@@ -140,7 +140,7 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
 
     @Test
     void testUpgradeWithNoMessageAndProtocolVersionsSet(ExtensionContext testContext) {
-        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getKafkaVersions();
+        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
 
         String clusterName = mapWithClusterNames.get(testContext.getDisplayName());
         String producerName = clusterName + "-producer";

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeST.java
@@ -67,7 +67,7 @@ public class OlmUpgradeST extends AbstractUpgradeST {
         JsonArray upgradeData = readUpgradeJson(UPGRADE_JSON_FILE);
         JsonObject latestUpgradeData = upgradeData.getJsonObject(upgradeData.size() - 1);
 
-        List<TestKafkaVersion> testKafkaVersions = TestKafkaVersion.getKafkaVersions();
+        List<TestKafkaVersion> testKafkaVersions = TestKafkaVersion.getSupportedKafkaVersions();
         TestKafkaVersion testKafkaVersion = testKafkaVersions.get(testKafkaVersions.size() - 1);
 
         // Generate procedures and data for OLM upgrade

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziDowngradeST.java
@@ -56,7 +56,7 @@ public class StrimziDowngradeST extends AbstractUpgradeST {
 
         // Setup env
         // We support downgrade only when you didn't upgrade to new inter.broker.protocol.version and log.message.format.version
-        // https://strimzi.io/docs/operators/0.22.1/full/deploying.html#con-target-downgrade-version-str
+        // https://strimzi.io/docs/operators/latest/full/deploying.html#con-target-downgrade-version-str
         setupEnvAndUpgradeClusterOperator(extensionContext, testParameters, producerName, consumerName, continuousTopicName, continuousConsumerGroup, testParameters.getString("deployKafkaVersion"), NAMESPACE);
         logPodImages(clusterName);
         // Downgrade CO

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziDowngradeST.java
@@ -55,10 +55,10 @@ public class StrimziDowngradeST extends AbstractUpgradeST {
         String continuousConsumerGroup = "continuous-consumer-group";
 
         // Setup env
-        setupEnvAndUpgradeClusterOperator(extensionContext, testParameters, producerName, consumerName, continuousTopicName, continuousConsumerGroup, "", NAMESPACE);
+        // We support downgrade only when you didn't upgrade to new inter.broker.protocol.version and log.message.format.version
+        // https://strimzi.io/docs/operators/0.22.1/full/deploying.html#con-target-downgrade-version-str
+        setupEnvAndUpgradeClusterOperator(extensionContext, testParameters, producerName, consumerName, continuousTopicName, continuousConsumerGroup, testParameters.getString("deployKafkaVersion"), NAMESPACE);
         logPodImages(clusterName);
-        //  Upgrade kafka
-        changeKafkaAndLogFormatVersion(testParameters.getJsonObject("proceduresBeforeOperatorDowngrade"), testParameters, clusterName, extensionContext);
         // Downgrade CO
         changeClusterOperator(testParameters, NAMESPACE);
         // Wait for Kafka cluster rolling update

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -191,7 +191,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
     }
 
     private JsonObject buildDataForUpgradeAcrossVersions() throws IOException {
-        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getKafkaVersions();
+        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
         TestKafkaVersion latestKafkaSupported = sortedVersions.get(sortedVersions.size() - 1);
 
         JsonArray upgradeJson = readUpgradeJson(UPGRADE_JSON_FILE);
@@ -224,7 +224,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
     }
 
     private JsonObject getDataForStartUpgrade(JsonArray upgradeJson) throws IOException {
-        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getKafkaVersions();
+        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
         List<String> versions = sortedVersions.stream().map(item -> item.version()).collect(Collectors.toList());
 
         Collections.reverse(upgradeJson.getList());

--- a/systemtest/src/test/java/io/strimzi/systemtest/utils/KafkaVersionUtilsTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/utils/KafkaVersionUtilsTest.java
@@ -16,7 +16,7 @@ public class KafkaVersionUtilsTest {
 
     @ParallelTest
     public void parsingTest() {
-        List<TestKafkaVersion> versions = TestKafkaVersion.getKafkaVersions();
+        List<TestKafkaVersion> versions = TestKafkaVersion.getSupportedKafkaVersions();
         assertTrue(versions.size() > 0);
     }
 }

--- a/systemtest/src/test/resources/upgrade/StrimziDowngradeST.json
+++ b/systemtest/src/test/resources/upgrade/StrimziDowngradeST.json
@@ -15,11 +15,7 @@
       "topicOperator": "strimzi/operator:0.22.0",
       "userOperator": "strimzi/operator:0.22.0"
     },
-    "proceduresBeforeOperatorDowngrade": {
-      "kafkaVersion": "2.7.0",
-      "logMessageVersion": "2.7",
-      "interBrokerProtocolVersion": "2.7"
-    },
+    "deployKafkaVersion": "2.7.0",
     "client": {
       "continuousClientsMessages": 500
     },


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

We support downgrade only when `inter.broker.protocol.version` and `log.message.format.version` wasn't upgraded to the new Kafka version. We should reflect this in tests.

https://strimzi.io/docs/operators/latest/full/deploying.html#con-target-downgrade-version-str

### Checklist

- [x] Make sure all tests pass


