### PR TITLE
Mark v1beta2 version as stored version

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -43,8 +43,8 @@ import static java.util.Collections.unmodifiableList;
                 group = Kafka.RESOURCE_GROUP,
                 scope = Kafka.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = Kafka.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = Kafka.V1BETA1, served = true, storage = true),
+                        @Crd.Spec.Version(name = Kafka.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = Kafka.V1BETA1, served = true, storage = false),
                         @Crd.Spec.Version(name = Kafka.V1ALPHA1, served = true, storage = false)
                 },
                 subresources = @Crd.Spec.Subresources(

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
@@ -42,8 +42,8 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaBridge.RESOURCE_GROUP,
                 scope = KafkaBridge.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaBridge.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaBridge.V1ALPHA1, served = true, storage = true)
+                        @Crd.Spec.Version(name = KafkaBridge.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaBridge.V1ALPHA1, served = true, storage = false)
                 },
                 subresources = @Crd.Spec.Subresources(
                         status = @Crd.Spec.Subresources.Status(),

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
@@ -43,8 +43,8 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaConnect.RESOURCE_GROUP,
                 scope = KafkaConnect.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaConnect.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaConnect.V1BETA1, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaConnect.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaConnect.V1BETA1, served = true, storage = false),
                         @Crd.Spec.Version(name = KafkaConnect.V1ALPHA1, served = true, storage = false)
                 },
                 subresources = @Crd.Spec.Subresources(

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
@@ -47,8 +47,8 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaConnectS2I.RESOURCE_GROUP,
                 scope = KafkaConnectS2I.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaConnectS2I.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaConnectS2I.V1BETA1, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaConnectS2I.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaConnectS2I.V1BETA1, served = true, storage = false),
                         @Crd.Spec.Version(name = KafkaConnectS2I.V1ALPHA1, served = true, storage = false)
                 },
                 subresources = @Crd.Spec.Subresources(

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
@@ -39,8 +39,8 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaConnector.RESOURCE_GROUP,
                 scope = KafkaConnector.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaConnector.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaConnector.V1ALPHA1, served = true, storage = true)
+                        @Crd.Spec.Version(name = KafkaConnector.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaConnector.V1ALPHA1, served = true, storage = false)
                 },
                 subresources = @Crd.Spec.Subresources(
                         status = @Crd.Spec.Subresources.Status(),

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
@@ -42,8 +42,8 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaMirrorMaker.RESOURCE_GROUP,
                 scope = KafkaMirrorMaker.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaMirrorMaker.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaMirrorMaker.V1BETA1, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaMirrorMaker.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaMirrorMaker.V1BETA1, served = true, storage = false),
                         @Crd.Spec.Version(name = KafkaMirrorMaker.V1ALPHA1, served = true, storage = false)
                 },
                 subresources = @Crd.Spec.Subresources(

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
@@ -42,8 +42,8 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaMirrorMaker2.RESOURCE_GROUP,
                 scope = KafkaMirrorMaker2.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaMirrorMaker2.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaMirrorMaker2.V1ALPHA1, served = true, storage = true)
+                        @Crd.Spec.Version(name = KafkaMirrorMaker2.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaMirrorMaker2.V1ALPHA1, served = true, storage = false)
                 },
                 subresources = @Crd.Spec.Subresources(
                         status = @Crd.Spec.Subresources.Status(),

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
@@ -42,8 +42,8 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaRebalance.RESOURCE_GROUP,
                 scope = KafkaRebalance.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaRebalance.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaRebalance.V1ALPHA1, served = true, storage = true)
+                        @Crd.Spec.Version(name = KafkaRebalance.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaRebalance.V1ALPHA1, served = true, storage = false)
                 },
                 subresources = @Crd.Spec.Subresources(
                         status = @Crd.Spec.Subresources.Status()

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
@@ -42,8 +42,8 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaTopic.RESOURCE_GROUP,
                 scope = KafkaTopic.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaTopic.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaTopic.V1BETA1, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaTopic.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaTopic.V1BETA1, served = true, storage = false),
                         @Crd.Spec.Version(name = KafkaTopic.V1ALPHA1, served = true, storage = false)
                 },
                 subresources = @Crd.Spec.Subresources(

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -42,8 +42,8 @@ import static java.util.Collections.unmodifiableList;
                 group = KafkaUser.RESOURCE_GROUP,
                 scope = KafkaUser.SCOPE,
                 versions = {
-                        @Crd.Spec.Version(name = KafkaUser.V1BETA2, served = true, storage = false),
-                        @Crd.Spec.Version(name = KafkaUser.V1BETA1, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaUser.V1BETA2, served = true, storage = true),
+                        @Crd.Spec.Version(name = KafkaUser.V1BETA1, served = true, storage = false),
                         @Crd.Spec.Version(name = KafkaUser.V1ALPHA1, served = true, storage = false)
                 },
                 subresources = @Crd.Spec.Subresources(

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
@@ -41,7 +41,7 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -5907,7 +5907,7 @@ spec:
               Operator.
   - name: v1beta1
     served: true
-    storage: true
+    storage: false
     schema:
       openAPIV3Schema:
         type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/041-Crd-kafkaconnect.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/041-Crd-kafkaconnect.yaml
@@ -37,7 +37,7 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -1814,7 +1814,7 @@ spec:
             description: The status of the Kafka Connect cluster.
   - name: v1beta1
     served: true
-    storage: true
+    storage: false
     schema:
       openAPIV3Schema:
         type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/042-Crd-kafkaconnects2i.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/042-Crd-kafkaconnects2i.yaml
@@ -37,7 +37,7 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -1831,7 +1831,7 @@ spec:
             description: The status of the Kafka Connect Source-to-Image (S2I) cluster.
   - name: v1beta1
     served: true
-    storage: true
+    storage: false
     schema:
       openAPIV3Schema:
         type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/043-Crd-kafkatopic.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/043-Crd-kafkatopic.yaml
@@ -41,10 +41,10 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
   - name: v1beta1
     served: true
-    storage: true
+    storage: false
   - name: v1alpha1
     served: true
     storage: false

--- a/api/src/test/resources/io/strimzi/api/kafka/model/044-Crd-kafkauser.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/044-Crd-kafkauser.yaml
@@ -41,10 +41,10 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
   - name: v1beta1
     served: true
-    storage: true
+    storage: false
   - name: v1alpha1
     served: true
     storage: false

--- a/api/src/test/resources/io/strimzi/api/kafka/model/045-Crd-kafkamirrormaker.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/045-Crd-kafkamirrormaker.yaml
@@ -47,7 +47,7 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -1204,7 +1204,7 @@ spec:
             description: The status of Kafka MirrorMaker.
   - name: v1beta1
     served: true
-    storage: true
+    storage: false
     schema:
       openAPIV3Schema:
         type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/046-Crd-kafkabridge.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/046-Crd-kafkabridge.yaml
@@ -42,7 +42,7 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -1003,7 +1003,7 @@ spec:
             description: The status of the Kafka Bridge.
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
     schema:
       openAPIV3Schema:
         type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/047-Crd-kafkaconnector.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/047-Crd-kafkaconnector.yaml
@@ -44,10 +44,10 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
   validation:
     openAPIV3Schema:
       type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/048-Crd-kafkamirrormaker2.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/048-Crd-kafkamirrormaker2.yaml
@@ -37,7 +37,7 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -1810,7 +1810,7 @@ spec:
             description: The status of the Kafka MirrorMaker 2.0 cluster.
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
     schema:
       openAPIV3Schema:
         type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/049-Crd-kafkarebalance.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/049-Crd-kafkarebalance.yaml
@@ -29,10 +29,10 @@ spec:
   versions:
   - name: v1beta2
     served: true
-    storage: false
+    storage: true
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
   validation:
     openAPIV3Schema:
       type: object


### PR DESCRIPTION
### Type of change

- Task

### Description

Originally done as part of #4807 which was closed because it is not backwards compatible with Kube 1.18 and lower. This PR updates the stored version in our CRDs to `v1beta2`. This was already used in the `apiextensions/v1` CRDs anyway, so this affects only the old `apiextensions/v1beta1` used for testing.