### PR TITLE
[MO] - [Azure] -> Disabling paralelism on all regression pipelines

### DIFF
--- a/.azure/regression-pipeline.yaml
+++ b/.azure/regression-pipeline.yaml
@@ -34,7 +34,6 @@ jobs:
       test_case: 'connect/**/*ST,tracing/**/*ST,watcher/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
-      run_parallel: false
       timeout: 360
 
   - template: 'templates/system_test_general.yaml'
@@ -62,7 +61,6 @@ jobs:
       test_case: 'mirrormaker/**/*ST,kafka/dynamicconfiguration/**/*ST'
       groups: 'regression'
       cluster_operator_install_type: 'bundle'
-      run_parallel: false
       timeout: 360
 
   - template: 'templates/system_test_general.yaml'

--- a/.azure/templates/system_test_general.yaml
+++ b/.azure/templates/system_test_general.yaml
@@ -8,9 +8,10 @@ parameters:
   cluster_operator_install_type: ''
   timeout: ''
   strimzi_rbac_scope: 'CLUSTER'
-  # currently minikube with 2 CPUs and ~8GB RAM can handle 2 parallel tests at once (not more)
-  parallel: '2'
-  run_parallel: true
+  # Currently minikube with 2 CPUs and ~8GB RAM can handle 1 test at once (not more).
+  # If these resources will be upgraded in the future, we can enable parallelism.
+  parallel: '1'
+  run_parallel: false
 
 jobs:
 - job: '${{ parameters.name }}_system_tests'


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- BugFix

### Description

This PR is disabling all regression pipelines running in the parallel mode. The reason for that is that it's sometimes failing because of `OOM` or `CPU problems`.

### Checklist

- [ ] Make sure all tests pass