### PR TITLE
Topic operator tls auth switch

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -276,6 +276,7 @@ public class EntityTopicOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS, Integer.toString(zookeeperSessionTimeoutMs)));
         varList.add(buildEnvVar(ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS, String.valueOf(topicMetadataMaxAttempts)));
         varList.add(buildEnvVar(ENV_VAR_TLS_ENABLED, Boolean.toString(true)));
+        varList.add(buildEnvVar(ENV_VAR_TLS_AUTH_ENABLED, Boolean.toString(true)));
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
         EntityOperator.javaOptions(varList, getJvmOptions(), javaSystemProperties);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -55,7 +55,7 @@ public class EntityTopicOperator extends AbstractModel {
     public static final String ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
     public static final String ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS = "STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS";
     public static final String ENV_VAR_TLS_ENABLED = "STRIMZI_TLS_ENABLED";
-    public static final String ENV_VAR_TLS_ENABLED = "STRIMZI_TLS_AUTH_ENABLED";
+    public static final String ENV_VAR_TLS_AUTH_ENABLED = "STRIMZI_TLS_AUTH_ENABLED";
     public static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder()
             .withInitialDelaySeconds(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY)
             .withTimeoutSeconds(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT).build();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -55,6 +55,7 @@ public class EntityTopicOperator extends AbstractModel {
     public static final String ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
     public static final String ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS = "STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS";
     public static final String ENV_VAR_TLS_ENABLED = "STRIMZI_TLS_ENABLED";
+    public static final String ENV_VAR_TLS_ENABLED = "STRIMZI_TLS_AUTH_ENABLED";
     public static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder()
             .withInitialDelaySeconds(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY)
             .withTimeoutSeconds(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT).build();

--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -34,14 +34,16 @@ Default `20000` (20 seconds).
 Default `/strimzi/topics`.
 .. `STRIMZI_TLS_ENABLED` to enable TLS support for encrypting the communication with Kafka brokers.
 Default `true`.
+.. `STRIMZI_TLS_AUTH_ENABLED` to enable authenticated communication with Kafka brokers.
+Default `true`.
 .. `STRIMZI_TRUSTSTORE_LOCATION` to the path to the truststore containing certificates for enabling TLS based communication.
-Mandatory only if TLS is enabled through `STRIMZI_TLS_ENABLED`.
+Mandatory only if TLS and authentication are enabled through `STRIMZI_TLS_ENABLED` and `STRIMZI_TLS_AUTH_ENABLED`.
 .. `STRIMZI_TRUSTSTORE_PASSWORD` to the password for accessing the truststore defined by `STRIMZI_TRUSTSTORE_LOCATION`.
-Mandatory only if TLS is enabled through `STRIMZI_TLS_ENABLED`.
+Mandatory only if TLS and authentication are enabled through `STRIMZI_TLS_ENABLED` and `STRIMZI_TLS_AUTH_ENABLED`.
 .. `STRIMZI_KEYSTORE_LOCATION` to the path to the keystore containing private keys for enabling TLS based communication.
-Mandatory only if TLS is enabled through `STRIMZI_TLS_ENABLED`.
+Mandatory only if TLS and authentication are enabled through `STRIMZI_TLS_ENABLED` and `STRIMZI_TLS_AUTH_ENABLED`.
 .. `STRIMZI_KEYSTORE_PASSWORD` to the password for accessing the keystore defined by `STRIMZI_KEYSTORE_LOCATION`.
-Mandatory only if TLS is enabled through `STRIMZI_TLS_ENABLED`.
+Mandatory only if TLS and authentication are enabled through `STRIMZI_TLS_ENABLED` and `STRIMZI_TLS_AUTH_ENABLED`.
 .. `STRIMZI_LOG_LEVEL` to the level for printing logging messages.
 The value can be set to: `ERROR`, `WARNING`, `INFO`, `DEBUG`, and `TRACE`.
 Default `INFO`.

--- a/topic-operator/scripts/topic_operator_run.sh
+++ b/topic-operator/scripts/topic_operator_run.sh
@@ -14,7 +14,7 @@ if [ -n "$STRIMZI_JAVA_OPTS" ]; then
     export JAVA_OPTS="${JAVA_OPTS} ${STRIMZI_JAVA_OPTS}"
 fi
 
-if [ "$STRIMZI_TLS_ENABLED" = "true" ]; then
+if [ "$STRIMZI_TLS_ENABLED" = "true" ] && [ "$STRIMZI_TLS_AUTH_ENABLED" = "true" ]; then
     if [ -z "$STRIMZI_TRUSTSTORE_LOCATION" ] && [ -z "$STRIMZI_KEYSTORE_LOCATION" ]; then
         # Generate temporary keystore password
         CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
@@ -112,6 +112,7 @@ public class Config {
     public static final String TC_TOPICS_PATH = "STRIMZI_TOPICS_PATH";
 
     public static final String TC_TLS_ENABLED = "STRIMZI_TLS_ENABLED";
+    public static final String TC_TLS_AUTH_ENABLED = "STRIMZI_TLS_AUTH_ENABLED";
     public static final String TC_TLS_TRUSTSTORE_LOCATION = "STRIMZI_TRUSTSTORE_LOCATION";
     public static final String TC_TLS_TRUSTSTORE_PASSWORD = "STRIMZI_TRUSTSTORE_PASSWORD";
     public static final String TC_TLS_KEYSTORE_LOCATION = "STRIMZI_KEYSTORE_LOCATION";
@@ -169,6 +170,8 @@ public class Config {
 
     /** If the connection with Kafka has to be encrypted by TLS protocol */
     public static final Value<String> TLS_ENABLED = new Value<>(TC_TLS_ENABLED, STRING, "false");
+    /** If the connection with Kafka has to be encrypted by TLS protocol */
+    public static final Value<String> TLS_AUTH_ENABLED = new Value<>(TC_TLS_AUTH_ENABLED, STRING, "true");
     /** The truststore with CA certificate for Kafka broker/server authentication */
     public static final Value<String> TLS_TRUSTSTORE_LOCATION = new Value<>(TC_TLS_TRUSTSTORE_LOCATION, STRING, "");
     /** The password for the truststore with CA certificate for Kafka broker/server authentication */
@@ -211,6 +214,7 @@ public class Config {
         addConfigValue(configValues, TOPIC_METADATA_MAX_ATTEMPTS);
         addConfigValue(configValues, TOPICS_PATH);
         addConfigValue(configValues, TLS_ENABLED);
+        addConfigValue(configValues, TLS_AUTH_ENABLED);
         addConfigValue(configValues, TLS_TRUSTSTORE_LOCATION);
         addConfigValue(configValues, TLS_TRUSTSTORE_PASSWORD);
         addConfigValue(configValues, TLS_KEYSTORE_LOCATION);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
@@ -170,7 +170,7 @@ public class Config {
 
     /** If the connection with Kafka has to be encrypted by TLS protocol */
     public static final Value<String> TLS_ENABLED = new Value<>(TC_TLS_ENABLED, STRING, "false");
-    /** If the connection with Kafka has to be encrypted by TLS protocol */
+    /** If the connection with Kafka has to be authenticated */
     public static final Value<String> TLS_AUTH_ENABLED = new Value<>(TC_TLS_AUTH_ENABLED, STRING, "true");
     /** The truststore with CA certificate for Kafka broker/server authentication */
     public static final Value<String> TLS_TRUSTSTORE_LOCATION = new Value<>(TC_TLS_TRUSTSTORE_LOCATION, STRING, "");

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -156,11 +156,15 @@ public class Session extends AbstractVerticle {
 
         if (Boolean.parseBoolean(config.get(Config.TLS_ENABLED))) {
             kafkaClientProps.setProperty(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, "SSL");
-            kafkaClientProps.setProperty(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, config.get(Config.TLS_TRUSTSTORE_LOCATION));
-            kafkaClientProps.setProperty(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, config.get(Config.TLS_TRUSTSTORE_PASSWORD));
-            kafkaClientProps.setProperty(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, config.get(Config.TLS_KEYSTORE_LOCATION));
-            kafkaClientProps.setProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, config.get(Config.TLS_KEYSTORE_PASSWORD));
-            kafkaClientProps.setProperty(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, config.get(Config.TLS_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM));
+            if (Boolean.parseBoolean(config.get(Config.TLS_AUTH_ENABLED))) {
+                kafkaClientProps.setProperty(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, config.get(Config.TLS_TRUSTSTORE_LOCATION));
+                kafkaClientProps.setProperty(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, config.get(Config.TLS_TRUSTSTORE_PASSWORD));
+                kafkaClientProps.setProperty(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, config.get(Config.TLS_KEYSTORE_LOCATION));
+                kafkaClientProps.setProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, config.get(Config.TLS_KEYSTORE_PASSWORD));
+                kafkaClientProps.setProperty(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, config.get(Config.TLS_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM));
+            } else {
+                kafkaClientProps.setProperty(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, config.get(Config.TLS_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM));
+            }
         }
 
         this.adminClient = AdminClient.create(kafkaClientProps);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -156,14 +156,12 @@ public class Session extends AbstractVerticle {
 
         if (Boolean.parseBoolean(config.get(Config.TLS_ENABLED))) {
             kafkaClientProps.setProperty(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, "SSL");
+            kafkaClientProps.setProperty(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, config.get(Config.TLS_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM));
             if (Boolean.parseBoolean(config.get(Config.TLS_AUTH_ENABLED))) {
                 kafkaClientProps.setProperty(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, config.get(Config.TLS_TRUSTSTORE_LOCATION));
                 kafkaClientProps.setProperty(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, config.get(Config.TLS_TRUSTSTORE_PASSWORD));
                 kafkaClientProps.setProperty(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, config.get(Config.TLS_KEYSTORE_LOCATION));
                 kafkaClientProps.setProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, config.get(Config.TLS_KEYSTORE_PASSWORD));
-                kafkaClientProps.setProperty(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, config.get(Config.TLS_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM));
-            } else {
-                kafkaClientProps.setProperty(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, config.get(Config.TLS_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM));
             }
         }
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Previously standalone topic-operator didn't support the TLS encrypted connection without authentication.
This fix allows you to establish an encrypted TLS connection without authentication to your kafka cluster.
This fix won't affect the current approach until you set the new variable `STRIMZI_TLS_AUTH_ENABLED` to `false` in the `05-Deployment-strimzi-topic-operator.yaml`

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
