### PR TITLE
Make operators use apiextensions/v1 APIs

### DIFF
--- a/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/cli/AbstractCommand.java
+++ b/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/cli/AbstractCommand.java
@@ -7,7 +7,6 @@ package io.strimzi.kafka.api.conversion.cli;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.strimzi.api.annotations.ApiVersion;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaConnect;
@@ -18,6 +17,7 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
+import io.strimzi.kafka.api.conversion.utils.LegacyCrds;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -64,16 +64,16 @@ public abstract class AbstractCommand implements Runnable {
     // Versioned operations are used to write the converted resource using the target API
     @SuppressWarnings({"rawtypes"})
     protected final static Map<String, BiFunction<KubernetesClient, String, MixedOperation>> VERSIONED_OPERATIONS = Map.of(
-            "Kafka", Crds::kafkaOperation,
-            "KafkaConnect", Crds::kafkaConnectOperation,
-            "KafkaConnectS2I", Crds::kafkaConnectS2iOperation,
-            "KafkaMirrorMaker", Crds::mirrorMakerOperation,
-            "KafkaBridge", Crds::kafkaBridgeOperation,
-            "KafkaMirrorMaker2", Crds::kafkaMirrorMaker2Operation,
-            "KafkaTopic", Crds::topicOperation,
-            "KafkaUser", Crds::kafkaUserOperation,
-            "KafkaConnector", Crds::kafkaConnectorOperation,
-            "KafkaRebalance", Crds::kafkaRebalanceOperation
+            "Kafka", LegacyCrds::kafkaOperation,
+            "KafkaConnect", LegacyCrds::kafkaConnectOperation,
+            "KafkaConnectS2I", LegacyCrds::kafkaConnectS2iOperation,
+            "KafkaMirrorMaker", LegacyCrds::mirrorMakerOperation,
+            "KafkaBridge", LegacyCrds::kafkaBridgeOperation,
+            "KafkaMirrorMaker2", LegacyCrds::kafkaMirrorMaker2Operation,
+            "KafkaTopic", LegacyCrds::topicOperation,
+            "KafkaUser", LegacyCrds::kafkaUserOperation,
+            "KafkaConnector", LegacyCrds::kafkaConnectorOperation,
+            "KafkaRebalance", LegacyCrds::kafkaRebalanceOperation
     );
 
     @CommandLine.Spec

--- a/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/utils/LegacyCrds.java
+++ b/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/utils/LegacyCrds.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.api.conversion.utils;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.KafkaBridgeList;
+import io.strimzi.api.kafka.KafkaConnectList;
+import io.strimzi.api.kafka.KafkaConnectS2IList;
+import io.strimzi.api.kafka.KafkaConnectorList;
+import io.strimzi.api.kafka.KafkaList;
+import io.strimzi.api.kafka.KafkaMirrorMaker2List;
+import io.strimzi.api.kafka.KafkaMirrorMakerList;
+import io.strimzi.api.kafka.KafkaRebalanceList;
+import io.strimzi.api.kafka.KafkaTopicList;
+import io.strimzi.api.kafka.KafkaUserList;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBridge;
+import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaConnectS2I;
+import io.strimzi.api.kafka.model.KafkaConnector;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
+import io.strimzi.api.kafka.model.KafkaRebalance;
+import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.api.kafka.model.KafkaUser;
+
+/**
+ * "Static" information about the CRDs defined in this package
+ */
+@SuppressWarnings("deprecation")
+public class LegacyCrds {
+    private static CustomResourceDefinitionContext crdCtx(io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition crd, String version)   {
+        return new CustomResourceDefinitionContext.Builder()
+                .withKind(crd.getSpec().getNames().getKind())
+                .withName(crd.getSpec().getNames().getSingular())
+                .withPlural(crd.getSpec().getNames().getPlural())
+                .withScope(crd.getSpec().getScope())
+                .withGroup(crd.getSpec().getGroup())
+                .withVersion(version)
+                .build();
+    }
+
+    public static MixedOperation<Kafka, KafkaList, Resource<Kafka>> kafkaOperation(KubernetesClient client, String version) {
+        return client.customResources(crdCtx(Crds.kafka(), version), Kafka.class, KafkaList.class);
+    }
+
+    public static MixedOperation<KafkaConnect, KafkaConnectList, Resource<KafkaConnect>> kafkaConnectOperation(KubernetesClient client, String version) {
+        return client.customResources(crdCtx(Crds.kafkaConnect(), version), KafkaConnect.class, KafkaConnectList.class);
+    }
+
+    public static MixedOperation<KafkaConnector, KafkaConnectorList, Resource<KafkaConnector>> kafkaConnectorOperation(KubernetesClient client, String version) {
+        return client.customResources(crdCtx(Crds.kafkaConnector(), version), KafkaConnector.class, KafkaConnectorList.class);
+    }
+
+    public static MixedOperation<KafkaConnectS2I, KafkaConnectS2IList, Resource<KafkaConnectS2I>> kafkaConnectS2iOperation(KubernetesClient client, String version) {
+        return client.customResources(crdCtx(Crds.kafkaConnectS2I(), version), KafkaConnectS2I.class, KafkaConnectS2IList.class);
+    }
+
+    public static MixedOperation<KafkaTopic, KafkaTopicList, Resource<KafkaTopic>> topicOperation(KubernetesClient client, String version) {
+        return client.customResources(crdCtx(Crds.kafkaTopic(), version), KafkaTopic.class, KafkaTopicList.class);
+    }
+
+    public static MixedOperation<KafkaUser, KafkaUserList, Resource<KafkaUser>> kafkaUserOperation(KubernetesClient client, String version) {
+        return client.customResources(crdCtx(Crds.kafkaUser(), version), KafkaUser.class, KafkaUserList.class);
+    }
+
+    public static MixedOperation<KafkaMirrorMaker, KafkaMirrorMakerList, Resource<KafkaMirrorMaker>> mirrorMakerOperation(KubernetesClient client, String version) {
+        return client.customResources(crdCtx(Crds.kafkaMirrorMaker(), version), KafkaMirrorMaker.class, KafkaMirrorMakerList.class);
+    }
+
+    public static MixedOperation<KafkaBridge, KafkaBridgeList, Resource<KafkaBridge>> kafkaBridgeOperation(KubernetesClient client, String version) {
+        return client.customResources(crdCtx(Crds.kafkaBridge(), version), KafkaBridge.class, KafkaBridgeList.class);
+    }
+
+    public static MixedOperation<KafkaMirrorMaker2, KafkaMirrorMaker2List, Resource<KafkaMirrorMaker2>> kafkaMirrorMaker2Operation(KubernetesClient client, String version) {
+        return client.customResources(crdCtx(Crds.kafkaMirrorMaker2(), version), KafkaMirrorMaker2.class, KafkaMirrorMaker2List.class);
+    }
+
+    public static MixedOperation<KafkaRebalance, KafkaRebalanceList, Resource<KafkaRebalance>> kafkaRebalanceOperation(KubernetesClient client, String version) {
+        return client.customResources(crdCtx(Crds.kafkaRebalance(), version), KafkaRebalance.class, KafkaRebalanceList.class);
+    }
+}

--- a/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/ConvertResourceCommandIT.java
+++ b/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/ConvertResourceCommandIT.java
@@ -13,7 +13,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.annotations.ApiVersion;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaConnectS2IList;
 import io.strimzi.api.kafka.KafkaList;
 import io.strimzi.api.kafka.model.JmxPrometheusExporterMetrics;
@@ -23,6 +22,7 @@ import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaConnectS2IBuilder;
 import io.strimzi.api.kafka.model.listener.KafkaListenersBuilder;
 import io.strimzi.kafka.api.conversion.converter.MultipartConversions;
+import io.strimzi.kafka.api.conversion.utils.LegacyCrds;
 import io.strimzi.test.k8s.KubeClusterResource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -66,7 +66,7 @@ public class ConvertResourceCommandIT {
 
     @Test
     public void testNamedConversion() {
-        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = Crds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = LegacyCrds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
 
         try {
             Kafka kafka1 = new KafkaBuilder()
@@ -143,7 +143,7 @@ public class ConvertResourceCommandIT {
 
     @Test
     public void testMultiResourceConversion() {
-        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = Crds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = LegacyCrds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
 
         try {
             Kafka kafka1 = new KafkaBuilder()
@@ -228,7 +228,7 @@ public class ConvertResourceCommandIT {
 
     @Test
     public void testMultipleResourcesConversion() {
-        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = Crds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = LegacyCrds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
 
         try {
             Kafka kafka1 = new KafkaBuilder()
@@ -306,8 +306,8 @@ public class ConvertResourceCommandIT {
 
     @Test
     public void testMultipleKindsConversion() {
-        MixedOperation<Kafka, KafkaList, Resource<Kafka>> kafkaOp = Crds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
-        MixedOperation<KafkaConnectS2I, KafkaConnectS2IList, Resource<KafkaConnectS2I>> connectOp = Crds.kafkaConnectS2iOperation(client, ApiVersion.V1BETA1.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> kafkaOp = LegacyCrds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
+        MixedOperation<KafkaConnectS2I, KafkaConnectS2IList, Resource<KafkaConnectS2I>> connectOp = LegacyCrds.kafkaConnectS2iOperation(client, ApiVersion.V1BETA1.toString());
 
         try {
             Kafka kafka1 = new KafkaBuilder()
@@ -406,7 +406,7 @@ public class ConvertResourceCommandIT {
 
     @Test
     public void testFailingTopicOperatorConversion() {
-        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = Crds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = LegacyCrds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
 
         try {
             Kafka kafka1 = new KafkaBuilder()
@@ -497,7 +497,7 @@ public class ConvertResourceCommandIT {
 
     @Test
     public void testFailingAffinityConversion() {
-        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = Crds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = LegacyCrds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
 
         try {
             Affinity affinity = new AffinityBuilder()
@@ -580,7 +580,7 @@ public class ConvertResourceCommandIT {
 
     @Test
     public void testFailingLoadBalancerSourceRangesConversion() {
-        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = Crds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = LegacyCrds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
 
         try {
             Kafka kafka1 = new KafkaBuilder()
@@ -653,8 +653,8 @@ public class ConvertResourceCommandIT {
 
     @Test
     public void testAllKindsConversion() {
-        MixedOperation<Kafka, KafkaList, Resource<Kafka>> kafkaOp = Crds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
-        MixedOperation<KafkaConnectS2I, KafkaConnectS2IList, Resource<KafkaConnectS2I>> connectOp = Crds.kafkaConnectS2iOperation(client, ApiVersion.V1BETA1.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> kafkaOp = LegacyCrds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
+        MixedOperation<KafkaConnectS2I, KafkaConnectS2IList, Resource<KafkaConnectS2I>> connectOp = LegacyCrds.kafkaConnectS2iOperation(client, ApiVersion.V1BETA1.toString());
 
         try {
             Kafka kafka1 = new KafkaBuilder()
@@ -755,7 +755,7 @@ public class ConvertResourceCommandIT {
     public void tesAllNamespacesConversion() {
         String namespace2 = NAMESPACE + "2";
         CLUSTER.createNamespace(namespace2);
-        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = Crds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = LegacyCrds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
 
         try {
             Kafka kafka1 = new KafkaBuilder()
@@ -836,7 +836,7 @@ public class ConvertResourceCommandIT {
     @Test
     public void testWrongNamespaceOrKindConversion() {
         CLUSTER.createNamespace(NAMESPACE + "-other");
-        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = Crds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = LegacyCrds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
 
         try {
             Kafka kafka1 = new KafkaBuilder()

--- a/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/CrdUpgradeCommandIT.java
+++ b/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/CrdUpgradeCommandIT.java
@@ -10,7 +10,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.annotations.ApiVersion;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaList;
 import io.strimzi.api.kafka.model.JmxPrometheusExporterMetrics;
 import io.strimzi.api.kafka.model.Kafka;
@@ -18,6 +17,7 @@ import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.listener.KafkaListenersBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.kafka.api.conversion.utils.LegacyCrds;
 import io.strimzi.test.k8s.KubeClusterResource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,7 +61,7 @@ public class CrdUpgradeCommandIT {
      */
     @Test
     public void testCrdUpgradeWithConvertedResources() {
-        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = Crds.kafkaOperation(client, ApiVersion.V1BETA2.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = LegacyCrds.kafkaOperation(client, ApiVersion.V1BETA2.toString());
 
         try {
             Kafka kafka1 = new KafkaBuilder()
@@ -175,7 +175,7 @@ public class CrdUpgradeCommandIT {
      */
     @Test
     public void testUpgradeWithUnconvertedResourcesFails() {
-        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = Crds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> op = LegacyCrds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
 
         try {
             Kafka kafka1 = new KafkaBuilder()

--- a/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/FullUpgradeLifecycleIT.java
+++ b/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/FullUpgradeLifecycleIT.java
@@ -9,12 +9,12 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.annotations.ApiVersion;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaList;
 import io.strimzi.api.kafka.model.JmxPrometheusExporterMetrics;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.listener.KafkaListenersBuilder;
+import io.strimzi.kafka.api.conversion.utils.LegacyCrds;
 import io.strimzi.test.k8s.KubeClusterResource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,8 +64,8 @@ public class FullUpgradeLifecycleIT {
      */
     @Test
     public void testFullLifecycleAsExpected() {
-        MixedOperation<Kafka, KafkaList, Resource<Kafka>> opV1Beta2 = Crds.kafkaOperation(client, ApiVersion.V1BETA2.toString());
-        MixedOperation<Kafka, KafkaList, Resource<Kafka>> opV1Beta1 = Crds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> opV1Beta2 = LegacyCrds.kafkaOperation(client, ApiVersion.V1BETA2.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> opV1Beta1 = LegacyCrds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
 
         try {
             Kafka kafka1 = new KafkaBuilder()
@@ -160,8 +160,8 @@ public class FullUpgradeLifecycleIT {
      */
     @Test
     public void testFullLifecycleOnSecondTry() {
-        MixedOperation<Kafka, KafkaList, Resource<Kafka>> opV1Beta2 = Crds.kafkaOperation(client, ApiVersion.V1BETA2.toString());
-        MixedOperation<Kafka, KafkaList, Resource<Kafka>> opV1Beta1 = Crds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> opV1Beta2 = LegacyCrds.kafkaOperation(client, ApiVersion.V1BETA2.toString());
+        MixedOperation<Kafka, KafkaList, Resource<Kafka>> opV1Beta1 = LegacyCrds.kafkaOperation(client, ApiVersion.V1BETA1.toString());
 
         try {
             Kafka kafka1 = new KafkaBuilder()

--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -86,7 +86,7 @@ public class Crds {
             group = KafkaConnect.RESOURCE_GROUP;
             kind = KafkaConnect.RESOURCE_KIND;
             listKind = KafkaConnect.RESOURCE_LIST_KIND;
-            versions = Kafka.VERSIONS;
+            versions = KafkaConnect.VERSIONS;
             status = new CustomResourceSubresourceStatus();
         } else if (cls.equals(KafkaConnectS2I.class)) {
             scope = KafkaConnectS2I.SCOPE;
@@ -95,7 +95,7 @@ public class Crds {
             group = KafkaConnectS2I.RESOURCE_GROUP;
             kind = KafkaConnectS2I.RESOURCE_KIND;
             listKind = KafkaConnectS2I.RESOURCE_LIST_KIND;
-            versions = Kafka.VERSIONS;
+            versions = KafkaConnectS2I.VERSIONS;
             status = new CustomResourceSubresourceStatus();
         } else if (cls.equals(KafkaTopic.class)) {
             scope = KafkaTopic.SCOPE;
@@ -104,7 +104,7 @@ public class Crds {
             group = KafkaTopic.RESOURCE_GROUP;
             kind = KafkaTopic.RESOURCE_KIND;
             listKind = KafkaTopic.RESOURCE_LIST_KIND;
-            versions = Kafka.VERSIONS;
+            versions = KafkaTopic.VERSIONS;
         } else if (cls.equals(KafkaUser.class)) {
             scope = KafkaUser.SCOPE;
             plural = KafkaUser.RESOURCE_PLURAL;
@@ -112,7 +112,7 @@ public class Crds {
             group = KafkaUser.RESOURCE_GROUP;
             kind = KafkaUser.RESOURCE_KIND;
             listKind = KafkaUser.RESOURCE_LIST_KIND;
-            versions = Kafka.VERSIONS;
+            versions = KafkaUser.VERSIONS;
             status = new CustomResourceSubresourceStatus();
         } else if (cls.equals(KafkaMirrorMaker.class)) {
             scope = KafkaMirrorMaker.SCOPE;
@@ -121,7 +121,7 @@ public class Crds {
             group = KafkaMirrorMaker.RESOURCE_GROUP;
             kind = KafkaMirrorMaker.RESOURCE_KIND;
             listKind = KafkaMirrorMaker.RESOURCE_LIST_KIND;
-            versions = Kafka.VERSIONS;
+            versions = KafkaMirrorMaker.VERSIONS;
             status = new CustomResourceSubresourceStatus();
         } else if (cls.equals(KafkaBridge.class)) {
             scope = KafkaBridge.SCOPE;
@@ -130,7 +130,7 @@ public class Crds {
             group = KafkaBridge.RESOURCE_GROUP;
             kind = KafkaBridge.RESOURCE_KIND;
             listKind = KafkaBridge.RESOURCE_LIST_KIND;
-            versions = Kafka.VERSIONS;
+            versions = KafkaBridge.VERSIONS;
             status = new CustomResourceSubresourceStatus();
         } else if (cls.equals(KafkaConnector.class)) {
             scope = KafkaConnector.SCOPE;
@@ -139,7 +139,7 @@ public class Crds {
             group = KafkaConnector.RESOURCE_GROUP;
             kind = KafkaConnector.RESOURCE_KIND;
             listKind = KafkaConnector.RESOURCE_LIST_KIND;
-            versions = Kafka.VERSIONS;
+            versions = KafkaConnector.VERSIONS;
             status = new CustomResourceSubresourceStatus();
         } else if (cls.equals(KafkaMirrorMaker2.class)) {
             scope = KafkaMirrorMaker2.SCOPE;
@@ -148,7 +148,7 @@ public class Crds {
             group = KafkaMirrorMaker2.RESOURCE_GROUP;
             kind = KafkaMirrorMaker2.RESOURCE_KIND;
             listKind = KafkaMirrorMaker2.RESOURCE_LIST_KIND;
-            versions = Kafka.VERSIONS;
+            versions = KafkaMirrorMaker2.VERSIONS;
             status = new CustomResourceSubresourceStatus();
         } else if (cls.equals(KafkaRebalance.class)) {
             scope = KafkaRebalance.SCOPE;
@@ -157,7 +157,7 @@ public class Crds {
             group = KafkaRebalance.RESOURCE_GROUP;
             kind = KafkaRebalance.RESOURCE_KIND;
             listKind = KafkaRebalance.RESOURCE_LIST_KIND;
-            versions = Kafka.VERSIONS;
+            versions = KafkaRebalance.VERSIONS;
             status = new CustomResourceSubresourceStatus();
         } else {
             throw new RuntimeException();

--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -4,17 +4,17 @@
  */
 package io.strimzi.api.kafka;
 
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionBuilder;
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceSubresourceStatus;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionBuilder;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionVersion;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionVersionBuilder;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceSubresourceStatus;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.internal.KubernetesDeserializer;
-import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaConnect;
@@ -26,17 +26,16 @@ import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static io.strimzi.api.kafka.model.Constants.CRD_KIND;
 import static java.util.Collections.singletonList;
 
 /**
  * "Static" information about the CRDs defined in this package
  */
 public class Crds {
-
     @SuppressWarnings("unchecked")
     private static final Class<? extends CustomResource>[] CRDS = new Class[] {
         Kafka.class,
@@ -65,182 +64,137 @@ public class Crds {
         }
     }
 
+    @SuppressWarnings({"checkstyle:JavaNCSS"})
     private static CustomResourceDefinition crd(Class<? extends CustomResource> cls) {
-        String version = null;
-        if (cls.equals(Kafka.class)) {
-            version = Kafka.CONSUMED_VERSION;
-        } else if (cls.equals(KafkaConnect.class)) {
-            version = KafkaConnect.CONSUMED_VERSION;
-        } else if (cls.equals(KafkaConnectS2I.class)) {
-            version = KafkaConnectS2I.CONSUMED_VERSION;
-        } else if (cls.equals(KafkaTopic.class)) {
-            version = KafkaTopic.CONSUMED_VERSION;
-        } else if (cls.equals(KafkaUser.class)) {
-            version = KafkaUser.CONSUMED_VERSION;
-        } else if (cls.equals(KafkaMirrorMaker.class)) {
-            version = KafkaMirrorMaker.CONSUMED_VERSION;
-        } else if (cls.equals(KafkaBridge.class)) {
-            version = KafkaBridge.CONSUMED_VERSION;
-        } else if (cls.equals(KafkaConnector.class)) {
-            version = KafkaConnector.CONSUMED_VERSION;
-        } else if (cls.equals(KafkaMirrorMaker2.class)) {
-            version = KafkaMirrorMaker2.CONSUMED_VERSION;
-        } else if (cls.equals(KafkaRebalance.class)) {
-            version = KafkaRebalance.CONSUMED_VERSION;
-        } else {
-            throw new RuntimeException();
-        }
-
-        return crd(cls, version);
-    }
-
-    @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:JavaNCSS"})
-    private static CustomResourceDefinition crd(Class<? extends CustomResource> cls, String version) {
-        String scope, crdApiVersion, plural, singular, group, kind, listKind;
+        String scope, plural, singular, group, kind, listKind;
+        List<String> versions;
         CustomResourceSubresourceStatus status = null;
 
         if (cls.equals(Kafka.class)) {
             scope = Kafka.SCOPE;
-            crdApiVersion = Kafka.CRD_API_VERSION;
             plural = Kafka.RESOURCE_PLURAL;
             singular = Kafka.RESOURCE_SINGULAR;
             group = Kafka.RESOURCE_GROUP;
             kind = Kafka.RESOURCE_KIND;
             listKind = Kafka.RESOURCE_LIST_KIND;
+            versions = Kafka.VERSIONS;
             status = new CustomResourceSubresourceStatus();
-            if (!Kafka.VERSIONS.contains(version)) {
-                throw new RuntimeException();
-            }
         } else if (cls.equals(KafkaConnect.class)) {
             scope = KafkaConnect.SCOPE;
-            crdApiVersion = KafkaConnect.CRD_API_VERSION;
             plural = KafkaConnect.RESOURCE_PLURAL;
             singular = KafkaConnect.RESOURCE_SINGULAR;
             group = KafkaConnect.RESOURCE_GROUP;
             kind = KafkaConnect.RESOURCE_KIND;
             listKind = KafkaConnect.RESOURCE_LIST_KIND;
+            versions = Kafka.VERSIONS;
             status = new CustomResourceSubresourceStatus();
-            if (!KafkaConnect.VERSIONS.contains(version)) {
-                throw new RuntimeException();
-            }
         } else if (cls.equals(KafkaConnectS2I.class)) {
             scope = KafkaConnectS2I.SCOPE;
-            crdApiVersion = KafkaConnectS2I.CRD_API_VERSION;
             plural = KafkaConnectS2I.RESOURCE_PLURAL;
             singular = KafkaConnectS2I.RESOURCE_SINGULAR;
             group = KafkaConnectS2I.RESOURCE_GROUP;
             kind = KafkaConnectS2I.RESOURCE_KIND;
             listKind = KafkaConnectS2I.RESOURCE_LIST_KIND;
+            versions = Kafka.VERSIONS;
             status = new CustomResourceSubresourceStatus();
-            if (!KafkaConnectS2I.VERSIONS.contains(version)) {
-                throw new RuntimeException();
-            }
         } else if (cls.equals(KafkaTopic.class)) {
             scope = KafkaTopic.SCOPE;
-            crdApiVersion = KafkaTopic.CRD_API_VERSION;
             plural = KafkaTopic.RESOURCE_PLURAL;
             singular = KafkaTopic.RESOURCE_SINGULAR;
             group = KafkaTopic.RESOURCE_GROUP;
             kind = KafkaTopic.RESOURCE_KIND;
             listKind = KafkaTopic.RESOURCE_LIST_KIND;
-            if (!KafkaTopic.VERSIONS.contains(version)) {
-                throw new RuntimeException();
-            }
+            versions = Kafka.VERSIONS;
         } else if (cls.equals(KafkaUser.class)) {
             scope = KafkaUser.SCOPE;
-            crdApiVersion = KafkaUser.CRD_API_VERSION;
             plural = KafkaUser.RESOURCE_PLURAL;
             singular = KafkaUser.RESOURCE_SINGULAR;
             group = KafkaUser.RESOURCE_GROUP;
             kind = KafkaUser.RESOURCE_KIND;
             listKind = KafkaUser.RESOURCE_LIST_KIND;
+            versions = Kafka.VERSIONS;
             status = new CustomResourceSubresourceStatus();
-            if (!KafkaUser.VERSIONS.contains(version)) {
-                throw new RuntimeException();
-            }
         } else if (cls.equals(KafkaMirrorMaker.class)) {
             scope = KafkaMirrorMaker.SCOPE;
-            crdApiVersion = KafkaMirrorMaker.CRD_API_VERSION;
             plural = KafkaMirrorMaker.RESOURCE_PLURAL;
             singular = KafkaMirrorMaker.RESOURCE_SINGULAR;
             group = KafkaMirrorMaker.RESOURCE_GROUP;
             kind = KafkaMirrorMaker.RESOURCE_KIND;
             listKind = KafkaMirrorMaker.RESOURCE_LIST_KIND;
+            versions = Kafka.VERSIONS;
             status = new CustomResourceSubresourceStatus();
-            if (!KafkaMirrorMaker.VERSIONS.contains(version)) {
-                throw new RuntimeException();
-            }
         } else if (cls.equals(KafkaBridge.class)) {
             scope = KafkaBridge.SCOPE;
-            crdApiVersion = KafkaBridge.CRD_API_VERSION;
             plural = KafkaBridge.RESOURCE_PLURAL;
             singular = KafkaBridge.RESOURCE_SINGULAR;
             group = KafkaBridge.RESOURCE_GROUP;
             kind = KafkaBridge.RESOURCE_KIND;
             listKind = KafkaBridge.RESOURCE_LIST_KIND;
+            versions = Kafka.VERSIONS;
             status = new CustomResourceSubresourceStatus();
-            if (!KafkaBridge.VERSIONS.contains(version)) {
-                throw new RuntimeException();
-            }
         } else if (cls.equals(KafkaConnector.class)) {
             scope = KafkaConnector.SCOPE;
-            crdApiVersion = KafkaConnector.CRD_API_VERSION;
             plural = KafkaConnector.RESOURCE_PLURAL;
             singular = KafkaConnector.RESOURCE_SINGULAR;
             group = KafkaConnector.RESOURCE_GROUP;
             kind = KafkaConnector.RESOURCE_KIND;
             listKind = KafkaConnector.RESOURCE_LIST_KIND;
+            versions = Kafka.VERSIONS;
             status = new CustomResourceSubresourceStatus();
-            if (!KafkaConnector.VERSIONS.contains(version)) {
-                throw new RuntimeException();
-            }
         } else if (cls.equals(KafkaMirrorMaker2.class)) {
             scope = KafkaMirrorMaker2.SCOPE;
-            crdApiVersion = KafkaMirrorMaker2.CRD_API_VERSION;
             plural = KafkaMirrorMaker2.RESOURCE_PLURAL;
             singular = KafkaMirrorMaker2.RESOURCE_SINGULAR;
             group = KafkaMirrorMaker2.RESOURCE_GROUP;
             kind = KafkaMirrorMaker2.RESOURCE_KIND;
             listKind = KafkaMirrorMaker2.RESOURCE_LIST_KIND;
+            versions = Kafka.VERSIONS;
             status = new CustomResourceSubresourceStatus();
-            if (!KafkaMirrorMaker2.VERSIONS.contains(version)) {
-                throw new RuntimeException();
-            }
         } else if (cls.equals(KafkaRebalance.class)) {
             scope = KafkaRebalance.SCOPE;
-            crdApiVersion = KafkaRebalance.CRD_API_VERSION;
             plural = KafkaRebalance.RESOURCE_PLURAL;
             singular = KafkaRebalance.RESOURCE_SINGULAR;
             group = KafkaRebalance.RESOURCE_GROUP;
             kind = KafkaRebalance.RESOURCE_KIND;
             listKind = KafkaRebalance.RESOURCE_LIST_KIND;
+            versions = Kafka.VERSIONS;
             status = new CustomResourceSubresourceStatus();
-            if (!KafkaRebalance.VERSIONS.contains(version)) {
-                throw new RuntimeException();
-            }
         } else {
             throw new RuntimeException();
         }
 
+        List<CustomResourceDefinitionVersion> crVersions = new ArrayList<>(versions.size());
+        for (String apiVersion : versions)  {
+            crVersions.add(new CustomResourceDefinitionVersionBuilder()
+                    .withNewName(apiVersion)
+                    .withNewSubresources()
+                        .withStatus(status)
+                    .endSubresources()
+                    .withNewSchema()
+                        .withNewOpenAPIV3Schema()
+                            .withType("object")
+                            .withXKubernetesPreserveUnknownFields(true)
+                        .endOpenAPIV3Schema()
+                    .endSchema()
+                    .withStorage("v1beta2".equals(apiVersion))
+                    .withServed(true)
+                    .build());
+        }
+
         return new CustomResourceDefinitionBuilder()
-                .withApiVersion(crdApiVersion)
-                .withKind(CRD_KIND)
                 .withNewMetadata()
                     .withName(plural + "." + group)
                 .endMetadata()
                 .withNewSpec()
                     .withScope(scope)
                     .withGroup(group)
-                    .withVersion(version)
+                    .withVersions(crVersions)
                     .withNewNames()
                         .withSingular(singular)
                         .withPlural(plural)
                         .withKind(kind)
                         .withListKind(listKind)
                     .endNames()
-                    .withNewSubresources()
-                        .withStatus(status)
-                    .endSubresources()
                 .endSpec()
                 .build();
     }
@@ -250,71 +204,31 @@ public class Crds {
     }
 
     public static MixedOperation<Kafka, KafkaList, Resource<Kafka>> kafkaOperation(KubernetesClient client) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafka()), Kafka.class, KafkaList.class);
-    }
-
-    public static MixedOperation<Kafka, KafkaList, Resource<Kafka>> kafkaOperation(KubernetesClient client, String version) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd(Kafka.class, version)), Kafka.class, KafkaList.class);
-    }
-
-    public static MixedOperation<Kafka, KafkaList, Resource<Kafka>> kafkaV1Alpha1Operation(KubernetesClient client) {
-        return kafkaOperation(client, Constants.V1ALPHA1);
-    }
-
-    public static MixedOperation<Kafka, KafkaList, Resource<Kafka>> kafkaV1Beta1Operation(KubernetesClient client) {
-        return kafkaOperation(client, Constants.V1BETA1);
-    }
-
-    public static MixedOperation<Kafka, KafkaList, Resource<Kafka>> kafkaV1Beta2Operation(KubernetesClient client) {
-        return kafkaOperation(client, Constants.V1BETA2);
+        return client.customResources(Kafka.class, KafkaList.class);
     }
 
     public static CustomResourceDefinition kafkaConnect() {
         return crd(KafkaConnect.class);
     }
 
-    public static MixedOperation<KafkaConnect, KafkaConnectList, Resource<KafkaConnect>> kafkaConnectOperation(KubernetesClient client, String version) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd(KafkaConnect.class, version)), KafkaConnect.class, KafkaConnectList.class);
-    }
-
     public static MixedOperation<KafkaConnect, KafkaConnectList, Resource<KafkaConnect>> kafkaConnectOperation(KubernetesClient client) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaConnect()), KafkaConnect.class, KafkaConnectList.class);
-    }
-
-    public static MixedOperation<KafkaConnect, KafkaConnectList, Resource<KafkaConnect>> kafkaConnectV1Beta2Operation(KubernetesClient client) {
-        return kafkaConnectOperation(client, Constants.V1BETA2);
+        return client.customResources(KafkaConnect.class, KafkaConnectList.class);
     }
 
     public static CustomResourceDefinition kafkaConnector() {
         return crd(KafkaConnector.class);
     }
 
-    public static MixedOperation<KafkaConnector, KafkaConnectorList, Resource<KafkaConnector>> kafkaConnectorOperation(KubernetesClient client, String version) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd(KafkaConnector.class, version)), KafkaConnector.class, KafkaConnectorList.class);
-    }
-
     public static MixedOperation<KafkaConnector, KafkaConnectorList, Resource<KafkaConnector>> kafkaConnectorOperation(KubernetesClient client) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaConnector()), KafkaConnector.class, KafkaConnectorList.class);
-    }
-
-    public static MixedOperation<KafkaConnector, KafkaConnectorList, Resource<KafkaConnector>> kafkaConnectorV1Beta2Operation(KubernetesClient client) {
-        return kafkaConnectorOperation(client, Constants.V1BETA2);
+        return client.customResources(KafkaConnector.class, KafkaConnectorList.class);
     }
 
     public static CustomResourceDefinition kafkaConnectS2I() {
         return crd(KafkaConnectS2I.class);
     }
 
-    public static <T extends CustomResource> MixedOperation<KafkaConnectS2I, KafkaConnectS2IList, Resource<KafkaConnectS2I>> kafkaConnectS2iOperation(KubernetesClient client, String version) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd(KafkaConnectS2I.class, version)), KafkaConnectS2I.class, KafkaConnectS2IList.class);
-    }
-
-    public static <T extends CustomResource> MixedOperation<KafkaConnectS2I, KafkaConnectS2IList, Resource<KafkaConnectS2I>> kafkaConnectS2iOperation(KubernetesClient client) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaConnectS2I()), KafkaConnectS2I.class, KafkaConnectS2IList.class);
-    }
-
-    public static <T extends CustomResource> MixedOperation<KafkaConnectS2I, KafkaConnectS2IList, Resource<KafkaConnectS2I>> kafkaConnectS2iV1Beta2Operation(KubernetesClient client) {
-        return kafkaConnectS2iOperation(client, Constants.V1BETA2);
+    public static MixedOperation<KafkaConnectS2I, KafkaConnectS2IList, Resource<KafkaConnectS2I>> kafkaConnectS2iOperation(KubernetesClient client) {
+        return client.customResources(KafkaConnectS2I.class, KafkaConnectS2IList.class);
     }
 
     public static CustomResourceDefinition kafkaTopic() {
@@ -322,15 +236,7 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaTopic, KafkaTopicList, Resource<KafkaTopic>> topicOperation(KubernetesClient client) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaTopic()), KafkaTopic.class, KafkaTopicList.class);
-    }
-
-    public static MixedOperation<KafkaTopic, KafkaTopicList, Resource<KafkaTopic>> topicV1Beta2Operation(KubernetesClient client) {
-        return topicOperation(client, Constants.V1BETA2);
-    }
-
-    public static MixedOperation<KafkaTopic, KafkaTopicList, Resource<KafkaTopic>> topicOperation(KubernetesClient client, String version) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd(KafkaTopic.class, version)), KafkaTopic.class, KafkaTopicList.class);
+        return client.customResources(KafkaTopic.class, KafkaTopicList.class);
     }
 
     public static CustomResourceDefinition kafkaUser() {
@@ -338,31 +244,15 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaUser, KafkaUserList, Resource<KafkaUser>> kafkaUserOperation(KubernetesClient client) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaUser()), KafkaUser.class, KafkaUserList.class);
-    }
-
-    public static MixedOperation<KafkaUser, KafkaUserList, Resource<KafkaUser>> kafkaUserV1Beta2Operation(KubernetesClient client) {
-        return kafkaUserOperation(client, Constants.V1BETA2);
-    }
-
-    public static MixedOperation<KafkaUser, KafkaUserList, Resource<KafkaUser>> kafkaUserOperation(KubernetesClient client, String version) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd(KafkaUser.class, version)), KafkaUser.class, KafkaUserList.class);
+        return client.customResources(KafkaUser.class, KafkaUserList.class);
     }
 
     public static CustomResourceDefinition kafkaMirrorMaker() {
         return crd(KafkaMirrorMaker.class);
     }
 
-    public static MixedOperation<KafkaMirrorMaker, KafkaMirrorMakerList, Resource<KafkaMirrorMaker>> mirrorMakerOperation(KubernetesClient client, String version) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd(KafkaMirrorMaker.class, version)), KafkaMirrorMaker.class, KafkaMirrorMakerList.class);
-    }
-
     public static MixedOperation<KafkaMirrorMaker, KafkaMirrorMakerList, Resource<KafkaMirrorMaker>> mirrorMakerOperation(KubernetesClient client) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaMirrorMaker()), KafkaMirrorMaker.class, KafkaMirrorMakerList.class);
-    }
-
-    public static MixedOperation<KafkaMirrorMaker, KafkaMirrorMakerList, Resource<KafkaMirrorMaker>> mirrorMakerV1Beta2Operation(KubernetesClient client) {
-        return mirrorMakerOperation(client, Constants.V1BETA2);
+        return client.customResources(KafkaMirrorMaker.class, KafkaMirrorMakerList.class);
     }
 
     public static CustomResourceDefinition kafkaBridge() {
@@ -370,31 +260,15 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaBridge, KafkaBridgeList, Resource<KafkaBridge>> kafkaBridgeOperation(KubernetesClient client) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaBridge()), KafkaBridge.class, KafkaBridgeList.class);
-    }
-
-    public static MixedOperation<KafkaBridge, KafkaBridgeList, Resource<KafkaBridge>> kafkaBridgeV1Beta2Operation(KubernetesClient client) {
-        return kafkaBridgeOperation(client, Constants.V1BETA2);
-    }
-
-    public static MixedOperation<KafkaBridge, KafkaBridgeList, Resource<KafkaBridge>> kafkaBridgeOperation(KubernetesClient client, String version) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd(KafkaBridge.class, version)), KafkaBridge.class, KafkaBridgeList.class);
+        return client.customResources(KafkaBridge.class, KafkaBridgeList.class);
     }
 
     public static CustomResourceDefinition kafkaMirrorMaker2() {
         return crd(KafkaMirrorMaker2.class);
     }
 
-    public static MixedOperation<KafkaMirrorMaker2, KafkaMirrorMaker2List, Resource<KafkaMirrorMaker2>> kafkaMirrorMaker2Operation(KubernetesClient client, String version) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd(KafkaMirrorMaker2.class, version)), KafkaMirrorMaker2.class, KafkaMirrorMaker2List.class);
-    }
-
     public static MixedOperation<KafkaMirrorMaker2, KafkaMirrorMaker2List, Resource<KafkaMirrorMaker2>> kafkaMirrorMaker2Operation(KubernetesClient client) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaMirrorMaker2()), KafkaMirrorMaker2.class, KafkaMirrorMaker2List.class);
-    }
-
-    public static MixedOperation<KafkaMirrorMaker2, KafkaMirrorMaker2List, Resource<KafkaMirrorMaker2>> kafkaMirrorMaker2V1Beta2Operation(KubernetesClient client) {
-        return kafkaMirrorMaker2Operation(client, Constants.V1BETA2);
+        return client.customResources(KafkaMirrorMaker2.class, KafkaMirrorMaker2List.class);
     }
 
     public static CustomResourceDefinition kafkaRebalance() {
@@ -402,22 +276,14 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaRebalance, KafkaRebalanceList, Resource<KafkaRebalance>> kafkaRebalanceOperation(KubernetesClient client) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(kafkaRebalance()), KafkaRebalance.class, KafkaRebalanceList.class);
-    }
-
-    public static MixedOperation<KafkaRebalance, KafkaRebalanceList, Resource<KafkaRebalance>> kafkaRebalanceV1Beta2Operation(KubernetesClient client) {
-        return kafkaRebalanceOperation(client, Constants.V1BETA2);
-    }
-
-    public static MixedOperation<KafkaRebalance, KafkaRebalanceList, Resource<KafkaRebalance>> kafkaRebalanceOperation(KubernetesClient client, String version) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd(KafkaRebalance.class, version)), KafkaRebalance.class, KafkaRebalanceList.class);
+        return client.customResources(KafkaRebalance.class, KafkaRebalanceList.class);
     }
 
     public static <T extends CustomResource, L extends CustomResourceList<T>> MixedOperation<T, L, Resource<T>>
             operation(KubernetesClient client,
                       Class<T> cls,
                       Class<L> listCls) {
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd(cls)), cls, listCls);
+        return client.customResources(cls, listCls);
     }
 
     public static <T extends CustomResource> String kind(Class<T> cls) {

--- a/api/src/main/java/io/strimzi/api/kafka/model/Constants.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Constants.java
@@ -13,11 +13,8 @@ public class Constants {
     public static final String V1BETA1 = "v1beta1";
     public static final String V1ALPHA1 = "v1alpha1";
 
-    public static final String CRD_KIND = "CustomResourceDefinition";
     public static final String STRIMZI_CATEGORY = "strimzi";
     public static final String STRIMZI_GROUP = "kafka.strimzi.io";
 
     public static final String FABRIC8_KUBERNETES_API = "io.fabric8.kubernetes.api.builder";
-
-    public static final String V1BETA1_API_VERSION = "apiextensions.k8s.io/" + V1BETA1;
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -103,7 +103,6 @@ public class Kafka extends CustomResource<KafkaSpec, KafkaStatus> implements Nam
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkas";
     public static final String RESOURCE_SINGULAR = "kafka";
-    public static final String CRD_API_VERSION = Constants.V1BETA1_API_VERSION;
     public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
     public static final String SHORT_NAME = "k";
     public static final List<String> RESOURCE_SHORTNAMES = unmodifiableList(singletonList(SHORT_NAME));

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
@@ -99,7 +99,6 @@ public class KafkaBridge extends CustomResource<KafkaBridgeSpec, KafkaBridgeStat
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkabridges";
     public static final String RESOURCE_SINGULAR = "kafkabridge";
-    public static final String CRD_API_VERSION = Constants.V1BETA1_API_VERSION;
     public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
     public static final String SHORT_NAME = "kb";
     public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
@@ -95,7 +95,6 @@ public class KafkaConnect extends CustomResource<KafkaConnectSpec, KafkaConnectS
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkaconnects";
     public static final String RESOURCE_SINGULAR = "kafkaconnect";
-    public static final String CRD_API_VERSION = Constants.V1BETA1_API_VERSION;
     public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
     public static final String SHORT_NAME = "kc";
     public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
@@ -101,7 +101,6 @@ public class KafkaConnectS2I extends CustomResource<KafkaConnectS2ISpec, KafkaCo
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkaconnects2is";
     public static final String RESOURCE_SINGULAR = "kafkaconnects2i";
-    public static final String CRD_API_VERSION = Constants.V1BETA1_API_VERSION;
     public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
     public static final String SHORT_NAME = "kcs2i";
     public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
@@ -95,12 +95,12 @@ public class KafkaConnector extends CustomResource<KafkaConnectorSpec, KafkaConn
     public static final String CONSUMED_VERSION = V1BETA2;
     public static final List<String> VERSIONS = unmodifiableList(asList(V1BETA2, V1ALPHA1));
     public static final String SCOPE = "Namespaced";
-    public static final String CRD_API_VERSION = Constants.V1BETA1_API_VERSION;
     public static final String RESOURCE_PLURAL = "kafkaconnectors";
     public static final String RESOURCE_SINGULAR = "kafkaconnector";
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_KIND = "KafkaConnector";
     public static final String RESOURCE_LIST_KIND = RESOURCE_KIND + "List";
+    public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
     public static final String SHORT_NAME = "kctr";
     public static final String SPEC_REPLICAS_PATH = ".spec.tasksMax";
     public static final String STATUS_REPLICAS_PATH = ".status.tasksMax";

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
@@ -109,7 +109,6 @@ public class KafkaMirrorMaker extends CustomResource<KafkaMirrorMakerSpec, Kafka
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkamirrormakers";
     public static final String RESOURCE_SINGULAR = "kafkamirrormaker";
-    public static final String CRD_API_VERSION = Constants.V1BETA1_API_VERSION;
     public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
     public static final String SHORT_NAME = "kmm";
     public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
@@ -93,7 +93,6 @@ public class KafkaMirrorMaker2 extends CustomResource<KafkaMirrorMaker2Spec, Kaf
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkamirrormaker2s";
     public static final String RESOURCE_SINGULAR = "kafkamirrormaker2";
-    public static final String CRD_API_VERSION = Constants.V1BETA1_API_VERSION;
     public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
     public static final String SHORT_NAME = "kmm2";
     public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
@@ -83,7 +83,6 @@ public class KafkaRebalance extends CustomResource<KafkaRebalanceSpec, KafkaReba
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkarebalances";
     public static final String RESOURCE_SINGULAR = "kafkarebalance";
-    public static final String CRD_API_VERSION = Constants.V1BETA1_API_VERSION;
     public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
     public static final String SHORT_NAME = "kr";
     public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
@@ -102,7 +102,6 @@ public class KafkaTopic extends CustomResource<KafkaTopicSpec, KafkaTopicStatus>
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkatopics";
     public static final String RESOURCE_SINGULAR = "kafkatopic";
-    public static final String CRD_API_VERSION = Constants.V1BETA1_API_VERSION;
     public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
     public static final String SHORT_NAME = "kt";
     public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -101,7 +101,6 @@ public class KafkaUser extends CustomResource<KafkaUserSpec, KafkaUserStatus> im
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkausers";
     public static final String RESOURCE_SINGULAR = "kafkauser";
-    public static final String CRD_API_VERSION = Constants.V1BETA1_API_VERSION;
     public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
     public static final String SHORT_NAME = "ku";
     public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);

--- a/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.api.kafka.model;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.VersionInfo;
@@ -120,27 +119,6 @@ public abstract class AbstractCrdIT implements TestSeparator {
                     containsStringIgnoringCase("missing required field \"" + requiredProperty + "\"")
             ));
         }
-    }
-
-    protected void waitForCrd(String resource, String name) {
-        cluster.cmdClient().waitFor(resource, name, crd -> {
-            JsonNode json = (JsonNode) crd;
-            if (json != null
-                    && json.hasNonNull("status")
-                    && json.get("status").hasNonNull("conditions")
-                    && json.get("status").get("conditions").isArray()) {
-                for (JsonNode condition : json.get("status").get("conditions")) {
-                    if ("Established".equals(condition.get("type").asText())
-                            && "True".equals(condition.get("status").asText()))   {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-
-            return false;
-        });
     }
 
     @BeforeEach

--- a/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionSpec;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionSpec;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.Test;

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
@@ -136,7 +136,7 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
     void setupEnvironment() throws InterruptedException {
         cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA_BRIDGE);
-        waitForCrd("crd", "kafkabridges.kafka.strimzi.io");
+        cluster.waitForCustomResourceDefinition("kafkabridges.kafka.strimzi.io");
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
@@ -122,7 +122,7 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
     @BeforeEach
     void setup() {
         cluster.createCustomResources(TestUtils.CRD_KAFKA_CONNECT);
-        waitForCrd("crd", "kafkaconnects.kafka.strimzi.io");
+        cluster.waitForCustomResourceDefinition("kafkaconnects.kafka.strimzi.io");
     }
 
     @AfterEach

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectorCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectorCrdIT.java
@@ -32,7 +32,7 @@ public class KafkaConnectorCrdIT extends AbstractCrdIT {
     void setupEnvironment() {
         cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA_CONNECTOR);
-        waitForCrd("crd", "kafkaconnectors.kafka.strimzi.io");
+        cluster.waitForCustomResourceDefinition("kafkaconnectors.kafka.strimzi.io");
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -156,7 +156,7 @@ public class KafkaCrdIT extends AbstractCrdIT {
     void setupEnvironment() {
         cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA);
-        waitForCrd("crd", "kafkas.kafka.strimzi.io");
+        cluster.waitForCustomResourceDefinition("kafkas.kafka.strimzi.io");
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2CrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2CrdIT.java
@@ -112,7 +112,7 @@ public class KafkaMirrorMaker2CrdIT extends AbstractCrdIT {
     void setupEnvironment() {
         cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA_MIRROR_MAKER_2);
-        waitForCrd("crd", "kafkamirrormaker2s.kafka.strimzi.io");
+        cluster.waitForCustomResourceDefinition("kafkamirrormaker2s.kafka.strimzi.io");
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
@@ -100,7 +100,7 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
     void setupEnvironment() {
         cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA_MIRROR_MAKER);
-        waitForCrd("crd", "kafkamirrormakers.kafka.strimzi.io");
+        cluster.waitForCustomResourceDefinition("kafkamirrormakers.kafka.strimzi.io");
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaRebalanceCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaRebalanceCrdIT.java
@@ -56,7 +56,7 @@ public class KafkaRebalanceCrdIT extends AbstractCrdIT {
     void setupEnvironment() {
         cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA_REBALANCE);
-        waitForCrd("crd", "kafkarebalances.kafka.strimzi.io");
+        cluster.waitForCustomResourceDefinition("kafkarebalances.kafka.strimzi.io");
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
@@ -59,7 +59,7 @@ public class KafkaTopicCrdIT extends AbstractCrdIT {
     void setupEnvironment() {
         cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_TOPIC);
-        waitForCrd("crd", "kafkatopics.kafka.strimzi.io");
+        cluster.waitForCustomResourceDefinition("kafkatopics.kafka.strimzi.io");
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
@@ -58,7 +58,7 @@ public class KafkaUserCrdIT extends AbstractCrdIT {
     void setupEnvironment() {
         cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA_USER);
-        waitForCrd("crd", "kafkausers.kafka.strimzi.io");
+        cluster.waitForCustomResourceDefinition("kafkausers.kafka.strimzi.io");
     }
 
     @AfterAll

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.cluster.operator.resource;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaBridgeList;
 import io.strimzi.api.kafka.KafkaConnectList;
 import io.strimzi.api.kafka.KafkaConnectS2IList;
@@ -127,14 +126,14 @@ public class ResourceOperatorSupplier {
                 pfa.hasBuilds() ? new BuildConfigOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
                 pfa.hasBuilds() ? new BuildOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
                 pfa.hasApps() ? new DeploymentConfigOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
-                new CrdOperator<>(vertx, client, Kafka.class, KafkaList.class, Crds.kafka()),
-                new CrdOperator<>(vertx, client, KafkaConnect.class, KafkaConnectList.class, Crds.kafkaConnect()),
-                pfa.hasBuilds() && pfa.hasApps() && pfa.hasImages() ? new CrdOperator<>(vertx, client.adapt(OpenShiftClient.class), KafkaConnectS2I.class, KafkaConnectS2IList.class, Crds.kafkaConnectS2I()) : null,
-                new CrdOperator<>(vertx, client, KafkaMirrorMaker.class, KafkaMirrorMakerList.class, Crds.kafkaMirrorMaker()),
-                new CrdOperator<>(vertx, client, KafkaBridge.class, KafkaBridgeList.class, Crds.kafkaBridge()),
-                new CrdOperator<>(vertx, client, KafkaConnector.class, KafkaConnectorList.class, Crds.kafkaConnector()),
-                new CrdOperator<>(vertx, client, KafkaMirrorMaker2.class, KafkaMirrorMaker2List.class, Crds.kafkaMirrorMaker2()),
-                new CrdOperator<>(vertx, client, KafkaRebalance.class, KafkaRebalanceList.class, Crds.kafkaRebalance()),
+                new CrdOperator<>(vertx, client, Kafka.class, KafkaList.class, Kafka.RESOURCE_KIND),
+                new CrdOperator<>(vertx, client, KafkaConnect.class, KafkaConnectList.class, KafkaConnect.RESOURCE_KIND),
+                pfa.hasBuilds() && pfa.hasApps() && pfa.hasImages() ? new CrdOperator<>(vertx, client.adapt(OpenShiftClient.class), KafkaConnectS2I.class, KafkaConnectS2IList.class, KafkaConnectS2I.RESOURCE_KIND) : null,
+                new CrdOperator<>(vertx, client, KafkaMirrorMaker.class, KafkaMirrorMakerList.class, KafkaMirrorMaker.RESOURCE_KIND),
+                new CrdOperator<>(vertx, client, KafkaBridge.class, KafkaBridgeList.class, KafkaBridge.RESOURCE_KIND),
+                new CrdOperator<>(vertx, client, KafkaConnector.class, KafkaConnectorList.class, KafkaConnector.RESOURCE_KIND),
+                new CrdOperator<>(vertx, client, KafkaMirrorMaker2.class, KafkaMirrorMaker2List.class, KafkaMirrorMaker2.RESOURCE_KIND),
+                new CrdOperator<>(vertx, client, KafkaRebalance.class, KafkaRebalanceList.class, KafkaRebalance.RESOURCE_KIND),
                 new StorageClassOperator(vertx, client),
                 new NodeOperator(vertx, client),
                 zkScalerProvider,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -4,8 +4,8 @@
  */
 package io.strimzi.operator.cluster;
 
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionList;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
@@ -5,7 +5,7 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaList;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -13,7 +13,7 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetSpec;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetStatus;
@@ -510,7 +510,7 @@ public class KafkaAssemblyOperatorMockTest {
     }
 
     private Resource<Kafka> kafkaAssembly(String namespace, String name) {
-        CustomResourceDefinition crd = client.apiextensions().v1beta1().customResourceDefinitions().withName(Kafka.CRD_NAME).get();
+        CustomResourceDefinition crd = client.apiextensions().v1().customResourceDefinitions().withName(Kafka.CRD_NAME).get();
         return client.customResources(CustomResourceDefinitionContext.fromCrd(crd), Kafka.class, KafkaList.class)
                 .inNamespace(namespace).withName(name);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
@@ -6,7 +6,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -7,7 +7,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.Crds;

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
@@ -22,8 +22,8 @@ import io.fabric8.kubernetes.api.model.SecretList;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountList;
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionList;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionList;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetList;
@@ -41,8 +41,8 @@ import io.fabric8.kubernetes.api.model.rbac.RoleBindingList;
 import io.fabric8.kubernetes.api.model.rbac.RoleList;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.V1ApiextensionAPIGroupDSL;
 import io.fabric8.kubernetes.client.V1NetworkAPIGroupDSL;
-import io.fabric8.kubernetes.client.V1beta1ApiextensionAPIGroupDSL;
 import io.fabric8.kubernetes.client.V1beta1NetworkAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.ApiextensionsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
@@ -313,11 +313,11 @@ public class MockKube {
             }
 
             ApiextensionsAPIGroupDSL mockApiEx = mock(ApiextensionsAPIGroupDSL.class);
-            V1beta1ApiextensionAPIGroupDSL mockv1b1 = mock(V1beta1ApiextensionAPIGroupDSL.class);
+            V1ApiextensionAPIGroupDSL mockv1 = mock(V1ApiextensionAPIGroupDSL.class);
 
             when(mockClient.apiextensions()).thenReturn(mockApiEx);
-            when(mockApiEx.v1beta1()).thenReturn(mockv1b1);
-            when(mockv1b1.customResourceDefinitions()).thenReturn(mockCrds);
+            when(mockApiEx.v1()).thenReturn(mockv1);
+            when(mockv1.customResourceDefinitions()).thenReturn(mockCrds);
 
             mockCrs(mockClient);
         }
@@ -352,11 +352,11 @@ public class MockKube {
         buildConfigMockBuilder.build2(mockOpenShiftClient::buildConfigs);
         if (mockedCrds != null && !mockedCrds.isEmpty()) {
             ApiextensionsAPIGroupDSL mockApiEx = mock(ApiextensionsAPIGroupDSL.class);
-            V1beta1ApiextensionAPIGroupDSL mockv1b1 = mock(V1beta1ApiextensionAPIGroupDSL.class);
+            V1ApiextensionAPIGroupDSL mockv1 = mock(V1ApiextensionAPIGroupDSL.class);
 
             when(mockOpenShiftClient.apiextensions()).thenReturn(mockApiEx);
-            when(mockApiEx.v1beta1()).thenReturn(mockv1b1);
-            when(mockv1b1.customResourceDefinitions()).thenReturn(mockCrds);
+            when(mockApiEx.v1()).thenReturn(mockv1);
+            when(mockv1.customResourceDefinitions()).thenReturn(mockCrds);
             mockCrs(mockOpenShiftClient);
         }
 

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -47,10 +47,6 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model-apiextensions</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-model-core</artifactId>
         </dependency>
         <dependency>

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -6,7 +6,6 @@ package io.strimzi.operator.common.operator.resource;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -34,10 +33,10 @@ public class CrdOperator<C extends KubernetesClient,
      * @param client The Kubernetes client
      * @param cls The class of the CR
      * @param listCls The class of the list.
-     * @param crd The CustomResourceDefinition of the CR
+     * @param kind The Kind of the CR for which this operator should be used
      */
-    public CrdOperator(Vertx vertx, C client, Class<T> cls, Class<L> listCls, CustomResourceDefinition crd) {
-        super(vertx, client, crd.getSpec().getNames().getKind());
+    public CrdOperator(Vertx vertx, C client, Class<T> cls, Class<L> listCls, String kind) {
+        super(vertx, client, kind);
         this.cls = cls;
         this.listCls = listCls;
     }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractCustomResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractCustomResourceOperatorIT.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
@@ -65,7 +64,8 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
     private static KubeClusterResource cluster;
 
     protected abstract CrdOperator<C, T, L> operator();
-    protected abstract CustomResourceDefinition getCrd();
+    protected abstract String getCrd();
+    protected abstract String getCrdName();
     protected abstract String getNamespace();
     protected abstract T getResource(String name);
     protected abstract T getResourceWithModifications(T resourceInCluster);
@@ -93,7 +93,8 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
         cmdKubeClient().waitForResourceCreation("Namespace", namespace);
 
         log.info("Creating CRD");
-        client.apiextensions().v1beta1().customResourceDefinitions().createOrReplace(getCrd());
+        cluster.createCustomResources(getCrd());
+        cluster.waitForCustomResourceDefinition(getCrdName());
         log.info("Created CRD");
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaBridgeCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaBridgeCrdOperatorIT.java
@@ -4,15 +4,13 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaBridgeList;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridgeBuilder;
 import io.strimzi.api.kafka.model.status.ConditionBuilder;
-
+import io.strimzi.test.TestUtils;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -34,12 +32,17 @@ public class KafkaBridgeCrdOperatorIT extends AbstractCustomResourceOperatorIT<K
 
     @Override
     protected CrdOperator operator() {
-        return new CrdOperator(vertx, client, KafkaBridge.class, KafkaBridgeList.class, Crds.kafkaBridge());
+        return new CrdOperator(vertx, client, KafkaBridge.class, KafkaBridgeList.class, KafkaBridge.RESOURCE_KIND);
     }
 
     @Override
-    protected CustomResourceDefinition getCrd() {
-        return Crds.kafkaBridge();
+    protected String getCrd() {
+        return TestUtils.CRD_KAFKA_BRIDGE;
+    }
+
+    @Override
+    protected String getCrdName() {
+        return KafkaBridge.CRD_NAME;
     }
 
     @Override
@@ -51,10 +54,11 @@ public class KafkaBridgeCrdOperatorIT extends AbstractCustomResourceOperatorIT<K
     protected KafkaBridge getResource(String resourceName) {
         return new KafkaBridgeBuilder()
                 .withNewMetadata()
-                .withName(resourceName)
-                .withNamespace(getNamespace())
+                    .withName(resourceName)
+                    .withNamespace(getNamespace())
                 .endMetadata()
                 .withNewSpec()
+                    .withNewBootstrapServers("localhost:9092")
                 .endSpec()
                 .withNewStatus()
                 .endStatus()
@@ -65,7 +69,7 @@ public class KafkaBridgeCrdOperatorIT extends AbstractCustomResourceOperatorIT<K
     protected KafkaBridge getResourceWithModifications(KafkaBridge resourceInCluster) {
         return new KafkaBridgeBuilder(resourceInCluster)
                 .editSpec()
-                .withLogging(new InlineLogging())
+                    .withLogging(new InlineLogging())
                 .endSpec()
                 .build();
     }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectCrdOperatorIT.java
@@ -4,12 +4,11 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaConnectList;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectBuilder;
+import io.strimzi.test.TestUtils;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -31,12 +30,17 @@ public class KafkaConnectCrdOperatorIT extends AbstractCustomResourceOperatorIT<
 
     @Override
     protected CrdOperator operator() {
-        return new CrdOperator(vertx, client, KafkaConnect.class, KafkaConnectList.class, Crds.kafkaConnect());
+        return new CrdOperator(vertx, client, KafkaConnect.class, KafkaConnectList.class, KafkaConnect.RESOURCE_KIND);
     }
 
     @Override
-    protected CustomResourceDefinition getCrd() {
-        return Crds.kafkaConnect();
+    protected String getCrd() {
+        return TestUtils.CRD_KAFKA_CONNECT;
+    }
+
+    @Override
+    protected String getCrdName() {
+        return KafkaConnect.CRD_NAME;
     }
 
     @Override
@@ -52,6 +56,7 @@ public class KafkaConnectCrdOperatorIT extends AbstractCustomResourceOperatorIT<
                     .withNamespace(getNamespace())
                 .endMetadata()
                 .withNewSpec()
+                    .withNewBootstrapServers("localhost:9092")
                 .endSpec()
                 .withNewStatus()
                 .endStatus()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectS2ICrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectS2ICrdOperatorIT.java
@@ -4,12 +4,11 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaConnectS2IList;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaConnectS2IBuilder;
+import io.strimzi.test.TestUtils;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -31,13 +30,18 @@ public class KafkaConnectS2ICrdOperatorIT extends AbstractCustomResourceOperator
 
     @Override
     protected CrdOperator operator() {
-        return new CrdOperator(vertx, client, KafkaConnectS2I.class, KafkaConnectS2IList.class, Crds.kafkaConnectS2I());
+        return new CrdOperator(vertx, client, KafkaConnectS2I.class, KafkaConnectS2IList.class, KafkaConnectS2I.RESOURCE_KIND);
 
     }
 
     @Override
-    protected CustomResourceDefinition getCrd() {
-        return Crds.kafkaConnectS2I();
+    protected String getCrd() {
+        return TestUtils.CRD_KAFKA_CONNECT_S2I;
+    }
+
+    @Override
+    protected String getCrdName() {
+        return KafkaConnectS2I.CRD_NAME;
     }
 
     @Override
@@ -49,10 +53,11 @@ public class KafkaConnectS2ICrdOperatorIT extends AbstractCustomResourceOperator
     protected KafkaConnectS2I getResource(String resourceName) {
         return new KafkaConnectS2IBuilder()
                 .withNewMetadata()
-                .withName(resourceName)
-                .withNamespace(getNamespace())
+                    .withName(resourceName)
+                    .withNamespace(getNamespace())
                 .endMetadata()
                 .withNewSpec()
+                    .withNewBootstrapServers("localhost:9092")
                 .endSpec()
                 .withNewStatus()
                 .endStatus()
@@ -63,9 +68,9 @@ public class KafkaConnectS2ICrdOperatorIT extends AbstractCustomResourceOperator
     protected KafkaConnectS2I getResourceWithModifications(KafkaConnectS2I resourceInCluster) {
         return new KafkaConnectS2IBuilder(resourceInCluster)
                 .editSpec()
-                .withNewLivenessProbe()
-                .withInitialDelaySeconds(14)
-                .endLivenessProbe()
+                    .withNewLivenessProbe()
+                        .withInitialDelaySeconds(14)
+                    .endLivenessProbe()
                 .endSpec()
                 .build();
 
@@ -75,7 +80,7 @@ public class KafkaConnectS2ICrdOperatorIT extends AbstractCustomResourceOperator
     protected KafkaConnectS2I getResourceWithNewReadyStatus(KafkaConnectS2I resourceInCluster) {
         return new KafkaConnectS2IBuilder(resourceInCluster)
                 .withNewStatus()
-                .withConditions(READY_CONDITION)
+                    .withConditions(READY_CONDITION)
                 .endStatus()
                 .build();
     }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectorCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectorCrdOperatorIT.java
@@ -4,12 +4,11 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaConnectorList;
 import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
+import io.strimzi.test.TestUtils;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -31,12 +30,17 @@ public class KafkaConnectorCrdOperatorIT extends AbstractCustomResourceOperatorI
 
     @Override
     protected CrdOperator operator() {
-        return new CrdOperator(vertx, client, KafkaConnector.class, KafkaConnectorList.class, Crds.kafkaConnector());
+        return new CrdOperator(vertx, client, KafkaConnector.class, KafkaConnectorList.class, KafkaConnector.RESOURCE_KIND);
     }
 
     @Override
-    protected CustomResourceDefinition getCrd() {
-        return Crds.kafkaConnector();
+    protected String getCrd() {
+        return TestUtils.CRD_KAFKA_CONNECTOR;
+    }
+
+    @Override
+    protected String getCrdName() {
+        return KafkaConnector.CRD_NAME;
     }
 
     @Override

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaList;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
@@ -76,7 +75,7 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
 
     @Override
     protected CrdOperator createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
-        return new CrdOperator(vertx, mockClient, Kafka.class, KafkaList.class, Crds.kafka());
+        return new CrdOperator(vertx, mockClient, Kafka.class, KafkaList.class, Kafka.RESOURCE_KIND);
     }
 
     @Test

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMaker2CrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMaker2CrdOperatorIT.java
@@ -4,12 +4,11 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaMirrorMaker2List;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Builder;
+import io.strimzi.test.TestUtils;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -31,12 +30,17 @@ public class KafkaMirrorMaker2CrdOperatorIT extends AbstractCustomResourceOperat
 
     @Override
     protected CrdOperator operator() {
-        return new CrdOperator(vertx, client, KafkaMirrorMaker2.class, KafkaMirrorMaker2List.class, Crds.kafkaMirrorMaker2());
+        return new CrdOperator(vertx, client, KafkaMirrorMaker2.class, KafkaMirrorMaker2List.class, KafkaMirrorMaker2.RESOURCE_KIND);
     }
 
     @Override
-    protected CustomResourceDefinition getCrd() {
-        return Crds.kafkaMirrorMaker2();
+    protected String getCrd() {
+        return TestUtils.CRD_KAFKA_MIRROR_MAKER_2;
+    }
+
+    @Override
+    protected String getCrdName() {
+        return KafkaMirrorMaker2.CRD_NAME;
     }
 
     @Override
@@ -52,6 +56,7 @@ public class KafkaMirrorMaker2CrdOperatorIT extends AbstractCustomResourceOperat
                     .withNamespace(getNamespace())
                 .endMetadata()
                 .withNewSpec()
+                    .withConnectCluster("target-cluster")
                 .endSpec()
                 .withNewStatus()
                 .endStatus()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMakerCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMakerCrdOperatorIT.java
@@ -4,13 +4,12 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaMirrorMakerList;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerBuilder;
+import io.strimzi.test.TestUtils;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -32,12 +31,17 @@ public class KafkaMirrorMakerCrdOperatorIT extends AbstractCustomResourceOperato
 
     @Override
     protected CrdOperator operator() {
-        return new CrdOperator(vertx, client, KafkaMirrorMaker.class, KafkaMirrorMakerList.class, Crds.kafkaMirrorMaker());
+        return new CrdOperator(vertx, client, KafkaMirrorMaker.class, KafkaMirrorMakerList.class, KafkaMirrorMaker.RESOURCE_KIND);
     }
 
     @Override
-    protected CustomResourceDefinition getCrd() {
-        return Crds.kafkaMirrorMaker();
+    protected String getCrd() {
+        return TestUtils.CRD_KAFKA_MIRROR_MAKER;
+    }
+
+    @Override
+    protected String getCrdName() {
+        return KafkaMirrorMaker.CRD_NAME;
     }
 
     @Override
@@ -53,6 +57,14 @@ public class KafkaMirrorMakerCrdOperatorIT extends AbstractCustomResourceOperato
                     .withNamespace(getNamespace())
                 .endMetadata()
                 .withNewSpec()
+                    .withNewConsumer()
+                        .withBootstrapServers("localhost:9092")
+                        .withGroupId("my-group")
+                    .endConsumer()
+                    .withNewProducer()
+                        .withBootstrapServers("localhost:9092")
+                    .endProducer()
+                    .withWhitelist(".*")
                 .endSpec()
                 .withNewStatus()
                 .endStatus()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaUserCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaUserCrdOperatorIT.java
@@ -4,12 +4,11 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaUserList;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserBuilder;
+import io.strimzi.test.TestUtils;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -31,12 +30,17 @@ public class KafkaUserCrdOperatorIT extends AbstractCustomResourceOperatorIT<Kub
 
     @Override
     protected CrdOperator operator() {
-        return new CrdOperator(vertx, client, KafkaUser.class, KafkaUserList.class, Crds.kafkaUser());
+        return new CrdOperator(vertx, client, KafkaUser.class, KafkaUserList.class, KafkaUser.RESOURCE_KIND);
     }
 
     @Override
-    protected CustomResourceDefinition getCrd() {
-        return Crds.kafkaUser();
+    protected String getCrd() {
+        return TestUtils.CRD_KAFKA_USER;
+    }
+
+    @Override
+    protected String getCrdName() {
+        return KafkaUser.CRD_NAME;
     }
 
     @Override

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -16,7 +16,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.batch.Job;
@@ -772,7 +772,7 @@ public class KubeClient {
     // =========================
 
     public List<CustomResourceDefinition> listCustomResourceDefinition() {
-        return client.apiextensions().v1beta1().customResourceDefinitions().list().getItems();
+        return client.apiextensions().v1().customResourceDefinitions().list().getItems();
     }
 
     private static class SimpleListener implements ExecListener {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
@@ -10,7 +10,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.operator.common.Util;
@@ -38,7 +37,7 @@ public class K8sImpl implements K8s {
     public K8sImpl(Vertx vertx, KubernetesClient client, Labels labels, String namespace) {
         this.vertx = vertx;
         this.client = client;
-        this.crdOperator = new CrdOperator<>(vertx, client, KafkaTopic.class, KafkaTopicList.class, Crds.kafkaTopic());
+        this.crdOperator = new CrdOperator<>(vertx, client, KafkaTopic.class, KafkaTopicList.class, KafkaTopic.RESOURCE_KIND);
         this.labels = labels;
         this.namespace = namespace;
     }

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -78,7 +78,7 @@ public class Main {
 
         OpenSslCertManager certManager = new OpenSslCertManager();
         SecretOperator secretOperations = new SecretOperator(vertx, client);
-        CrdOperator<KubernetesClient, KafkaUser, KafkaUserList> crdOperations = new CrdOperator<>(vertx, client, KafkaUser.class, KafkaUserList.class, Crds.kafkaUser());
+        CrdOperator<KubernetesClient, KafkaUser, KafkaUserList> crdOperations = new CrdOperator<>(vertx, client, KafkaUser.class, KafkaUserList.class, KafkaUser.RESOURCE_KIND);
         return createAdminClient(adminClientProvider, config, secretOperations)
                 .compose(adminClient -> {
                     SimpleAclOperator aclOperations = new SimpleAclOperator(vertx, adminClient);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We have already moved to use `apiextensions/v1` CRD in our YAML files. This PR moves the Strimzi components to use `apiextensions/v1` API also when talking with the API server. `apiextensions/v1beta1` are now used only for `api-conversion` tool which needs to work with the old APIs and in two ITs in the `api` module.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally