### PR TITLE
[MO] - [Azure] -> MM pipeline paralelism disabled

### DIFF
--- a/.azure/regression-pipeline.yaml
+++ b/.azure/regression-pipeline.yaml
@@ -62,6 +62,7 @@ jobs:
       test_case: 'mirrormaker/**/*ST,kafka/dynamicconfiguration/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
+      run_parallel: false
       timeout: 360
 
   - template: 'templates/system_test_general.yaml'


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix

### Description

Same problem as with https://github.com/strimzi/strimzi-kafka-operator/pull/4806 PR. Mirror maker regression pipeline sometimes end up because of the OOM problem. 

### Checklist

- [x] Make sure all tests pass