### PR TITLE
Make it possible to disable service links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Changed Reconciliation interval for Topic Operator from 90 to 120 seconds (to keep it the same as for other operators)
 * Changed Zookeeper session timeout default value to 18 seconds for Topic and User Operators (for improved resiliency)
 * Removed requirement for replicas and partitions KafkaTopic spec making these parameters optional
+* Allow disabling service links (environment variables describing Kubernetes services) in Pod template
 
 ### Changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
@@ -52,6 +52,7 @@ public class PodTemplate implements Serializable, UnknownPropertyPreserving {
     private String priorityClassName;
     private String schedulerName;
     private List<HostAlias> hostAliases;
+    private Boolean enableServiceLinks;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Metadata applied to the resource.")
@@ -169,6 +170,16 @@ public class PodTemplate implements Serializable, UnknownPropertyPreserving {
 
     public void setHostAliases(List<HostAlias> hostAliases) {
         this.hostAliases = hostAliases;
+    }
+
+    @Description("Indicates whether information about services should be injected into pod's environment variables.")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public Boolean getEnableServiceLinks() {
+        return enableServiceLinks;
+    }
+
+    public void setEnableServiceLinks(Boolean enableServiceLinks) {
+        this.enableServiceLinks = enableServiceLinks;
     }
 
     @Override

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
@@ -1392,6 +1392,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -2422,6 +2426,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -3427,6 +3435,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -4364,6 +4376,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -5121,6 +5137,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -5633,6 +5653,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -8542,6 +8566,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -9928,6 +9956,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -11825,6 +11857,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -12766,6 +12802,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -13527,6 +13567,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -14039,6 +14083,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -16948,6 +16996,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -18334,6 +18386,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -20231,6 +20287,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -21172,6 +21232,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -21933,6 +21997,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -22445,6 +22513,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/041-Crd-kafkaconnect.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/041-Crd-kafkaconnect.yaml
@@ -774,6 +774,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -1263,6 +1267,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -2784,6 +2792,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -3273,6 +3285,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -4794,6 +4810,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -5283,6 +5303,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/042-Crd-kafkaconnects2i.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/042-Crd-kafkaconnects2i.yaml
@@ -782,6 +782,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -1271,6 +1275,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -2809,6 +2817,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -3298,6 +3310,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -4836,6 +4852,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -5325,6 +5345,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/045-Crd-kafkamirrormaker.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/045-Crd-kafkamirrormaker.yaml
@@ -959,6 +959,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -2349,6 +2353,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -3739,6 +3747,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/046-Crd-kafkabridge.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/046-Crd-kafkabridge.yaml
@@ -789,6 +789,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -1754,6 +1758,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/048-Crd-kafkamirrormaker2.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/048-Crd-kafkamirrormaker2.yaml
@@ -887,6 +887,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -1376,6 +1380,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -2893,6 +2901,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -3382,6 +3394,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -276,6 +276,7 @@ public abstract class AbstractModel {
     protected List<HostAlias> templatePodHostAliases;
     protected List<TopologySpreadConstraint> templatePodTopologySpreadConstraints;
     protected PodManagementPolicy templatePodManagementPolicy = PodManagementPolicy.PARALLEL;
+    protected Boolean templatePodEnableServiceLinks;
     protected Map<String, String> templateClusterRoleBindingLabels;
     protected Map<String, String> templateClusterRoleBindingAnnotations;
 
@@ -1027,6 +1028,7 @@ public abstract class AbstractModel {
                         .endMetadata()
                         .withNewSpec()
                             .withServiceAccountName(getServiceAccountName())
+                            .withEnableServiceLinks(templatePodEnableServiceLinks)
                             .withAffinity(affinity)
                             .withInitContainers(initContainers)
                             .withContainers(containers)
@@ -1079,6 +1081,7 @@ public abstract class AbstractModel {
                 .withNewSpec()
                     .withRestartPolicy("Never")
                     .withServiceAccountName(getServiceAccountName())
+                    .withEnableServiceLinks(templatePodEnableServiceLinks)
                     .withAffinity(getUserAffinity())
                     .withInitContainers(initContainers)
                     .withContainers(containers)
@@ -1125,6 +1128,7 @@ public abstract class AbstractModel {
                         .withNewSpec()
                             .withAffinity(affinity)
                             .withServiceAccountName(getServiceAccountName())
+                            .withEnableServiceLinks(templatePodEnableServiceLinks)
                             .withInitContainers(initContainers)
                             .withContainers(containers)
                             .withVolumes(volumes)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -145,6 +145,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                             .withLabels(getLabelsWithStrimziName(name, templatePodLabels).toMap())
                         .endMetadata()
                         .withNewSpec()
+                            .withEnableServiceLinks(templatePodEnableServiceLinks)
                             .withContainers(container)
                             .withVolumes(getVolumes(isOpenShift, true))
                             .withTolerations(getTolerations())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -254,6 +254,7 @@ public class ModelUtils {
             model.templatePodSchedulerName = pod.getSchedulerName();
             model.templatePodHostAliases = pod.getHostAliases();
             model.templatePodTopologySpreadConstraints = pod.getTopologySpreadConstraints();
+            model.templatePodEnableServiceLinks = pod.getEnableServiceLinks();
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -223,6 +223,7 @@ public class EntityOperatorTest {
                                         .withNewSchedulerName("my-scheduler")
                                         .withTolerations(singletonList(toleration))
                                         .withTopologySpreadConstraints(tsc1, tsc2)
+                                        .withEnableServiceLinks(false)
                                     .endPod()
                                 .endTemplate()
                             .endEntityOperator()
@@ -241,6 +242,7 @@ public class EntityOperatorTest {
         assertThat(dep.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnots.entrySet()), is(true));
         assertThat(dep.getSpec().getTemplate().getSpec().getSchedulerName(), is("my-scheduler"));
         assertThat(dep.getSpec().getTemplate().getSpec().getTopologySpreadConstraints(), containsInAnyOrder(tsc1, tsc2));
+        assertThat(dep.getSpec().getTemplate().getSpec().getEnableServiceLinks(), is(false));
 
         assertThat(dep.getSpec().getTemplate().getSpec().getTolerations(), is(singletonList(assertToleration)));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JmxTransTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JmxTransTest.java
@@ -238,6 +238,7 @@ public class JmxTransTest {
                                 .withNewSchedulerName("my-scheduler")
                                 .withAffinity(affinity)
                                 .withTolerations(tolerations)
+                                .withEnableServiceLinks(false)
                             .endPod()
                         .endTemplate()
                     .endJmxTrans()
@@ -257,6 +258,7 @@ public class JmxTransTest {
         assertThat(dep.getSpec().getTemplate().getMetadata().getLabels(), hasEntries(podLabels));
         assertThat(dep.getSpec().getTemplate().getMetadata().getAnnotations(), hasEntries(podAnots));
         assertThat(dep.getSpec().getTemplate().getSpec().getSchedulerName(), is("my-scheduler"));
+        assertThat(dep.getSpec().getTemplate().getSpec().getEnableServiceLinks(), is(false));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -407,6 +407,7 @@ public class KafkaBridgeClusterTest {
                             .withAffinity(affinity)
                             .withTolerations(tolerations)
                             .withTopologySpreadConstraints(tsc1, tsc2)
+                            .withEnableServiceLinks(false)
                         .endPod()
                         .withNewApiService()
                             .withNewMetadata()
@@ -440,6 +441,7 @@ public class KafkaBridgeClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getAffinity(), is(affinity));
         assertThat(dep.getSpec().getTemplate().getSpec().getTolerations(), is(tolerations));
         assertThat(dep.getSpec().getTemplate().getSpec().getTopologySpreadConstraints(), containsInAnyOrder(tsc1, tsc2));
+        assertThat(dep.getSpec().getTemplate().getSpec().getEnableServiceLinks(), is(false));
 
         // Check Service
         Service svc = kbc.generateService();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -1513,6 +1513,7 @@ public class KafkaClusterTest {
                                 .withNewSchedulerName("my-scheduler")
                                 .withHostAliases(hostAlias1, hostAlias2)
                                 .withTopologySpreadConstraints(tsc1, tsc2)
+                                .withEnableServiceLinks(false)
                             .endPod()
                             .withNewBootstrapService()
                                 .withNewMetadata()
@@ -1580,6 +1581,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getSchedulerName(), is("my-scheduler"));
         assertThat(sts.getSpec().getTemplate().getSpec().getHostAliases(), containsInAnyOrder(hostAlias1, hostAlias2));
         assertThat(sts.getSpec().getTemplate().getSpec().getTopologySpreadConstraints(), containsInAnyOrder(tsc1, tsc2));
+        assertThat(sts.getSpec().getTemplate().getSpec().getEnableServiceLinks(), is(false));
 
         // Check Service
         Service svc = kc.generateService();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -411,6 +411,7 @@ public class KafkaConnectBuildTest {
                             .endMetadata()
                             .withNewPriorityClassName("top-priority")
                             .withNewSchedulerName("my-scheduler")
+                            .withEnableServiceLinks(false)
                         .endBuildPod()
                         .withNewBuildContainer()
                             .withEnv(new ContainerEnvVarBuilder().withName("TEST_ENV_VAR").withValue("testValue").build())
@@ -432,6 +433,7 @@ public class KafkaConnectBuildTest {
         assertThat(pod.getMetadata().getAnnotations().entrySet().containsAll(buildPodAnnos.entrySet()), is(true));
         assertThat(pod.getSpec().getPriorityClassName(), is("top-priority"));
         assertThat(pod.getSpec().getSchedulerName(), is("my-scheduler"));
+        assertThat(pod.getSpec().getEnableServiceLinks(), is(false));
         assertThat(pod.getSpec().getContainers().get(0).getEnv().stream().filter(env -> "TEST_ENV_VAR".equals(env.getName())).findFirst().get().getValue(), is("testValue"));
 
         KafkaConnectDockerfile dockerfile = new KafkaConnectDockerfile("my-image:latest", kc.getSpec().getBuild());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -598,6 +598,7 @@ public class KafkaConnectClusterTest {
                             .withNewSchedulerName("my-scheduler")
                             .withHostAliases(hostAlias1, hostAlias2)
                             .withTopologySpreadConstraints(tsc1, tsc2)
+                            .withEnableServiceLinks(false)
                         .endPod()
                         .withNewApiService()
                             .withNewMetadata()
@@ -636,6 +637,7 @@ public class KafkaConnectClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getSchedulerName(), is("my-scheduler"));
         assertThat(dep.getSpec().getTemplate().getSpec().getHostAliases(), containsInAnyOrder(hostAlias1, hostAlias2));
         assertThat(dep.getSpec().getTemplate().getSpec().getTopologySpreadConstraints(), containsInAnyOrder(tsc1, tsc2));
+        assertThat(dep.getSpec().getTemplate().getSpec().getEnableServiceLinks(), is(false));
 
         // Check Service
         Service svc = kc.generateService();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -577,6 +577,7 @@ public class KafkaConnectS2IClusterTest {
                             .withNewSchedulerName("my-scheduler")
                             .withHostAliases(hostAlias1, hostAlias2)
                             .withTopologySpreadConstraints(tsc1, tsc2)
+                            .withEnableServiceLinks(false)
                         .endPod()
                         .withNewApiService()
                             .withNewMetadata()
@@ -615,6 +616,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getSchedulerName(), is("my-scheduler"));
         assertThat(dep.getSpec().getTemplate().getSpec().getHostAliases(), containsInAnyOrder(hostAlias1, hostAlias2));
         assertThat(dep.getSpec().getTemplate().getSpec().getTopologySpreadConstraints(), containsInAnyOrder(tsc1, tsc2));
+        assertThat(dep.getSpec().getTemplate().getSpec().getEnableServiceLinks(), is(false));
 
         // Check Service
         Service svc = kc.generateService();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -392,6 +392,7 @@ public class KafkaExporterTest {
                                 .withAffinity(affinity)
                                 .withTolerations(tolerations)
                                 .withTopologySpreadConstraints(tsc1, tsc2)
+                                .withEnableServiceLinks(false)
                             .endPod()
                             .withNewService()
                                 .withNewMetadata()
@@ -418,6 +419,7 @@ public class KafkaExporterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getAffinity(), is(affinity));
         assertThat(dep.getSpec().getTemplate().getSpec().getTolerations(), is(tolerations));
         assertThat(dep.getSpec().getTemplate().getSpec().getTopologySpreadConstraints(), containsInAnyOrder(tsc1, tsc2));
+        assertThat(dep.getSpec().getTemplate().getSpec().getEnableServiceLinks(), is(false));
     }
 
     @AfterAll

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -723,6 +723,7 @@ public class KafkaMirrorMaker2ClusterTest {
                             .withNewPriorityClassName("top-priority")
                             .withNewSchedulerName("my-scheduler")
                             .withHostAliases(hostAlias1, hostAlias2)
+                            .withEnableServiceLinks(false)
                         .endPod()
                         .withNewApiService()
                             .withNewMetadata()
@@ -754,6 +755,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(dep.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnots.entrySet()), is(true));
         assertThat(dep.getSpec().getTemplate().getSpec().getSchedulerName(), is("my-scheduler"));
         assertThat(dep.getSpec().getTemplate().getSpec().getHostAliases(), containsInAnyOrder(hostAlias1, hostAlias2));
+        assertThat(dep.getSpec().getTemplate().getSpec().getEnableServiceLinks(), is(false));
 
         // Check Service
         Service svc = kmm2.generateService();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -534,6 +534,7 @@ public class KafkaMirrorMakerClusterTest {
                             .withNewPriorityClassName("top-priority")
                             .withNewSchedulerName("my-scheduler")
                             .withHostAliases(hostAlias1, hostAlias2)
+                            .withEnableServiceLinks(false)
                         .endPod()
                         .withNewPodDisruptionBudget()
                             .withNewMetadata()
@@ -559,6 +560,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(dep.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnots.entrySet()), is(true));
         assertThat(dep.getSpec().getTemplate().getSpec().getSchedulerName(), is("my-scheduler"));
         assertThat(dep.getSpec().getTemplate().getSpec().getHostAliases(), containsInAnyOrder(hostAlias1, hostAlias2));
+        assertThat(dep.getSpec().getTemplate().getSpec().getEnableServiceLinks(), is(false));
 
         // Check PodDisruptionBudget
         PodDisruptionBudget pdb = mmc.generatePodDisruptionBudget();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -437,6 +437,7 @@ public class ZookeeperClusterTest {
                                 .withNewSchedulerName("my-scheduler")
                                 .withHostAliases(hostAlias1, hostAlias2)
                                 .withTopologySpreadConstraints(tsc1, tsc2)
+                                .withEnableServiceLinks(false)
                             .endPod()
                             .withNewClientService()
                                 .withNewMetadata()
@@ -474,6 +475,7 @@ public class ZookeeperClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getSchedulerName(), is("my-scheduler"));
         assertThat(sts.getSpec().getTemplate().getSpec().getHostAliases(), containsInAnyOrder(hostAlias1, hostAlias2));
         assertThat(sts.getSpec().getTemplate().getSpec().getTopologySpreadConstraints(), containsInAnyOrder(tsc1, tsc2));
+        assertThat(sts.getSpec().getTemplate().getSpec().getEnableServiceLinks(), is(false));
 
         // Check Service
         Service svc = zc.generateService();

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -886,6 +886,8 @@ include::../api/io.strimzi.api.kafka.model.template.PodTemplate.adoc[leveloffset
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#HostAlias-v1-core[HostAlias] array
+|enableServiceLinks             1.2+<.<a|Indicates whether information about services should be injected into pod's environment variables.
+|boolean
 |topologySpreadConstraints      1.2+<.<a|The pod's topology spread constraints. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#topologyspreadconstraint-v1-core[external documentation for core/v1 topologyspreadconstraint].
 
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1082,6 +1082,9 @@ spec:
                                   ip:
                                     type: string
                               description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                            enableServiceLinks:
+                              type: boolean
+                              description: Indicates whether information about services should be injected into pod's environment variables.
                             topologySpreadConstraints:
                               type: array
                               items:
@@ -2017,6 +2020,9 @@ spec:
                                   ip:
                                     type: string
                               description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                            enableServiceLinks:
+                              type: boolean
+                              description: Indicates whether information about services should be injected into pod's environment variables.
                             topologySpreadConstraints:
                               type: array
                               items:
@@ -2926,6 +2932,9 @@ spec:
                                   ip:
                                     type: string
                               description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                            enableServiceLinks:
+                              type: boolean
+                              description: Indicates whether information about services should be injected into pod's environment variables.
                             topologySpreadConstraints:
                               type: array
                               items:
@@ -3773,6 +3782,9 @@ spec:
                                   ip:
                                     type: string
                               description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                            enableServiceLinks:
+                              type: boolean
+                              description: Indicates whether information about services should be injected into pod's environment variables.
                             topologySpreadConstraints:
                               type: array
                               items:
@@ -4456,6 +4468,9 @@ spec:
                                   ip:
                                     type: string
                               description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                            enableServiceLinks:
+                              type: boolean
+                              description: Indicates whether information about services should be injected into pod's environment variables.
                             topologySpreadConstraints:
                               type: array
                               items:
@@ -4940,6 +4955,9 @@ spec:
                                   ip:
                                     type: string
                               description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                            enableServiceLinks:
+                              type: boolean
+                              description: Indicates whether information about services should be injected into pod's environment variables.
                             topologySpreadConstraints:
                               type: array
                               items:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -698,6 +698,9 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        enableServiceLinks:
+                          type: boolean
+                          description: Indicates whether information about services should be injected into pod's environment variables.
                         topologySpreadConstraints:
                           type: array
                           items:
@@ -1162,6 +1165,9 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        enableServiceLinks:
+                          type: boolean
+                          description: Indicates whether information about services should be injected into pod's environment variables.
                         topologySpreadConstraints:
                           type: array
                           items:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -708,6 +708,9 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        enableServiceLinks:
+                          type: boolean
+                          description: Indicates whether information about services should be injected into pod's environment variables.
                         topologySpreadConstraints:
                           type: array
                           items:
@@ -1172,6 +1175,9 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        enableServiceLinks:
+                          type: boolean
+                          description: Indicates whether information about services should be injected into pod's environment variables.
                         topologySpreadConstraints:
                           type: array
                           items:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -846,6 +846,9 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        enableServiceLinks:
+                          type: boolean
+                          description: Indicates whether information about services should be injected into pod's environment variables.
                         topologySpreadConstraints:
                           type: array
                           items:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -715,6 +715,9 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        enableServiceLinks:
+                          type: boolean
+                          description: Indicates whether information about services should be injected into pod's environment variables.
                         topologySpreadConstraints:
                           type: array
                           items:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -786,6 +786,9 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        enableServiceLinks:
+                          type: boolean
+                          description: Indicates whether information about services should be injected into pod's environment variables.
                         topologySpreadConstraints:
                           type: array
                           items:
@@ -1250,6 +1253,9 @@ spec:
                               ip:
                                 type: string
                           description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+                        enableServiceLinks:
+                          type: boolean
+                          description: Indicates whether information about services should be injected into pod's environment variables.
                         topologySpreadConstraints:
                           type: array
                           items:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -1413,6 +1413,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -2482,6 +2486,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -3514,6 +3522,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -4466,6 +4478,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -5239,6 +5255,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -5762,6 +5782,10 @@ spec:
                             description: The pod's HostAliases. HostAliases is an
                               optional list of hosts and IPs that will be injected
                               into the pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services
+                              should be injected into pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -787,6 +787,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -1287,6 +1291,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:

--- a/packaging/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/packaging/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -797,6 +797,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -1297,6 +1301,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -973,6 +973,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -803,6 +803,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -903,6 +903,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -1403,6 +1407,10 @@ spec:
                         description: The pod's HostAliases. HostAliases is an optional
                           list of hosts and IPs that will be injected into the pod's
                           hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services
+                          should be injected into pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Kubernetes by default inject into each Pod environment variables describing them for service discovery. For example:
```
MY_CLUSTER_ZOOKEEPER_CLIENT_PORT=tcp://10.105.193.26:2181
MY_CLUSTER_ZOOKEEPER_CLIENT_PORT_2181_TCP=tcp://10.105.193.26:2181
MY_CLUSTER_ZOOKEEPER_CLIENT_PORT_2181_TCP_ADDR=10.105.193.26
MY_CLUSTER_ZOOKEEPER_CLIENT_PORT_2181_TCP_PORT=2181
MY_CLUSTER_ZOOKEEPER_CLIENT_PORT_2181_TCP_PROTO=tcp
MY_CLUSTER_ZOOKEEPER_CLIENT_SERVICE_HOST=10.105.193.26
MY_CLUSTER_ZOOKEEPER_CLIENT_SERVICE_PORT=2181
MY_CLUSTER_ZOOKEEPER_CLIENT_SERVICE_PORT_TCP_CLIENTS=2181
```

In some cases - as described for example in #4800 this is not desired. This PR adds new field to the Pod template which allows disabling this.

During my tests, disabling it did not seem to have any negative effects on Strimzi (especially with regards of the operators or init images discovering the Kubernetes API server etc.)

This should close #4800.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md