### PR TITLE
[MO] - [Azure] -> ConnectST pipeline parallelism disabled (OOM)

### DIFF
--- a/.azure/regression-pipeline.yaml
+++ b/.azure/regression-pipeline.yaml
@@ -34,7 +34,7 @@ jobs:
       test_case: 'connect/**/*ST,tracing/**/*ST,watcher/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
-      run_parallel: 'false'
+      run_parallel: false
       timeout: 360
 
   - template: 'templates/system_test_general.yaml'

--- a/.azure/regression-pipeline.yaml
+++ b/.azure/regression-pipeline.yaml
@@ -34,7 +34,7 @@ jobs:
       test_case: 'connect/**/*ST,tracing/**/*ST,watcher/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
-      paralell: '1'
+      run_parallel: 'false'
       timeout: 360
 
   - template: 'templates/system_test_general.yaml'

--- a/.azure/regression-pipeline.yaml
+++ b/.azure/regression-pipeline.yaml
@@ -34,6 +34,7 @@ jobs:
       test_case: 'connect/**/*ST,tracing/**/*ST,watcher/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
+      paralell: '1'
       timeout: 360
 
   - template: 'templates/system_test_general.yaml'

--- a/.azure/templates/system_test_general.yaml
+++ b/.azure/templates/system_test_general.yaml
@@ -10,7 +10,7 @@ parameters:
   strimzi_rbac_scope: 'CLUSTER'
   # currently minikube with 2 CPUs and ~8GB RAM can handle 2 parallel tests at once (not more)
   parallel: '2'
-  run_parallel: 'true'
+  run_parallel: true
 
 jobs:
 - job: '${{ parameters.name }}_system_tests'
@@ -72,7 +72,7 @@ jobs:
         publishJUnitResults: true
         testResultsFiles: '**/failsafe-reports/TEST-*.xml'
         goals: 'verify'
-        options: '-Dgroups=${{ parameters.groups }} -Dit.test="${{ parameters.test_case }}" -DexcludedGroups=flaky,loadbalancer,networkpolicies,${{ parameters.excludedGroups }} -Dmaven.javadoc.skip=true -B -V -Dfailsafe.rerunFailingTestsCount=2 -Djunit.jupiter.execution.parallel.enabled="${{ parameters.run_parallel }}" -Djunit.jupiter.execution.parallel.config.fixed.parallelism="${{ parameters.parallel }}"'
+        options: '-Dgroups=${{ parameters.groups }} -Dit.test="${{ parameters.test_case }}" -DexcludedGroups=flaky,loadbalancer,networkpolicies,${{ parameters.excludedGroups }} -Dmaven.javadoc.skip=true -B -V -Dfailsafe.rerunFailingTestsCount=2 -Djunit.jupiter.execution.parallel.enabled=${{ parameters.run_parallel }} -Djunit.jupiter.execution.parallel.config.fixed.parallelism="${{ parameters.parallel }}"'
       env:
         DOCKER_TAG: $(docker_tag)
         BRIDGE_IMAGE: "latest-released"

--- a/.azure/templates/system_test_general.yaml
+++ b/.azure/templates/system_test_general.yaml
@@ -9,7 +9,8 @@ parameters:
   timeout: ''
   strimzi_rbac_scope: 'CLUSTER'
   # currently minikube with 2 CPUs and ~8GB RAM can handle 2 parallel tests at once (not more)
-  parallel: '2' 
+  parallel: '2'
+  run_parallel: 'true'
 
 jobs:
 - job: '${{ parameters.name }}_system_tests'
@@ -71,7 +72,7 @@ jobs:
         publishJUnitResults: true
         testResultsFiles: '**/failsafe-reports/TEST-*.xml'
         goals: 'verify'
-        options: '-Dgroups=${{ parameters.groups }} -Dit.test="${{ parameters.test_case }}" -DexcludedGroups=flaky,loadbalancer,networkpolicies,${{ parameters.excludedGroups }} -Dmaven.javadoc.skip=true -B -V -Dfailsafe.rerunFailingTestsCount=2 -Djunit.jupiter.execution.parallel.enabled=true -Djunit.jupiter.execution.parallel.config.fixed.parallelism="${{ parameters.parallel }}"'
+        options: '-Dgroups=${{ parameters.groups }} -Dit.test="${{ parameters.test_case }}" -DexcludedGroups=flaky,loadbalancer,networkpolicies,${{ parameters.excludedGroups }} -Dmaven.javadoc.skip=true -B -V -Dfailsafe.rerunFailingTestsCount=2 -Djunit.jupiter.execution.parallel.enabled="${{ parameters.run_parallel }}" -Djunit.jupiter.execution.parallel.config.fixed.parallelism="${{ parameters.parallel }}"'
       env:
         DOCKER_TAG: $(docker_tag)
         BRIDGE_IMAGE: "latest-released"


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature

### Description

After some observation of how our system tests behave I found out that `ConnectST` pipeline fails because of out of memory. So I decided to set specifically this pipeline to run only one test at the same time.  


### Checklist

- [x] Make sure all tests pass
