### PR TITLE
Make `setup-kubernetes.sh` fail on any exception

### DIFF
--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -x
+set -xe
 
 rm -rf ~/.kube
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

Currently when we are starting `minikube` using the `setup-kubernetes.sh` script, the `registry` addon is enabled. Problem is that even the `registry` image is not pulled and the `minikube start` fails, we continue to build images/run STs and then the pipeline fails. This PR makes `setup-kubernetes.sh` more "sensitive" to fail on any exception.

### Checklist

- [x] Make sure all tests pass

