### PR TITLE
Make Kafka Connect Build not trigger failing OCP Build again and again

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -509,7 +509,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                             return Future.succeededFuture();
                         } else {
                             log.warn("Build {} completed successfully. But the new container image was not found.", buildState.currentBuildName);
-                            return Future.failedFuture("The Kafka Connect build " + buildState.currentBuildName + " completed, but the new container image was not found");
+                            return Future.failedFuture("The Kafka Connect build completed, but the new container image was not found.");
                         }
                     } else {
                         // Build failed. If the Status exists, we try to provide more detailed information
@@ -519,7 +519,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                             log.warn("Build {} failed for unknown reason", buildState.currentBuildName);
                         }
 
-                        return Future.failedFuture("The Kafka Connect build " + buildState.currentBuildName + " failed");
+                        return Future.failedFuture("The Kafka Connect build failed.");
                     }
                 })
                 .compose(ignore -> podOperator.reconcile(namespace, KafkaConnectResources.buildPodName(connectBuild.getCluster()), null))


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the Kafka Connect Build on OCP fails for example because of incorrect checksum, we set the error condition in the `KafkaConnect` CR to include also the build number. For example `The Kafka Connect build my-connect-connect-build-31 failed`.

This updates the `KafkaConnect` CR and triggers another reconciliation immediately. The new reconciliation starts new build with new number and fails again with `The Kafka Connect build my-connect-connect-build-32 failed`. Because of the build number change, this gets through the `StatusDiff` and updates the `KafkaConnect` CR again. That in turn starts immediately new reconciliation and ... I guess you get the point. The reconciliations are running in a tight loop starting new build almost immediately after the previous one fails.

This PR changes the message set to the error condition to be more generic: `The Kafka Connect build failed.`. That filters this out in the `StatusDiff`. That way, the reconciliations will not be triggered again and again by each failure. Next build attempt will instead happen only during the periodical reconciliations. The operator log still logs the full message including the full build name, so the details can be found there.

This should close #4817.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging