### PR TITLE
Remove support for legacy metrics configuration from the CO code

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -224,7 +224,6 @@ public abstract class AbstractModel {
     protected static final String METRICS_PORT_NAME = "tcp-prometheus";
     protected static final int METRICS_PORT = 9404;
     protected static final String METRICS_PATH = "/metrics";
-    protected Iterable<Map.Entry<String, Object>> metricsConfig;
     protected MetricsConfig metricsConfigInCm;
     protected String ancillaryConfigMapName;
     protected String logAndMetricsConfigMountPath;
@@ -554,7 +553,7 @@ public abstract class AbstractModel {
     public ConfigMap generateMetricsAndLogConfigMap(MetricsAndLogging metricsAndLogging) {
         Map<String, String> data = new HashMap<>(2);
         data.put(getAncillaryConfigMapKeyLogConfig(), parseLogging(getLogging(), metricsAndLogging.getLoggingCm()));
-        if (getMetricsConfigInCm() != null || (isMetricsEnabled() && getMetricsConfig() != null)) {
+        if (getMetricsConfigInCm() != null) {
             String parseResult = parseMetrics(metricsAndLogging.getMetricsCm());
             if (parseResult != null) {
                 this.setMetricsEnabled(true);
@@ -596,22 +595,8 @@ public abstract class AbstractModel {
                 log.warn("Unknown type of metrics {}.", getMetricsConfigInCm().getClass());
                 throw new InvalidResourceException("Unknown type of metrics " + getMetricsConfigInCm().getClass() + ".");
             }
-        } else if (isMetricsEnabled() && getMetricsConfig() != null) {
-            HashMap<String, Object> m = new HashMap<>();
-            for (Map.Entry<String, Object> entry : getMetricsConfig()) {
-                m.put(entry.getKey(), entry.getValue());
-            }
-            return new JsonObject(m).toString();
         }
         return null;
-    }
-
-    protected Iterable<Map.Entry<String, Object>> getMetricsConfig() {
-        return metricsConfig;
-    }
-
-    protected void setMetricsConfig(Iterable<Map.Entry<String, Object>> metricsConfig) {
-        this.metricsConfig = metricsConfig;
     }
 
     protected void setMetricsConfigInCm(MetricsConfig metricsConfigInCm) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -84,7 +84,6 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
-import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -126,7 +126,6 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
                 .withReadinessProbe(spec.getReadinessProbe())
                 .withJvmOptions(spec.getJvmOptions())
                 .withJmxOptions(spec.getJmxOptions())
-                .withMetrics(spec.getMetrics())
                 .withMetricsConfig(spec.getMetricsConfig())
                 .withTracing(spec.getTracing())
                 .withAffinity(spec.getAffinity())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -504,9 +504,6 @@ public class ModelUtils {
         if (resourceWithMetrics.getMetricsConfig() != null)    {
             model.setMetricsEnabled(true);
             model.setMetricsConfigInCm(resourceWithMetrics.getMetricsConfig());
-        } else if (resourceWithMetrics.getMetrics() != null) {
-            model.setMetricsEnabled(true);
-            model.setMetricsConfig(resourceWithMetrics.getMetrics().entrySet());
         }
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -926,7 +926,6 @@ public class CruiseControlTest {
 
         assertThat(cc.isMetricsEnabled(), is(true));
         assertThat(cc.getMetricsConfigInCm(), is(metrics));
-        assertThat(cc.getMetricsConfig(), is(nullValue()));
     }
 
     @ParallelTest
@@ -943,7 +942,6 @@ public class CruiseControlTest {
 
         assertThat(cc.isMetricsEnabled(), is(false));
         assertThat(cc.getMetricsConfigInCm(), is(nullValue()));
-        assertThat(cc.getMetricsConfig(), is(nullValue()));
     }
 
     @AfterAll

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -886,26 +886,6 @@ public class CruiseControlTest {
     }
 
     @ParallelTest
-    public void testMetricsParsingInline() {
-        Map<String, Object> dummyMetrics = singletonMap("dummy", "metrics");
-
-        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
-                image, healthDelay, healthTimeout))
-                .editSpec()
-                    .withNewCruiseControl()
-                        .withMetrics(dummyMetrics)
-                    .endCruiseControl()
-                .endSpec()
-                .build();
-
-        CruiseControl cc = CruiseControl.fromCrd(kafkaAssembly, VERSIONS);
-
-        assertThat(cc.isMetricsEnabled(), is(true));
-        assertThat(cc.getMetricsConfig(), is(dummyMetrics.entrySet()));
-        assertThat(cc.getMetricsConfigInCm(), is(nullValue()));
-    }
-
-    @ParallelTest
     public void testMetricsParsingFromConfigMap() {
         MetricsConfig metrics = new JmxPrometheusExporterMetricsBuilder()
                 .withNewValueFrom()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -3655,7 +3655,6 @@ public class KafkaClusterTest {
 
         assertThat(kc.isMetricsEnabled(), is(true));
         assertThat(kc.getMetricsConfigInCm(), is(metrics));
-        assertThat(kc.getMetricsConfig(), is(nullValue()));
     }
 
     @ParallelTest
@@ -3665,6 +3664,5 @@ public class KafkaClusterTest {
 
         assertThat(kc.isMetricsEnabled(), is(false));
         assertThat(kc.getMetricsConfigInCm(), is(nullValue()));
-        assertThat(kc.getMetricsConfig(), is(nullValue()));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -159,26 +159,6 @@ public class KafkaClusterTest {
         assertThat(resource.getMetadata().getOwnerReferences().get(0), is(ownerRef));
     }
 
-    @Deprecated
-    @ParallelTest
-    public void testMetricsConfigMapDeprecatedMetrics() {
-        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, null, configuration, kafkaLog, zooLog))
-                .editSpec()
-                .editKafka()
-                .withNewJvmOptions()
-                .addAllToJavaSystemProperties(javaSystemProperties)
-                .endJvmOptions()
-                .endKafka()
-                .endSpec()
-                .build();
-
-        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
-
-        ConfigMap metricsCm = kc.generateMetricsAndLogConfigMap(new MetricsAndLogging(null, null));
-        checkMetricsConfigMap(metricsCm);
-        checkOwnerReference(kc.createOwnerReference(), metricsCm);
-    }
-
     @ParallelTest
     public void testMetricsConfigMap() {
         ConfigMap metricsCm = kc.generateMetricsAndLogConfigMap(new MetricsAndLogging(metricsCM, null));
@@ -3652,26 +3632,6 @@ public class KafkaClusterTest {
                 .build();
 
         assertThrows(IllegalArgumentException.class, () -> KafkaCluster.fromCrd(kafkaAssembly, VERSIONS));
-    }
-
-    @ParallelTest
-    public void testMetricsParsingInline() {
-        Map<String, Object> dummyMetrics = singletonMap("dummy", "metrics");
-
-        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
-                image, healthDelay, healthTimeout))
-                .editSpec()
-                    .editKafka()
-                        .withMetrics(dummyMetrics)
-                    .endKafka()
-                .endSpec()
-                .build();
-
-        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
-
-        assertThat(kc.isMetricsEnabled(), is(true));
-        assertThat(kc.getMetricsConfig(), is(dummyMetrics.entrySet()));
-        assertThat(kc.getMetricsConfigInCm(), is(nullValue()));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -1616,7 +1616,6 @@ public class KafkaConnectClusterTest {
 
         assertThat(kc.isMetricsEnabled(), is(true));
         assertThat(kc.getMetricsConfigInCm(), is(metrics));
-        assertThat(kc.getMetricsConfig(), is(nullValue()));
     }
 
     @ParallelTest
@@ -1625,6 +1624,5 @@ public class KafkaConnectClusterTest {
 
         assertThat(kc.isMetricsEnabled(), is(false));
         assertThat(kc.getMetricsConfigInCm(), is(nullValue()));
-        assertThat(kc.getMetricsConfig(), is(nullValue()));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -137,26 +137,6 @@ public class KafkaConnectClusterTest {
 
     private final KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(resourceWithMetrics, VERSIONS);
 
-    @Deprecated
-    @ParallelTest
-    public void testMetricsConfigMapDeprecatedMetrics() {
-        KafkaConnect resource = new KafkaConnectBuilder(ResourceUtils.createEmptyKafkaConnect(namespace, cluster))
-                .withNewSpec()
-                    .withMetrics((Map<String, Object>) TestUtils.fromJson(metricsCmJson, Map.class))
-                    .withMetricsConfig(null)
-                    .withConfig((Map<String, Object>) TestUtils.fromJson(configurationJson, Map.class))
-                    .withImage(image)
-                    .withReplicas(replicas)
-                    .withReadinessProbe(new Probe(healthDelay, healthTimeout))
-                    .withLivenessProbe(new Probe(healthDelay, healthTimeout))
-                    .withBootstrapServers(bootstrapServers)
-                .endSpec()
-                .build();
-        KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(resource, VERSIONS);
-        ConfigMap metricsCm = kc.generateMetricsAndLogConfigMap(new MetricsAndLogging(null, null));
-        checkMetricsConfigMap(metricsCm);
-    }
-
     @ParallelTest
     public void testMetricsConfigMap() {
         ConfigMap metricsCm = kc.generateMetricsAndLogConfigMap(new MetricsAndLogging(metricsCM, null));
@@ -1616,23 +1596,6 @@ public class KafkaConnectClusterTest {
                     initContainers.stream().anyMatch(container -> container.getName().equals(KafkaConnectCluster.INIT_NAME));
             assertThat(isInitKafkaConnect, is(true));
         }
-    }
-
-    @ParallelTest
-    public void testMetricsParsingInline() {
-        Map<String, Object> dummyMetrics = singletonMap("dummy", "metrics");
-
-        KafkaConnect kafkaConnect = new KafkaConnectBuilder(this.resource)
-                .editSpec()
-                    .withMetrics(dummyMetrics)
-                .endSpec()
-                .build();
-
-        KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(kafkaConnect, VERSIONS);
-
-        assertThat(kc.isMetricsEnabled(), is(true));
-        assertThat(kc.getMetricsConfig(), is(dummyMetrics.entrySet()));
-        assertThat(kc.getMetricsConfigInCm(), is(nullValue()));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -145,16 +145,6 @@ public class KafkaConnectS2IClusterTest {
     private final KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(resourceWithMetrics, VERSIONS);
 
     @ParallelTest
-    @Deprecated
-    public void testMetricsConfigMapDeprecatedMetrics() {
-        KafkaConnectS2I resource = ResourceUtils.createKafkaConnectS2I(namespace, cluster, replicas, image,
-                healthDelay, healthTimeout, null, metricsCmJson, configurationJson, insecureSourceRepo, bootstrapServers, buildResourceRequirements);
-        KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(resource, VERSIONS);
-        ConfigMap metricsCm = kc.generateMetricsAndLogConfigMap(new MetricsAndLogging(null, null));
-        checkMetricsConfigMap(metricsCm);
-    }
-
-    @ParallelTest
     public void testMetricsConfigMap() {
         ConfigMap metricsCm = kc.generateMetricsAndLogConfigMap(new MetricsAndLogging(metricsCM, null));
         checkMetricsConfigMap(metricsCm);
@@ -1470,23 +1460,6 @@ public class KafkaConnectS2IClusterTest {
         KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(resource, VERSIONS);
 
         assertThat(kc.generateNetworkPolicy(false, null, null), is(nullValue()));
-    }
-
-    @ParallelTest
-    public void testMetricsParsingInline() {
-        Map<String, Object> dummyMetrics = singletonMap("dummy", "metrics");
-
-        KafkaConnectS2I kafkaConnect = new KafkaConnectS2IBuilder(this.resource)
-                .editSpec()
-                    .withMetrics(dummyMetrics)
-                .endSpec()
-                .build();
-
-        KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(kafkaConnect, VERSIONS);
-
-        assertThat(kc.isMetricsEnabled(), is(true));
-        assertThat(kc.getMetricsConfig(), is(dummyMetrics.entrySet()));
-        assertThat(kc.getMetricsConfigInCm(), is(nullValue()));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -1480,7 +1480,6 @@ public class KafkaConnectS2IClusterTest {
 
         assertThat(kc.isMetricsEnabled(), is(true));
         assertThat(kc.getMetricsConfigInCm(), is(metrics));
-        assertThat(kc.getMetricsConfig(), is(nullValue()));
     }
 
     @ParallelTest
@@ -1489,6 +1488,5 @@ public class KafkaConnectS2IClusterTest {
 
         assertThat(kc.isMetricsEnabled(), is(false));
         assertThat(kc.getMetricsConfigInCm(), is(nullValue()));
-        assertThat(kc.getMetricsConfig(), is(nullValue()));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -141,28 +141,6 @@ public class KafkaMirrorMaker2ClusterTest {
         kmm2.generateMetricsAndLogConfigMap(new MetricsAndLogging(metricsCM, null));
     }
 
-    @Deprecated
-    @ParallelTest
-    public void testMetricsConfigMapDeprecatedMetrics() {
-        KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(ResourceUtils.createEmptyKafkaMirrorMaker2(namespace, cluster))
-                .withNewSpec()
-                    .withMetrics((Map<String, Object>) TestUtils.fromJson(metricsCmJson, Map.class))
-                    .withMetricsConfig(null)
-                    .withImage(image)
-                    .withReplicas(replicas)
-                    .withReadinessProbe(new Probe(healthDelay, healthTimeout))
-                    .withLivenessProbe(new Probe(healthDelay, healthTimeout))
-                    .withConnectCluster(targetClusterAlias)
-                    .withClusters(targetCluster)
-                .endSpec()
-                .build();
-
-        KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(resource, VERSIONS);
-
-        ConfigMap metricsCm = kmm2.generateMetricsAndLogConfigMap(new MetricsAndLogging(null, null));
-        checkMetricsConfigMap(metricsCm);
-    }
-
     @ParallelTest
     public void testMetricsConfigMap() {
         ConfigMap metricsCm = kmm2.generateMetricsAndLogConfigMap(new MetricsAndLogging(metricsCM, null));
@@ -1576,23 +1554,6 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getNamespaceSelector().getMatchLabels(), is(Collections.singletonMap("nsLabelKey", "nsLabelValue")));
         assertThat(np.getSpec().getIngress().get(1).getPorts().size(), is(1));
         assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
-    }
-    
-    @ParallelTest
-    public void testMetricsParsingInline() {
-        Map<String, Object> dummyMetrics = singletonMap("dummy", "metrics");
-
-        KafkaMirrorMaker2 kafkaMirrorMaker2 = new KafkaMirrorMaker2Builder(this.resource)
-                .editSpec()
-                    .withMetrics(dummyMetrics)
-                .endSpec()
-                .build();
-
-        KafkaMirrorMaker2Cluster kmm = KafkaMirrorMaker2Cluster.fromCrd(kafkaMirrorMaker2, VERSIONS);
-
-        assertThat(kmm.isMetricsEnabled(), is(true));
-        assertThat(kmm.getMetricsConfig(), is(dummyMetrics.entrySet()));
-        assertThat(kmm.getMetricsConfigInCm(), is(nullValue()));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -1574,7 +1574,6 @@ public class KafkaMirrorMaker2ClusterTest {
 
         assertThat(kmm.isMetricsEnabled(), is(true));
         assertThat(kmm.getMetricsConfigInCm(), is(metrics));
-        assertThat(kmm.getMetricsConfig(), is(nullValue()));
     }
 
     @ParallelTest
@@ -1583,6 +1582,5 @@ public class KafkaMirrorMaker2ClusterTest {
 
         assertThat(kmm.isMetricsEnabled(), is(false));
         assertThat(kmm.getMetricsConfigInCm(), is(nullValue()));
-        assertThat(kmm.getMetricsConfig(), is(nullValue()));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -1460,7 +1460,6 @@ public class KafkaMirrorMakerClusterTest {
 
         assertThat(kmm.isMetricsEnabled(), is(true));
         assertThat(kmm.getMetricsConfigInCm(), is(metrics));
-        assertThat(kmm.getMetricsConfig(), is(nullValue()));
     }
 
     @ParallelTest
@@ -1469,6 +1468,5 @@ public class KafkaMirrorMakerClusterTest {
 
         assertThat(kmm.isMetricsEnabled(), is(false));
         assertThat(kmm.getMetricsConfigInCm(), is(nullValue()));
-        assertThat(kmm.getMetricsConfig(), is(nullValue()));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -1144,7 +1144,6 @@ public class ZookeeperClusterTest {
 
         assertThat(zc.isMetricsEnabled(), is(true));
         assertThat(zc.getMetricsConfigInCm(), is(metrics));
-        assertThat(zc.getMetricsConfig(), is(nullValue()));
     }
 
     @ParallelTest
@@ -1154,6 +1153,5 @@ public class ZookeeperClusterTest {
 
         assertThat(zc.isMetricsEnabled(), is(false));
         assertThat(zc.getMetricsConfigInCm(), is(nullValue()));
-        assertThat(zc.getMetricsConfig(), is(nullValue()));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -114,18 +114,6 @@ public class ZookeeperClusterTest {
 
     private final ZookeeperCluster zc = ZookeeperCluster.fromCrd(ka, VERSIONS);
 
-    @Deprecated
-    @ParallelTest
-    public void testMetricsConfigMapDeprecatedMetrics() {
-        Kafka ka = ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, null, configurationJson, zooConfigurationJson, null, null, kafkaLogConfigJson, zooLogConfigJson, null, null);
-        ZookeeperCluster zc = ZookeeperCluster.fromCrd(ka, VERSIONS);
-
-        ConfigMap metricsCm = zc.generateConfigurationConfigMap(new MetricsAndLogging(null, null));
-        checkMetricsConfigMap(metricsCm);
-        checkOwnerReference(zc.createOwnerReference(), metricsCm);
-    }
-
-
     @ParallelTest
     public void testMetricsConfigMap() {
         ConfigMap metricsCm = zc.generateConfigurationConfigMap(new MetricsAndLogging(metricsCM, null));
@@ -1133,26 +1121,6 @@ public class ZookeeperClusterTest {
                         hasProperty("name", equalTo(ZookeeperCluster.ZOOKEEPER_NAME)),
                         hasProperty("securityContext", equalTo(securityContext))
                 )));
-    }
-
-    @ParallelTest
-    public void testMetricsParsingInline() {
-        Map<String, Object> dummyMetrics = singletonMap("dummy", "metrics");
-
-        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
-                image, healthDelay, healthTimeout))
-                .editSpec()
-                    .editZookeeper()
-                        .withMetrics(dummyMetrics)
-                    .endZookeeper()
-                .endSpec()
-                .build();
-
-        ZookeeperCluster zc = ZookeeperCluster.fromCrd(kafkaAssembly, VERSIONS);
-
-        assertThat(zc.isMetricsEnabled(), is(true));
-        assertThat(zc.getMetricsConfig(), is(dummyMetrics.entrySet()));
-        assertThat(zc.getMetricsConfigInCm(), is(nullValue()));
     }
 
     @ParallelTest


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <shubhamrwt02@gmail.com>

### Type of change

- Refactoring

### Description

This PR removes the support for legacy metrics configuration like this :- 

```
metrics:
  # ...  
```
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

