### PR TITLE
Delete olm and helm resources properly

### DIFF
--- a/.azure/templates/system_test_general.yaml
+++ b/.azure/templates/system_test_general.yaml
@@ -77,6 +77,7 @@ jobs:
         BRIDGE_IMAGE: "latest-released"
         STRIMZI_RBAC_SCOPE: '${{ parameters.strimzi_rbac_scope }}'
         DOCKER_REGISTRY: registry.minikube
+        CLUSTER_OPERATOR_INSTALL_TYPE: '${{ parameters.cluster_operator_install_type }}'
       displayName: 'Run systemtests'
 
     - task: PublishTestResults@2

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/specific/HelmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/specific/HelmResource.java
@@ -13,12 +13,14 @@ import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeClusterResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Stack;
 import java.util.stream.Stream;
 
 import static io.strimzi.test.TestUtils.entry;
@@ -35,14 +37,17 @@ public class HelmResource implements SpecificResourceType {
     public static final String LIMITS_MEMORY = "512Mi";
     public static final String LIMITS_CPU = "1000m";
 
-    public void create() {
-        this.clusterOperator();
+    public void create(ExtensionContext extensionContext) {
+        this.create(extensionContext, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Constants.RECONCILIATION_INTERVAL);
     }
 
-    public void create(long operationTimeout, long reconciliationInterval) {
+    public void create(ExtensionContext extensionContext, long operationTimeout, long reconciliationInterval) {
+        ResourceManager.STORED_RESOURCES.computeIfAbsent(extensionContext.getDisplayName(), k -> new Stack<>());
+        ResourceManager.STORED_RESOURCES.get(extensionContext.getDisplayName()).push(this::delete);
         this.clusterOperator(operationTimeout, reconciliationInterval);
     }
 
+    @Override
     public void delete() {
         this.deleteClusterOperator();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/specific/OlmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/specific/OlmResource.java
@@ -17,6 +17,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -27,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Stack;
 import java.util.stream.Collectors;
 
 import static io.strimzi.systemtest.resources.ResourceManager.CR_CREATION_TIMEOUT;
@@ -48,11 +50,13 @@ public class OlmResource implements SpecificResourceType {
     private String csvName;
 
     @Override
-    public void create() {
-        this.clusterOperator(namespace);
+    public void create(ExtensionContext extensionContext) {
+        this.create(extensionContext, namespace, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Constants.RECONCILIATION_INTERVAL);
     }
 
-    public void create(String namespace, long operationTimeout, long reconciliationInterval) {
+    public void create(ExtensionContext extensionContext, String namespace, long operationTimeout, long reconciliationInterval) {
+        ResourceManager.STORED_RESOURCES.computeIfAbsent(extensionContext.getDisplayName(), k -> new Stack<>());
+        ResourceManager.STORED_RESOURCES.get(extensionContext.getDisplayName()).push(this::delete);
         this.clusterOperator(namespace, operationTimeout, reconciliationInterval);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/specific/SpecificResourceType.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/specific/SpecificResourceType.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.systemtest.resources.specific;
 
+import org.junit.jupiter.api.extension.ExtensionContext;
+
 /**
  * Interface for resources which has different deployment strategies such as Helm or Olm.
  */
@@ -12,7 +14,7 @@ public interface SpecificResourceType {
     /**
      * Creates specific resource
      */
-    void create();
+    void create(ExtensionContext extensionContext);
 
     /**
      * Delete specific resource

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -139,12 +139,12 @@ public abstract class AbstractST implements TestSeparator {
             cluster.setNamespace(namespace);
             cluster.createNamespace(namespace);
             olmResource = new OlmResource(namespace);
-            olmResource.create(namespace, operationTimeout, reconciliationInterval);
+            olmResource.create(extensionContext, namespace, operationTimeout, reconciliationInterval);
         } else if (Environment.isHelmInstall()) {
             LOGGER.info("Going to install ClusterOperator via Helm");
             cluster.setNamespace(namespace);
             cluster.createNamespace(namespace);
-            helmResource.create(operationTimeout, reconciliationInterval);
+            helmResource.create(extensionContext, operationTimeout, reconciliationInterval);
         } else {
             LOGGER.info("Going to install ClusterOperator via Yaml bundle");
             prepareEnvForOperator(extensionContext,  namespace, bindingsNamespaces);

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/AllNamespacesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/AllNamespacesST.java
@@ -5,7 +5,6 @@
 package io.strimzi.systemtest.olm;
 
 import io.strimzi.systemtest.resources.specific.OlmResource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -78,18 +77,13 @@ public class AllNamespacesST extends OlmAbstractST {
     }
 
     @BeforeAll
-    void setup() {
+    void setup(ExtensionContext extensionContext) {
         cluster.setNamespace(cluster.getDefaultOlmNamespace());
 
         olmResource = new OlmResource(cluster.getDefaultOlmNamespace());
-        olmResource.create();
+        olmResource.create(extensionContext);
 
         cluster.setNamespace(NAMESPACE);
         cluster.createNamespace(NAMESPACE);
-    }
-
-    @AfterAll
-    void tearDown() {
-        olmResource.delete();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/SingleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/SingleNamespaceST.java
@@ -7,7 +7,6 @@ package io.strimzi.systemtest.olm;
 import io.strimzi.systemtest.resources.specific.OlmResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -81,16 +80,11 @@ public class SingleNamespaceST extends OlmAbstractST {
     }
 
     @BeforeAll
-    void setup() {
+    void setup(ExtensionContext extensionContext) {
         cluster.setNamespace(NAMESPACE);
         cluster.createNamespace(NAMESPACE);
 
         olmResource = new OlmResource(NAMESPACE);
-        olmResource.create();
-    }
-
-    @AfterAll
-    void tearDown() {
-        olmResource.delete();
+        olmResource.create(extensionContext);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/HelmChartST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/HelmChartST.java
@@ -59,12 +59,11 @@ class HelmChartST extends AbstractST {
     void setup(ExtensionContext extensionContext) {
         LOGGER.info("Creating resources before the test class");
         cluster.createNamespace(NAMESPACE);
-        helmResource.create();
+        helmResource.create(extensionContext);
     }
 
     @AfterAll
     protected void tearDownEnvironmentAfterAll() {
-        helmResource.delete();
         cluster.deleteNamespaces();
     }
 }


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix


### Description

After merging of first steps for test parallel execution, we didn't realize, that helm and olm resources are not deleted properly. 

Also in helm azure pipeline we didn't set properly env variable for install type.

### Checklist

- [x] Make sure all tests pass


