### PR TITLE
Mark CRD versions as deprecated

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -43,9 +43,9 @@ import static java.util.Collections.unmodifiableList;
                 group = Kafka.RESOURCE_GROUP,
                 scope = Kafka.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = Kafka.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = Kafka.V1BETA1, served = true, storage = true),
-                        @Crd.Spec.Version(name = Kafka.V1ALPHA1, served = true, storage = false)
+                        @Crd.Spec.Version(name = Kafka.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = Kafka.V1BETA1, served = true, storage = false, deprecated = true),
+                        @Crd.Spec.Version(name = Kafka.V1ALPHA1, served = true, storage = false, deprecated = true)
                 },
                 subresources = @Crd.Spec.Subresources(
                         status = @Crd.Spec.Subresources.Status()

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
@@ -42,8 +42,8 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaBridge.RESOURCE_GROUP,
                 scope = KafkaBridge.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaBridge.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaBridge.V1ALPHA1, served = true, storage = true)
+                        @Crd.Spec.Version(name = KafkaBridge.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaBridge.V1ALPHA1, served = true, storage = false, deprecated = true)
                 },
                 subresources = @Crd.Spec.Subresources(
                         status = @Crd.Spec.Subresources.Status(),

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
@@ -43,9 +43,9 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaConnect.RESOURCE_GROUP,
                 scope = KafkaConnect.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaConnect.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaConnect.V1BETA1, served = true, storage = true),
-                        @Crd.Spec.Version(name = KafkaConnect.V1ALPHA1, served = true, storage = false)
+                        @Crd.Spec.Version(name = KafkaConnect.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaConnect.V1BETA1, served = true, storage = false, deprecated = true),
+                        @Crd.Spec.Version(name = KafkaConnect.V1ALPHA1, served = true, storage = false, deprecated = true)
                 },
                 subresources = @Crd.Spec.Subresources(
                         status = @Crd.Spec.Subresources.Status(),

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
@@ -47,9 +47,12 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaConnectS2I.RESOURCE_GROUP,
                 scope = KafkaConnectS2I.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaConnectS2I.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaConnectS2I.V1BETA1, served = true, storage = true),
-                        @Crd.Spec.Version(name = KafkaConnectS2I.V1ALPHA1, served = true, storage = false)
+                        @Crd.Spec.Version(name = KafkaConnectS2I.V1BETA2, served = true, storage = true, deprecated = true,
+                                deprecationWarning = "KafkaConnectS2I resource is deprecated. " +
+                                        "Use the KafkaConnect resource instead. " +
+                                        "See https://strimzi.io/docs/operators/latest/using.html#proc-migrating-kafka-connect-s2i-str for instructions how to migrate."),
+                        @Crd.Spec.Version(name = KafkaConnectS2I.V1BETA1, served = true, storage = false, deprecated = true),
+                        @Crd.Spec.Version(name = KafkaConnectS2I.V1ALPHA1, served = true, storage = false, deprecated = true)
                 },
                 subresources = @Crd.Spec.Subresources(
                         status = @Crd.Spec.Subresources.Status(),

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
@@ -39,8 +39,8 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaConnector.RESOURCE_GROUP,
                 scope = KafkaConnector.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaConnector.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaConnector.V1ALPHA1, served = true, storage = true)
+                        @Crd.Spec.Version(name = KafkaConnector.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaConnector.V1ALPHA1, served = true, storage = false, deprecated = true)
                 },
                 subresources = @Crd.Spec.Subresources(
                         status = @Crd.Spec.Subresources.Status(),

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
@@ -42,9 +42,9 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaMirrorMaker.RESOURCE_GROUP,
                 scope = KafkaMirrorMaker.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaMirrorMaker.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaMirrorMaker.V1BETA1, served = true, storage = true),
-                        @Crd.Spec.Version(name = KafkaMirrorMaker.V1ALPHA1, served = true, storage = false)
+                        @Crd.Spec.Version(name = KafkaMirrorMaker.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaMirrorMaker.V1BETA1, served = true, storage = false, deprecated = true),
+                        @Crd.Spec.Version(name = KafkaMirrorMaker.V1ALPHA1, served = true, storage = false, deprecated = true)
                 },
                 subresources = @Crd.Spec.Subresources(
                         status = @Crd.Spec.Subresources.Status(),

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
@@ -42,8 +42,8 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaMirrorMaker2.RESOURCE_GROUP,
                 scope = KafkaMirrorMaker2.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaMirrorMaker2.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaMirrorMaker2.V1ALPHA1, served = true, storage = true)
+                        @Crd.Spec.Version(name = KafkaMirrorMaker2.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaMirrorMaker2.V1ALPHA1, served = true, storage = false, deprecated = true)
                 },
                 subresources = @Crd.Spec.Subresources(
                         status = @Crd.Spec.Subresources.Status(),

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
@@ -42,8 +42,8 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaRebalance.RESOURCE_GROUP,
                 scope = KafkaRebalance.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaRebalance.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaRebalance.V1ALPHA1, served = true, storage = true)
+                        @Crd.Spec.Version(name = KafkaRebalance.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaRebalance.V1ALPHA1, served = true, storage = false, deprecated = true)
                 },
                 subresources = @Crd.Spec.Subresources(
                         status = @Crd.Spec.Subresources.Status()

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
@@ -42,9 +42,9 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaTopic.RESOURCE_GROUP,
                 scope = KafkaTopic.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaTopic.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaTopic.V1BETA1, served = true, storage = true),
-                        @Crd.Spec.Version(name = KafkaTopic.V1ALPHA1, served = true, storage = false)
+                        @Crd.Spec.Version(name = KafkaTopic.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaTopic.V1BETA1, served = true, storage = false, deprecated = true),
+                        @Crd.Spec.Version(name = KafkaTopic.V1ALPHA1, served = true, storage = false, deprecated = true)
                 },
                 subresources = @Crd.Spec.Subresources(
                         status = @Crd.Spec.Subresources.Status()

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -42,9 +42,9 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaUser.RESOURCE_GROUP,
                 scope = KafkaUser.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaUser.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaUser.V1BETA1, served = true, storage = true),
-                        @Crd.Spec.Version(name = KafkaUser.V1ALPHA1, served = true, storage = false)
+                        @Crd.Spec.Version(name = KafkaUser.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaUser.V1BETA1, served = true, storage = false, deprecated = true),
+                        @Crd.Spec.Version(name = KafkaUser.V1ALPHA1, served = true, storage = false, deprecated = true)
                 },
                 subresources = @Crd.Spec.Subresources(
                         status = @Crd.Spec.Subresources.Status()

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
@@ -41,7 +41,7 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -5907,7 +5907,8 @@ spec:
               Operator.
   - name: v1beta1
     served: true
-    storage: true
+    storage: false
+    deprecated: true
     schema:
       openAPIV3Schema:
         type: object
@@ -14314,6 +14315,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
+    deprecated: true
     schema:
       openAPIV3Schema:
         type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/041-Crd-kafkaconnect.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/041-Crd-kafkaconnect.yaml
@@ -37,7 +37,7 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -1814,7 +1814,8 @@ spec:
             description: The status of the Kafka Connect cluster.
   - name: v1beta1
     served: true
-    storage: true
+    storage: false
+    deprecated: true
     schema:
       openAPIV3Schema:
         type: object
@@ -3825,6 +3826,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
+    deprecated: true
     schema:
       openAPIV3Schema:
         type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/042-Crd-kafkaconnects2i.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/042-Crd-kafkaconnects2i.yaml
@@ -37,7 +37,11 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
+    deprecated: true
+    deprecationWarning: KafkaConnectS2I resource is deprecated. Use the KafkaConnect
+      resource instead. See https://strimzi.io/docs/operators/latest/using.html#proc-migrating-kafka-connect-s2i-str
+      for instructions how to migrate.
     schema:
       openAPIV3Schema:
         type: object
@@ -1831,7 +1835,8 @@ spec:
             description: The status of the Kafka Connect Source-to-Image (S2I) cluster.
   - name: v1beta1
     served: true
-    storage: true
+    storage: false
+    deprecated: true
     schema:
       openAPIV3Schema:
         type: object
@@ -3859,6 +3864,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
+    deprecated: true
     schema:
       openAPIV3Schema:
         type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/043-Crd-kafkatopic.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/043-Crd-kafkatopic.yaml
@@ -41,13 +41,15 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
   - name: v1beta1
     served: true
-    storage: true
+    storage: false
+    deprecated: true
   - name: v1alpha1
     served: true
     storage: false
+    deprecated: true
   validation:
     openAPIV3Schema:
       type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/044-Crd-kafkauser.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/044-Crd-kafkauser.yaml
@@ -41,13 +41,15 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
   - name: v1beta1
     served: true
-    storage: true
+    storage: false
+    deprecated: true
   - name: v1alpha1
     served: true
     storage: false
+    deprecated: true
   validation:
     openAPIV3Schema:
       type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/045-Crd-kafkamirrormaker.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/045-Crd-kafkamirrormaker.yaml
@@ -47,7 +47,7 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -1204,7 +1204,8 @@ spec:
             description: The status of Kafka MirrorMaker.
   - name: v1beta1
     served: true
-    storage: true
+    storage: false
+    deprecated: true
     schema:
       openAPIV3Schema:
         type: object
@@ -2595,6 +2596,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
+    deprecated: true
     schema:
       openAPIV3Schema:
         type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/046-Crd-kafkabridge.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/046-Crd-kafkabridge.yaml
@@ -42,7 +42,7 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -1003,7 +1003,8 @@ spec:
             description: The status of the Kafka Bridge.
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
+    deprecated: true
     schema:
       openAPIV3Schema:
         type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/047-Crd-kafkaconnector.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/047-Crd-kafkaconnector.yaml
@@ -44,10 +44,11 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
+    deprecated: true
   validation:
     openAPIV3Schema:
       type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/048-Crd-kafkamirrormaker2.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/048-Crd-kafkamirrormaker2.yaml
@@ -37,7 +37,7 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -1810,7 +1810,8 @@ spec:
             description: The status of the Kafka MirrorMaker 2.0 cluster.
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
+    deprecated: true
     schema:
       openAPIV3Schema:
         type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/049-Crd-kafkarebalance.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/049-Crd-kafkarebalance.yaml
@@ -29,10 +29,11 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
+    deprecated: true
   validation:
     openAPIV3Schema:
       type: object

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -339,7 +339,7 @@ public class CrdGenerator {
         return numErrors;
     }
 
-    @SuppressWarnings("NPathComplexity")
+    @SuppressWarnings({"NPathComplexity"})
     private ObjectNode buildSpec(ApiVersion crdApiVersion,
                                  Crd.Spec crd, Class<? extends CustomResource> crdClass) {
         checkKubeVersionsSupportCrdVersion(crdApiVersion);
@@ -390,6 +390,8 @@ public class CrdGenerator {
             versionNode.put("served", servedVersion != null ? servedVersion.contains(crApiVersion) : version.served());
             versionNode.put("storage", storageVersion != null ? crApiVersion.equals(storageVersion) : version.storage());
 
+            deprecatedVersion(version, versionNode);
+
             if (perVersionSubResources) {
                 ObjectNode subresourcesForVersion = subresources.get(crApiVersion);
                 if (!subresourcesForVersion.isEmpty()) {
@@ -421,6 +423,22 @@ public class CrdGenerator {
         }
 
         return result;
+    }
+
+    /**
+     * Checks of the CRD version is deprecated and sets the deprecated and deprecatedWarning fields.
+     *
+     * @param version       The CRD version
+     * @param versionNode   The node in the CRD spec which represents the version
+     */
+    private void deprecatedVersion(Crd.Spec.Version version, ObjectNode versionNode)    {
+        if (version.deprecated())   {
+            versionNode.put("deprecated", true);
+
+            if (!version.deprecationWarning().isEmpty())    {
+                versionNode.put("deprecationWarning", version.deprecationWarning());
+            }
+        }
     }
 
     private ObjectNode buildConversion(ApiVersion crdApiVersion) {

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Crd.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Crd.java
@@ -88,6 +88,8 @@ public @interface Crd {
             String name();
             boolean served();
             boolean storage();
+            String deprecationWarning() default "";
+            boolean deprecated() default false;
         }
 
         /**

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -24,6 +24,8 @@ spec:
     - name: v1beta2
       served: true
       storage: true
+      deprecated: true
+      deprecationWarning: KafkaConnectS2I resource is deprecated. Use the KafkaConnect resource instead. See https://strimzi.io/docs/operators/latest/using.html#proc-migrating-kafka-connect-s2i-str for instructions how to migrate.
       subresources:
         status: {}
         scale:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
@@ -101,6 +101,7 @@ spec:
     - name: v1beta1
       served: true
       storage: false
+      deprecated: true
       subresources:
         status: {}
       additionalPrinterColumns:
@@ -178,6 +179,7 @@ spec:
     - name: v1alpha1
       served: true
       storage: false
+      deprecated: true
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
@@ -204,6 +204,7 @@ spec:
     - name: v1beta1
       served: true
       storage: false
+      deprecated: true
       subresources:
         status: {}
       additionalPrinterColumns:
@@ -384,6 +385,7 @@ spec:
     - name: v1alpha1
       served: true
       storage: false
+      deprecated: true
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/packaging/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/packaging/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -23,6 +23,10 @@ spec:
   - name: v1beta2
     served: true
     storage: true
+    deprecated: true
+    deprecationWarning: KafkaConnectS2I resource is deprecated. Use the KafkaConnect
+      resource instead. See https://strimzi.io/docs/operators/latest/using.html#proc-migrating-kafka-connect-s2i-str
+      for instructions how to migrate.
     subresources:
       status: {}
       scale:

--- a/packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -114,6 +114,7 @@ spec:
   - name: v1beta1
     served: true
     storage: false
+    deprecated: true
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -205,6 +206,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
+    deprecated: true
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -242,6 +242,7 @@ spec:
   - name: v1beta1
     served: true
     storage: false
+    deprecated: true
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -461,6 +462,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
+    deprecated: true
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/packaging/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/packaging/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -114,6 +114,7 @@ spec:
   - name: v1beta1
     served: true
     storage: false
+    deprecated: true
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -205,6 +206,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
+    deprecated: true
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/packaging/install/user-operator/04-Crd-kafkauser.yaml
+++ b/packaging/install/user-operator/04-Crd-kafkauser.yaml
@@ -242,6 +242,7 @@ spec:
   - name: v1beta1
     served: true
     storage: false
+    deprecated: true
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -461,6 +462,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
+    deprecated: true
     subresources:
       status: {}
     additionalPrinterColumns:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We should have used this earlier. But I did not know CRDs have such option. This PR adds support for the `deprecated` field in the CRD version specification. It is used to:
* Mark all `KafkaConnectS2I` versions as deprecated together with a custom message pointing to the migration doc:
    ```
    Warning: KafkaConnectS2I resource is deprecated. Use the KafkaConnect resource instead. See https://strimzi.io/docs/operators/latest/using.html#proc-migrating-kafka-connect-s2i-str for instructions how to migrate.
    kafkaconnects2i.kafka.strimzi.io/my-connect-s2i created
    ```
* Mark all v1beta1 and v1alpha1 versions in the other resources as deprecated. In the new CRDs, the older verions are actually used only for `KafkaUser` and `KafkaTopics` resources, but in case we need to generate some v1beta1 CRDs as an emergency it might be handy:
    ```
    Warning: kafka.strimzi.io/v1alpha1 KafkaTopic is deprecated; use kafka.strimzi.io/v1beta2 KafkaTopic
    kafkatopic.kafka.strimzi.io/kafka-test-apps created
    Warning: kafka.strimzi.io/v1alpha1 KafkaUser is deprecated; use kafka.strimzi.io/v1beta2 KafkaUser
    kafkauser.kafka.strimzi.io/my-user created
    ```
* I noticed we did not had the `v1beta2` versions set as stored versions (although they ar eused as stored version in the generated v1 CRDs). So I updated this as part of this PR as well.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Supply screenshots for visual changes, such as Grafana dashboards

