### PR TITLE
[setup-kubernetes.sh] Add option for specifying credentials to docker.io for pulling images

### DIFF
--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -88,8 +88,7 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
 
     if [ "$COPY_DOCKER_LOGIN" = "true" ]
     then
-      scp -i $(minikube ssh-key) $HOME/.docker/config.json docker@$(minikube ip):/var/lib/kubelet/config.json
-      docker exec "minikube" bash -c "sudo systemctl restart kubelet"
+      docker exec "minikube" bash -c "echo '$(cat $HOME/.docker/config.json)'| sudo tee -a /var/lib/kubelet/config.json > /dev/null && sudo systemctl restart kubelet"
     fi
 
     set -ex

--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -80,7 +80,8 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     fi
 
     minikube addons enable default-storageclass
-	  minikube addons enable registry
+	  minikube addons enable registry \
+	   --images="Registry=openshift/community-e2e-images@sha256:bac2d7050dc4826516650267fe7dc6627e9e11ad653daca0641437abdf18df27" --registries="Registry=quay.io"
 	  minikube addons enable registry-aliases
 
 	  kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default

--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -84,11 +84,10 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     # Add Docker hub credentials to Minikube
     # template = username:password encoded in Base64
 
-#    set +ex
+    set +ex
 
     if [ -n "$DOCKER_LOGIN" ]
     then
-      echo "docker login not empty"
       docker exec "minikube" bash -c "echo '{
         \"auths\": {
           \"https://index.docker.io/v1/\": {
@@ -98,7 +97,7 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
       }' | sudo tee -a /var/lib/kubelet/config.json > /dev/null && sudo systemctl restart kubelet"
     fi
 
-#    set -ex
+    set -ex
 
 	  minikube addons enable registry
 	  minikube addons enable registry-aliases

--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -4,7 +4,7 @@ set -xe
 rm -rf ~/.kube
 
 KUBE_VERSION=${KUBE_VERSION:-1.16.0}
-COPY_DOCKER_LOGIN=${1:-"false"}
+COPY_DOCKER_LOGIN=${COPY_DOCKER_LOGIN:-"false"}
 
 DEFAULT_MINIKUBE_MEMORY=$(free -m | grep "Mem" | awk '{print $2}')
 DEFAULT_MINIKUBE_CPU=$(awk '$1~/cpu[0-9]/{usage=($2+$4)*100/($2+$4+$5); print $1": "usage"%"}' /proc/stat | wc -l)

--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -92,10 +92,10 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
       set -ex
     fi
 
-	  minikube addons enable registry
-	  minikube addons enable registry-aliases
+    minikube addons enable registry
+    minikube addons enable registry-aliases
 
-	  kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
+    kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
 else
     echo "Unsupported TEST_CLUSTER '$TEST_CLUSTER'"
     exit 1

--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -80,8 +80,26 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     fi
 
     minikube addons enable default-storageclass
-	  minikube addons enable registry \
-	   --images="Registry=openshift/community-e2e-images@sha256:bac2d7050dc4826516650267fe7dc6627e9e11ad653daca0641437abdf18df27" --registries="Registry=quay.io"
+
+    # Add Docker hub credentials to Minikube
+    # template = username:password encoded in Base64
+
+    set +ex
+
+    if [ -n "$DOCKER_LOGIN" ]
+    then
+      docker exec "minikube" bash -c "echo '{
+        \"auths\": {
+          \"https://index.docker.io/v1/\": {
+            \"auth\": \"'$DOCKER_LOGIN'\"
+          }
+        }
+      }' | sudo tee -a /var/lib/kubelet/config.json > /dev/null && sudo systemctl restart kubelet"
+    fi
+
+    set -ex
+
+	  minikube addons enable registry
 	  minikube addons enable registry-aliases
 
 	  kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default

--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -83,13 +83,13 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     minikube addons enable default-storageclass
 
     # Add Docker hub credentials to Minikube
-    # template = username:password encoded in Base64
 
     set +ex
 
     if [ "$COPY_DOCKER_LOGIN" = "true" ]
     then
       scp -i $(minikube ssh-key) $HOME/.docker/config.json docker@$(minikube ip):/var/lib/kubelet/config.json
+      docker exec "minikube" bash -c "sudo systemctl restart kubelet"
     fi
 
     set -ex

--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -84,10 +84,11 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     # Add Docker hub credentials to Minikube
     # template = username:password encoded in Base64
 
-    set +ex
+#    set +ex
 
     if [ -n "$DOCKER_LOGIN" ]
     then
+      echo "docker login not empty"
       docker exec "minikube" bash -c "echo '{
         \"auths\": {
           \"https://index.docker.io/v1/\": {
@@ -97,7 +98,7 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
       }' | sudo tee -a /var/lib/kubelet/config.json > /dev/null && sudo systemctl restart kubelet"
     fi
 
-    set -ex
+#    set -ex
 
 	  minikube addons enable registry
 	  minikube addons enable registry-aliases

--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -83,15 +83,14 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     minikube addons enable default-storageclass
 
     # Add Docker hub credentials to Minikube
-
-    set +ex
-
     if [ "$COPY_DOCKER_LOGIN" = "true" ]
     then
-      docker exec "minikube" bash -c "echo '$(cat $HOME/.docker/config.json)'| sudo tee -a /var/lib/kubelet/config.json > /dev/null && sudo systemctl restart kubelet"
-    fi
+      set +ex
 
-    set -ex
+      docker exec "minikube" bash -c "echo '$(cat $HOME/.docker/config.json)'| sudo tee -a /var/lib/kubelet/config.json > /dev/null && sudo systemctl restart kubelet"
+
+      set -ex
+    fi
 
 	  minikube addons enable registry
 	  minikube addons enable registry-aliases

--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -31,7 +31,7 @@ pipeline {
         TEST_HELM2_VERSION = "v2.17.0"
         TEST_HELM3_VERSION = "v3.4.2"
         TEST_CLUSTER = "minikube"
-        DOCKER_LOGIN = credentials('strimziqe-dockerhub-login')
+        COPY_DOCKER_LOGIN = "true"
     }
     stages {
         stage('Clean WS') {

--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -31,6 +31,7 @@ pipeline {
         TEST_HELM2_VERSION = "v2.17.0"
         TEST_HELM3_VERSION = "v3.4.2"
         TEST_CLUSTER = "minikube"
+        DOCKER_LOGIN = credentials('strimziqe-dockerhub-login')
     }
     stages {
         stage('Clean WS') {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

Currently our PR jobs and nightlies are failing because of reaching the pull limit from docker hub, when we are deploying `minikube`.

This PR adding option to specify the `DOCKER_LOGIN` env, which value should be in the pattern `username:password` and encoded in Base64. By this, we will be able to log in and pull the image without problem with reaching the pull limit.

### Checklist

- [x] Make sure all tests pass

