### PR TITLE
[MO] - [Parallel namespace test] -> CruiseControlConfigurationST removing ordering + make all test…

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -51,7 +51,7 @@ public class CruiseControlApiST extends AbstractST {
         assertThat(response, containsString("RUNNING"));
         assertThat(response, containsString("NO_TASK_IN_PROGRESS"));
 
-        CruiseControlUtils.verifyThatCruiseControlTopicsArePresent();
+        CruiseControlUtils.verifyThatCruiseControlTopicsArePresent(NAMESPACE);
 
         LOGGER.info("----> KAFKA REBALANCE <----");
 

--- a/systemtest/src/test/resources/junit-platform.properties
+++ b/systemtest/src/test/resources/junit-platform.properties
@@ -1,9 +1,9 @@
 # These are default values if @ParallelTest or @ParallelSuite is not specified
 # junit.jupiter.execution.parallel.mode.default <==> ParallelTest = concurrent
 # junit.jupiter.execution.parallel.mode.classes.default <==> ParallelSuite = concurrent
-junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.enabled=true
 junit.jupiter.execution.parallel.mode.default=same_thread
 junit.jupiter.execution.parallel.mode.classes.default=same_thread
 junit.jupiter.execution.parallel.config.strategy=fixed
-junit.jupiter.execution.parallel.config.fixed.parallelism=1
+junit.jupiter.execution.parallel.config.fixed.parallelism=5
 junit.platform.output.capture.maxBuffer=true

--- a/systemtest/src/test/resources/junit-platform.properties
+++ b/systemtest/src/test/resources/junit-platform.properties
@@ -1,9 +1,9 @@
 # These are default values if @ParallelTest or @ParallelSuite is not specified
 # junit.jupiter.execution.parallel.mode.default <==> ParallelTest = concurrent
 # junit.jupiter.execution.parallel.mode.classes.default <==> ParallelSuite = concurrent
-junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.enabled=false
 junit.jupiter.execution.parallel.mode.default=same_thread
 junit.jupiter.execution.parallel.mode.classes.default=same_thread
 junit.jupiter.execution.parallel.config.strategy=fixed
-junit.jupiter.execution.parallel.config.fixed.parallelism=5
+junit.jupiter.execution.parallel.config.fixed.parallelism=1
 junit.platform.output.capture.maxBuffer=true


### PR DESCRIPTION
…s parallel

Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature

### Description

This PR removing unnecessary ordering of tests, which is bad practice. Moreover adding support for namespace parallel execution of `CruiseControlConfigurationST`.

### Checklist

- [x] Make sure all tests pass