### PR TITLE
[MO] - [unit tests] -> model package (class + method parallelism)

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractConfigurationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractConfigurationTest.java
@@ -10,8 +10,9 @@ import java.util.Map;
 
 import io.strimzi.operator.common.InvalidConfigParameterException;
 import io.strimzi.operator.common.model.OrderedProperties;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.json.JsonObject;
-import org.junit.jupiter.api.Test;
 
 import static io.strimzi.test.TestUtils.LINE_SEPARATOR;
 import static java.util.Arrays.asList;
@@ -20,6 +21,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@ParallelSuite
 public class AbstractConfigurationTest {
 
     static OrderedProperties createProperties(String... keyValues) {
@@ -36,57 +38,57 @@ public class AbstractConfigurationTest {
 
     final private OrderedProperties defaultConfiguration = createProperties("default.option", "hello");
 
-    @Test
+    @ParallelTest
     public void testConfigurationStringDefaults()  {
         AbstractConfiguration config = new TestConfiguration("");
         assertThat(config.asOrderedProperties(), is(defaultConfiguration));
     }
 
-    @Test
+    @ParallelTest
     public void testConfigurationStringOverridingDefaults()  {
         AbstractConfiguration config = new TestConfiguration("default.option=world");
         assertThat(config.asOrderedProperties(), is(createProperties("default.option", "world")));
     }
 
-    @Test
+    @ParallelTest
     public void testConfigurationStringOverridingDefaultsWithMore()  {
         AbstractConfiguration config = new TestConfiguration("default.option=world" + LINE_SEPARATOR + "var1=aaa" + LINE_SEPARATOR);
         assertThat(config.asOrderedProperties(), is(createProperties("default.option", "world", "var1", "aaa")));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultsFromJson()  {
         AbstractConfiguration config = new TestConfiguration(new JsonObject());
         assertThat(config.asOrderedProperties(), is(defaultConfiguration));
     }
 
-    @Test
+    @ParallelTest
     public void testJsonOverridingDefaults()  {
         AbstractConfiguration config = new TestConfiguration(new JsonObject().put("default.option", "world"));
         assertThat(config.asOrderedProperties(), is(createProperties("default.option", "world")));
     }
 
-    @Test
+    @ParallelTest
     public void testJsonOverridingDefaultsWithMore()  {
         AbstractConfiguration config = new TestConfiguration(new JsonObject().put("default.option", "world").put("var1", "aaa"));
         assertThat(config.asOrderedProperties(), is(createProperties("default.option", "world", "var1", "aaa")));
     }
 
-    @Test
+    @ParallelTest
     public void testEmptyConfigurationString() {
         String configuration = "";
         AbstractConfiguration config = new TestConfigurationWithoutDefaults(configuration);
         assertThat(config.getConfiguration().isEmpty(), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testEmptyJson() {
         JsonObject configuration = new JsonObject();
         AbstractConfiguration config = new TestConfigurationWithoutDefaults(configuration);
         assertThat(config.getConfiguration().isEmpty(), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testNonEmptyConfigurationString() {
         String configuration = "var1=aaa" + LINE_SEPARATOR +
                 "var2=bbb" + LINE_SEPARATOR +
@@ -99,7 +101,7 @@ public class AbstractConfigurationTest {
         assertThat(config.asOrderedProperties(), is(expectedConfiguration));
     }
 
-    @Test
+    @ParallelTest
     public void testNonEmptyJson() {
         JsonObject configuration = new JsonObject()
                 .put("var1", "aaa")
@@ -113,7 +115,7 @@ public class AbstractConfigurationTest {
         assertThat(config.asOrderedProperties(), is(expectedConfiguration));
     }
 
-    @Test
+    @ParallelTest
     public void testConfigurationStringWithDuplicates() {
         String configuration = "var1=aaa" + LINE_SEPARATOR +
                 "var2=bbb" + LINE_SEPARATOR +
@@ -127,7 +129,7 @@ public class AbstractConfigurationTest {
         assertThat(config.asOrderedProperties(), is(expectedConfiguration));
     }
 
-    @Test
+    @ParallelTest
     public void testJsonWithDuplicates() {
         JsonObject configuration = new JsonObject()
                 .put("var1", "aaa")
@@ -142,7 +144,7 @@ public class AbstractConfigurationTest {
         assertThat(config.asOrderedProperties(), is(expectedConfiguration));
     }
 
-    @Test
+    @ParallelTest
     public void testConfigurationStringWithForbiddenKeys() {
         String configuration = "var1=aaa" + LINE_SEPARATOR +
                 "var2=bbb" + LINE_SEPARATOR +
@@ -156,7 +158,7 @@ public class AbstractConfigurationTest {
         assertThat(config.asOrderedProperties(), is(expectedConfiguration));
     }
 
-    @Test
+    @ParallelTest
     public void testConfigurationStringWithForbiddenKeysInUpperCase() {
         String configuration = "var1=aaa" + LINE_SEPARATOR +
                 "var2=bbb" + LINE_SEPARATOR +
@@ -170,7 +172,7 @@ public class AbstractConfigurationTest {
         assertThat(config.asOrderedProperties(), is(expectedConfiguration));
     }
 
-    @Test
+    @ParallelTest
     public void testJsonWithForbiddenKeys() {
         JsonObject configuration = new JsonObject().put("var1", "aaa")
                 .put("var2", "bbb")
@@ -184,7 +186,7 @@ public class AbstractConfigurationTest {
         assertThat(config.asOrderedProperties(), is(expectedConfiguration));
     }
 
-    @Test
+    @ParallelTest
     public void testJsonWithForbiddenKeysPrefix() {
         JsonObject configuration = new JsonObject().put("var1", "aaa")
                 .put("var2", "bbb")
@@ -199,7 +201,7 @@ public class AbstractConfigurationTest {
         assertThat(config.asOrderedProperties(), is(expectedConfiguration));
     }
 
-    @Test
+    @ParallelTest
     public void testJsonWithDifferentTypes() {
         JsonObject configuration = new JsonObject().put("var1", 1)
                 .put("var2", "bbb")
@@ -212,7 +214,7 @@ public class AbstractConfigurationTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testWithHostPort() {
         JsonObject configuration = new JsonObject().put("option.with.port", "my-server:9092");
         OrderedProperties expectedConfiguration = createWithDefaults("option.with.port", "my-server:9092");
@@ -221,7 +223,7 @@ public class AbstractConfigurationTest {
         assertThat(config.asOrderedProperties(), is(expectedConfiguration));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaZookeeperTimeout() {
         Map<String, Object> conf = new HashMap<>();
         conf.put("valid", "validValue");
@@ -239,7 +241,7 @@ public class AbstractConfigurationTest {
         assertThat(kc.asOrderedProperties().asMap().get("zookeeper.connection.timeout"), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaCipherSuiteOverride() {
         Map<String, Object> conf = new HashMap<>();
         conf.put("ssl.cipher.suites", "cipher1,cipher2,cipher3"); // valid
@@ -249,7 +251,7 @@ public class AbstractConfigurationTest {
         assertThat(kc.asOrderedProperties().asMap().get("ssl.cipher.suites"), is("cipher1,cipher2,cipher3"));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaConnectHostnameVerification() {
         Map<String, Object> conf = new HashMap<>();
         conf.put("key.converter", "my.package.Converter"); // valid
@@ -263,7 +265,7 @@ public class AbstractConfigurationTest {
         assertThat(configuration.asOrderedProperties().asMap().get("ssl.endpoint.identification.algorithm"), is(""));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaMirrorMakerConsumerHostnameVerification() {
         Map<String, Object> conf = new HashMap<>();
         conf.put("compression.type", "zstd"); // valid
@@ -277,7 +279,7 @@ public class AbstractConfigurationTest {
         assertThat(configuration.asOrderedProperties().asMap().get("ssl.endpoint.identification.algorithm"), is(""));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaMirrorMakerProducerHostnameVerification() {
         Map<String, Object> conf = new HashMap<>();
         conf.put("compression.type", "zstd"); // valid
@@ -291,7 +293,7 @@ public class AbstractConfigurationTest {
         assertThat(configuration.asOrderedProperties().asMap().get("ssl.endpoint.identification.algorithm"), is(""));
     }
 
-    @Test
+    @ParallelTest
     public void testSplittingOfPrefixes()   {
         String prefixes = "prefix1.field,prefix2.field , prefix3.field, prefix4.field,, ";
         List<String> prefixList = asList("prefix1.field", "prefix2.field", "prefix3.field", "prefix4.field");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -17,7 +17,8 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
 
 import io.fabric8.kubernetes.api.model.OwnerReference;
-import org.junit.jupiter.api.Test;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +29,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ParallelSuite
 public class AbstractModelTest {
 
     // Implement AbstractModel to test the abstract class
@@ -54,7 +56,7 @@ public class AbstractModelTest {
         return result;
     }
 
-    @Test
+    @ParallelTest
     public void testJvmMemoryOptionsExplicit() {
         Map<String, String> env = getStringStringMap("4", "4",
                 0.5, 4_000_000_000L, null);
@@ -78,7 +80,7 @@ public class AbstractModelTest {
         return envVars.stream().collect(Collectors.toMap(e -> e.getName(), e -> e.getValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testJvmMemoryOptionsXmsOnly() {
         Map<String, String> env = getStringStringMap(null, "4",
                 0.5, 5_000_000_000L, null);
@@ -87,7 +89,7 @@ public class AbstractModelTest {
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testJvmMemoryOptionsXmxOnly() {
         Map<String, String> env = getStringStringMap("4", null,
                 0.5, 5_000_000_000L, null);
@@ -97,7 +99,7 @@ public class AbstractModelTest {
     }
 
 
-    @Test
+    @ParallelTest
     public void testJvmMemoryOptionsDefaultWithNoMemoryLimitOrJvmOptions() {
         Map<String, String> env = getStringStringMap(null, null,
                 0.5, 5_000_000_000L, null);
@@ -111,7 +113,7 @@ public class AbstractModelTest {
                 .addToRequests("memory", new Quantity("16000000000")).build();
     }
 
-    @Test
+    @ParallelTest
     public void testJvmMemoryOptionsDefaultWithMemoryLimit() {
         Map<String, String> env = getStringStringMap(null, "4",
                 0.5, 5_000_000_000L, getResourceRequest());
@@ -120,7 +122,7 @@ public class AbstractModelTest {
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is("5000000000"));
     }
 
-    @Test
+    @ParallelTest
     public void testJvmMemoryOptionsMemoryRequest() {
         Map<String, String> env = getStringStringMap(null, null,
                 0.7, 10_000_000_000L, getResourceRequest());
@@ -129,7 +131,7 @@ public class AbstractModelTest {
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is("10000000000"));
     }
 
-    @Test
+    @ParallelTest
     public void testJvmPerformanceOptions() {
         JvmOptions opts = TestUtils.fromJson("{}", JvmOptions.class);
 
@@ -166,7 +168,7 @@ public class AbstractModelTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testOwnerReference() {
         Kafka kafka = new KafkaBuilder()
                 .withNewMetadata()
@@ -187,7 +189,7 @@ public class AbstractModelTest {
         assertThat(ref.getUid(), is(kafka.getMetadata().getUid()));
     }
 
-    @Test
+    @ParallelTest
     public void testDetermineImagePullPolicy()  {
         Kafka kafka = new KafkaBuilder()
                 .withNewMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CaRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CaRenewalTest.java
@@ -8,8 +8,9 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.certs.Subject;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.junit5.VertxExtension;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
@@ -23,9 +24,10 @@ import java.util.function.Function;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ParallelSuite
 @ExtendWith(VertxExtension.class)
 public class CaRenewalTest {
-    @Test
+    @ParallelTest
     public void renewalOfStatefulSetCertificatesWithNullSecret() throws IOException {
         Ca mockedCa = new Ca(null, null, null, null, null, null, null, 2, 1, true, null) {
             private AtomicInteger invocationCount = new AtomicInteger(0);
@@ -82,7 +84,7 @@ public class CaRenewalTest {
         assertThat(newCerts.get("pod2").storePassword(), is("new-password2"));
     }
 
-    @Test
+    @ParallelTest
     public void renewalOfStatefulSetCertificatesWithCaRenewal() throws IOException {
         Ca mockedCa = new Ca(null, null, null, null, null, null, null, 2, 1, true, null) {
             private AtomicInteger invocationCount = new AtomicInteger(0);
@@ -157,7 +159,7 @@ public class CaRenewalTest {
         assertThat(newCerts.get("pod2").storePassword(), is("new-password2"));
     }
 
-    @Test
+    @ParallelTest
     public void renewalOfStatefulSetCertificatesDelayedRenewalInWindow() throws IOException {
         Ca mockedCa = new Ca(null, null, null, null, null, null, null, 2, 1, true, null) {
             private AtomicInteger invocationCount = new AtomicInteger(0);
@@ -242,7 +244,7 @@ public class CaRenewalTest {
         assertThat(newCerts.get("pod2").storePassword(), is("new-password2"));
     }
 
-    @Test
+    @ParallelTest
     public void renewalOfStatefulSetCertificatesDelayedRenewalOutsideWindow() throws IOException {
         Ca mockedCa = new Ca(null, null, null, null, null, null, null, 2, 1, true, null) {
             private AtomicInteger invocationCount = new AtomicInteger(0);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -54,7 +54,6 @@ import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -51,6 +51,8 @@ import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.cruisecontrol.Capacity;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
@@ -89,6 +91,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
         "checkstyle:ClassDataAbstractionCoupling",
         "checkstyle:ClassFanOutComplexity"
 })
+@ParallelSuite
 public class CruiseControlTest {
     private final String namespace = "test";
     private final String cluster = "foo";
@@ -188,7 +191,7 @@ public class CruiseControlTest {
         return ccEnvVars.stream().filter(var -> envVar.equals(var.getName())).map(EnvVar::getValue).findFirst().get();
     }
 
-    @Test
+    @ParallelTest
     public void testBrokerCapacities() {
         // Test user defined capacities
         BrokerCapacity userDefinedBrokerCapacity = new BrokerCapacity();
@@ -245,14 +248,14 @@ public class CruiseControlTest {
         assertThat(getCapacityConfigurationFromEnvVar(resource, ENV_VAR_BROKER_DISK_MIB_CAPACITY), is(Double.toString(generatedCapacity.getDiskMiB())));
     }
 
-    @Test
+    @ParallelTest
     public void testFromConfigMap() {
         assertThat(cc.namespace, is(namespace));
         assertThat(cc.cluster, is(cluster));
         assertThat(cc.getImage(), is(ccImage));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeployment() {
         Deployment dep = cc.generateDeployment(true, null, null, null);
 
@@ -340,12 +343,12 @@ public class CruiseControlTest {
         assertThat(volumeMount.getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
     }
 
-    @Test
+    @ParallelTest
     public void testEnvVars()   {
         assertThat(cc.getEnvVars(), is(getExpectedEnvVars()));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullPolicy() {
         Deployment dep = cc.generateDeployment(true, null, ImagePullPolicy.ALWAYS, null);
         List<Container> containers = dep.getSpec().getTemplate().getSpec().getContainers();
@@ -358,7 +361,7 @@ public class CruiseControlTest {
         assertThat(ccContainer.getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
     }
 
-    @Test
+    @ParallelTest
     public void testContainerTemplateEnvVars() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = "TEST_ENV_1";
@@ -392,7 +395,7 @@ public class CruiseControlTest {
         assertThat(envVarList, hasItems(new EnvVar(testEnvTwoKey, testEnvTwoValue, null)));
     }
 
-    @Test
+    @ParallelTest
     public void testContainerTemplateEnvVarsWithKeyConflict() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = "TEST_ENV_1";
@@ -426,7 +429,7 @@ public class CruiseControlTest {
         assertThat(envVarList, hasItems(new EnvVar(testEnvTwoKey, testEnvTwoValue, null)));
     }
 
-    @Test
+    @ParallelTest
     public void testCruiseControlNotDeployed() {
         Kafka resource = ResourceUtils.createKafka(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, kafkaConfig, zooConfig,
@@ -442,7 +445,7 @@ public class CruiseControlTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateService()   {
         Service svc = cc.generateService();
 
@@ -457,7 +460,7 @@ public class CruiseControlTest {
         TestUtils.checkOwnerReference(cc.createOwnerReference(), svc);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateServiceWhenDisabled()   {
         Kafka resource = ResourceUtils.createKafka(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, kafkaConfig, zooConfig,
@@ -467,7 +470,7 @@ public class CruiseControlTest {
         assertThrows(NullPointerException.class, () -> cc.generateService());
     }
 
-    @Test
+    @ParallelTest
     public void testTemplate() {
         Map<String, String> depLabels = TestUtils.map("l1", "v1", "l2", "v2");
         Map<String, String> depAnots = TestUtils.map("a1", "v1", "a2", "v2");
@@ -566,7 +569,7 @@ public class CruiseControlTest {
         assertThat(svc.getMetadata().getAnnotations(),  is(svcAnots));
     }
 
-    @Test
+    @ParallelTest
     public void testPodDisruptionBudget() {
         int maxUnavailable = 2;
         CruiseControlSpec cruiseControlSpec = new CruiseControlSpecBuilder()
@@ -597,7 +600,7 @@ public class CruiseControlTest {
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(maxUnavailable)));
     }
 
-    @Test
+    @ParallelTest
     public void testResources() {
         Map<String, Quantity> requests = new HashMap<>(2);
         requests.put("cpu", new Quantity("250m"));
@@ -631,7 +634,7 @@ public class CruiseControlTest {
         assertThat(ccContainer.getResources().getRequests(), is(requests));
     }
 
-    @Test
+    @ParallelTest
     public void testProbeConfiguration()   {
         CruiseControlSpec cruiseControlSpec = new CruiseControlSpecBuilder()
                 .withImage(ccImage)
@@ -668,7 +671,7 @@ public class CruiseControlTest {
         assertThat(ccContainer.getReadinessProbe().getTimeoutSeconds(), is(Integer.valueOf(healthTimeout)));
     }
 
-    @Test
+    @ParallelTest
     public void testSecurityContext() {
         CruiseControlSpec cruiseControlSpec = new CruiseControlSpecBuilder()
                 .withImage(ccImage)
@@ -699,13 +702,13 @@ public class CruiseControlTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsUser(), is(Long.valueOf(789)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultSecurityContext() {
         Deployment dep = cc.generateDeployment(true, null, null, null);
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testCruiseControlContainerSecurityContext() {
         SecurityContext securityContext = new SecurityContextBuilder()
                 .withPrivileged(false)
@@ -748,7 +751,7 @@ public class CruiseControlTest {
                 )));
     }
 
-    @Test
+    @ParallelTest
     public void testTlsSidecarContainerSecurityContext() {
         SecurityContext securityContext = new SecurityContextBuilder()
                 .withPrivileged(false)
@@ -791,7 +794,7 @@ public class CruiseControlTest {
                 )));
     }
 
-    @Test
+    @ParallelTest
     public void testRestApiPortNetworkPolicy() {
         NetworkPolicyPeer clusterOperatorPeer = new NetworkPolicyPeerBuilder()
                 .withNewPodSelector()
@@ -810,7 +813,7 @@ public class CruiseControlTest {
         assertThat(rules.contains(clusterOperatorPeer), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testRestApiPortNetworkPolicyInTheSameNamespace() {
         NetworkPolicyPeer clusterOperatorPeer = new NetworkPolicyPeerBuilder()
                 .withNewPodSelector()
@@ -828,7 +831,7 @@ public class CruiseControlTest {
         assertThat(rules.contains(clusterOperatorPeer), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testRestApiPortNetworkPolicyWithNamespaceLabels() {
         NetworkPolicyPeer clusterOperatorPeer = new NetworkPolicyPeerBuilder()
                 .withNewPodSelector()
@@ -849,7 +852,7 @@ public class CruiseControlTest {
         assertThat(rules.contains(clusterOperatorPeer), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testGoalsCheck() {
 
         String customGoals = "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal," +
@@ -883,7 +886,7 @@ public class CruiseControlTest {
         assertThat(anomalyDetectionGoals, is(customGoals));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingInline() {
         Map<String, Object> dummyMetrics = singletonMap("dummy", "metrics");
 
@@ -903,7 +906,7 @@ public class CruiseControlTest {
         assertThat(cc.getMetricsConfigInCm(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingFromConfigMap() {
         MetricsConfig metrics = new JmxPrometheusExporterMetricsBuilder()
                 .withNewValueFrom()
@@ -927,7 +930,7 @@ public class CruiseControlTest {
         assertThat(cc.getMetricsConfig(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingNoMetrics() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/DnsNameGeneratorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/DnsNameGeneratorTest.java
@@ -4,48 +4,50 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import org.junit.jupiter.api.Test;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ParallelSuite
 public class DnsNameGeneratorTest {
 
     private static final String NAMESPACE = "my-ns";
     private static final String SERVICE_NAME = "my-service";
     private static final String POD_NAME = "my-pod-1";
 
-    @Test
+    @ParallelTest
     public void testPodDnsName() {
         assertThat(DnsNameGenerator.of(NAMESPACE, SERVICE_NAME).podDnsName(POD_NAME),
                 is("my-pod-1.my-service.my-ns.svc.cluster.local"));
     }
 
-    @Test
+    @ParallelTest
     public void testPodDnsNameWithoutClusterDomain()  {
         assertThat(DnsNameGenerator.of(NAMESPACE, SERVICE_NAME).podDnsNameWithoutClusterDomain(POD_NAME),
                 is("my-pod-1.my-service.my-ns.svc"));
     }
 
-    @Test
+    @ParallelTest
     public void testServiceDnsName()  {
         assertThat(DnsNameGenerator.of(NAMESPACE, SERVICE_NAME).serviceDnsName(),
                 is("my-service.my-ns.svc.cluster.local"));
     }
 
-    @Test
+    @ParallelTest
     public void testServiceDnsNameWithoutClusterDomain()  {
         assertThat(DnsNameGenerator.of(NAMESPACE, SERVICE_NAME).serviceDnsNameWithoutClusterDomain(),
                 is("my-service.my-ns.svc"));
     }
 
-    @Test
+    @ParallelTest
     public void testWildcardServiceDnsName()  {
         assertThat(DnsNameGenerator.of(NAMESPACE, SERVICE_NAME).wildcardServiceDnsName(),
                 is("*.my-service.my-ns.svc.cluster.local"));
     }
 
-    @Test
+    @ParallelTest
     public void testWildcardServiceDnsNameWithoutClusterDomain()  {
         assertThat(DnsNameGenerator.of(NAMESPACE, SERVICE_NAME).wildcardServiceDnsNameWithoutClusterDomain(),
                 is("*.my-service.my-ns.svc"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -39,8 +39,9 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -63,6 +64,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasProperty;
 
+@ParallelSuite
 public class EntityOperatorTest {
 
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
@@ -104,7 +106,7 @@ public class EntityOperatorTest {
 
     private final EntityOperator entityOperator = EntityOperator.fromCrd(resource, VERSIONS);
 
-    @Test
+    @ParallelTest
     public void testGenerateDeployment() {
 
         Deployment dep = entityOperator.generateDeployment(true, Collections.EMPTY_MAP, null, null);
@@ -136,14 +138,14 @@ public class EntityOperatorTest {
         assertThat(tlsSidecarContainer.getLivenessProbe().getTimeoutSeconds(), is(Integer.valueOf(tlsHealthTimeout)));
     }
 
-    @Test
+    @ParallelTest
     public void testFromCrd() {
         assertThat(entityOperator.namespace, is(namespace));
         assertThat(entityOperator.cluster, is(cluster));
         assertThat(entityOperator.getZookeeperConnect(), is(EntityOperator.defaultZookeeperConnect(cluster)));
     }
 
-    @Test
+    @ParallelTest
     public void testFromCrdNoTopicAndUserOperatorInEntityOperator() {
         EntityOperatorSpec entityOperatorSpec = new EntityOperatorSpecBuilder().build();
         Kafka resource =
@@ -158,14 +160,14 @@ public class EntityOperatorTest {
         assertThat(entityOperator.getUserOperator(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void withAffinityAndTolerations() throws IOException {
         ResourceTester<Kafka, EntityOperator> helper = new ResourceTester<>(Kafka.class, VERSIONS, EntityOperator::fromCrd, this.getClass().getSimpleName() + ".withAffinityAndTolerations");
         helper.assertDesiredResource("-DeploymentAffinity.yaml", zc -> zc.generateDeployment(true, Collections.EMPTY_MAP, null, null).getSpec().getTemplate().getSpec().getAffinity());
         helper.assertDesiredResource("-DeploymentTolerations.yaml", zc -> zc.generateDeployment(true, Collections.EMPTY_MAP, null, null).getSpec().getTemplate().getSpec().getTolerations());
     }
 
-    @Test
+    @ParallelTest
     public void testTemplate() {
         Map<String, String> depLabels = TestUtils.map("l1", "v1", "l2", "v2",
                 Labels.KUBERNETES_PART_OF_LABEL, "custom-part",
@@ -245,7 +247,7 @@ public class EntityOperatorTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getTolerations(), is(singletonList(assertToleration)));
     }
 
-    @Test
+    @ParallelTest
     public void testGracePeriod() {
         Kafka resource = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout))
                 .editSpec()
@@ -268,7 +270,7 @@ public class EntityOperatorTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(2).getLifecycle().getPreStop().getExec().getCommand().contains("/opt/stunnel/entity_operator_stunnel_pre_stop.sh"), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultGracePeriod() {
         Kafka resource = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout))
                 .editSpec()
@@ -286,7 +288,7 @@ public class EntityOperatorTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(2).getLifecycle().getPreStop().getExec().getCommand().contains("/opt/stunnel/entity_operator_stunnel_pre_stop.sh"), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecrets() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -312,7 +314,7 @@ public class EntityOperatorTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecretsFromCo() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -337,7 +339,7 @@ public class EntityOperatorTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecretsFromBoth() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -363,7 +365,7 @@ public class EntityOperatorTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultImagePullSecrets() {
         Kafka resource = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout))
                 .editSpec()
@@ -379,7 +381,7 @@ public class EntityOperatorTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testSecurityContext() {
         Kafka resource = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout))
                 .editSpec()
@@ -403,7 +405,7 @@ public class EntityOperatorTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsUser(), is(Long.valueOf(789)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultSecurityContext() {
         Kafka resource = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout))
                 .editSpec()
@@ -425,7 +427,7 @@ public class EntityOperatorTest {
      * <li>Kafka.spec.kafka.image</li>
      * <li>image for default version of Kafka</li></ul>
      */
-    @Test
+    @ParallelTest
     public void testStunnelImage() {
         Kafka kafka = new KafkaBuilder(resource)
                 .editSpec()
@@ -486,7 +488,7 @@ public class EntityOperatorTest {
         assertThat(EntityOperator.fromCrd(kafka, VERSIONS).getContainers(ImagePullPolicy.ALWAYS).get(2).getImage(), is(KafkaVersionTestUtils.DEFAULT_KAFKA_IMAGE));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullPolicy() {
         Kafka resource = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout))
                 .editSpec()
@@ -514,7 +516,7 @@ public class EntityOperatorTest {
         ResourceUtils.cleanUpTemporaryTLSFiles();
     }
 
-    @Test
+    @ParallelTest
     public void testTopicOperatorContainerEnvVars() {
 
         ContainerEnvVar envVar1 = new ContainerEnvVar();
@@ -561,7 +563,7 @@ public class EntityOperatorTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testTopicOperatorContainerEnvVarsConflict() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = EntityTopicOperator.ENV_VAR_RESOURCE_LABELS;
@@ -605,7 +607,7 @@ public class EntityOperatorTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testUserOperatorContainerEnvVars() {
 
         ContainerEnvVar envVar1 = new ContainerEnvVar();
@@ -651,7 +653,7 @@ public class EntityOperatorTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testUserOperatorContainerEnvVarsConflict() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = EntityUserOperator.ENV_VAR_ZOOKEEPER_CONNECT;
@@ -694,7 +696,7 @@ public class EntityOperatorTest {
                         .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testTlsSideCarContainerEnvVars() {
 
         ContainerEnvVar envVar1 = new ContainerEnvVar();
@@ -740,7 +742,7 @@ public class EntityOperatorTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testTlsSidecarContainerEnvVarsConflict() {
 
         ContainerEnvVar envVar1 = new ContainerEnvVar();
@@ -775,7 +777,7 @@ public class EntityOperatorTest {
                         .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvOneValue), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testUserOperatorContainerSecurityContext() {
 
         SecurityContext securityContext = new SecurityContextBuilder()
@@ -812,7 +814,7 @@ public class EntityOperatorTest {
                 )));
     }
 
-    @Test
+    @ParallelTest
     public void testTopicOperatorContainerSecurityContext() {
 
         SecurityContext securityContext = new SecurityContextBuilder()
@@ -849,7 +851,7 @@ public class EntityOperatorTest {
                 )));
     }
 
-    @Test
+    @ParallelTest
     public void testTlsSidecarContainerSecurityContext() {
 
         SecurityContext securityContext = new SecurityContextBuilder()
@@ -886,7 +888,7 @@ public class EntityOperatorTest {
                 )));
     }
 
-    @Test
+    @ParallelTest
     public void testRole() {
         Kafka resource = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout))
                 .editSpec()
@@ -920,7 +922,7 @@ public class EntityOperatorTest {
         assertThat(role.getRules(), is(rules));
     }
 
-    @Test
+    @ParallelTest
     public void testRoleInDifferentNamespace() {
         Kafka resource = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout))
                 .editSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -19,7 +19,8 @@ import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.SystemProperty;
 import io.strimzi.api.kafka.model.SystemPropertyBuilder;
 import io.strimzi.operator.cluster.ResourceUtils;
-import org.junit.jupiter.api.Test;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,6 +31,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ParallelSuite
 public class EntityTopicOperatorTest {
 
     private final String namespace = "test";
@@ -117,12 +119,12 @@ public class EntityTopicOperatorTest {
         return expected;
     }
 
-    @Test
+    @ParallelTest
     public void testEnvVars()   {
         assertThat(entityTopicOperator.getEnvVars(), is(getExpectedEnvVars()));
     }
 
-    @Test
+    @ParallelTest
     public void testFromCrd() {
         assertThat(entityTopicOperator.namespace, is(namespace));
         assertThat(entityTopicOperator.cluster, is(cluster));
@@ -148,7 +150,7 @@ public class EntityTopicOperatorTest {
         assertThat(((InlineLogging) entityTopicOperator.getLogging()).getLoggers(), is(topicOperatorLogging.getLoggers()));
     }
 
-    @Test
+    @ParallelTest
     public void testFromCrdDefault() {
         EntityTopicOperatorSpec entityTopicOperatorSpec = new EntityTopicOperatorSpecBuilder()
                 .build();
@@ -178,7 +180,7 @@ public class EntityTopicOperatorTest {
         assertThat(entityTopicOperator.getLogging(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testFromCrdNoEntityOperator() {
         Kafka resource = ResourceUtils.createKafka(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout);
@@ -186,7 +188,7 @@ public class EntityTopicOperatorTest {
         assertThat(entityTopicOperator, is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testFromCrdNoTopicOperatorInEntityOperator() {
         EntityOperatorSpec entityOperatorSpec = new EntityOperatorSpecBuilder().build();
         Kafka resource =
@@ -199,7 +201,7 @@ public class EntityTopicOperatorTest {
         assertThat(entityTopicOperator, is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testGetContainers() {
         List<Container> containers = entityTopicOperator.getContainers(null);
         assertThat(containers.size(), is(1));
@@ -223,7 +225,7 @@ public class EntityTopicOperatorTest {
                 EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT)));
     }
 
-    @Test
+    @ParallelTest
     public void testRoleBindingInOtherNamespace()   {
         RoleBinding binding = entityTopicOperator.generateRoleBindingForRole(namespace, toWatchedNamespace);
 
@@ -235,7 +237,7 @@ public class EntityTopicOperatorTest {
         assertThat(binding.getRoleRef().getName(), is("foo-entity-operator"));
     }
 
-    @Test
+    @ParallelTest
     public void testRoleBindingInTheSameNamespace()   {
         RoleBinding binding = entityTopicOperator.generateRoleBindingForRole(namespace, namespace);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -24,7 +24,6 @@ import io.strimzi.api.kafka.model.SystemPropertyBuilder;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -22,6 +22,8 @@ import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.SystemProperty;
 import io.strimzi.api.kafka.model.SystemPropertyBuilder;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -35,6 +37,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ParallelSuite
 public class EntityUserOperatorTest {
 
     private final String namespace = "test";
@@ -139,12 +142,12 @@ public class EntityUserOperatorTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testEnvVars()   {
         checkEnvVars(getExpectedEnvVars(), entityUserOperator.getEnvVars());
     }
 
-    @Test
+    @ParallelTest
     public void testFromCrd() {
         assertThat(entityUserOperator.namespace, is(namespace));
         assertThat(entityUserOperator.cluster, is(cluster));
@@ -169,7 +172,7 @@ public class EntityUserOperatorTest {
         assertThat(entityUserOperator.getSecretPrefix(), is(secretPrefix));
     }
 
-    @Test
+    @ParallelTest
     public void testFromCrdDefault() {
         EntityUserOperatorSpec entityUserOperatorSpec = new EntityUserOperatorSpecBuilder()
                 .build();
@@ -198,7 +201,7 @@ public class EntityUserOperatorTest {
         assertThat(entityUserOperator.getSecretPrefix(), is(EntityUserOperatorSpec.DEFAULT_SECRET_PREFIX));
     }
 
-    @Test
+    @ParallelTest
     public void testFromCrdNoEntityOperator() {
         Kafka resource = ResourceUtils.createKafka(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout);
@@ -206,7 +209,7 @@ public class EntityUserOperatorTest {
         assertThat(entityUserOperator, is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testFromCrdNoUserOperatorInEntityOperator() {
         EntityOperatorSpec entityOperatorSpec = new EntityOperatorSpecBuilder().build();
         Kafka resource =
@@ -219,7 +222,7 @@ public class EntityUserOperatorTest {
         assertThat(entityUserOperator, is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testGetContainers() {
         List<Container> containers = entityUserOperator.getContainers(null);
         assertThat(containers.size(), is(1));
@@ -243,7 +246,7 @@ public class EntityUserOperatorTest {
                 EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT)));
     }
 
-    @Test
+    @ParallelTest
     public void testFromCrdCaValidityAndRenewal() {
         EntityUserOperatorSpec entityUserOperatorSpec = new EntityUserOperatorSpecBuilder()
                 .build();
@@ -276,7 +279,7 @@ public class EntityUserOperatorTest {
         assertThat(entityUserOperator2.getClientsCaRenewalDays(), is(Long.valueOf(CertificateAuthority.DEFAULT_CERTS_RENEWAL_DAYS)));
     }
 
-    @Test
+    @ParallelTest
     public void testEntityUserOperatorEnvVarValidityAndRenewal() {
         int validity = 100;
         int renewal = 42;
@@ -301,7 +304,7 @@ public class EntityUserOperatorTest {
         assertThat(Integer.parseInt(envvar.stream().filter(a -> a.getName().equals(EntityUserOperator.ENV_VAR_CLIENTS_CA_RENEWAL)).findFirst().get().getValue()), is(renewal));
     }
 
-    @Test
+    @ParallelTest
     public void testRoleBindingInOtherNamespace()   {
         RoleBinding binding = entityUserOperator.generateRoleBindingForRole(namespace, uoWatchedNamespace);
 
@@ -313,7 +316,7 @@ public class EntityUserOperatorTest {
         assertThat(binding.getRoleRef().getName(), is("foo-entity-operator"));
     }
 
-    @Test
+    @ParallelTest
     public void testRoleBindingInTheSameNamespace() {
         RoleBinding binding = entityUserOperator.generateRoleBindingForRole(namespace, namespace);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JmxTransTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JmxTransTest.java
@@ -37,7 +37,6 @@ import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.json.JsonObject;
-import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JmxTransTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JmxTransTest.java
@@ -34,6 +34,8 @@ import io.strimzi.operator.cluster.model.components.JmxTransQueries;
 import io.strimzi.operator.cluster.model.components.JmxTransServer;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
@@ -53,6 +55,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasProperty;
 
+@ParallelSuite
 public class JmxTransTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private final String namespace = "test";
@@ -93,7 +96,7 @@ public class JmxTransTest {
 
     private final JmxTrans jmxTrans = JmxTrans.fromCrd(kafkaAssembly, VERSIONS);
 
-    @Test
+    @ParallelTest
     public void testOutputDefinitionWriterDeserialization() {
         JmxTransOutputWriter outputWriter = new JmxTransOutputWriter();
 
@@ -114,7 +117,7 @@ public class JmxTransTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testServersDeserialization() {
         JmxTransServer server = new JmxTransServer();
 
@@ -133,7 +136,7 @@ public class JmxTransTest {
         assertThat(targetJson.getJsonArray("queries").getList().size(), is(0));
     }
 
-    @Test
+    @ParallelTest
     public void testQueriesDeserialization() {
         JmxTransOutputWriter outputWriter = new JmxTransOutputWriter();
 
@@ -165,7 +168,7 @@ public class JmxTransTest {
         assertThat(outputWriterJson.getJsonArray("typeNames").getList().get(0), is("SingleType"));
     }
 
-    @Test
+    @ParallelTest
     public void testConfigMapOnScaleUp() throws JsonProcessingException  {
         ConfigMap originalCM = jmxTrans.generateJmxTransConfigMap(jmxTransSpec, 1);
         ConfigMap scaledCM = jmxTrans.generateJmxTransConfigMap(jmxTransSpec, 2);
@@ -175,7 +178,7 @@ public class JmxTransTest {
                 is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testConfigMapOnScaleDown() throws JsonProcessingException  {
         ConfigMap originalCM = jmxTrans.generateJmxTransConfigMap(jmxTransSpec, 2);
         ConfigMap scaledCM = jmxTrans.generateJmxTransConfigMap(jmxTransSpec, 1);
@@ -185,7 +188,7 @@ public class JmxTransTest {
                 is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testTemplate() {
         Map<String, String> depLabels = TestUtils.map("l1", "v1", "l2", "v2",
                 Labels.KUBERNETES_PART_OF_LABEL, "custom-part",
@@ -259,7 +262,7 @@ public class JmxTransTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getSchedulerName(), is("my-scheduler"));
     }
 
-    @Test
+    @ParallelTest
     public void testContainerEnvVars() {
 
         ContainerEnvVar envVar1 = new ContainerEnvVar();
@@ -302,7 +305,7 @@ public class JmxTransTest {
                         .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testContainerEnvVarsConflict() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = JmxTrans.ENV_VAR_JMXTRANS_LOGGING_LEVEL;
@@ -334,7 +337,7 @@ public class JmxTransTest {
                         .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvOneValue), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testContainerSecurityContext() {
 
         SecurityContext securityContext = new SecurityContextBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -45,7 +45,6 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -43,6 +43,8 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -61,6 +63,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ParallelSuite
 public class KafkaBridgeClusterTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private final String namespace = "test";
@@ -124,7 +127,7 @@ public class KafkaBridgeClusterTest {
         return expected;
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultValues() {
         KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(ResourceUtils.createEmptyKafkaBridge(namespace, cluster), VERSIONS);
 
@@ -136,7 +139,7 @@ public class KafkaBridgeClusterTest {
         assertThat(kbc.livenessProbeOptions.getTimeoutSeconds(), is(KafkaBridgeCluster.DEFAULT_HEALTHCHECK_TIMEOUT));
     }
 
-    @Test
+    @ParallelTest
     public void testFromCrd() {
         assertThat(kbc.replicas, is(replicas));
         assertThat(kbc.image, is(image));
@@ -146,12 +149,12 @@ public class KafkaBridgeClusterTest {
         assertThat(kbc.livenessProbeOptions.getTimeoutSeconds(), is(healthTimeout));
     }
 
-    @Test
+    @ParallelTest
     public void testEnvVars()   {
         assertThat(kbc.getEnvVars(), is(getExpectedEnvVars()));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateService()   {
         Service svc = kbc.generateService();
 
@@ -168,7 +171,7 @@ public class KafkaBridgeClusterTest {
         checkOwnerReference(kbc.createOwnerReference(), svc);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeployment()   {
         Deployment dep = kbc.generateDeployment(new HashMap<String, String>(), true, null, null);
 
@@ -198,7 +201,7 @@ public class KafkaBridgeClusterTest {
         checkOwnerReference(kbc.createOwnerReference(), dep);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithTls() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
@@ -224,7 +227,7 @@ public class KafkaBridgeClusterTest {
         assertThat(AbstractModel.containerEnvVars(containers.get(0)).get(KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_TLS), is("true"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithTlsAuth() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
@@ -255,7 +258,7 @@ public class KafkaBridgeClusterTest {
         assertThat(AbstractModel.containerEnvVars(containers.get(0)).get(KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_TLS), is("true"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithTlsSameSecret() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
@@ -280,7 +283,7 @@ public class KafkaBridgeClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("my-secret"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithScramSha512Auth() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
@@ -307,7 +310,7 @@ public class KafkaBridgeClusterTest {
         assertThat(AbstractModel.containerEnvVars(containers.get(0)).get(KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_SASL_MECHANISM), is("scram-sha-512"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithPlainAuth() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
@@ -334,7 +337,7 @@ public class KafkaBridgeClusterTest {
         assertThat(AbstractModel.containerEnvVars(containers.get(0)).get(KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_SASL_MECHANISM), is("plain"));
     }
 
-    @Test
+    @ParallelTest
     public void testTemplate() {
         Map<String, String> depLabels = TestUtils.map("l1", "v1", "l2", "v2",
                 Labels.KUBERNETES_PART_OF_LABEL, "custom-part",
@@ -457,7 +460,7 @@ public class KafkaBridgeClusterTest {
         assertThat(resource.getMetadata().getOwnerReferences().get(0), is(ownerRef));
     }
 
-    @Test
+    @ParallelTest
     public void testGracePeriod() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
@@ -474,7 +477,7 @@ public class KafkaBridgeClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(123)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultGracePeriod() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource).build();
         KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(resource, VERSIONS);
@@ -483,7 +486,7 @@ public class KafkaBridgeClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(30)));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecrets() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -505,7 +508,7 @@ public class KafkaBridgeClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecretsCO() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -522,7 +525,7 @@ public class KafkaBridgeClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecretsBoth() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -544,7 +547,7 @@ public class KafkaBridgeClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultImagePullSecrets() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource).build();
         KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(resource, VERSIONS);
@@ -553,7 +556,7 @@ public class KafkaBridgeClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testSecurityContext() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
@@ -573,7 +576,7 @@ public class KafkaBridgeClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsUser(), is(Long.valueOf(789)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultSecurityContext() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource).build();
         KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(resource, VERSIONS);
@@ -582,7 +585,7 @@ public class KafkaBridgeClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testPodDisruptionBudget() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
@@ -599,7 +602,7 @@ public class KafkaBridgeClusterTest {
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(2)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultPodDisruptionBudget() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource).build();
         KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(resource, VERSIONS);
@@ -608,7 +611,7 @@ public class KafkaBridgeClusterTest {
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullPolicy() {
         KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(resource, VERSIONS);
 
@@ -619,7 +622,7 @@ public class KafkaBridgeClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
     }
 
-    @Test
+    @ParallelTest
     public void testResources() {
         Map<String, Quantity> requests = new HashMap<>(2);
         requests.put("cpu", new Quantity("250m"));
@@ -642,7 +645,7 @@ public class KafkaBridgeClusterTest {
         assertThat(cont.getResources().getRequests(), is(requests));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaBridgeContainerEnvVars() {
 
         ContainerEnvVar envVar1 = new ContainerEnvVar();
@@ -681,7 +684,7 @@ public class KafkaBridgeClusterTest {
                         .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaBridgeContainerEnvVarsConflict() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_BOOTSTRAP_SERVERS;
@@ -719,7 +722,7 @@ public class KafkaBridgeClusterTest {
                         .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithAccessToken() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
@@ -743,7 +746,7 @@ public class KafkaBridgeClusterTest {
         assertThat(cont.getEnv().stream().filter(var -> KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_OAUTH_CONFIG.equals(var.getName())).findFirst().orElse(null).getValue().isEmpty(), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithRefreshToken() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
@@ -770,7 +773,7 @@ public class KafkaBridgeClusterTest {
                 is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server")));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithClientSecret() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
@@ -797,7 +800,7 @@ public class KafkaBridgeClusterTest {
                 is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server")));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithMissingClientSecret() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
@@ -814,7 +817,7 @@ public class KafkaBridgeClusterTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithMissingUri() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
@@ -835,7 +838,7 @@ public class KafkaBridgeClusterTest {
     }
 
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithTls() {
         CertSecretSource cert1 = new CertSecretSourceBuilder()
                 .withSecretName("first-certificate")
@@ -897,7 +900,7 @@ public class KafkaBridgeClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream().filter(vol -> "oauth-certs-2".equals(vol.getName())).findFirst().orElse(null).getSecret().getItems().get(0).getPath(), is("tls.crt"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthUsingOpaqueTokens() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
@@ -926,7 +929,7 @@ public class KafkaBridgeClusterTest {
                 is(String.format("%s=\"%s\" %s=\"%s\" %s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server", ClientConfig.OAUTH_ACCESS_TOKEN_IS_JWT, "false", ClientConfig.OAUTH_MAX_TOKEN_EXPIRY_SECONDS, "600")));
     }
 
-    @Test
+    @ParallelTest
     public void testDifferentHttpPort()   {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
@@ -959,7 +962,7 @@ public class KafkaBridgeClusterTest {
         checkOwnerReference(kbc.createOwnerReference(), svc);
     }
 
-    @Test
+    @ParallelTest
     public void testProbeConfiguration()   {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
@@ -988,7 +991,7 @@ public class KafkaBridgeClusterTest {
         assertThat(cont.getReadinessProbe().getTimeoutSeconds(), is(Integer.valueOf(32)));
     }
 
-    @Test
+    @ParallelTest
     public void testTracingConfiguration() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
@@ -1003,7 +1006,7 @@ public class KafkaBridgeClusterTest {
         assertThat(AbstractModel.containerEnvVars(container).get(KafkaBridgeCluster.ENV_VAR_STRIMZI_TRACING), is("jaeger"));
     }
 
-    @Test
+    @ParallelTest
     public void testCorsConfiguration() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -32,7 +32,6 @@ import io.strimzi.test.annotations.ParallelTest;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.jupiter.api.Test;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -27,6 +27,8 @@ import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -51,8 +53,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
+@ParallelSuite
 public class KafkaBrokerConfigurationBuilderTest {
-    @Test
+    @ParallelTest
     public void testBrokerId()  {
         String configuration = new KafkaBrokerConfigurationBuilder()
                 .withBrokerId()
@@ -61,7 +64,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         assertThat(configuration, isEquivalent("broker.id=${STRIMZI_BROKER_ID}"));
     }
 
-    @Test
+    @ParallelTest
     public void testNoCruiseControl()  {
         String configuration = new KafkaBrokerConfigurationBuilder()
                 .withCruiseControl("my-cluster", null, "1", "1", "1")
@@ -70,7 +73,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         assertThat(configuration, isEquivalent(""));
     }
 
-    @Test
+    @ParallelTest
     public void testCruiseControl()  {
         CruiseControlSpec cruiseControlSpec = new CruiseControlSpecBuilder().build();
 
@@ -96,7 +99,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR + "=1"));
     }
 
-    @Test
+    @ParallelTest
     public void testNoRackAwareness()  {
         String configuration = new KafkaBrokerConfigurationBuilder()
                 .withRackId(null)
@@ -105,7 +108,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         assertThat(configuration, isEquivalent(""));
     }
 
-    @Test
+    @ParallelTest
     public void testRackId()  {
         String configuration = new KafkaBrokerConfigurationBuilder()
                 .withRackId(new Rack("failure-domain.kubernetes.io/zone"))
@@ -114,7 +117,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         assertThat(configuration, isEquivalent("broker.rack=${STRIMZI_RACK_ID}"));
     }
 
-    @Test
+    @ParallelTest
     public void testRackAndBrokerId()  {
         String configuration = new KafkaBrokerConfigurationBuilder()
                 .withBrokerId()
@@ -125,7 +128,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                                                                 "broker.rack=${STRIMZI_RACK_ID}"));
     }
 
-    @Test
+    @ParallelTest
     public void testZookeeperConfig()  {
         String configuration = new KafkaBrokerConfigurationBuilder()
                 .withZookeeper("my-cluster")
@@ -142,7 +145,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "zookeeper.ssl.truststore.type=PKCS12"));
     }
 
-    @Test
+    @ParallelTest
     public void testNoAuthorization()  {
         String configuration = new KafkaBrokerConfigurationBuilder()
                 .withAuthorization("my-cluster", null)
@@ -151,7 +154,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         assertThat(configuration, isEquivalent(""));
     }
 
-    @Test
+    @ParallelTest
     public void testSimpleAuthorizationWithSuperUsers()  {
         KafkaAuthorization auth = new KafkaAuthorizationSimpleBuilder()
                 .addToSuperUsers("jakub", "CN=kuba")
@@ -165,7 +168,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi;User:jakub;User:CN=kuba"));
     }
 
-    @Test
+    @ParallelTest
     public void testSimpleAuthorizationWithoutSuperUsers()  {
         KafkaAuthorization auth = new KafkaAuthorizationSimpleBuilder()
                 .build();
@@ -178,7 +181,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi"));
     }
 
-    @Test
+    @ParallelTest
     public void testKeycloakAuthorization() {
         CertSecretSource cert = new CertSecretSourceBuilder()
                 .withNewSecretName("my-secret")
@@ -215,7 +218,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi;User:giada;User:CN=paccu"));
     }
 
-    @Test
+    @ParallelTest
     public void testKeycloakAuthorizationWithDefaults() {
         CertSecretSource cert = new CertSecretSourceBuilder()
                 .withNewSecretName("my-secret")
@@ -245,7 +248,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi"));
     }
 
-    @Test
+    @ParallelTest
     public void testOpaAuthorizationWithDefaults() {
         KafkaAuthorization auth = new KafkaAuthorizationOpaBuilder()
                 .withUrl("http://opa:8181/v1/data/kafka/allow")
@@ -264,7 +267,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi"));
     }
 
-    @Test
+    @ParallelTest
     public void testOpaAuthorization() {
         KafkaAuthorization auth = new KafkaAuthorizationOpaBuilder()
                 .withUrl("http://opa:8181/v1/data/kafka/allow")
@@ -288,7 +291,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi;User:jack;User:CN=conor"));
     }
 
-    @Test
+    @ParallelTest
     public void testNullUserConfiguration()  {
         String configuration = new KafkaBrokerConfigurationBuilder()
                 .withUserConfiguration(null)
@@ -297,7 +300,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         assertThat(configuration, isEquivalent(""));
     }
 
-    @Test
+    @ParallelTest
     public void testEmptyUserConfiguration()  {
         Map<String, Object> userConfiguration = new HashMap<>();
         KafkaConfiguration kafkaConfiguration = new KafkaConfiguration(userConfiguration.entrySet());
@@ -309,7 +312,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         assertThat(configuration, isEquivalent(""));
     }
 
-    @Test
+    @ParallelTest
     public void testUserConfiguration()  {
         Map<String, Object> userConfiguration = new HashMap<>();
         userConfiguration.put("auto.create.topics.enable", "false");
@@ -329,7 +332,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                                                             "transaction.state.log.min.isr=2"));
     }
 
-    @Test
+    @ParallelTest
     public void testEphemeralStorageLogDirs()  {
         Storage storage = new EphemeralStorageBuilder()
                 .withNewSizeLimit("5Gi")
@@ -342,7 +345,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         assertThat(configuration, isEquivalent("log.dirs=/var/lib/kafka/data/kafka-log${STRIMZI_BROKER_ID}"));
     }
 
-    @Test
+    @ParallelTest
     public void testPersistentStorageLogDirs()  {
         Storage storage = new PersistentClaimStorageBuilder()
                 .withSize("1Ti")
@@ -357,7 +360,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         assertThat(configuration, isEquivalent("log.dirs=/var/lib/kafka/data/kafka-log${STRIMZI_BROKER_ID}"));
     }
 
-    @Test
+    @ParallelTest
     public void testJbodStorageLogDirs()  {
         SingleVolumeStorage vol1 = new PersistentClaimStorageBuilder()
                 .withId(1)
@@ -389,7 +392,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         assertThat(configuration, isEquivalent("log.dirs=/var/lib/kafka/data-1/kafka-log${STRIMZI_BROKER_ID},/var/lib/kafka/data-2/kafka-log${STRIMZI_BROKER_ID},/var/lib/kafka/data-5/kafka-log${STRIMZI_BROKER_ID}"));
     }
 
-    @Test
+    @ParallelTest
     public void testWithNoListeners()  {
         String configuration = new KafkaBrokerConfigurationBuilder()
                 .withListeners("my-cluster", "my-namespace", emptyList())
@@ -411,7 +414,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "ssl.endpoint.identification.algorithm=HTTPS"));
     }
 
-    @Test
+    @ParallelTest
     public void testConnectionLimits()  {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
@@ -475,7 +478,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "ssl.endpoint.identification.algorithm=HTTPS"));
     }
 
-    @Test
+    @ParallelTest
     public void testWithPlainListenersWithoutAuth()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("plain")
@@ -504,7 +507,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "ssl.endpoint.identification.algorithm=HTTPS"));
     }
 
-    @Test
+    @ParallelTest
     public void testWithPlainListenersWithSaslAuth()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("plain")
@@ -537,7 +540,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "listener.name.plain-9092.sasl.enabled.mechanisms=SCRAM-SHA-512"));
     }
 
-    @Test
+    @ParallelTest
     public void testWithTlsListenersWithoutAuth()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("tls")
@@ -569,7 +572,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "listener.name.tls-9093.ssl.keystore.type=PKCS12"));
     }
 
-    @Test
+    @ParallelTest
     public void testWithTlsListenersWithTlsAuth()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("tls")
@@ -607,7 +610,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "listener.name.tls-9093.ssl.keystore.type=PKCS12"));
     }
 
-    @Test
+    @ParallelTest
     public void testWithTlsListenersWithCustomCerts()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("tls")
@@ -646,7 +649,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "listener.name.tls-9093.ssl.keystore.type=PKCS12"));
     }
 
-    @Test
+    @ParallelTest
     public void testWithExternalRouteListenersWithoutAuth()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("external")
@@ -678,7 +681,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "listener.name.external-9094.ssl.keystore.type=PKCS12"));
     }
 
-    @Test
+    @ParallelTest
     public void testWithExternalRouteListenersWithTlsAuth()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("external")
@@ -716,7 +719,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "listener.name.external-9094.ssl.keystore.type=PKCS12"));
     }
 
-    @Test
+    @ParallelTest
     public void testWithExternalRouteListenersWithSaslAuth()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("external")
@@ -752,7 +755,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "listener.name.external-9094.ssl.keystore.type=PKCS12"));
     }
 
-    @Test
+    @ParallelTest
     public void testWithExternalRouteListenersWithCustomCerts()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("external")
@@ -791,7 +794,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "listener.name.external-9094.ssl.keystore.type=PKCS12"));
     }
 
-    @Test
+    @ParallelTest
     public void testWithExternalListenersLoadBalancerWithTls()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("external")
@@ -823,7 +826,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "listener.name.external-9094.ssl.keystore.type=PKCS12"));
     }
 
-    @Test
+    @ParallelTest
     public void testWithExternalListenersLoadBalancerWithoutTls()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("external")
@@ -852,7 +855,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "ssl.endpoint.identification.algorithm=HTTPS"));
     }
 
-    @Test
+    @ParallelTest
     public void testWithExternalListenersNodePortWithTls()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("external")
@@ -884,7 +887,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "listener.name.external-9094.ssl.keystore.type=PKCS12"));
     }
 
-    @Test
+    @ParallelTest
     public void testWithExternalListenersNodePortWithoutTls()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("external")
@@ -913,7 +916,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "ssl.endpoint.identification.algorithm=HTTPS"));
     }
 
-    @Test
+    @ParallelTest
     public void testWithExternalListenersIngress()  {
         GenericKafkaListenerConfigurationBroker broker = new GenericKafkaListenerConfigurationBrokerBuilder()
                 .withBroker(0)
@@ -957,7 +960,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "listener.name.external-9094.ssl.keystore.type=PKCS12"));
     }
 
-    @Test
+    @ParallelTest
     public void testOauthConfiguration()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("plain")
@@ -1003,7 +1006,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "listener.name.plain-9092.connections.max.reauth.ms=3600000"));
     }
 
-    @Test
+    @ParallelTest
     public void testOauthConfigurationWithoutOptions()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("plain")
@@ -1038,7 +1041,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "principal.builder.class=io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder"));
     }
 
-    @Test
+    @ParallelTest
     public void testOauthConfigurationWithTlsConfig()  {
         CertSecretSource cert = new CertSecretSourceBuilder()
                 .withNewSecretName("my-secret")
@@ -1084,7 +1087,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "principal.builder.class=io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder"));
     }
 
-    @Test
+    @ParallelTest
     public void testOauthConfigurationWithClientSecret()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("plain")
@@ -1128,7 +1131,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "principal.builder.class=io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder"));
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthOptions()  {
         KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
                 .withValidIssuerUri("http://valid-issuer")
@@ -1180,7 +1183,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         assertThat(actualOptions, is(equalTo(expectedOptions)));
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthDefaultOptions()  {
         KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
                 .build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
@@ -16,6 +16,8 @@ import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBui
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.api.kafka.model.storage.EphemeralStorage;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -23,6 +25,7 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ParallelSuite
 public class KafkaClusterOAuthValidationTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
 
@@ -37,7 +40,7 @@ public class KafkaClusterOAuthValidationTest {
         return asList(listener1);
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthValidationWithIntrospectionMinimalPlain() {
         KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
                 .withClientId("my-client-id")
@@ -52,7 +55,7 @@ public class KafkaClusterOAuthValidationTest {
         ListenersValidator.validate(3, getListeners(auth));
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthAuthnAuthz() {
         List<GenericKafkaListener> listeners = asList(new GenericKafkaListenerBuilder()
                 .withName("listener1")
@@ -103,7 +106,7 @@ public class KafkaClusterOAuthValidationTest {
         KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthAuthzWithoutAuthn() {
         assertThrows(InvalidResourceException.class, () -> {
             List<GenericKafkaListener> listeners = asList(new GenericKafkaListenerBuilder()
@@ -145,7 +148,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthValidationWithJwksMinRefreshPauseAndIntrospection() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
@@ -163,7 +166,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthValidationWithJwksExpiryAndIntrospection() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
@@ -181,7 +184,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthValidationWithJwksRefreshAndIntrospection() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
@@ -199,7 +202,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthValidationWithReauthAndIntrospection() {
         KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
                 .withClientId("my-client-id")
@@ -215,7 +218,7 @@ public class KafkaClusterOAuthValidationTest {
         ListenersValidator.validate(3, getListeners(auth));
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthValidationMissingValidIssuerUri() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
@@ -231,7 +234,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthValidationRefreshSecondsRelationWithExpirySeconds() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
@@ -245,7 +248,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthValidationRefreshSecondsSetWithExpirySecondsNotSet() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
@@ -258,7 +261,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthValidationRefreshSecondsNotSetWithExpirySecondsSet() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
@@ -271,7 +274,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthValidationNoUriSpecified() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder().build();
@@ -280,7 +283,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthValidationIntrospectionEndpointUriWithoutClientId() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
@@ -295,7 +298,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthValidationIntrospectionEndpointUriWithoutClientSecret() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
@@ -307,7 +310,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthValidationExpirySecondsWithoutEndpointUri() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
@@ -320,7 +323,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthValidationRefreshSecondsWithoutEndpointUri() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
@@ -333,7 +336,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthValidationWithOAuthWithIntrospectionWithNoTypeCheck() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
@@ -351,7 +354,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testOAuthValidationWithOAuthWithJwksWithNotJwt() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
@@ -18,7 +18,6 @@ import io.strimzi.api.kafka.model.storage.EphemeralStorage;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import java.util.List;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -79,6 +79,8 @@ import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -115,6 +117,7 @@ import static org.junit.jupiter.api.Assertions.fail;
         "checkstyle:ClassDataAbstractionCoupling",
         "checkstyle:ClassFanOutComplexity"
 })
+@ParallelSuite
 public class KafkaClusterTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private final String namespace = "test";
@@ -158,7 +161,7 @@ public class KafkaClusterTest {
     }
 
     @Deprecated
-    @Test
+    @ParallelTest
     public void testMetricsConfigMapDeprecatedMetrics() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, null, configuration, kafkaLog, zooLog))
                 .editSpec()
@@ -177,14 +180,14 @@ public class KafkaClusterTest {
         checkOwnerReference(kc.createOwnerReference(), metricsCm);
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsConfigMap() {
         ConfigMap metricsCm = kc.generateMetricsAndLogConfigMap(new MetricsAndLogging(metricsCM, null));
         checkMetricsConfigMap(metricsCm);
         checkOwnerReference(kc.createOwnerReference(), metricsCm);
     }
 
-    @Test
+    @ParallelTest
     public void  testJavaSystemProperties() {
         assertThat(kc.getEnvVars().get(2).getName(), is("STRIMZI_JAVA_SYSTEM_PROPERTIES"));
         assertThat(kc.getEnvVars().get(2).getValue(), is("-D" + javaSystemProperties.get(0).getName() + "=" + javaSystemProperties.get(0).getValue() + " " +
@@ -211,7 +214,7 @@ public class KafkaClusterTest {
         return Labels.fromMap(expectedLabels()).strimziSelectorLabels().toMap();
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateService() {
         Service headful = kc.generateService();
 
@@ -236,7 +239,7 @@ public class KafkaClusterTest {
         checkOwnerReference(kc.createOwnerReference(), headful);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateServiceWithoutMetrics() {
         Kafka kafka = new KafkaBuilder(kafkaAssembly)
                 .editSpec()
@@ -271,7 +274,7 @@ public class KafkaClusterTest {
         checkOwnerReference(kc.createOwnerReference(), headful);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateHeadlessServiceWithJmxMetrics() {
         Kafka kafka = new KafkaBuilder(kafkaAssembly)
                 .editSpec()
@@ -304,7 +307,7 @@ public class KafkaClusterTest {
         checkOwnerReference(kc.createOwnerReference(), headless);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateHeadlessService() {
         Service headless = kc.generateHeadlessService();
         checkHeadlessService(headless);
@@ -330,7 +333,7 @@ public class KafkaClusterTest {
         assertThat(headless.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateStatefulSet() {
         // We expect a single statefulSet ...
         StatefulSet sts = kc.generateStatefulSet(true, null, null);
@@ -338,7 +341,7 @@ public class KafkaClusterTest {
         checkOwnerReference(kc.createOwnerReference(), sts);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateStatefulSetWithSetStorageSelector() {
         Map<String, String> selector = TestUtils.map("foo", "bar");
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
@@ -354,7 +357,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getVolumeClaimTemplates().get(0).getSpec().getSelector().getMatchLabels(), is(selector));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateStatefulSetWithEmptyStorageSelector() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -369,7 +372,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getVolumeClaimTemplates().get(0).getSpec().getSelector(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateStatefulSetWithSetSizeLimit() {
         String sizeLimit = "1Gi";
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
@@ -385,7 +388,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit(), is(new Quantity("1", "Gi")));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateStatefulSetWithEmptySizeLimit() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -400,7 +403,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateStatefulSetWithRack() {
         Kafka editKafkaAssembly = new KafkaBuilder(kafkaAssembly)
                 .editSpec()
@@ -414,7 +417,7 @@ public class KafkaClusterTest {
         checkStatefulSet(sts, editKafkaAssembly, true);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateStatefulSetWithInitContainers() {
         Kafka editKafkaAssembly =
                 new KafkaBuilder(kafkaAssembly)
@@ -429,7 +432,7 @@ public class KafkaClusterTest {
         checkStatefulSet(sts, editKafkaAssembly, false);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateStatefulSetWithPodManagementPolicy() {
         Kafka editKafkaAssembly =
                 new KafkaBuilder(kafkaAssembly)
@@ -515,7 +518,7 @@ public class KafkaClusterTest {
 
     // TODO test volume claim templates
 
-    @Test
+    @ParallelTest
     public void testPodNames() {
 
         for (int i = 0; i < replicas; i++) {
@@ -523,7 +526,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testPvcNames() {
         Kafka assembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -566,42 +569,42 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void withAffinityWithoutRack() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, KafkaCluster::fromCrd, this.getClass().getSimpleName() + ".withAffinityWithoutRack");
         resourceTester.assertDesiredResource("-STS.yaml",
             kc -> kc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getAffinity());
     }
 
-    @Test
+    @ParallelTest
     public void withRackWithoutAffinity() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, KafkaCluster::fromCrd, this.getClass().getSimpleName() + ".withRackWithoutAffinity");
         resourceTester.assertDesiredResource("-STS.yaml",
             kc -> kc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getAffinity());
     }
 
-    @Test
+    @ParallelTest
     public void withRackAndAffinityWithMoreTerms() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, KafkaCluster::fromCrd, this.getClass().getSimpleName() + ".withRackAndAffinityWithMoreTerms");
         resourceTester.assertDesiredResource("-STS.yaml",
             kc -> kc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getAffinity());
     }
 
-    @Test
+    @ParallelTest
     public void withRackAndAffinity() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, KafkaCluster::fromCrd, this.getClass().getSimpleName() + ".withRackAndAffinity");
         resourceTester.assertDesiredResource("-STS.yaml",
             kc -> kc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getAffinity());
     }
 
-    @Test
+    @ParallelTest
     public void withTolerations() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, KafkaCluster::fromCrd, this.getClass().getSimpleName() + ".withTolerations");
         resourceTester.assertDesiredResource("-STS.yaml",
             kc -> kc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getTolerations());
     }
 
-    @Test
+    @ParallelTest
     public void testExternalRoutes() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -668,7 +671,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testExternalRoutesWithHostOverrides() {
         GenericKafkaListenerConfigurationBroker routeListenerBrokerConfig0 = new GenericKafkaListenerConfigurationBroker();
         routeListenerBrokerConfig0.setBroker(0);
@@ -721,7 +724,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testExternalRoutesWithLabelsAndAnnotations() {
         GenericKafkaListenerConfigurationBroker routeListenerBrokerConfig0 = new GenericKafkaListenerConfigurationBroker();
         routeListenerBrokerConfig0.setBroker(0);
@@ -780,7 +783,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testExternalLoadBalancers() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -834,7 +837,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testLoadBalancerExternalTrafficPolicyLocalFromListener() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -867,7 +870,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testLoadBalancerExternalTrafficPolicyClusterFromListener() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -900,7 +903,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testFinalizersFromListener() {
         List<String> finalizers = List.of("service.kubernetes.io/load-balancer-cleanup", "mydomain.io/my-custom-finalizer");
 
@@ -935,7 +938,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testLoadBalancerSourceRangeFromListener() {
         List<String> sourceRanges = new ArrayList();
         sourceRanges.add("10.0.0.0/8");
@@ -972,7 +975,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testExternalLoadBalancersWithLabelsAndAnnotations() {
         GenericKafkaListenerConfigurationBootstrap bootstrapConfig = new GenericKafkaListenerConfigurationBootstrapBuilder()
                 .withAnnotations(Collections.singletonMap("external-dns.alpha.kubernetes.io/hostname", "bootstrap.myingress.com."))
@@ -1023,7 +1026,7 @@ public class KafkaClusterTest {
         assertThat(kc.generateExternalServices(2).get(0).getMetadata().getLabels().get("label"), is("label-value"));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalLoadBalancersWithLoadBalancerIPOverride() {
         GenericKafkaListenerConfigurationBootstrap bootstrapConfig = new GenericKafkaListenerConfigurationBootstrapBuilder()
                 .withLoadBalancerIP("10.0.0.1")
@@ -1067,7 +1070,7 @@ public class KafkaClusterTest {
         assertThat(kc.generateExternalServices(2).get(0).getSpec().getLoadBalancerIP(), is("10.0.0.3"));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalNodePortWithLabelsAndAnnotations() {
         GenericKafkaListenerConfigurationBootstrap bootstrapConfig = new GenericKafkaListenerConfigurationBootstrapBuilder()
                 .withAnnotations(Collections.singletonMap("external-dns.alpha.kubernetes.io/hostname", "bootstrap.myingress.com."))
@@ -1119,7 +1122,7 @@ public class KafkaClusterTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testExternalNodePorts() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -1165,7 +1168,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testExternalNodePortsWithAddressType() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -1196,7 +1199,7 @@ public class KafkaClusterTest {
                         .map(EnvVar::getValue).findFirst().orElse(""), is("TRUE"));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalNodePortOverrides() {
         GenericKafkaListenerConfigurationBroker nodePortListenerBrokerConfig = new GenericKafkaListenerConfigurationBroker();
         nodePortListenerBrokerConfig.setBroker(0);
@@ -1254,7 +1257,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testGetExternalNodePortServiceAddressOverrideWithNullAdvertisedHost() {
         GenericKafkaListenerConfigurationBroker nodePortListenerBrokerConfig = new GenericKafkaListenerConfigurationBroker();
         nodePortListenerBrokerConfig.setBroker(0);
@@ -1289,7 +1292,7 @@ public class KafkaClusterTest {
         assertThat(ListenersUtils.brokerNodePort(kc.getListeners().get(0), 0), is(32101));
     }
 
-    @Test
+    @ParallelTest
     public void testGetExternalNodePortServiceAddressOverrideWithNonNullAdvertisedHost() {
         GenericKafkaListenerConfigurationBroker nodePortListenerBrokerConfig = new GenericKafkaListenerConfigurationBroker();
         nodePortListenerBrokerConfig.setBroker(0);
@@ -1327,7 +1330,7 @@ public class KafkaClusterTest {
         assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), 0), is("advertised.host"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateBrokerSecret() throws CertificateParsingException {
         Secret secret = generateBrokerSecret(null, emptyMap());
         assertThat(secret.getData().keySet(), is(set(
@@ -1350,7 +1353,7 @@ public class KafkaClusterTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateBrokerSecretExternal() throws CertificateParsingException {
         Map<Integer, Set<String>> externalAddresses = new HashMap<>();
         externalAddresses.put(0, Collections.singleton("123.10.125.130"));
@@ -1379,7 +1382,7 @@ public class KafkaClusterTest {
                 asList(7, "123.10.125.130"))));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateBrokerSecretExternalWithManyDNS() throws CertificateParsingException {
         Map<Integer, Set<String>> externalAddresses = new HashMap<>();
         externalAddresses.put(0, TestUtils.set("123.10.125.130", "my-broker-0"));
@@ -1418,7 +1421,7 @@ public class KafkaClusterTest {
         return kc.generateBrokersSecret();
     }
 
-    @Test
+    @ParallelTest
     @SuppressWarnings({"checkstyle:MethodLength"})
     public void testTemplate() {
         Map<String, String> ssLabels = TestUtils.map("l1", "v1", "l2", "v2",
@@ -1622,7 +1625,7 @@ public class KafkaClusterTest {
         assertThat(crb.getMetadata().getAnnotations().entrySet().containsAll(crbAnots.entrySet()), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testReplicationPortNetworkPolicy() {
         NetworkPolicyPeer kafkaBrokersPeer = new NetworkPolicyPeerBuilder()
                 .withNewPodSelector()
@@ -1717,7 +1720,7 @@ public class KafkaClusterTest {
         assertThat(rules.contains(clusterOperatorPeerNamespaceWithLabels), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testNetworkPolicyPeers() {
         NetworkPolicyPeer peer1 = new NetworkPolicyPeerBuilder()
                 .withNewPodSelector()
@@ -1781,7 +1784,7 @@ public class KafkaClusterTest {
         assertThat(rules.get(0).getFrom().contains(peer2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testNoNetworkPolicyPeers() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -1828,7 +1831,7 @@ public class KafkaClusterTest {
         assertThat(rules.get(0).getFrom(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testGracePeriod() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -1848,7 +1851,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(123)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultGracePeriod() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -1859,7 +1862,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(30)));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecrets() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -1884,7 +1887,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecretsFromCO() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -1903,7 +1906,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecretsFromBoth() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -1928,7 +1931,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultImagePullSecrets() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -1939,7 +1942,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testSecurityContext() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -1962,7 +1965,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsUser(), is(Long.valueOf(789)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultSecurityContext() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -1973,7 +1976,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testPodDisruptionBudget() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -1993,7 +1996,7 @@ public class KafkaClusterTest {
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(2)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultPodDisruptionBudget() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -2004,7 +2007,7 @@ public class KafkaClusterTest {
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullPolicy() {
         Kafka kafkaAssembly = ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap());
@@ -2020,7 +2023,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
     }
 
-    @Test
+    @ParallelTest
     public void testGetExternalServiceAdvertisedHostAndPortOverride() {
         GenericKafkaListenerConfigurationBroker nodePortListenerBrokerConfig0 = new GenericKafkaListenerConfigurationBroker();
         nodePortListenerBrokerConfig0.setBroker(0);
@@ -2068,7 +2071,7 @@ public class KafkaClusterTest {
         assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), 2), is("my-host-2.cz"));
     }
 
-    @Test
+    @ParallelTest
     public void testGetExternalServiceWithoutAdvertisedHostAndPortOverride() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -2098,7 +2101,7 @@ public class KafkaClusterTest {
         assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), 2), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testGetExternalAdvertisedUrlWithOverrides() {
         GenericKafkaListenerConfigurationBroker nodePortListenerBrokerConfig0 = new GenericKafkaListenerConfigurationBroker();
         nodePortListenerBrokerConfig0.setBroker(0);
@@ -2137,7 +2140,7 @@ public class KafkaClusterTest {
         assertThat(kc.getAdvertisedPort(kc.getListeners().get(0), 1, 12345), is("EXTERNAL_9094_1://12345"));
     }
 
-    @Test
+    @ParallelTest
     public void testGetExternalAdvertisedUrlWithoutOverrides() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -2164,7 +2167,7 @@ public class KafkaClusterTest {
         assertThat(kc.getAdvertisedPort(kc.getListeners().get(0), 0, 12345), is("EXTERNAL_9094_0://12345"));
     }
 
-    @Test
+    @ParallelTest
     public void testGeneratePersistentVolumeClaimsPersistentWithClaimDeletion() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -2198,7 +2201,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testGeneratePersistentVolumeClaimsPersistentWithoutClaimDeletion() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -2228,7 +2231,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testGeneratePersistentVolumeClaimsPersistentWithOverride() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -2274,7 +2277,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testGeneratePersistentVolumeClaimsJbod() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -2340,7 +2343,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testGeneratePersistentVolumeClaimsJbodWithTemplate() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -2386,7 +2389,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testGeneratePersistentVolumeClaimsJbodWithOverrides() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -2429,7 +2432,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testGeneratePersistentVolumeClaimsJbodWithoutVolumes() {
         assertThrows(InvalidResourceException.class, () -> {
             Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
@@ -2445,7 +2448,7 @@ public class KafkaClusterTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testStorageValidationAfterInitialDeployment() {
         assertThrows(InvalidResourceException.class, () -> {
             Storage oldStorage = new JbodStorageBuilder()
@@ -2465,7 +2468,7 @@ public class KafkaClusterTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testGeneratePersistentVolumeClaimsEphemeral()    {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -2487,7 +2490,7 @@ public class KafkaClusterTest {
         assertThat(pvcs.size(), is(0));
     }
 
-    @Test
+    @ParallelTest
     public void testStorageReverting() {
         Storage jbod = new JbodStorageBuilder().withVolumes(
                 new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build(),
@@ -2569,7 +2572,7 @@ public class KafkaClusterTest {
         assertThat(kc.getWarningConditions().get(0).getReason(), is("KafkaStorage"));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalIngress() {
         GenericKafkaListenerConfigurationBroker broker0 = new GenericKafkaListenerConfigurationBrokerBuilder()
                 .withHost("my-broker-kafka-0.com")
@@ -2713,7 +2716,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testExternalIngressClass() {
         GenericKafkaListenerConfigurationBroker broker0 = new GenericKafkaListenerConfigurationBrokerBuilder()
                 .withHost("my-broker-kafka-0.com")
@@ -2773,7 +2776,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testExternalIngressMissingConfiguration() {
         GenericKafkaListenerConfigurationBroker broker0 = new GenericKafkaListenerConfigurationBrokerBuilder()
                 .withBroker(0)
@@ -2811,7 +2814,7 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testClusterRoleBindingNodePort() {
         String testNamespace = "other-namespace";
 
@@ -2842,7 +2845,7 @@ public class KafkaClusterTest {
         assertThat(crb.getSubjects().get(0).getName(), is(kc.getServiceAccountName()));
     }
 
-    @Test
+    @ParallelTest
     public void testClusterRoleBindingRack() {
         String testNamespace = "other-namespace";
 
@@ -2864,7 +2867,7 @@ public class KafkaClusterTest {
         assertThat(crb.getSubjects().get(0).getName(), is(kc.getServiceAccountName()));
     }
 
-    @Test
+    @ParallelTest
     public void testNullClusterRoleBinding() {
         String testNamespace = "other-namespace";
 
@@ -2877,7 +2880,7 @@ public class KafkaClusterTest {
         assertThat(crb, is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaContainerEnvars() {
 
         ContainerEnvVar envVar1 = new ContainerEnvVar();
@@ -2922,7 +2925,7 @@ public class KafkaClusterTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaContainerEnvVarsConflict() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = KafkaCluster.ENV_VAR_KAFKA_JMX_ENABLED;
@@ -2970,7 +2973,7 @@ public class KafkaClusterTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testInitContainerEnvVars() {
 
         ContainerEnvVar envVar1 = new ContainerEnvVar();
@@ -3013,7 +3016,7 @@ public class KafkaClusterTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testInitContainerEnvVarsConflict() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = KafkaCluster.ENV_VAR_KAFKA_INIT_EXTERNAL_ADDRESS;
@@ -3065,7 +3068,7 @@ public class KafkaClusterTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaContainerSecurityContext() {
 
         SecurityContext securityContext = new SecurityContextBuilder()
@@ -3103,7 +3106,7 @@ public class KafkaClusterTest {
                 )));
     }
 
-    @Test
+    @ParallelTest
     public void testInitContainerSecurityContext() {
 
         SecurityContext securityContext = new SecurityContextBuilder()
@@ -3143,7 +3146,7 @@ public class KafkaClusterTest {
                 )));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithClientSecret() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configuration, emptyMap()))
@@ -3179,7 +3182,7 @@ public class KafkaClusterTest {
         assertThat(cont.getEnv().stream().filter(var -> "STRIMZI_PLAIN_9092_OAUTH_CLIENT_SECRET".equals(var.getName())).findFirst().orElse(null).getValueFrom().getSecretKeyRef().getKey(), is("my-secret-key"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithClientSecretAndTls() {
         CertSecretSource cert1 = new CertSecretSourceBuilder()
                 .withSecretName("first-certificate")
@@ -3250,7 +3253,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().stream().filter(vol -> "oauth-plain-9092-2".equals(vol.getName())).findFirst().orElse(null).getSecret().getItems().get(0).getPath(), is("tls.crt"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthEverywhere() {
         CertSecretSource cert1 = new CertSecretSourceBuilder()
                 .withSecretName("first-certificate")
@@ -3389,7 +3392,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().stream().filter(vol -> "oauth-external-9094-2".equals(vol.getName())).findFirst().orElse(null).getSecret().getItems().get(0).getPath(), is("tls.crt"));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalCertificateIngress() {
         String cert = "my-external-cert.crt";
         String key = "my.key";
@@ -3438,7 +3441,7 @@ public class KafkaClusterTest {
         assertThat(mount.getMountPath(), is("/opt/kafka/certificates/custom-external-9094-certs"));
     }
 
-    @Test
+    @ParallelTest
     public void testCustomCertificateTls() {
         String cert = "my-external-cert.crt";
         String key = "my.key";
@@ -3486,7 +3489,7 @@ public class KafkaClusterTest {
         assertThat(mount.getMountPath(), is("/opt/kafka/certificates/custom-tls-9093-certs"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithKeycloakAuthorizationMissingOAuthListeners() {
         assertThrows(InvalidResourceException.class, () -> {
             Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
@@ -3504,7 +3507,7 @@ public class KafkaClusterTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithKeycloakAuthorization() {
         CertSecretSource cert1 = new CertSecretSourceBuilder()
                 .withSecretName("first-certificate")
@@ -3573,7 +3576,7 @@ public class KafkaClusterTest {
         assertThat(volumes.stream().filter(vol -> "authz-keycloak-1".equals(vol.getName())).findFirst().orElse(null).getSecret().getItems().get(0).getPath(), is("tls.crt"));
     }
 
-    @Test
+    @ParallelTest
     public void testReplicasAndRelatedOptionsValidationNok() {
         String propertyName = "offsets.topic.replication.factor";
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
@@ -3590,7 +3593,7 @@ public class KafkaClusterTest {
         assertThat(ex.getMessage().equals("Kafka configuration option '" + propertyName + "' should be set to " + replicas + " or less because 'spec.kafka.replicas' is " + replicas), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testReplicasAndRelatedOptionsValidationOk() {
 
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
@@ -3604,7 +3607,7 @@ public class KafkaClusterTest {
         KafkaCluster.validateIntConfigProperty("offsets.topic.replication.factor", kafkaAssembly.getSpec().getKafka());
     }
 
-    @Test
+    @ParallelTest
     public void testCruiseControlWithSingleNodeKafka() {
         Map<String, Object> config = new HashMap<>();
         config.put("offsets.topic.replication.factor", 1);
@@ -3629,7 +3632,7 @@ public class KafkaClusterTest {
                 "Cruise Control cannot be deployed with a single-node Kafka cluster. It requires at least two Kafka nodes."));
     }
 
-    @Test
+    @ParallelTest
     public void testCruiseControlWithMinISRgtReplicas() {
         Map<String, Object> config = new HashMap<>();
         int minInsyncReplicas = 2;
@@ -3650,7 +3653,7 @@ public class KafkaClusterTest {
         assertThrows(IllegalArgumentException.class, () -> KafkaCluster.fromCrd(kafkaAssembly, VERSIONS));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingInline() {
         Map<String, Object> dummyMetrics = singletonMap("dummy", "metrics");
 
@@ -3670,7 +3673,7 @@ public class KafkaClusterTest {
         assertThat(kc.getMetricsConfigInCm(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingFromConfigMap() {
         MetricsConfig metrics = new JmxPrometheusExporterMetricsBuilder()
                 .withNewValueFrom()
@@ -3694,7 +3697,7 @@ public class KafkaClusterTest {
         assertThat(kc.getMetricsConfig(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingNoMetrics() {
         KafkaCluster kc = KafkaCluster.fromCrd(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout), VERSIONS);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -81,7 +81,6 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.security.cert.CertificateParsingException;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConfigurationTests.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConfigurationTests.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.cluster.model;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConfigurationTests.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConfigurationTests.java
@@ -5,6 +5,8 @@
 package io.strimzi.operator.cluster.model;
 
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.singletonList;
@@ -12,6 +14,7 @@ import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ParallelSuite
 public class KafkaConfigurationTests {
 
     KafkaVersion kafkaVersion = KafkaVersionTestUtils.getKafkaVersionLookup().defaultVersion();
@@ -21,7 +24,7 @@ public class KafkaConfigurationTests {
         assertThat(kafkaConfiguration.validate(kafkaVersion), is(singletonList(errorMsg)));
     }
 
-    @Test
+    @ParallelTest
     public void unknownConfigIsNotAnError() {
         assertNoError("foo", true);
     }
@@ -31,63 +34,63 @@ public class KafkaConfigurationTests {
         kafkaConfiguration.validate(kafkaVersion);
     }
 
-    @Test
+    @ParallelTest
     public void outOfBoundsLong() {
         assertConfigError("log.flush.interval.messages", -2,
                 "log.flush.interval.messages has value -2 which less than the minimum value 1");
     }
 
-    @Test
+    @ParallelTest
     public void outOfBoundsInt() {
         assertConfigError("log.flush.offset.checkpoint.interval.ms", Long.MAX_VALUE,
                 "log.flush.offset.checkpoint.interval.ms has value '9223372036854775807' which is not an int");
     }
 
-    @Test
+    @ParallelTest
     public void wrongType() {
         assertConfigError("log.cleaner.io.buffer.load.factor", true,
                 "log.cleaner.io.buffer.load.factor has value 'true' which is not a double");
     }
 
-    @Test
+    @ParallelTest
     public void notAValidValue() {
         assertConfigError("log.message.timestamp.type", "dog",
                 "log.message.timestamp.type has value 'dog' which is not one of the allowed values: [CreateTime, LogAppendTime]");
     }
 
-    @Test
+    @ParallelTest
     public void listContainsInvalidItem() {
         assertConfigError("log.cleanup.policy", "csat, delete",
                 "log.cleanup.policy contains values [csat] which are not in the allowed items [compact, delete]");
     }
 
-    @Test
+    @ParallelTest
     public void classType() {
         assertNoError("principal.builder.class", "dof");
     }
 
-    @Test
+    @ParallelTest
     public void doubleType() {
         assertNoError("sasl.kerberos.ticket.renew.jitter", 101);
     }
 
-    @Test
+    @ParallelTest
     public void booleanType() {
         assertNoError("auto.create.topics.enable", "false");
     }
 
-    @Test
+    @ParallelTest
     public void passwordType() {
         assertNoError("delegation.token.master.key", "dclncswn");
     }
 
-    @Test
+    @ParallelTest
     public void invalidVersion() {
         assertConfigError("inter.broker.protocol.version", "dclncswn",
                 "inter.broker.protocol.version has value 'dclncswn' which does not match the required pattern: \\Q0.8.0\\E(\\.[0-9]+)*|\\Q0.8.0\\E|\\Q0.8.1\\E(\\.[0-9]+)*|\\Q0.8.1\\E|\\Q0.8.2\\E(\\.[0-9]+)*|\\Q0.8.2\\E|\\Q0.9.0\\E(\\.[0-9]+)*|\\Q0.9.0\\E|\\Q0.10.0\\E(\\.[0-9]+)*|\\Q0.10.0-IV0\\E|\\Q0.10.0-IV1\\E|\\Q0.10.1\\E(\\.[0-9]+)*|\\Q0.10.1-IV0\\E|\\Q0.10.1-IV1\\E|\\Q0.10.1-IV2\\E|\\Q0.10.2\\E(\\.[0-9]+)*|\\Q0.10.2-IV0\\E|\\Q0.11.0\\E(\\.[0-9]+)*|\\Q0.11.0-IV0\\E|\\Q0.11.0-IV1\\E|\\Q0.11.0-IV2\\E|\\Q1.0\\E(\\.[0-9]+)*|\\Q1.0-IV0\\E|\\Q1.1\\E(\\.[0-9]+)*|\\Q1.1-IV0\\E|\\Q2.0\\E(\\.[0-9]+)*|\\Q2.0-IV0\\E|\\Q2.0-IV1\\E|\\Q2.1\\E(\\.[0-9]+)*|\\Q2.1-IV0\\E|\\Q2.1-IV1\\E|\\Q2.1-IV2\\E|\\Q2.2\\E(\\.[0-9]+)*|\\Q2.2-IV0\\E|\\Q2.2-IV1\\E|\\Q2.3\\E(\\.[0-9]+)*|\\Q2.3-IV0\\E|\\Q2.3-IV1\\E|\\Q2.4\\E(\\.[0-9]+)*|\\Q2.4-IV0\\E|\\Q2.4-IV1\\E|\\Q2.5\\E(\\.[0-9]+)*|\\Q2.5-IV0\\E|\\Q2.6\\E(\\.[0-9]+)*|\\Q2.6-IV0\\E|\\Q2.7\\E(\\.[0-9]+)*|\\Q2.7-IV0\\E|\\Q2.7-IV1\\E|\\Q2.7-IV2\\E|\\Q2.8\\E(\\.[0-9]+)*|\\Q2.8-IV0\\E|\\Q2.8-IV1\\E");
     }
 
-    @Test
+    @ParallelTest
     public void validVersion() {
         assertNoError("inter.broker.protocol.version", "2.5-IV0");
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -19,6 +19,8 @@ import io.strimzi.api.kafka.model.connect.build.PluginBuilder;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -32,6 +34,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ParallelSuite
 public class KafkaConnectBuildTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
 
@@ -52,7 +55,7 @@ public class KafkaConnectBuildTest {
             "--image-name-with-digest-file=/dev/termination-log",
             "--destination=my-image:latest");
 
-    @Test
+    @ParallelTest
     public void testFromCrd()   {
         KafkaConnect kc = new KafkaConnectBuilder()
                 .withNewMetadata()
@@ -75,7 +78,7 @@ public class KafkaConnectBuildTest {
         KafkaConnectBuild.fromCrd(kc, VERSIONS);
     }
 
-    @Test
+    @ParallelTest
     public void testValidationPluginsExist()   {
         KafkaConnect kc = new KafkaConnectBuilder()
                 .withNewMetadata()
@@ -98,7 +101,7 @@ public class KafkaConnectBuildTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testValidationArtifactsExist()   {
         KafkaConnect kc = new KafkaConnectBuilder()
                 .withNewMetadata()
@@ -122,7 +125,7 @@ public class KafkaConnectBuildTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testValidationUniqueNames()   {
         KafkaConnect kc = new KafkaConnectBuilder()
                 .withNewMetadata()
@@ -147,7 +150,7 @@ public class KafkaConnectBuildTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testDeployment()   {
         Map<String, Quantity> limit = new HashMap<>();
         limit.put("cpu", new Quantity("500m"));
@@ -216,7 +219,7 @@ public class KafkaConnectBuildTest {
         assertThat(pod.getMetadata().getOwnerReferences().get(0), is(build.createOwnerReference()));
     }
 
-    @Test
+    @ParallelTest
     public void testDeploymentWithoutPushSecret()   {
         KafkaConnect kc = new KafkaConnectBuilder()
                 .withNewMetadata()
@@ -251,7 +254,7 @@ public class KafkaConnectBuildTest {
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/dockerfile"));
     }
 
-    @Test
+    @ParallelTest
     public void testConfigMap()   {
         KafkaConnect kc = new KafkaConnectBuilder()
                 .withNewMetadata()
@@ -283,7 +286,7 @@ public class KafkaConnectBuildTest {
         assertThat(cm.getMetadata().getOwnerReferences().get(0), is(build.createOwnerReference()));
     }
 
-    @Test
+    @ParallelTest
     public void testBuildconfigWithDockerOutput()   {
         Map<String, Quantity> limit = new HashMap<>();
         limit.put("cpu", new Quantity("500m"));
@@ -338,7 +341,7 @@ public class KafkaConnectBuildTest {
         assertThat(bc.getMetadata().getOwnerReferences().get(0), is(build.createOwnerReference()));
     }
 
-    @Test
+    @ParallelTest
     public void testBuildconfigWithImageStreamOutput()   {
         KafkaConnect kc = new KafkaConnectBuilder()
                 .withNewMetadata()
@@ -380,7 +383,7 @@ public class KafkaConnectBuildTest {
         assertThat(bc.getMetadata().getOwnerReferences().get(0), is(build.createOwnerReference()));
     }
 
-    @Test
+    @ParallelTest
     public void testTemplate()   {
         Map<String, String> buildPodLabels = TestUtils.map("l1", "v1", "l2", "v2");
         Map<String, String> buildPodAnnos = TestUtils.map("a1", "v1", "a2", "v2");
@@ -440,7 +443,7 @@ public class KafkaConnectBuildTest {
         assertThat(bc.getMetadata().getAnnotations().entrySet().containsAll(buildConfigAnnos.entrySet()), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testValidKanikoOptions()   {
         List<String> expectedArgs = new ArrayList<>(defaultArgs);
         expectedArgs.add("--reproducible");
@@ -472,7 +475,7 @@ public class KafkaConnectBuildTest {
         assertThat(pod.getSpec().getContainers().get(0).getArgs(), is(expectedArgs));
     }
 
-    @Test
+    @ParallelTest
     public void testInvalidKanikoOptions()   {
         KafkaConnect kc = new KafkaConnectBuilder()
                 .withNewMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -21,7 +21,6 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -61,6 +61,8 @@ import io.strimzi.operator.common.MetricsAndLogging;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -88,6 +90,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity", "checkstyle:ClassDataAbstractionCoupling"})
+@ParallelSuite
 public class KafkaConnectClusterTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private final String namespace = "test";
@@ -136,7 +139,7 @@ public class KafkaConnectClusterTest {
     private final KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(resourceWithMetrics, VERSIONS);
 
     @Deprecated
-    @Test
+    @ParallelTest
     public void testMetricsConfigMapDeprecatedMetrics() {
         KafkaConnect resource = new KafkaConnectBuilder(ResourceUtils.createEmptyKafkaConnect(namespace, cluster))
                 .withNewSpec()
@@ -155,7 +158,7 @@ public class KafkaConnectClusterTest {
         checkMetricsConfigMap(metricsCm);
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsConfigMap() {
         ConfigMap metricsCm = kc.generateMetricsAndLogConfigMap(new MetricsAndLogging(metricsCM, null));
         checkMetricsConfigMap(metricsCm);
@@ -195,7 +198,7 @@ public class KafkaConnectClusterTest {
         return expected;
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultValues() {
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(ResourceUtils.createEmptyKafkaConnect(namespace, cluster), VERSIONS);
 
@@ -208,7 +211,7 @@ public class KafkaConnectClusterTest {
         assertThat(kc.getConfiguration().asOrderedProperties(), is(defaultConfiguration));
     }
 
-    @Test
+    @ParallelTest
     public void testFromCrd() {
         assertThat(kc.replicas, is(replicas));
         assertThat(kc.image, is(image));
@@ -220,12 +223,12 @@ public class KafkaConnectClusterTest {
         assertThat(kc.bootstrapServers, is(bootstrapServers));
     }
 
-    @Test
+    @ParallelTest
     public void testEnvVars()   {
         assertThat(kc.getEnvVars(), is(getExpectedEnvVars()));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateService()   {
         Service svc = kc.generateService();
 
@@ -241,7 +244,7 @@ public class KafkaConnectClusterTest {
         checkOwnerReference(kc.createOwnerReference(), svc);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateServiceWithoutMetrics()   {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .editSpec()
@@ -266,14 +269,14 @@ public class KafkaConnectClusterTest {
         checkOwnerReference(kc.createOwnerReference(), svc);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeployment()   {
         Deployment dep = kc.generateDeployment(new HashMap<>(), true, null, null);
 
         checkDeployment(dep, resource);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithRack() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resourceWithMetrics)
                 .editOrNewSpec()
@@ -289,21 +292,21 @@ public class KafkaConnectClusterTest {
         checkDeployment(deployment, resource);
     }
 
-    @Test
+    @ParallelTest
     public void withAffinity() throws IOException {
         ResourceTester<KafkaConnect, KafkaConnectCluster> resourceTester = new ResourceTester<>(KafkaConnect.class, VERSIONS, KafkaConnectCluster::fromCrd, this.getClass().getSimpleName() + ".withAffinity");
         resourceTester
             .assertDesiredResource("-Deployment.yaml", kcc -> kcc.generateDeployment(new HashMap<String, String>(), true, null, null).getSpec().getTemplate().getSpec().getAffinity());
     }
 
-    @Test
+    @ParallelTest
     public void withTolerations() throws IOException {
         ResourceTester<KafkaConnect, KafkaConnectCluster> resourceTester = new ResourceTester<>(KafkaConnect.class, VERSIONS, KafkaConnectCluster::fromCrd, this.getClass().getSimpleName() + ".withTolerations");
         resourceTester
             .assertDesiredResource("-Deployment.yaml", kcc -> kcc.generateDeployment(new HashMap<String, String>(), true, null, null).getSpec().getTemplate().getSpec().getTolerations());
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithTls() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .editSpec()
@@ -330,7 +333,7 @@ public class KafkaConnectClusterTest {
         assertThat(AbstractModel.containerEnvVars(containers.get(0)).get(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_TLS), is("true"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithTlsAuth() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .editSpec()
@@ -361,7 +364,7 @@ public class KafkaConnectClusterTest {
         assertThat(AbstractModel.containerEnvVars(containers.get(0)).get(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_TLS), is("true"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithTlsSameSecret() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .editSpec()
@@ -386,7 +389,7 @@ public class KafkaConnectClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("my-secret"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithScramSha512Auth() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .editSpec()
@@ -418,7 +421,7 @@ public class KafkaConnectClusterTest {
      * the volumes and volume mounts that reference the secret are correctly created and that each volume name is only created once - volumes
      * with duplicate names will cause Kubernetes to reject the deployment.
      */
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithScramSha512AuthAndTLSSameSecret() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
             .editSpec()
@@ -460,7 +463,7 @@ public class KafkaConnectClusterTest {
         assertThat(AbstractModel.containerEnvVars(containers.get(0)), hasEntry(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_TLS, "true"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithPlainAuth() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .editSpec()
@@ -492,7 +495,7 @@ public class KafkaConnectClusterTest {
      * the volumes and volume mounts that reference the secret are correctly created and that each volume name is only created once - volumes
      * with duplicate names will cause Kubernetes to reject the deployment.
      */
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithPlainAuthAndTLSSameSecret() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
             .editSpec()
@@ -534,7 +537,7 @@ public class KafkaConnectClusterTest {
         assertThat(AbstractModel.containerEnvVars(containers.get(0)), hasEntry(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_TLS, "true"));
     }
 
-    @Test
+    @ParallelTest
     public void testTemplate() {
         Map<String, String> depLabels = TestUtils.map("l1", "v1", "l2", "v2",
                 Labels.KUBERNETES_PART_OF_LABEL, "custom-part",
@@ -653,7 +656,7 @@ public class KafkaConnectClusterTest {
         assertThat(crb.getMetadata().getAnnotations().entrySet().containsAll(crbAnots.entrySet()), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationSecretEnvs() {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
@@ -681,7 +684,7 @@ public class KafkaConnectClusterTest {
         assertThat(selected.get(0).getValueFrom().getSecretKeyRef(), is(env.getValueFrom().getSecretKeyRef()));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationConfigEnvs() {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
@@ -708,7 +711,7 @@ public class KafkaConnectClusterTest {
         assertThat(selected.get(0).getValueFrom().getConfigMapKeyRef(), is(env.getValueFrom().getConfigMapKeyRef()));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationSecretVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -739,7 +742,7 @@ public class KafkaConnectClusterTest {
         assertThat(selectedVolumeMounts.get(0).getMountPath(), is(KafkaConnectCluster.EXTERNAL_CONFIGURATION_VOLUME_MOUNT_BASE_PATH + "my-volume"));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationSecretVolumesWithDots() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my.volume")
@@ -770,7 +773,7 @@ public class KafkaConnectClusterTest {
         assertThat(selectedVolumeMounts.get(0).getMountPath(), is(KafkaConnectCluster.EXTERNAL_CONFIGURATION_VOLUME_MOUNT_BASE_PATH + "my.volume"));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationConfigVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -801,7 +804,7 @@ public class KafkaConnectClusterTest {
         assertThat(selectedVolumeMounts.get(0).getMountPath(), is(KafkaConnectCluster.EXTERNAL_CONFIGURATION_VOLUME_MOUNT_BASE_PATH + "my-volume"));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationConfigVolumesWithDots() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my.volume")
@@ -832,7 +835,7 @@ public class KafkaConnectClusterTest {
         assertThat(selectedVolumeMounts.get(0).getMountPath(), is(KafkaConnectCluster.EXTERNAL_CONFIGURATION_VOLUME_MOUNT_BASE_PATH + "my.volume"));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationInvalidVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -860,7 +863,7 @@ public class KafkaConnectClusterTest {
         assertThat(selected.size(), is(0));
     }
 
-    @Test
+    @ParallelTest
     public void testNoExternalConfigurationVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -886,7 +889,7 @@ public class KafkaConnectClusterTest {
         assertThat(selected.size(), is(0));
     }
 
-    @Test
+    @ParallelTest
     public void testInvalidExternalConfigurationEnvs() {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
@@ -912,7 +915,7 @@ public class KafkaConnectClusterTest {
         assertThat(selected.size(), is(0));
     }
 
-    @Test
+    @ParallelTest
     public void testNoExternalConfigurationEnvs() {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
@@ -936,7 +939,7 @@ public class KafkaConnectClusterTest {
         assertThat(selected.size(), is(0));
     }
 
-    @Test
+    @ParallelTest
     public void testGracePeriod() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .editSpec()
@@ -953,7 +956,7 @@ public class KafkaConnectClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(123)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultGracePeriod() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource).build();
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(resource, VERSIONS);
@@ -962,7 +965,7 @@ public class KafkaConnectClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(30)));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecrets() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -984,7 +987,7 @@ public class KafkaConnectClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecretsCO() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -1001,7 +1004,7 @@ public class KafkaConnectClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecretsBoth() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -1023,7 +1026,7 @@ public class KafkaConnectClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultImagePullSecrets() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource).build();
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(resource, VERSIONS);
@@ -1032,7 +1035,7 @@ public class KafkaConnectClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testSecurityContext() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .editSpec()
@@ -1052,7 +1055,7 @@ public class KafkaConnectClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsUser(), is(Long.valueOf(789)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultSecurityContext() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource).build();
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(resource, VERSIONS);
@@ -1061,7 +1064,7 @@ public class KafkaConnectClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testPodDisruptionBudget() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .editSpec()
@@ -1078,7 +1081,7 @@ public class KafkaConnectClusterTest {
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(2)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultPodDisruptionBudget() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource).build();
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(resource, VERSIONS);
@@ -1087,7 +1090,7 @@ public class KafkaConnectClusterTest {
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullPolicy() {
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(resource, VERSIONS);
 
@@ -1098,7 +1101,7 @@ public class KafkaConnectClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
     }
 
-    @Test
+    @ParallelTest
     public void testResources() {
         Map<String, Quantity> requests = new HashMap<>(2);
         requests.put("cpu", new Quantity("250m"));
@@ -1121,7 +1124,7 @@ public class KafkaConnectClusterTest {
         assertThat(cont.getResources().getRequests(), is(requests));
     }
 
-    @Test
+    @ParallelTest
     public void testJvmOptions() {
         Map<String, String> xx = new HashMap<>(2);
         xx.put("UseG1GC", "true");
@@ -1146,7 +1149,7 @@ public class KafkaConnectClusterTest {
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_HEAP_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Xms512m"), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaConnectContainerEnvVars() {
 
         ContainerEnvVar envVar1 = new ContainerEnvVar();
@@ -1185,7 +1188,7 @@ public class KafkaConnectClusterTest {
                         .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaContainerEnvVarsConflict() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION;
@@ -1223,7 +1226,7 @@ public class KafkaConnectClusterTest {
                         .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaConnectContainerSecurityContext() {
 
         SecurityContext securityContext = new SecurityContextBuilder()
@@ -1256,7 +1259,7 @@ public class KafkaConnectClusterTest {
                 )));
     }
 
-    @Test
+    @ParallelTest
     public void testTracing() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .editSpec()
@@ -1273,7 +1276,7 @@ public class KafkaConnectClusterTest {
         assertThat(cont.getEnv().stream().filter(env -> KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION.equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("producer.interceptor.classes=io.opentracing.contrib.kafka.TracingProducerInterceptor"), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithAccessToken() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .editSpec()
@@ -1297,7 +1300,7 @@ public class KafkaConnectClusterTest {
         assertThat(cont.getEnv().stream().filter(var -> KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_OAUTH_CONFIG.equals(var.getName())).findFirst().orElse(null).getValue().isEmpty(), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithRefreshToken() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .editSpec()
@@ -1324,7 +1327,7 @@ public class KafkaConnectClusterTest {
                 is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server")));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithClientSecret() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .editSpec()
@@ -1351,7 +1354,7 @@ public class KafkaConnectClusterTest {
                 is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server")));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithMissingClientSecret() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaConnect resource = new KafkaConnectBuilder(this.resource)
@@ -1368,7 +1371,7 @@ public class KafkaConnectClusterTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithMissingUri() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaConnect resource = new KafkaConnectBuilder(this.resource)
@@ -1388,7 +1391,7 @@ public class KafkaConnectClusterTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithTls() {
         CertSecretSource cert1 = new CertSecretSourceBuilder()
                 .withSecretName("first-certificate")
@@ -1450,7 +1453,7 @@ public class KafkaConnectClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream().filter(vol -> "oauth-certs-2".equals(vol.getName())).findFirst().orElse(null).getSecret().getItems().get(0).getPath(), is("tls.crt"));
     }
 
-    @Test
+    @ParallelTest
     public void testNetworkPolicyWithConnectorOperator() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resourceWithMetrics)
                 .build();
@@ -1472,7 +1475,7 @@ public class KafkaConnectClusterTest {
         assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
     }
 
-    @Test
+    @ParallelTest
     public void testNetworkPolicyWithConnectorOperatorSameNamespace() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resourceWithMetrics)
                 .build();
@@ -1494,7 +1497,7 @@ public class KafkaConnectClusterTest {
         assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
     }
 
-    @Test
+    @ParallelTest
     public void testNetworkPolicyWithConnectorOperatorWithNamespaceLabels() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resourceWithMetrics)
                 .build();
@@ -1516,7 +1519,7 @@ public class KafkaConnectClusterTest {
         assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
     }
 
-    @Test
+    @ParallelTest
     public void testNetworkPolicyWithoutConnectorOperator() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .build();
@@ -1525,7 +1528,7 @@ public class KafkaConnectClusterTest {
         assertThat(kc.generateNetworkPolicy(false, null, null), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testClusterRoleBindingRack() {
         String testNamespace = "other-namespace";
 
@@ -1547,7 +1550,7 @@ public class KafkaConnectClusterTest {
         assertThat(crb.getSubjects().get(0).getName(), is(kafkaConnectCluster.getServiceAccountName()));
     }
 
-    @Test
+    @ParallelTest
     public void testNullClusterRoleBinding() {
         String testNamespace = "other-namespace";
 
@@ -1614,7 +1617,7 @@ public class KafkaConnectClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingInline() {
         Map<String, Object> dummyMetrics = singletonMap("dummy", "metrics");
 
@@ -1631,7 +1634,7 @@ public class KafkaConnectClusterTest {
         assertThat(kc.getMetricsConfigInCm(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingFromConfigMap() {
         MetricsConfig metrics = new JmxPrometheusExporterMetricsBuilder()
                 .withNewValueFrom()
@@ -1652,7 +1655,7 @@ public class KafkaConnectClusterTest {
         assertThat(kc.getMetricsConfig(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingNoMetrics() {
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(this.resource, VERSIONS);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -63,7 +63,6 @@ import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfileTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfileTest.java
@@ -11,6 +11,8 @@ import io.strimzi.api.kafka.model.connect.build.JarArtifactBuilder;
 import io.strimzi.api.kafka.model.connect.build.PluginBuilder;
 import io.strimzi.api.kafka.model.connect.build.TgzArtifactBuilder;
 import io.strimzi.api.kafka.model.connect.build.ZipArtifactBuilder;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import static io.strimzi.operator.cluster.model.KafkaBrokerConfigurationBuilderTest.IsEquivalent.isEquivalent;
@@ -18,6 +20,7 @@ import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ParallelSuite
 public class KafkaConnectDockerfileTest {
     private final Artifact jarArtifactNoChecksum = new JarArtifactBuilder()
             .withUrl("https://mydomain.tld/my.jar")
@@ -46,7 +49,7 @@ public class KafkaConnectDockerfileTest {
             .withSha512sum("sha-512-checksum")
             .build();
 
-    @Test
+    @ParallelTest
     public void testEmptyDockerfile()   {
         Build connectBuild = new BuildBuilder()
                 .withPlugins(emptyList())
@@ -59,7 +62,7 @@ public class KafkaConnectDockerfileTest {
                 "USER 1001"));
     }
 
-    @Test
+    @ParallelTest
     public void testNoArtifacts()   {
         Build connectBuild = new BuildBuilder()
                 .withPlugins(new PluginBuilder()
@@ -75,7 +78,7 @@ public class KafkaConnectDockerfileTest {
                 "USER 1001"));
     }
 
-    @Test
+    @ParallelTest
     public void testNoChecksumJarArtifact()   {
         Build connectBuild = new BuildBuilder()
                 .withPlugins(new PluginBuilder()
@@ -93,7 +96,7 @@ public class KafkaConnectDockerfileTest {
                 "USER 1001"));
     }
 
-    @Test
+    @ParallelTest
     public void testChecksumJarArtifact()   {
         Build connectBuild = new BuildBuilder()
                 .withPlugins(new PluginBuilder()
@@ -114,7 +117,7 @@ public class KafkaConnectDockerfileTest {
                 "USER 1001"));
     }
 
-    @Test
+    @ParallelTest
     public void testMultipleJarArtifact()   {
         Build connectBuild = new BuildBuilder()
                 .withPlugins(new PluginBuilder()
@@ -137,7 +140,7 @@ public class KafkaConnectDockerfileTest {
                 "USER 1001"));
     }
 
-    @Test
+    @ParallelTest
     public void testNoChecksumTgzArtifact()   {
         Build connectBuild = new BuildBuilder()
                 .withPlugins(new PluginBuilder()
@@ -157,7 +160,7 @@ public class KafkaConnectDockerfileTest {
                 "USER 1001"));
     }
 
-    @Test
+    @ParallelTest
     public void testNoChecksumZipArtifact()   {
         Build connectBuild = new BuildBuilder()
                 .withPlugins(new PluginBuilder()
@@ -178,7 +181,7 @@ public class KafkaConnectDockerfileTest {
                 "USER 1001"));
     }
 
-    @Test
+    @ParallelTest
     public void testChecksumZipArtifact()   {
         Build connectBuild = new BuildBuilder()
                 .withPlugins(new PluginBuilder()
@@ -202,7 +205,7 @@ public class KafkaConnectDockerfileTest {
                 "USER 1001"));
     }
 
-    @Test
+    @ParallelTest
     public void testChecksumTgzArtifact()   {
         Build connectBuild = new BuildBuilder()
                 .withPlugins(new PluginBuilder()
@@ -225,7 +228,7 @@ public class KafkaConnectDockerfileTest {
                 "USER 1001"));
     }
 
-    @Test
+    @ParallelTest
     public void testMultipleTgzArtifact()   {
         Build connectBuild = new BuildBuilder()
                 .withPlugins(new PluginBuilder()
@@ -252,7 +255,7 @@ public class KafkaConnectDockerfileTest {
                 "USER 1001"));
     }
 
-    @Test
+    @ParallelTest
     public void testMultipleZipArtifact()   {
         Build connectBuild = new BuildBuilder()
                 .withPlugins(new PluginBuilder()
@@ -281,7 +284,7 @@ public class KafkaConnectDockerfileTest {
                 "USER 1001"));
     }
 
-    @Test
+    @ParallelTest
     public void testDockerfileWithComments()   {
         Build connectBuild = new BuildBuilder()
                 .withPlugins(new PluginBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfileTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfileTest.java
@@ -13,7 +13,6 @@ import io.strimzi.api.kafka.model.connect.build.TgzArtifactBuilder;
 import io.strimzi.api.kafka.model.connect.build.ZipArtifactBuilder;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import static io.strimzi.operator.cluster.model.KafkaBrokerConfigurationBuilderTest.IsEquivalent.isEquivalent;
 import static java.util.Collections.emptyList;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -65,7 +65,6 @@ import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -63,6 +63,8 @@ import io.strimzi.operator.common.MetricsAndLogging;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -85,6 +87,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
+@ParallelSuite
 public class KafkaConnectS2IClusterTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private final String namespace = "test";
@@ -142,7 +145,7 @@ public class KafkaConnectS2IClusterTest {
 
     private final KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(resourceWithMetrics, VERSIONS);
 
-    @Test
+    @ParallelTest
     @Deprecated
     public void testMetricsConfigMapDeprecatedMetrics() {
         KafkaConnectS2I resource = ResourceUtils.createKafkaConnectS2I(namespace, cluster, replicas, image,
@@ -152,7 +155,7 @@ public class KafkaConnectS2IClusterTest {
         checkMetricsConfigMap(metricsCm);
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsConfigMap() {
         ConfigMap metricsCm = kc.generateMetricsAndLogConfigMap(new MetricsAndLogging(metricsCM, null));
         checkMetricsConfigMap(metricsCm);
@@ -191,7 +194,7 @@ public class KafkaConnectS2IClusterTest {
         return expected;
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultValues() {
         KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(ResourceUtils.createEmptyKafkaConnectS2I(namespace, cluster), VERSIONS);
 
@@ -206,7 +209,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(kc.isInsecureSourceRepository(), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testFromCrd() {
         assertThat(kc.image, is(KafkaConnectS2IResources.deploymentName(cluster) + ":latest"));
         assertThat(kc.replicas, is(replicas));
@@ -220,12 +223,12 @@ public class KafkaConnectS2IClusterTest {
         assertThat(kc.isInsecureSourceRepository(), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testEnvVars()   {
         assertThat(kc.getEnvVars(), is(getExpectedEnvVars()));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateService()   {
         Service svc = kc.generateService();
 
@@ -241,7 +244,7 @@ public class KafkaConnectS2IClusterTest {
         checkOwnerReference(kc.createOwnerReference(), svc);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateServiceWithoutMetrics()   {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
                 .editSpec()
@@ -266,7 +269,7 @@ public class KafkaConnectS2IClusterTest {
         checkOwnerReference(kc.createOwnerReference(), svc);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentConfig()   {
         DeploymentConfig dep = kc.generateDeploymentConfig(Collections.EMPTY_MAP, true, null, null);
 
@@ -305,7 +308,7 @@ public class KafkaConnectS2IClusterTest {
         checkOwnerReference(kc.createOwnerReference(), dep);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateBuildConfig() {
         BuildConfig bc = kc.generateBuildConfig();
 
@@ -332,7 +335,7 @@ public class KafkaConnectS2IClusterTest {
         checkOwnerReference(kc.createOwnerReference(), bc);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateSourceImageStream() {
         ImageStream is = kc.generateSourceImageStream();
 
@@ -349,7 +352,7 @@ public class KafkaConnectS2IClusterTest {
         checkOwnerReference(kc.createOwnerReference(), is);
     }
 
-    @Test
+    @ParallelTest
     public void testInsecureSourceRepo() {
         KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(ResourceUtils.createKafkaConnectS2I(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, jmxMetricsConfig, metricsCmJson, configurationJson, true, bootstrapServers, buildResourceRequirements), VERSIONS);
@@ -370,7 +373,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(is.getSpec().getTags().get(0).getReferencePolicy().getType(), is("Local"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateTargetImageStream() {
         ImageStream is = kc.generateTargetImageStream();
 
@@ -381,7 +384,7 @@ public class KafkaConnectS2IClusterTest {
         checkOwnerReference(kc.createOwnerReference(), is);
     }
 
-    @Test
+    @ParallelTest
     public void withAffinity() throws IOException {
         ResourceTester<KafkaConnectS2I, KafkaConnectS2ICluster> resourceTester = new ResourceTester<>(KafkaConnectS2I.class,
             x -> KafkaConnectS2ICluster.fromCrd(x, VERSIONS), this.getClass().getSimpleName() + ".withAffinity");
@@ -389,7 +392,7 @@ public class KafkaConnectS2IClusterTest {
                 .assertDesiredResource("-DeploymentConfig.yaml", kcc -> kcc.generateDeploymentConfig(Collections.EMPTY_MAP, true, null, null).getSpec().getTemplate().getSpec().getAffinity());
     }
 
-    @Test
+    @ParallelTest
     public void withTolerations() throws IOException {
         ResourceTester<KafkaConnectS2I, KafkaConnectS2ICluster> resourceTester = new ResourceTester<>(KafkaConnectS2I.class,
             x -> KafkaConnectS2ICluster.fromCrd(x, VERSIONS), this.getClass().getSimpleName() + ".withTolerations");
@@ -397,7 +400,7 @@ public class KafkaConnectS2IClusterTest {
             .assertDesiredResource("-DeploymentConfig.yaml", kcc -> kcc.generateDeploymentConfig(Collections.EMPTY_MAP, true, null, null).getSpec().getTemplate().getSpec().getTolerations());
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentConfigWithTls() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
                 .editSpec()
@@ -424,7 +427,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(AbstractModel.containerEnvVars(containers.get(0)).get(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_TLS), is("true"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentConfigWithTlsAuth() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
                 .editSpec()
@@ -455,7 +458,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(AbstractModel.containerEnvVars(containers.get(0)).get(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_TLS), is("true"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithTlsSameSecret() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
                 .editSpec()
@@ -480,7 +483,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(1).getName(), is("my-secret"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithScramSha512Auth() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
                 .editSpec()
@@ -513,7 +516,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(resource.getMetadata().getOwnerReferences().get(0), is(ownerRef));
     }
 
-    @Test
+    @ParallelTest
     public void testTemplate() {
         Map<String, String> depLabels = TestUtils.map("l1", "v1", "l2", "v2",
                 Labels.KUBERNETES_PART_OF_LABEL, "custom-part",
@@ -632,7 +635,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(crb.getMetadata().getAnnotations().entrySet().containsAll(crbAnots.entrySet()), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationSecretEnvs() {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
@@ -659,7 +662,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(selected.get(0).getValueFrom().getSecretKeyRef(), is(env.getValueFrom().getSecretKeyRef()));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationConfigEnvs() {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
@@ -686,7 +689,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(selected.get(0).getValueFrom().getConfigMapKeyRef(), is(env.getValueFrom().getConfigMapKeyRef()));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationSecretVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -717,7 +720,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(selectedVolumeMounts.get(0).getMountPath(), is(KafkaConnectCluster.EXTERNAL_CONFIGURATION_VOLUME_MOUNT_BASE_PATH + "my-volume"));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationSecretVolumesWithDots() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my.volume")
@@ -748,7 +751,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(selectedVolumeMounts.get(0).getMountPath(), is(KafkaConnectCluster.EXTERNAL_CONFIGURATION_VOLUME_MOUNT_BASE_PATH + "my.volume"));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationConfigVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -779,7 +782,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(selectedVolumeMounts.get(0).getMountPath(), is(KafkaConnectCluster.EXTERNAL_CONFIGURATION_VOLUME_MOUNT_BASE_PATH + "my-volume"));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationConfigVolumesWithDots() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my.volume")
@@ -810,7 +813,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(selectedVolumeMounts.get(0).getMountPath(), is(KafkaConnectCluster.EXTERNAL_CONFIGURATION_VOLUME_MOUNT_BASE_PATH + "my.volume"));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationInvalidVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -838,7 +841,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(selected.size(), is(0));
     }
 
-    @Test
+    @ParallelTest
     public void testNoExternalConfigurationVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -864,7 +867,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(selected.size(), is(0));
     }
 
-    @Test
+    @ParallelTest
     public void testInvalidExternalConfigurationEnvs() {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
@@ -890,7 +893,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(selected.size(), is(0));
     }
 
-    @Test
+    @ParallelTest
     public void testNoExternalConfigurationEnvs() {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
@@ -914,7 +917,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(selected.size(), is(0));
     }
 
-    @Test
+    @ParallelTest
     public void testGracePeriod() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
                 .editSpec()
@@ -931,7 +934,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(123)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultGracePeriod() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource).build();
         KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(resource, VERSIONS);
@@ -940,7 +943,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(30)));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecrets() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -962,7 +965,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecretsCO() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -979,7 +982,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecretsBoth() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -1001,7 +1004,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultImagePullSecrets() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource).build();
         KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(resource, VERSIONS);
@@ -1010,7 +1013,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testSecurityContext() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
                 .editSpec()
@@ -1030,7 +1033,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsUser(), is(Long.valueOf(789)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultSecurityContext() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource).build();
         KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(resource, VERSIONS);
@@ -1039,7 +1042,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testPodDisruptionBudget() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
                 .editSpec()
@@ -1056,7 +1059,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(2)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultPodDisruptionBudget() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource).build();
         KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(resource, VERSIONS);
@@ -1065,7 +1068,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullPolicy() {
         KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(resource, VERSIONS);
 
@@ -1076,7 +1079,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
     }
 
-    @Test
+    @ParallelTest
     public void testResources() {
         Map<String, Quantity> requests = new HashMap<>(2);
         requests.put("cpu", new Quantity("250m"));
@@ -1099,7 +1102,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(cont.getResources().getRequests(), is(requests));
     }
 
-    @Test
+    @ParallelTest
     public void testJvmOptions() {
         Map<String, String> xx = new HashMap<>(2);
         xx.put("UseG1GC", "true");
@@ -1124,7 +1127,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_HEAP_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Xms512m"), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaConnectContainerEnvVars() {
 
         ContainerEnvVar envVar1 = new ContainerEnvVar();
@@ -1163,7 +1166,7 @@ public class KafkaConnectS2IClusterTest {
                         .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaContainerEnvVarsConflict() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION;
@@ -1201,7 +1204,7 @@ public class KafkaConnectS2IClusterTest {
                         .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testTracing() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
                 .editSpec()
@@ -1218,7 +1221,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(cont.getEnv().stream().filter(env -> KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION.equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("producer.interceptor.classes=io.opentracing.contrib.kafka.TracingProducerInterceptor"), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithAccessToken() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
                 .editSpec()
@@ -1242,7 +1245,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(cont.getEnv().stream().filter(var -> KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_OAUTH_CONFIG.equals(var.getName())).findFirst().orElse(null).getValue().isEmpty(), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithRefreshToken() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
                 .editSpec()
@@ -1268,7 +1271,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(cont.getEnv().stream().filter(var -> KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_OAUTH_CONFIG.equals(var.getName())).findFirst().orElse(null).getValue().trim(), is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server")));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithClientSecret() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
                 .editSpec()
@@ -1294,7 +1297,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(cont.getEnv().stream().filter(var -> KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_OAUTH_CONFIG.equals(var.getName())).findFirst().orElse(null).getValue().trim(), is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server")));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithMissingClientSecret() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
@@ -1311,7 +1314,7 @@ public class KafkaConnectS2IClusterTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithMissingUri() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
@@ -1331,7 +1334,7 @@ public class KafkaConnectS2IClusterTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithTls() {
         CertSecretSource cert1 = new CertSecretSourceBuilder()
                 .withSecretName("first-certificate")
@@ -1393,7 +1396,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream().filter(vol -> "oauth-certs-2".equals(vol.getName())).findFirst().orElse(null).getSecret().getItems().get(0).getPath(), is("tls.crt"));
     }
 
-    @Test
+    @ParallelTest
     public void testNetworkPolicyWithConnectorOperator() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resourceWithMetrics)
                 .build();
@@ -1415,7 +1418,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
     }
 
-    @Test
+    @ParallelTest
     public void testNetworkPolicyWithConnectorOperatorSameNamespace() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resourceWithMetrics)
                 .build();
@@ -1437,7 +1440,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
     }
 
-    @Test
+    @ParallelTest
     public void testNetworkPolicyWithConnectorOperatorWithNamespaceLabels() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resourceWithMetrics)
                 .build();
@@ -1459,7 +1462,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
     }
 
-    @Test
+    @ParallelTest
     public void testNetworkPolicyWithoutConnectorOperator() {
         KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resourceWithMetrics)
                 .build();
@@ -1468,7 +1471,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(kc.generateNetworkPolicy(false, null, null), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingInline() {
         Map<String, Object> dummyMetrics = singletonMap("dummy", "metrics");
 
@@ -1485,7 +1488,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(kc.getMetricsConfigInCm(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingFromConfigMap() {
         MetricsConfig metrics = new JmxPrometheusExporterMetricsBuilder()
                 .withNewValueFrom()
@@ -1506,7 +1509,7 @@ public class KafkaConnectS2IClusterTest {
         assertThat(kc.getMetricsConfig(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingNoMetrics() {
         KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(this.resource, VERSIONS);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -36,6 +36,8 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +54,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
+@ParallelSuite
 public class KafkaExporterTest {
     private final String namespace = "test";
     private final String cluster = "foo";
@@ -135,7 +138,7 @@ public class KafkaExporterTest {
         return expected;
     }
 
-    @Test
+    @ParallelTest
     public void testFromConfigMapDefaultConfig() {
         Kafka resource = ResourceUtils.createKafka(namespace, cluster, replicas, null,
                 healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, kafkaConfig, zooConfig,
@@ -148,7 +151,7 @@ public class KafkaExporterTest {
         assertThat(ke.saramaLoggingEnabled, is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testFromConfigMap() {
         assertThat(ke.namespace, is(namespace));
         assertThat(ke.cluster, is(cluster));
@@ -159,7 +162,7 @@ public class KafkaExporterTest {
         assertThat(ke.saramaLoggingEnabled, is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeployment() {
         Deployment dep = ke.generateDeployment(true, null, null);
 
@@ -214,12 +217,12 @@ public class KafkaExporterTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testEnvVars()   {
         assertThat(ke.getEnvVars(), is(getExpectedEnvVars()));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullPolicy() {
         Deployment dep = ke.generateDeployment(true, ImagePullPolicy.ALWAYS, null);
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.ALWAYS.toString()));
@@ -228,7 +231,7 @@ public class KafkaExporterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
     }
 
-    @Test
+    @ParallelTest
     public void testContainerTemplateEnvVars() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = "TEST_ENV_1";
@@ -264,7 +267,7 @@ public class KafkaExporterTest {
         assertThat(kafkaEnvVars.stream().filter(var -> testEnvTwoKey.equals(var.getName())).map(EnvVar::getValue).findFirst().get(), is(testEnvTwoValue));
     }
 
-    @Test
+    @ParallelTest
     public void testContainerTemplateEnvVarsWithKeyConflict() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = "TEST_ENV_1";
@@ -300,7 +303,7 @@ public class KafkaExporterTest {
         assertThat(kafkaEnvVars.stream().filter(var -> testEnvTwoKey.equals(var.getName())).map(EnvVar::getValue).findFirst().get(), is(groupRegex));
     }
 
-    @Test
+    @ParallelTest
     public void testExporterNotDeployed() {
         Kafka resource = ResourceUtils.createKafka(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, kafkaConfig, zooConfig,
@@ -311,7 +314,7 @@ public class KafkaExporterTest {
         assertThat(ke.generateSecret(null, true), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWhenDisabled()   {
         Kafka resource = ResourceUtils.createKafka(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, kafkaConfig, zooConfig,
@@ -321,7 +324,7 @@ public class KafkaExporterTest {
         assertThat(ke.generateDeployment(true, null, null), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testTemplate() {
         Map<String, String> depLabels = TestUtils.map("l1", "v1", "l2", "v2",
                 Labels.KUBERNETES_PART_OF_LABEL, "custom-part",

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -39,7 +39,6 @@ import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -57,7 +57,6 @@ import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -55,6 +55,8 @@ import io.strimzi.operator.common.MetricsAndLogging;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -77,6 +79,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
+@ParallelSuite
 public class KafkaMirrorMaker2ClusterTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private final String namespace = "test";
@@ -140,7 +143,7 @@ public class KafkaMirrorMaker2ClusterTest {
     }
 
     @Deprecated
-    @Test
+    @ParallelTest
     public void testMetricsConfigMapDeprecatedMetrics() {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(ResourceUtils.createEmptyKafkaMirrorMaker2(namespace, cluster))
                 .withNewSpec()
@@ -161,7 +164,7 @@ public class KafkaMirrorMaker2ClusterTest {
         checkMetricsConfigMap(metricsCm);
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsConfigMap() {
         ConfigMap metricsCm = kmm2.generateMetricsAndLogConfigMap(new MetricsAndLogging(metricsCM, null));
         checkMetricsConfigMap(metricsCm);
@@ -205,7 +208,7 @@ public class KafkaMirrorMaker2ClusterTest {
         return dep.getSpec().getTemplate().getSpec().getContainers().get(0);
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultValues() {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(ResourceUtils.createEmptyKafkaMirrorMaker2(namespace, cluster), VERSIONS);
 
@@ -218,7 +221,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(kmm2.getConfiguration().asOrderedProperties(), is(defaultConfiguration));
     }
 
-    @Test
+    @ParallelTest
     public void testFromCrd() {
         assertThat(kmm2.replicas, is(replicas));
         assertThat(kmm2.image, is(image));
@@ -230,12 +233,12 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(kmm2.bootstrapServers, is(bootstrapServers));
     }
 
-    @Test
+    @ParallelTest
     public void testEnvVars() {
         assertThat(kmm2.getEnvVars(), is(getExpectedEnvVars()));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateService()   {
         Service svc = kmm2.generateService();
 
@@ -251,7 +254,7 @@ public class KafkaMirrorMaker2ClusterTest {
         checkOwnerReference(kmm2.createOwnerReference(), svc);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateServiceWithoutMetrics()   {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resource)
                 .editSpec()
@@ -276,7 +279,7 @@ public class KafkaMirrorMaker2ClusterTest {
         checkOwnerReference(kmm2.createOwnerReference(), svc);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeployment()   {
         Deployment dep = kmm2.generateDeployment(new HashMap<String, String>(), true, null, null);
 
@@ -307,21 +310,21 @@ public class KafkaMirrorMaker2ClusterTest {
         checkOwnerReference(kmm2.createOwnerReference(), dep);
     }
 
-    @Test
+    @ParallelTest
     public void withAffinity() throws IOException {
         ResourceTester<KafkaMirrorMaker2, KafkaMirrorMaker2Cluster> resourceTester = new ResourceTester<>(KafkaMirrorMaker2.class, VERSIONS, KafkaMirrorMaker2Cluster::fromCrd, this.getClass().getSimpleName() + ".withAffinity");
         resourceTester
             .assertDesiredResource("-Deployment.yaml", kmm2c -> kmm2c.generateDeployment(new HashMap<String, String>(), true, null, null).getSpec().getTemplate().getSpec().getAffinity());
     }
 
-    @Test
+    @ParallelTest
     public void withTolerations() throws IOException {
         ResourceTester<KafkaMirrorMaker2, KafkaMirrorMaker2Cluster> resourceTester = new ResourceTester<>(KafkaMirrorMaker2.class, VERSIONS, KafkaMirrorMaker2Cluster::fromCrd, this.getClass().getSimpleName() + ".withTolerations");
         resourceTester
             .assertDesiredResource("-Deployment.yaml", kmm2c -> kmm2c.generateDeployment(new HashMap<String, String>(), true, null, null).getSpec().getTemplate().getSpec().getTolerations());
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithTls() {
         KafkaMirrorMaker2ClusterSpec targetClusterWithTls = new KafkaMirrorMaker2ClusterSpecBuilder(this.targetCluster)
                 .withNewTls()
@@ -353,7 +356,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 is("target=my-secret/cert.crt;my-secret/new-cert.crt;my-another-secret/another-cert.crt"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithTlsWithoutCerts() {
         KafkaMirrorMaker2ClusterSpec targetClusterWithTls = new KafkaMirrorMaker2ClusterSpecBuilder(this.targetCluster)
                 .withNewTls()
@@ -378,7 +381,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithTlsAuth() {
         KafkaMirrorMaker2ClusterSpec targetClusterWithTlsAuth = new KafkaMirrorMaker2ClusterSpecBuilder(this.targetCluster)
                 .editOrNewTls()
@@ -413,7 +416,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(AbstractModel.containerEnvVars(cont).get(KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_TLS), is("true"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithTlsSameSecret() {
         KafkaMirrorMaker2ClusterSpec targetClusterWithTlsAuth = new KafkaMirrorMaker2ClusterSpecBuilder(this.targetCluster)
                 .editOrNewTls()
@@ -442,7 +445,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("my-secret"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithScramSha512Auth() {
         KafkaMirrorMaker2ClusterSpec targetClusterWithScramSha512Auth = new KafkaMirrorMaker2ClusterSpecBuilder(this.targetCluster)
                 .withNewKafkaClientAuthenticationScramSha512()
@@ -477,7 +480,7 @@ public class KafkaMirrorMaker2ClusterTest {
      * the volumes and volume mounts that reference the secret are correctly created and that each volume name is only created once - volumes
      * with duplicate names will cause Kubernetes to reject the deployment.
      */
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithScramSha512AuthAndTLSSameSecret() {
         KafkaMirrorMaker2ClusterSpec targetClusterWithScramSha512Auth = new KafkaMirrorMaker2ClusterSpecBuilder(this.targetCluster)
             .editOrNewTls()
@@ -532,7 +535,7 @@ public class KafkaMirrorMaker2ClusterTest {
      * It checks that the volumes and volume mounts that reference the secret are correctly created and that each volume name and volume mount path is only
      * created once - duplicate volume names and duplicate volume mount paths will cause Kubernetes to reject the deployment.
      */
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithMultipleClustersScramSha512AuthAndTLSSameSecret() {
         KafkaMirrorMaker2ClusterSpec targetClusterWithScramSha512Auth = new KafkaMirrorMaker2ClusterSpecBuilder(this.targetCluster)
             .editOrNewTls()
@@ -592,7 +595,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(AbstractModel.containerEnvVars(cont), hasEntry(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_TLS, "true"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithPlainAuth() {
         KafkaMirrorMaker2ClusterSpec targetClusterWithPlainAuth = new KafkaMirrorMaker2ClusterSpecBuilder(this.targetCluster)
                 .withNewKafkaClientAuthenticationPlain()
@@ -628,7 +631,7 @@ public class KafkaMirrorMaker2ClusterTest {
      * the volumes and volume mounts that reference the secret are correctly created and that each volume name is only created once - volumes
      * with duplicate names will cause Kubernetes to reject the deployment.
      */
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithPlainAuthAndTLSSameSecret() {
         KafkaMirrorMaker2ClusterSpec targetClusterWithPlainAuth = new KafkaMirrorMaker2ClusterSpecBuilder(this.targetCluster)
             .editOrNewTls()
@@ -678,7 +681,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(AbstractModel.containerEnvVars(cont), hasEntry(KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_TLS, "true"));
     }
 
-    @Test
+    @ParallelTest
     public void testTemplate() {
         Map<String, String> depLabels = TestUtils.map("l1", "v1", "l2", "v2",
                 Labels.KUBERNETES_PART_OF_LABEL, "custom-part",
@@ -771,7 +774,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(resource.getMetadata().getOwnerReferences().get(0), is(ownerRef));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationSecretEnvs() {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
@@ -799,7 +802,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(selected.get(0).getValueFrom().getSecretKeyRef(), is(env.getValueFrom().getSecretKeyRef()));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationConfigEnvs() {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
@@ -826,7 +829,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(selected.get(0).getValueFrom().getConfigMapKeyRef(), is(env.getValueFrom().getConfigMapKeyRef()));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationSecretVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -857,7 +860,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(selectedVolumeMounths.get(0).getMountPath(), is(KafkaMirrorMaker2Cluster.EXTERNAL_CONFIGURATION_VOLUME_MOUNT_BASE_PATH + "my-volume"));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationConfigVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -888,7 +891,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(selectedVolumeMounths.get(0).getMountPath(), is(KafkaMirrorMaker2Cluster.EXTERNAL_CONFIGURATION_VOLUME_MOUNT_BASE_PATH + "my-volume"));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalConfigurationInvalidVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -916,7 +919,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(selected.size(), is(0));
     }
 
-    @Test
+    @ParallelTest
     public void testNoExternalConfigurationVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -942,7 +945,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(selected.size(), is(0));
     }
 
-    @Test
+    @ParallelTest
     public void testInvalidExternalConfigurationEnvs() {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
@@ -968,7 +971,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(selected.size(), is(0));
     }
 
-    @Test
+    @ParallelTest
     public void testNoExternalConfigurationEnvs() {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
@@ -992,7 +995,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(selected.size(), is(0));
     }
 
-    @Test
+    @ParallelTest
     public void testGracePeriod() {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resource)
                 .editSpec()
@@ -1009,7 +1012,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(123)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultGracePeriod() {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resource).build();
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(resource, VERSIONS);
@@ -1018,7 +1021,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(30)));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecrets() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -1040,7 +1043,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecretsCO() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -1057,7 +1060,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecretsBoth() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -1079,7 +1082,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultImagePullSecrets() {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resource).build();
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(resource, VERSIONS);
@@ -1088,7 +1091,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testSecurityContext() {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resource)
                 .editSpec()
@@ -1108,7 +1111,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsUser(), is(Long.valueOf(789)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultSecurityContext() {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resource).build();
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(resource, VERSIONS);
@@ -1117,7 +1120,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testPodDisruptionBudget() {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resource)
                 .editSpec()
@@ -1134,7 +1137,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(2)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultPodDisruptionBudget() {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resource).build();
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(resource, VERSIONS);
@@ -1143,7 +1146,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullPolicy() {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(resource, VERSIONS);
 
@@ -1154,7 +1157,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(getContainer(dep).getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
     }
 
-    @Test
+    @ParallelTest
     public void testResources() {
         Map<String, Quantity> requests = new HashMap<>(2);
         requests.put("cpu", new Quantity("250m"));
@@ -1177,7 +1180,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(cont.getResources().getRequests(), is(requests));
     }
 
-    @Test
+    @ParallelTest
     public void testJvmOptions() {
         Map<String, String> xx = new HashMap<>(2);
         xx.put("UseG1GC", "true");
@@ -1202,7 +1205,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_HEAP_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Xms512m"), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaMirrorMaker2ContainerEnvVars() {
 
         ContainerEnvVar envVar1 = new ContainerEnvVar();
@@ -1241,7 +1244,7 @@ public class KafkaMirrorMaker2ClusterTest {
                         .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaContainerEnvVarsConflict() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION;
@@ -1279,7 +1282,7 @@ public class KafkaMirrorMaker2ClusterTest {
                         .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testTracing() {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resource)
                 .editSpec()
@@ -1296,7 +1299,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(cont.getEnv().stream().filter(env -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION.equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("producer.interceptor.classes=io.opentracing.contrib.kafka.TracingProducerInterceptor"), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithAccessToken() {
         KafkaMirrorMaker2ClusterSpec targetClusterWithOAuthWithAccessToken = new KafkaMirrorMaker2ClusterSpecBuilder(this.targetCluster)
                 .withAuthentication(
@@ -1323,7 +1326,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_OAUTH_CONFIG.equals(var.getName())).findFirst().orElse(null).getValue().isEmpty(), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithRefreshToken() {
         KafkaMirrorMaker2ClusterSpec targetClusterWithOAuthWithRefreshToken = new KafkaMirrorMaker2ClusterSpecBuilder(this.targetCluster)
                 .withAuthentication(
@@ -1353,7 +1356,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server")));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithClientSecret() {
         KafkaMirrorMaker2ClusterSpec targetClusterWithOAuthWithClientSecret = new KafkaMirrorMaker2ClusterSpecBuilder(this.targetCluster)
                 .withAuthentication(
@@ -1383,7 +1386,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server")));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithMissingClientSecret() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaMirrorMaker2ClusterSpec targetClusterWithOAuthWithMissingClientSecret = new KafkaMirrorMaker2ClusterSpecBuilder(this.targetCluster)
@@ -1403,7 +1406,7 @@ public class KafkaMirrorMaker2ClusterTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithMissingUri() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaMirrorMaker2ClusterSpec targetClusterWithOAuthWithMissingUri = new KafkaMirrorMaker2ClusterSpecBuilder(this.targetCluster)
@@ -1426,7 +1429,7 @@ public class KafkaMirrorMaker2ClusterTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthWithTls() {
         CertSecretSource cert1 = new CertSecretSourceBuilder()
                 .withSecretName("first-certificate")
@@ -1491,7 +1494,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream().filter(vol -> "oauth-certs-2".equals(vol.getName())).findFirst().orElse(null).getSecret().getItems().get(0).getPath(), is("tls.crt"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOldVersion() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resource)
@@ -1504,7 +1507,7 @@ public class KafkaMirrorMaker2ClusterTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testNetworkPolicy() {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resourceWithMetrics)
                 .build();
@@ -1528,7 +1531,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
     }
 
-    @Test
+    @ParallelTest
     public void testNetworkPolicyWithConnectorOperatorSameNamespace() {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resourceWithMetrics)
                 .build();
@@ -1551,7 +1554,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
     }
 
-    @Test
+    @ParallelTest
     public void testNetworkPolicyWithConnectorOperatorWithNamespaceLabels() {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resourceWithMetrics)
                 .build();
@@ -1574,7 +1577,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
     }
     
-    @Test
+    @ParallelTest
     public void testMetricsParsingInline() {
         Map<String, Object> dummyMetrics = singletonMap("dummy", "metrics");
 
@@ -1591,7 +1594,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(kmm.getMetricsConfigInCm(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingFromConfigMap() {
         MetricsConfig metrics = new JmxPrometheusExporterMetricsBuilder()
                 .withNewValueFrom()
@@ -1612,7 +1615,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(kmm.getMetricsConfig(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingNoMetrics() {
         KafkaMirrorMaker2Cluster kmm = KafkaMirrorMaker2Cluster.fromCrd(this.resource, VERSIONS);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -47,7 +47,6 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -45,6 +45,8 @@ import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.MetricsAndLogging;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -64,6 +66,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ParallelSuite
 public class KafkaMirrorMakerClusterTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private final String namespace = "test";
@@ -123,7 +126,7 @@ public class KafkaMirrorMakerClusterTest {
     private final KafkaMirrorMakerCluster mm = KafkaMirrorMakerCluster.fromCrd(resourceWithMetrics, VERSIONS);
 
     @Deprecated
-    @Test
+    @ParallelTest
     public void testMetricsConfigMapDeprecatedMetrics() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(ResourceUtils.createEmptyKafkaMirrorMaker(namespace, cluster))
                 .withNewSpec()
@@ -142,7 +145,7 @@ public class KafkaMirrorMakerClusterTest {
         checkMetricsConfigMap(metricsCm);
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsConfigMap() {
         ConfigMap metricsCm = mm.generateMetricsAndLogConfigMap(new MetricsAndLogging(metricsCM, null));
         checkMetricsConfigMap(metricsCm);
@@ -193,7 +196,7 @@ public class KafkaMirrorMakerClusterTest {
         return expected;
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultValues() {
         KafkaMirrorMakerProducerSpec producer = new KafkaMirrorMakerProducerSpecBuilder()
                 .withBootstrapServers(producerBootstrapServers)
@@ -217,7 +220,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(new KafkaMirrorMakerProducerConfiguration(mm.producer.getConfig().entrySet()).getConfiguration(), is(defaultProducerConfiguration));
     }
 
-    @Test
+    @ParallelTest
     public void testFromCrd() {
         assertThat(mm.getReplicas(), is(replicas));
         assertThat(mm.getImage(), is(image));
@@ -227,12 +230,12 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(mm.consumer.getGroupId(), is(groupId));
     }
 
-    @Test
+    @ParallelTest
     public void testEnvVars()   {
         assertThat(mm.getEnvVars(), is(getExpectedEnvVars()));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeployment()   {
         Deployment dep = mm.generateDeployment(new HashMap<String, String>(), true, null, null);
 
@@ -254,7 +257,7 @@ public class KafkaMirrorMakerClusterTest {
         checkOwnerReference(mm.createOwnerReference(), dep);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithTls() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -300,7 +303,7 @@ public class KafkaMirrorMakerClusterTest {
                 is("my-secret-c/cert.crt;my-secret-c/new-cert.crt;my-another-secret-c/another-cert.crt"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithTlsAuth() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -352,7 +355,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(AbstractModel.containerEnvVars(containers.get(0)).get(KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_TLS_AUTH_KEY_PRODUCER), is("user-secret-p/user.key"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithTlsSameSecret() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -393,7 +396,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(3).getName(), is("my-secret-c"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithScramSha512Auth() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -440,7 +443,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(AbstractModel.containerEnvVars(containers.get(0)).get(KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_SASL_USERNAME_CONSUMER), is("consumer"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithPlain() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -492,7 +495,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(resource.getMetadata().getOwnerReferences().get(0), is(ownerRef));
     }
 
-    @Test
+    @ParallelTest
     public void testTemplate() {
         Map<String, String> depLabels = TestUtils.map("l1", "v1", "l2", "v2",
                 Labels.KUBERNETES_PART_OF_LABEL, "custom-part",
@@ -566,7 +569,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(pdb.getMetadata().getAnnotations().entrySet().containsAll(pdbAnots.entrySet()), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testGracePeriod() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -583,7 +586,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(123)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultGracePeriod() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource).build();
         KafkaMirrorMakerCluster mmc = KafkaMirrorMakerCluster.fromCrd(resource, VERSIONS);
@@ -592,7 +595,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(30)));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecrets() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -614,7 +617,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecretsFromCo() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -631,7 +634,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecretsFromBoth() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -653,7 +656,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultImagePullSecrets() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource).build();
         KafkaMirrorMakerCluster mmc = KafkaMirrorMakerCluster.fromCrd(resource, VERSIONS);
@@ -662,7 +665,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testSecurityContext() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -682,7 +685,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsUser(), is(Long.valueOf(789)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultSecurityContext() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource).build();
         KafkaMirrorMakerCluster mmc = KafkaMirrorMakerCluster.fromCrd(resource, VERSIONS);
@@ -691,7 +694,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testPodDisruptionBudget() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -708,7 +711,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(2)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultPodDisruptionBudget() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource).build();
         KafkaMirrorMakerCluster mmc = KafkaMirrorMakerCluster.fromCrd(resource, VERSIONS);
@@ -717,7 +720,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullPolicy() {
         KafkaMirrorMakerCluster kc = KafkaMirrorMakerCluster.fromCrd(resource, VERSIONS);
 
@@ -728,7 +731,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
     }
 
-    @Test
+    @ParallelTest
     public void testResources() {
         Map<String, Quantity> requests = new HashMap<>(2);
         requests.put("cpu", new Quantity("250m"));
@@ -751,7 +754,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(cont.getResources().getRequests(), is(requests));
     }
 
-    @Test
+    @ParallelTest
     public void testJvmOptions() {
         Map<String, String> xx = new HashMap<>(2);
         xx.put("UseG1GC", "true");
@@ -776,7 +779,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_HEAP_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Xms512m"), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultProbes() {
         KafkaMirrorMakerCluster mmc = KafkaMirrorMakerCluster.fromCrd(this.resource, VERSIONS);
 
@@ -800,7 +803,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(cont.getEnv().stream().filter(env -> "STRIMZI_LIVENESS_PERIOD".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").equals("10"), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testConfiguredProbes() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -840,7 +843,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(cont.getEnv().stream().filter(env -> "STRIMZI_LIVENESS_PERIOD".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").equals("60"), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaMMContainerEnvVars() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = "TEST_ENV_1";
@@ -878,7 +881,7 @@ public class KafkaMirrorMakerClusterTest {
                         .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaMMContainerEnvVarsConflict() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_BOOTSTRAP_SERVERS_CONSUMER;
@@ -916,7 +919,7 @@ public class KafkaMirrorMakerClusterTest {
                         .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testTracing() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -933,7 +936,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(cont.getEnv().stream().filter(env -> KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_CONFIGURATION_PRODUCER.equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("interceptor.classes=io.opentracing.contrib.kafka.TracingProducerInterceptor"), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithConsumerOAuthWithAccessToken() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -959,7 +962,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_OAUTH_CONFIG_CONSUMER.equals(var.getName())).findFirst().orElse(null).getValue().isEmpty(), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithConsumerOAuthWithRefreshToken() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -988,7 +991,7 @@ public class KafkaMirrorMakerClusterTest {
                 is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server")));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithConsumerOAuthWithClientSecret() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -1017,7 +1020,7 @@ public class KafkaMirrorMakerClusterTest {
                 is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server")));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithConsumerOAuthWithMissingClientSecret() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
@@ -1036,7 +1039,7 @@ public class KafkaMirrorMakerClusterTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithConsumerOAuthWithMissingUri() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
@@ -1058,7 +1061,7 @@ public class KafkaMirrorMakerClusterTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithConsumerOAuthWithTls() {
         CertSecretSource cert1 = new CertSecretSourceBuilder()
                 .withSecretName("first-certificate")
@@ -1122,7 +1125,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream().filter(vol -> "consumer-oauth-certs-2".equals(vol.getName())).findFirst().orElse(null).getSecret().getItems().get(0).getPath(), is("tls.crt"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithProducerOAuthWithAccessToken() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -1148,7 +1151,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_OAUTH_CONFIG_PRODUCER.equals(var.getName())).findFirst().orElse(null).getValue().isEmpty(), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithProducerOAuthWithRefreshToken() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -1177,7 +1180,7 @@ public class KafkaMirrorMakerClusterTest {
                 is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server")));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithProducerOAuthWithClientSecret() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -1206,7 +1209,7 @@ public class KafkaMirrorMakerClusterTest {
                 is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server")));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithProducerOAuthWithMissingClientSecret() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
@@ -1225,7 +1228,7 @@ public class KafkaMirrorMakerClusterTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithProducerOAuthWithMissingUri() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
@@ -1247,7 +1250,7 @@ public class KafkaMirrorMakerClusterTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithProducerOAuthWithTls() {
         CertSecretSource cert1 = new CertSecretSourceBuilder()
                 .withSecretName("first-certificate")
@@ -1311,7 +1314,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream().filter(vol -> "producer-oauth-certs-2".equals(vol.getName())).findFirst().orElse(null).getSecret().getItems().get(0).getPath(), is("tls.crt"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithBothSidedOAuthWithTls() {
         CertSecretSource cert1 = new CertSecretSourceBuilder()
                 .withSecretName("first-certificate")
@@ -1409,7 +1412,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream().filter(vol -> "consumer-oauth-certs-2".equals(vol.getName())).findFirst().orElse(null).getSecret().getItems().get(0).getPath(), is("tls.crt"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateDeploymentWithOAuthUsingOpaqueTokens() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
@@ -1459,7 +1462,7 @@ public class KafkaMirrorMakerClusterTest {
                 is(String.format("%s=\"%s\" %s=\"%s\" %s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server", ClientConfig.OAUTH_ACCESS_TOKEN_IS_JWT, "false", ClientConfig.OAUTH_MAX_TOKEN_EXPIRY_SECONDS, "600")));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingInline() {
         Map<String, Object> dummyMetrics = singletonMap("dummy", "metrics");
 
@@ -1476,7 +1479,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(kmm.getMetricsConfigInCm(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingFromConfigMap() {
         MetricsConfig metrics = new JmxPrometheusExporterMetricsBuilder()
                 .withNewValueFrom()
@@ -1497,7 +1500,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(kmm.getMetricsConfig(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingNoMetrics() {
         KafkaMirrorMakerCluster kmm = KafkaMirrorMakerCluster.fromCrd(this.resource, VERSIONS);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
@@ -5,6 +5,8 @@
 package io.strimzi.operator.cluster.model;
 
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStreamReader;
@@ -19,6 +21,7 @@ import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ParallelSuite
 public class KafkaVersionTest {
     private static final String KAFKA_VERSIONS_VALID_RESOURCE = "kafka-versions/kafka-versions-valid.yaml";
     private static final String KAFKA_VERSIONS_NODEFAULT_RESOURCE = "kafka-versions/kafka-versions-nodefault.yaml";
@@ -29,7 +32,7 @@ public class KafkaVersionTest {
         return new InputStreamReader(KafkaVersion.class.getResourceAsStream("/" + kafkaVersions), StandardCharsets.UTF_8);
     }
 
-    @Test
+    @ParallelTest
     public void parsingTest() throws Exception {
         Map<String, KafkaVersion> map = new HashMap<>();
         KafkaVersion defaultVersion = KafkaVersion.parseKafkaVersions(getKafkaVersionsReader(KAFKA_VERSIONS_VALID_RESOURCE), map);
@@ -63,7 +66,7 @@ public class KafkaVersionTest {
         assertThat(map.get("1.0.0").isSupported(), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void duplicateVersionTest() {
         assertThrows(IllegalArgumentException.class, () -> {
             Map<String, KafkaVersion> map = new HashMap<>();
@@ -71,7 +74,7 @@ public class KafkaVersionTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void noDefaultTest() {
         assertThrows(RuntimeException.class, () -> {
             Map<String, KafkaVersion> map = new HashMap<>();
@@ -79,7 +82,7 @@ public class KafkaVersionTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void multipleDefaultTest() {
         assertThrows(IllegalArgumentException.class, () -> {
             Map<String, KafkaVersion> map = new HashMap<>();
@@ -87,17 +90,17 @@ public class KafkaVersionTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void compareEqualVersionTest() {
         assertThat(KafkaVersion.compareDottedVersions(KafkaVersionTestUtils.DEFAULT_KAFKA_VERSION, KafkaVersionTestUtils.DEFAULT_KAFKA_VERSION), is(0));
     }
 
-    @Test
+    @ParallelTest
     public void compareVersionLowerTest() {
         assertThat(KafkaVersion.compareDottedVersions(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_VERSION), lessThan(0));
     }
 
-    @Test
+    @ParallelTest
     public void compareVersionHigherTest() {
         assertThat(KafkaVersion.compareDottedVersions(KafkaVersionTestUtils.LATEST_KAFKA_VERSION, KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION), greaterThan(0));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.cluster.model;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import java.io.InputStreamReader;
 import java.io.Reader;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
@@ -12,7 +12,6 @@ import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.api.kafka.model.template.ExternalTrafficPolicy;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
@@ -10,6 +10,8 @@ import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBui
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBrokerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.api.kafka.model.template.ExternalTrafficPolicy;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -25,6 +27,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ParallelSuite
 public class ListenersUtilsTest {
     private GenericKafkaListener oldPlain = new GenericKafkaListenerBuilder()
             .withName("plain")
@@ -286,14 +289,14 @@ public class ListenersUtilsTest {
     List<GenericKafkaListener> allListeners = asList(oldPlain, oldTls, oldExternal, newPlain, newTls, newRoute,
             newNodePort, newNodePort2, newNodePort3, newLoadBalancer, newLoadBalancer2, newIngress, newIngress2);
 
-    @Test
+    @ParallelTest
     public void testInternalListeners()    {
         assertThat(ListenersUtils.internalListeners(allListeners), hasSize(4));
         assertThat(ListenersUtils.internalListeners(allListeners).stream().map(GenericKafkaListener::getName).collect(Collectors.toList()),
                 containsInAnyOrder("plain", "tls", "plain2", "tls2"));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalListeners()    {
         assertThat(ListenersUtils.externalListeners(allListeners), hasSize(9));
         assertThat(ListenersUtils.externalListeners(allListeners).stream().map(GenericKafkaListener::getName).collect(Collectors.toList()),
@@ -304,7 +307,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.hasExternalListener(internalListeners), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testLoadBalancerListeners()    {
         assertThat(ListenersUtils.loadBalancerListeners(allListeners), hasSize(2));
         assertThat(ListenersUtils.loadBalancerListeners(allListeners).stream().map(GenericKafkaListener::getName).collect(Collectors.toList()),
@@ -315,7 +318,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.hasLoadBalancerListener(internalListeners), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testNodePortListeners()    {
         assertThat(ListenersUtils.nodePortListeners(allListeners), hasSize(3));
         assertThat(ListenersUtils.nodePortListeners(allListeners).stream().map(GenericKafkaListener::getName).collect(Collectors.toList()),
@@ -326,7 +329,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.hasNodePortListener(internalListeners), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testIngressListeners()    {
         assertThat(ListenersUtils.ingressListeners(allListeners), hasSize(2));
         assertThat(ListenersUtils.ingressListeners(allListeners).stream().map(GenericKafkaListener::getName).collect(Collectors.toList()),
@@ -337,7 +340,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.hasIngressListener(internalListeners), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testRouteListeners()    {
         assertThat(ListenersUtils.routeListeners(allListeners), hasSize(2));
         assertThat(ListenersUtils.routeListeners(allListeners).stream().map(GenericKafkaListener::getName).collect(Collectors.toList()),
@@ -348,7 +351,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.hasRouteListener(internalListeners), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testAlternativeNames()  {
         assertThat(ListenersUtils.alternativeNames(simpleListeners), hasSize(0));
 
@@ -357,17 +360,17 @@ public class ListenersUtilsTest {
                 containsInAnyOrder("my-name-1", "my-name-2", "my-lb-1", "my-lb-2", "my-route-1", "my-route-2", "my-np-1", "my-np-2", "my-ing-1", "my-ing-2"));
     }
 
-    @Test
+    @ParallelTest
     public void testIdentifier()    {
         assertThat(ListenersUtils.identifier(oldPlain), is("plain-9092"));
     }
 
-    @Test
+    @ParallelTest
     public void testEnvVarIdentifier()    {
         assertThat(ListenersUtils.envVarIdentifier(oldPlain), is("PLAIN_9092"));
     }
 
-    @Test
+    @ParallelTest
     public void testBackwardsCompatiblePortName()    {
         assertThat(ListenersUtils.backwardsCompatiblePortName(oldPlain), is("tcp-clients"));
         assertThat(ListenersUtils.backwardsCompatiblePortName(oldTls), is("tcp-clientstls"));
@@ -377,7 +380,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.backwardsCompatiblePortName(newLoadBalancer), is("tcp-lb1"));
     }
 
-    @Test
+    @ParallelTest
     public void testBackwardsCompatibleServiceNames()    {
         String clusterName = "my-cluster";
 
@@ -390,7 +393,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.backwardsCompatibleBootstrapServiceName(clusterName, newNodePort), is(clusterName + "-kafka-np1-bootstrap"));
     }
 
-    @Test
+    @ParallelTest
     public void testBackwardsCompatibleBootstrapRouteOrIngressName()    {
         String clusterName = "my-cluster";
 
@@ -404,7 +407,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.backwardsCompatibleBootstrapRouteOrIngressName(clusterName, newRoute), is(clusterName + "-kafka-route-bootstrap"));
     }
 
-    @Test
+    @ParallelTest
     public void testBackwardsCompatibleBrokerServiceName()    {
         String clusterName = "my-cluster";
 
@@ -418,7 +421,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.backwardsCompatibleBrokerServiceName(clusterName, 1, newRoute), is(clusterName + "-kafka-route-1"));
     }
 
-    @Test
+    @ParallelTest
     public void testBootstrapNodePort() {
         assertThat(ListenersUtils.bootstrapNodePort(newNodePort), is(nullValue()));
         assertThat(ListenersUtils.bootstrapNodePort(newNodePort2), is(32189));
@@ -428,7 +431,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.bootstrapNodePort(newLoadBalancer), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testBrokerNodePort() {
         assertThat(ListenersUtils.brokerNodePort(newNodePort, 1), is(nullValue()));
         assertThat(ListenersUtils.brokerNodePort(newNodePort2, 0), is(32190));
@@ -440,7 +443,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.brokerNodePort(newLoadBalancer, 1), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testBootstrapLoadBalancerIP() {
         assertThat(ListenersUtils.bootstrapLoadBalancerIP(newLoadBalancer), is(nullValue()));
         assertThat(ListenersUtils.bootstrapLoadBalancerIP(newLoadBalancer2), is("130.211.204.1"));
@@ -450,7 +453,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.bootstrapLoadBalancerIP(newNodePort3), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testBrokerLoadBalancerIP() {
         assertThat(ListenersUtils.brokerLoadBalancerIP(newLoadBalancer, 1), is(nullValue()));
         assertThat(ListenersUtils.brokerLoadBalancerIP(newLoadBalancer2, 0), is("130.211.204.1"));
@@ -462,7 +465,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.brokerLoadBalancerIP(newNodePort3, 1), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testBootstrapLabelsAndAnnotations() {
         assertThat(ListenersUtils.bootstrapAnnotations(newLoadBalancer), is(emptyMap()));
         assertThat(ListenersUtils.bootstrapAnnotations(newLoadBalancer2), is(Collections.singletonMap("dns-anno", "dns-value")));
@@ -479,7 +482,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.bootstrapLabels(newNodePort3), is(emptyMap()));
     }
 
-    @Test
+    @ParallelTest
     public void testBrokerLabelsAndAnnotations() {
         assertThat(ListenersUtils.brokerAnnotations(newLoadBalancer, 1), is(emptyMap()));
         assertThat(ListenersUtils.brokerAnnotations(newLoadBalancer2, 0), is(Collections.singletonMap("dns-anno-1", "dns-value")));
@@ -500,7 +503,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.brokerLabels(newNodePort3, 1), is(emptyMap()));
     }
 
-    @Test
+    @ParallelTest
     public void testBootstrapHost() {
         assertThat(ListenersUtils.bootstrapHost(newLoadBalancer), is(nullValue()));
         assertThat(ListenersUtils.bootstrapHost(oldExternal), is(nullValue()));
@@ -513,7 +516,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.bootstrapHost(newNodePort3), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testBrokerHost() {
         assertThat(ListenersUtils.brokerHost(newLoadBalancer, 1), is(nullValue()));
         assertThat(ListenersUtils.brokerHost(oldExternal, 0), is(nullValue()));
@@ -529,7 +532,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.brokerHost(newNodePort3, 1), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testBrokerAdvertisedHost() {
         assertThat(ListenersUtils.brokerAdvertisedHost(newLoadBalancer, 1), is(nullValue()));
         assertThat(ListenersUtils.brokerAdvertisedHost(oldExternal, 0), is(nullValue()));
@@ -542,7 +545,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.brokerAdvertisedHost(newNodePort3, 1), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testBrokerAdvertisedPort() {
         assertThat(ListenersUtils.brokerAdvertisedPort(newLoadBalancer, 1), is(nullValue()));
         assertThat(ListenersUtils.brokerAdvertisedPort(oldExternal, 0), is(nullValue()));
@@ -555,7 +558,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.brokerAdvertisedPort(newNodePort3, 1), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testLoadBalancerSourceRanges() {
         assertThat(ListenersUtils.loadBalancerSourceRanges(newLoadBalancer), is(nullValue()));
         assertThat(ListenersUtils.loadBalancerSourceRanges(oldExternal), is(nullValue()));
@@ -567,7 +570,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.loadBalancerSourceRanges(newNodePort3), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testFinalizers() {
         assertThat(ListenersUtils.finalizers(newLoadBalancer), is(nullValue()));
         assertThat(ListenersUtils.finalizers(oldExternal), is(nullValue()));
@@ -579,7 +582,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.finalizers(newNodePort3), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testExternalTrafficPolicy() {
         assertThat(ListenersUtils.externalTrafficPolicy(newLoadBalancer), is(nullValue()));
         assertThat(ListenersUtils.externalTrafficPolicy(oldExternal), is(nullValue()));
@@ -592,7 +595,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.externalTrafficPolicy(newNodePort3), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testPreferredNodeAddressType() {
         assertThat(ListenersUtils.preferredNodeAddressType(newLoadBalancer), is(nullValue()));
         assertThat(ListenersUtils.preferredNodeAddressType(oldExternal), is(nullValue()));
@@ -605,7 +608,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.preferredNodeAddressType(newNodePort3), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testIngressClass() {
         assertThat(ListenersUtils.ingressClass(newLoadBalancer), is(nullValue()));
         assertThat(ListenersUtils.ingressClass(oldExternal), is(nullValue()));
@@ -617,7 +620,7 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.ingressClass(newNodePort3), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testServiceType() {
         assertThat(ListenersUtils.serviceType(oldPlain), is("ClusterIP"));
         assertThat(ListenersUtils.serviceType(newTls), is("ClusterIP"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -19,6 +19,8 @@ import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerCon
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.api.kafka.model.listener.arraylistener.ListenersConvertor;
 import io.strimzi.api.kafka.model.template.ExternalTrafficPolicy;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -35,8 +37,9 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ParallelSuite
 public class ListenersValidatorTest {
-    @Test
+    @ParallelTest
     public void testValidateOldListener() {
         KafkaListeners oldListeners = new KafkaListenersBuilder()
                 .withNewPlain()
@@ -54,7 +57,7 @@ public class ListenersValidatorTest {
         ListenersValidator.validate(3, newListeners);
     }
 
-    @Test
+    @ParallelTest
     public void testValidateNewListeners() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
@@ -72,7 +75,7 @@ public class ListenersValidatorTest {
         ListenersValidator.validate(3, listeners);
     }
 
-    @Test
+    @ParallelTest
     public void testValidateThrowsException() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
@@ -92,7 +95,7 @@ public class ListenersValidatorTest {
         assertThat(exception.getMessage(), containsString("every listener needs to have a unique port number"));
     }
 
-    @Test
+    @ParallelTest
     public void testValidateDuplicatePorts() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
@@ -116,7 +119,7 @@ public class ListenersValidatorTest {
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("every listener needs to have a unique port number"));
     }
 
-    @Test
+    @ParallelTest
     public void testValidateForbiddenPortByRange() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
@@ -128,7 +131,7 @@ public class ListenersValidatorTest {
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("port 9000 is forbidden and cannot be used"));
     }
 
-    @Test
+    @ParallelTest
     public void testValidateForbiddenPortByException() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
@@ -140,7 +143,7 @@ public class ListenersValidatorTest {
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("port 9404 is forbidden and cannot be used"));
     }
 
-    @Test
+    @ParallelTest
     public void testValidateDuplicateNames() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
@@ -164,7 +167,7 @@ public class ListenersValidatorTest {
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("every listener needs to have a unique name"));
     }
 
-    @Test
+    @ParallelTest
     public void testInvalidNames() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener 1")
@@ -188,7 +191,7 @@ public class ListenersValidatorTest {
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("listener names [listener 1, LISTENER2, listener12345678901234567890] are invalid and do not match the pattern ^[a-z0-9]{1,11}$"));
     }
 
-    @Test
+    @ParallelTest
     public void testTlsAuthOnNonTlsListener() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("plain")
@@ -203,7 +206,7 @@ public class ListenersValidatorTest {
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("listener plain cannot use tls type authentication with disabled TLS encryption"));
     }
 
-    @Test
+    @ParallelTest
     public void testTlsCustomCertOnNonTlsListener() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("plain")
@@ -223,7 +226,7 @@ public class ListenersValidatorTest {
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("listener plain cannot configure custom TLS certificate with disabled TLS encryption"));
     }
 
-    @Test
+    @ParallelTest
     public void testInternalListener() {
         String name = "plain";
 
@@ -292,7 +295,7 @@ public class ListenersValidatorTest {
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
-    @Test
+    @ParallelTest
     public void testLoadBalancerListener() {
         String name = "lb";
 
@@ -350,7 +353,7 @@ public class ListenersValidatorTest {
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
-    @Test
+    @ParallelTest
     public void testNodePortListener() {
         String name = "nodeport";
 
@@ -409,7 +412,7 @@ public class ListenersValidatorTest {
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
-    @Test
+    @ParallelTest
     public void testRouteListenerWithoutTls() {
         String name = "route";
 
@@ -429,7 +432,7 @@ public class ListenersValidatorTest {
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
-    @Test
+    @ParallelTest
     public void testRouteListener() {
         String name = "route";
 
@@ -494,7 +497,7 @@ public class ListenersValidatorTest {
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
-    @Test
+    @ParallelTest
     public void testIngressListenerWithoutTls() {
         String name = "ingress";
 
@@ -527,7 +530,7 @@ public class ListenersValidatorTest {
         assertThat(ListenersValidator.validateAndGetErrorMessages(2, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
-    @Test
+    @ParallelTest
     public void testIngressListener() {
         String name = "ingress";
 
@@ -588,7 +591,7 @@ public class ListenersValidatorTest {
         assertThat(ListenersValidator.validateAndGetErrorMessages(2, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
-    @Test
+    @ParallelTest
     public void testIngressListenerHostNames() {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("ingress")
@@ -650,7 +653,7 @@ public class ListenersValidatorTest {
         assertThat(ListenersValidator.validateAndGetErrorMessages(2, asList(listener)), hasSize(0));
     }
 
-    @Test
+    @ParallelTest
     public void testValidateOauth() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
@@ -667,7 +670,7 @@ public class ListenersValidatorTest {
                 containsString("listener listener1: Valid Issuer URI has to be specified or 'checkIssuer' set to 'false'")));
     }
 
-    @Test
+    @ParallelTest
     public void testValidateBrokerCertChainAndKey() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
@@ -690,7 +693,7 @@ public class ListenersValidatorTest {
                 containsString("listener 'listener1' cannot have an empty certificate in the brokerCertChainAndKey")));
     }
 
-    @Test
+    @ParallelTest
     public void testMinimalConfiguration() {
         GenericKafkaListener internal = new GenericKafkaListenerBuilder()
                 .withName("internal")
@@ -746,7 +749,7 @@ public class ListenersValidatorTest {
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), empty());
     }
 
-    @Test
+    @ParallelTest
     public void testValidateOauthPlain() {
         KafkaListenerAuthenticationOAuthBuilder authBuilder = new KafkaListenerAuthenticationOAuthBuilder()
                 .withEnableOauthBearer(false);
@@ -785,7 +788,7 @@ public class ListenersValidatorTest {
         assertDoesNotThrow(() -> ListenersValidator.validate(3, listeners3));
     }
 
-    @Test
+    @ParallelTest
     public void testValidateAudienceOauth() {
         KafkaListenerAuthenticationOAuthBuilder authBuilder = new KafkaListenerAuthenticationOAuthBuilder()
                 .withCheckAudience(true);
@@ -817,7 +820,7 @@ public class ListenersValidatorTest {
                 not(containsString("listener listener1: 'clientId' has to be configured when 'checkAudience' is 'true'"))));
     }
 
-    @Test
+    @ParallelTest
     public void testValidateCustomClaimCheckOauth() {
         KafkaListenerAuthenticationOAuthBuilder authBuilder = new KafkaListenerAuthenticationOAuthBuilder()
                 .withCustomClaimCheck("invalid");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -21,7 +21,6 @@ import io.strimzi.api.kafka.model.listener.arraylistener.ListenersConvertor;
 import io.strimzi.api.kafka.model.template.ExternalTrafficPolicy;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -35,6 +35,8 @@ import io.strimzi.api.kafka.model.template.PodTemplate;
 import io.strimzi.api.kafka.model.template.PodTemplateBuilder;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -50,6 +52,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ParallelSuite
 public class ModelUtilsTest {
 
     @Test
@@ -267,7 +270,7 @@ public class ModelUtilsTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testStorageSerializationAndDeserialization()    {
         Storage jbod = new JbodStorageBuilder().withVolumes(
                 new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build(),
@@ -283,7 +286,7 @@ public class ModelUtilsTest {
         assertThat(ModelUtils.decodeStorageFromJson(ModelUtils.encodeStorageToJson(persistent)), is(persistent));
     }
 
-    @Test
+    @ParallelTest
     public void testExistingCertificatesDiffer()   {
         Secret defaultSecret = new SecretBuilder()
                 .withNewMetadata()
@@ -378,7 +381,7 @@ public class ModelUtilsTest {
         assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, changedScaleDownSecret), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testEmptyTolerations() {
         Toleration t1 = new TolerationBuilder()
                 .withValue("")
@@ -443,14 +446,14 @@ public class ModelUtilsTest {
         assertThat(model1.getTolerations(), is(model2.getTolerations()));
     }
 
-    @Test
+    @ParallelTest
     public void testCONetworkPolicyPeerNamespaceSelectorSameNS()  {
         NetworkPolicyPeer peer = new NetworkPolicyPeer();
         ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(peer, "my-ns", "my-ns", null);
         assertThat(peer.getNamespaceSelector(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testCONetworkPolicyPeerNamespaceSelectorDifferentNSNoLabels()  {
         NetworkPolicyPeer peer = new NetworkPolicyPeer();
         ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(peer, "my-ns", "my-operator-ns", null);
@@ -460,7 +463,7 @@ public class ModelUtilsTest {
         assertThat(peer.getNamespaceSelector().getMatchLabels(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testCONetworkPolicyPeerNamespaceSelectorDifferentNSWithLabels()  {
         NetworkPolicyPeer peer = new NetworkPolicyPeer();
         Labels nsLabels = Labels.fromMap(singletonMap("labelKey", "labelValue"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ProbeGeneratorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ProbeGeneratorTest.java
@@ -8,6 +8,8 @@ import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TlsSidecarBuilder;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -18,6 +20,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ParallelSuite
 public class ProbeGeneratorTest {
 
     private static final io.strimzi.api.kafka.model.Probe DEFAULT_CONFIG = new io.strimzi.api.kafka.model.ProbeBuilder()
@@ -28,12 +31,12 @@ public class ProbeGeneratorTest {
             .withFailureThreshold(5)
             .build();
 
-    @Test
+    @ParallelTest
     public void testNullProbeConfigThrowsException() {
         assertThrows(IllegalArgumentException.class, () -> ProbeGenerator.defaultBuilder(null));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultBuilder() {
         Probe probe = ProbeGenerator.defaultBuilder(DEFAULT_CONFIG)
                 .build();
@@ -49,7 +52,7 @@ public class ProbeGeneratorTest {
     }
 
     // Inherits defaults from the io.strimzi.api.kafka.model.Probe class
-    @Test
+    @ParallelTest
     public void testDefaultBuilderNoValues() {
         Probe probe = ProbeGenerator.defaultBuilder(new io.strimzi.api.kafka.model.ProbeBuilder().build())
                 .build();
@@ -60,7 +63,7 @@ public class ProbeGeneratorTest {
         ));
     }
 
-    @Test
+    @ParallelTest
     public void testHttpProbe() {
         Probe probe = ProbeGenerator.httpProbe(DEFAULT_CONFIG, "path", "1001");
         assertThat(probe, is(new ProbeBuilder()
@@ -77,19 +80,19 @@ public class ProbeGeneratorTest {
         ));
     }
 
-    @Test
+    @ParallelTest
     public void testHttpProbeMissingPathThrows() {
         assertThrows(IllegalArgumentException.class, () -> ProbeGenerator.httpProbe(DEFAULT_CONFIG, null, "1001"));
         assertThrows(IllegalArgumentException.class, () -> ProbeGenerator.httpProbe(DEFAULT_CONFIG, "", "1001"));
     }
 
-    @Test
+    @ParallelTest
     public void testHttpProbeMissingPortThrows() {
         assertThrows(IllegalArgumentException.class, () -> ProbeGenerator.httpProbe(DEFAULT_CONFIG, "path", null));
         assertThrows(IllegalArgumentException.class, () -> ProbeGenerator.httpProbe(DEFAULT_CONFIG, "path", ""));
     }
 
-    @Test
+    @ParallelTest
     public void testExecProbe() {
         Probe probe = ProbeGenerator.execProbe(DEFAULT_CONFIG, Arrays.asList("command1", "command2"));
         assertThat(probe, is(new ProbeBuilder()
@@ -105,7 +108,7 @@ public class ProbeGeneratorTest {
         ));
     }
 
-    @Test
+    @ParallelTest
     public void testExecProbeMissingCommandsThrows() {
         assertThrows(IllegalArgumentException.class, () -> ProbeGenerator.execProbe(DEFAULT_CONFIG, null));
         assertThrows(IllegalArgumentException.class, () -> ProbeGenerator.execProbe(DEFAULT_CONFIG, Collections.emptyList()));
@@ -128,7 +131,7 @@ public class ProbeGeneratorTest {
             .endReadinessProbe()
             .build();
 
-    @Test
+    @ParallelTest
     public void testTlsSidecarLivenessProbe() {
         Probe probe = ProbeGenerator.tlsSidecarLivenessProbe(TLS_SIDECAR);
         assertThat(probe, is(new ProbeBuilder()
@@ -144,7 +147,7 @@ public class ProbeGeneratorTest {
         ));
     }
 
-    @Test
+    @ParallelTest
     public void testTlsSidecarLivenessProbeWithNullTlsSidecarDefaults() {
         Probe probe = ProbeGenerator.tlsSidecarLivenessProbe(null);
         assertThat(probe, is(new ProbeBuilder()
@@ -157,7 +160,7 @@ public class ProbeGeneratorTest {
         ));
     }
 
-    @Test
+    @ParallelTest
     public void testTlsSidecarReadinessProbe() {
         Probe probe = ProbeGenerator.tlsSidecarReadinessProbe(TLS_SIDECAR);
         assertThat(probe, is(new ProbeBuilder()
@@ -173,7 +176,7 @@ public class ProbeGeneratorTest {
         ));
     }
 
-    @Test
+    @ParallelTest
     public void testTlsSidecarReadinessProbeWithNullTlsSidecarDefaults() {
         Probe probe = ProbeGenerator.tlsSidecarLivenessProbe(null);
         assertThat(probe, is(new ProbeBuilder()
@@ -186,7 +189,7 @@ public class ProbeGeneratorTest {
         ));
     }
 
-    @Test
+    @ParallelTest
     public void testZeroInitialDelayIsSetToNull() {
         io.strimzi.api.kafka.model.Probe probeConfig = new io.strimzi.api.kafka.model.ProbeBuilder()
                 .withInitialDelaySeconds(0)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ProbeGeneratorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ProbeGeneratorTest.java
@@ -10,7 +10,6 @@ import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TlsSidecarBuilder;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StatusDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StatusDiffTest.java
@@ -14,7 +14,6 @@ import io.strimzi.api.kafka.model.status.ListenerStatusBuilder;
 import io.strimzi.operator.common.operator.resource.StatusUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StatusDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StatusDiffTest.java
@@ -12,6 +12,8 @@ import io.strimzi.api.kafka.model.status.ListenerAddressBuilder;
 import io.strimzi.api.kafka.model.status.ListenerStatus;
 import io.strimzi.api.kafka.model.status.ListenerStatusBuilder;
 import io.strimzi.operator.common.operator.resource.StatusUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
@@ -21,8 +23,9 @@ import java.util.Date;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ParallelSuite
 public class StatusDiffTest {
-    @Test
+    @ParallelTest
     public void testStatusDiff()    {
         ListenerStatus ls1 = new ListenerStatusBuilder()
                 .withNewType("plain")
@@ -109,7 +112,7 @@ public class StatusDiffTest {
         assertThat(diff.isEmpty(), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testTimestampDiff() throws ParseException {
         ListenerStatus ls1 = new ListenerStatusBuilder()
                 .withNewType("plain")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
@@ -9,13 +9,16 @@ import io.strimzi.api.kafka.model.storage.JbodStorageBuilder;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorageOverrideBuilder;
 import io.strimzi.api.kafka.model.storage.Storage;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ParallelSuite
 public class StorageDiffTest {
-    @Test
+    @ParallelTest
     public void testJbodDiff()    {
         Storage jbod = new JbodStorageBuilder().withVolumes(
                 new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build(),
@@ -40,7 +43,7 @@ public class StorageDiffTest {
         assertThat(diff.isVolumesAddedOrRemoved(), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testPersistentDiff()    {
         Storage persistent = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build();
         Storage persistent2 = new PersistentClaimStorageBuilder().withStorageClass("gp2-st1").withDeleteClaim(false).withId(0).withSize("1000Gi").build();
@@ -54,7 +57,7 @@ public class StorageDiffTest {
         assertThat(new StorageDiff(persistent, persistent2, 3, 3).shrinkSize(), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testPersistentDiffWithOverrides()    {
         Storage persistent = new PersistentClaimStorageBuilder()
                 .withStorageClass("gp2-ssd")
@@ -96,7 +99,7 @@ public class StorageDiffTest {
         assertThat(new StorageDiff(persistent2, persistent3, 3, 3).shrinkSize(), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testSizeChanges()    {
         Storage persistent = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build();
         Storage persistent2 = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("1000Gi").build();
@@ -107,7 +110,7 @@ public class StorageDiffTest {
         assertThat(new StorageDiff(persistent, persistent3, 3, 3).shrinkSize(), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testEphemeralDiff()    {
         Storage ephemeral = new EphemeralStorageBuilder().build();
 
@@ -116,7 +119,7 @@ public class StorageDiffTest {
         assertThat(new StorageDiff(ephemeral, ephemeral, 3, 3).shrinkSize(), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testCrossDiff()    {
         Storage jbod = new JbodStorageBuilder().withVolumes(
                 new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build(),
@@ -144,7 +147,7 @@ public class StorageDiffTest {
         assertThat(diffJbodPersistent.isVolumesAddedOrRemoved(), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testJbodDiffWithNewVolume()    {
         Storage jbod = new JbodStorageBuilder()
                 .withVolumes(new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("1000Gi").build())
@@ -237,7 +240,7 @@ public class StorageDiffTest {
         assertThat(diff.isVolumesAddedOrRemoved(), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testSizeChangesInJbod()    {
         Storage jbod = new JbodStorageBuilder().withVolumes(
                 new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("1000Gi").build(),
@@ -259,7 +262,7 @@ public class StorageDiffTest {
         assertThat(new StorageDiff(jbod, jbod3, 3, 3).shrinkSize(), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testPersistentDiffWithOverridesChangesToExistingOverrides()    {
         Storage persistent = new PersistentClaimStorageBuilder()
                 .withStorageClass("gp2-ssd")
@@ -310,7 +313,7 @@ public class StorageDiffTest {
         assertThat(new StorageDiff(persistent, persistent2, 2, 1).isEmpty(), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testPersistentDiffWithOverridesBeingAdded()    {
         Storage persistent = new PersistentClaimStorageBuilder()
                 .withStorageClass("gp2-ssd")
@@ -367,7 +370,7 @@ public class StorageDiffTest {
         assertThat(new StorageDiff(persistent2, persistent3, 1, 1).isEmpty(), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testPersistentDiffWithOverridesBeingRemoved()    {
         Storage persistent = new PersistentClaimStorageBuilder()
                 .withStorageClass("gp2-ssd")
@@ -424,7 +427,7 @@ public class StorageDiffTest {
         assertThat(new StorageDiff(persistent3, persistent2, 1, 1).isEmpty(), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testPersistentDiffWithOverridesBeingAddedAndRemoved()    {
         Storage persistent = new PersistentClaimStorageBuilder()
                 .withStorageClass("gp2-ssd")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
@@ -11,7 +11,6 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorageOverrideBuilder;
 import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageUtilsTest.java
@@ -11,7 +11,6 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageUtilsTest.java
@@ -9,13 +9,16 @@ import io.strimzi.api.kafka.model.storage.EphemeralStorageBuilder;
 import io.strimzi.api.kafka.model.storage.JbodStorageBuilder;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.storage.Storage;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ParallelSuite
 public class StorageUtilsTest {
-    @Test
+    @ParallelTest
     public void testSizeConversion() {
         assertThat(StorageUtils.parseMemory("100Gi"), is(100L * 1_024L * 1_024L * 1_024L));
         assertThat(StorageUtils.parseMemory("100G"), is(100L * 1_000L * 1_000L * 1_000L));
@@ -35,7 +38,7 @@ public class StorageUtilsTest {
         assertThat(StorageUtils.parseMemory("1000G") == StorageUtils.parseMemory("1T"), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testQuantityConversion()    {
         assertThat(StorageUtils.parseMemory(new Quantity("1000G")), is(1_000L * 1_000L * 1_000L * 1_000L));
         assertThat(StorageUtils.parseMemory(new Quantity("100Gi")), is(100L * 1_024L * 1_024L * 1_024L));
@@ -44,7 +47,7 @@ public class StorageUtilsTest {
         assertThat(StorageUtils.parseMemory(size), is(100L * 1_024L * 1_024L * 1_024L));
     }
 
-    @Test
+    @ParallelTest
     public void testEphemeralStorage() {
         Storage notEphemeral = new PersistentClaimStorageBuilder().build();
         Storage isEphemeral = new EphemeralStorageBuilder().build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/VolumeUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/VolumeUtilsTest.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.KeyToPathBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.Volume;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/VolumeUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/VolumeUtilsTest.java
@@ -6,6 +6,8 @@ package io.strimzi.operator.cluster.model;
 
 import io.fabric8.kubernetes.api.model.KeyToPathBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.Volume;
@@ -16,34 +18,35 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ParallelSuite
 public class VolumeUtilsTest {
 
-    @Test
+    @ParallelTest
     public void testCreateEmptyDirVolumeWithSizeLimit() {
         Volume volume = VolumeUtils.createEmptyDirVolume("bar", "1Gi");
         assertThat(volume.getEmptyDir().getSizeLimit(), is(new Quantity("1", "Gi")));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateEmptyDirVolumeWithNullSizeLimit() {
         Volume volume = VolumeUtils.createEmptyDirVolume("bar", null);
         assertThat(volume.getEmptyDir().getSizeLimit(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateEmptyDirVolumeWithEmptySizeLimit() {
         Volume volume = VolumeUtils.createEmptyDirVolume("bar", "");
         assertThat(volume.getEmptyDir().getSizeLimit(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testValidVolumeNames() {
         assertThat(VolumeUtils.getValidVolumeName("my-user"), is("my-user"));
         assertThat(VolumeUtils.getValidVolumeName("my-0123456789012345678901234567890123456789012345678901234-user"),
                 is("my-0123456789012345678901234567890123456789012345678901234-user"));
     }
 
-    @Test
+    @ParallelTest
     public void testInvalidVolumeNames() {
         assertThat(VolumeUtils.getValidVolumeName("my.user"), is("my-user-4dbf077e"));
         assertThat(VolumeUtils.getValidVolumeName("my_user"), is("my-user-e10dbc61"));
@@ -57,31 +60,31 @@ public class VolumeUtilsTest {
         assertThat(VolumeUtils.getValidVolumeName("a"), is("a-86f7e437"));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateSecretVolumeWithValidName() {
         Volume volume = VolumeUtils.createSecretVolume("oauth-my-secret", "my-secret", true);
         assertThat(volume.getName(), is("oauth-my-secret"));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateSecretVolumeWithInvalidName() {
         Volume volume = VolumeUtils.createSecretVolume("oauth-my.secret", "my.secret", true);
         assertThat(volume.getName(), is("oauth-my-secret-b744ae5a"));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateConfigMapVolumeWithValidName() {
         Volume volume = VolumeUtils.createConfigMapVolume("oauth-my-cm", "my-cm");
         assertThat(volume.getName(), is("oauth-my-cm"));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateConfigMapVolumeWithInvalidName() {
         Volume volume = VolumeUtils.createConfigMapVolume("oauth-my.cm", "my.cm");
         assertThat(volume.getName(), is("oauth-my-cm-62fdd747"));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateConfigMapVolumeWithItems() {
         Volume volume = VolumeUtils.createConfigMapVolume("my-cm-volume", "my-cm", Collections.singletonMap("fileName.txt", "/path/to/fileName.txt"));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -53,6 +53,8 @@ import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -82,6 +84,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
+@ParallelSuite
 public class ZookeeperClusterTest {
 
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
@@ -113,7 +116,7 @@ public class ZookeeperClusterTest {
     private final ZookeeperCluster zc = ZookeeperCluster.fromCrd(ka, VERSIONS);
 
     @Deprecated
-    @Test
+    @ParallelTest
     public void testMetricsConfigMapDeprecatedMetrics() {
         Kafka ka = ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, null, configurationJson, zooConfigurationJson, null, null, kafkaLogConfigJson, zooLogConfigJson, null, null);
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(ka, VERSIONS);
@@ -124,7 +127,7 @@ public class ZookeeperClusterTest {
     }
 
 
-    @Test
+    @ParallelTest
     public void testMetricsConfigMap() {
         ConfigMap metricsCm = zc.generateConfigurationConfigMap(new MetricsAndLogging(metricsCM, null));
         checkMetricsConfigMap(metricsCm);
@@ -150,7 +153,7 @@ public class ZookeeperClusterTest {
             Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateService() {
         Service headful = zc.generateService();
 
@@ -165,7 +168,7 @@ public class ZookeeperClusterTest {
         checkOwnerReference(zc.createOwnerReference(), headful);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateServiceWithoutMetrics() {
         Kafka kafka = new KafkaBuilder(ka)
                 .editSpec()
@@ -189,7 +192,7 @@ public class ZookeeperClusterTest {
         checkOwnerReference(zc.createOwnerReference(), headful);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateHeadlessService() {
         Service headless = zc.generateHeadlessService();
         checkHeadlessService(headless);
@@ -211,7 +214,7 @@ public class ZookeeperClusterTest {
         assertThat(headless.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateStatefulSet() {
         // We expect a single statefulSet ...
         StatefulSet sts = zc.generateStatefulSet(true, null, null);
@@ -219,7 +222,7 @@ public class ZookeeperClusterTest {
         checkOwnerReference(zc.createOwnerReference(), sts);
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateStatefulSetWithPodManagementPolicy() {
         Kafka editZooAssembly = new KafkaBuilder(ka)
                         .editSpec()
@@ -236,7 +239,7 @@ public class ZookeeperClusterTest {
         assertThat(sts.getSpec().getPodManagementPolicy(), is(PodManagementPolicy.ORDERED_READY.toValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testInvalidVersion() {
         assertThrows(InvalidResourceException.class, () -> {
             Kafka ka = new KafkaBuilder(this.ka)
@@ -298,7 +301,7 @@ public class ZookeeperClusterTest {
 
     // TODO test volume claim templates
 
-    @Test
+    @ParallelTest
     public void testPodNames() {
 
         for (int i = 0; i < replicas; i++) {
@@ -306,7 +309,7 @@ public class ZookeeperClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testPvcNames() {
         Kafka ka = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, zooConfigurationJson))
                 .editSpec()
@@ -325,13 +328,13 @@ public class ZookeeperClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void withAffinity() throws IOException {
         ResourceTester<Kafka, ZookeeperCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, ZookeeperCluster::fromCrd, this.getClass().getSimpleName() + ".withAffinity");
         resourceTester.assertDesiredResource("-STS.yaml", zc -> zc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getAffinity());
     }
 
-    @Test
+    @ParallelTest
     public void withTolerations() throws IOException {
         ResourceTester<Kafka, ZookeeperCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, ZookeeperCluster::fromCrd, this.getClass().getSimpleName() + ".withTolerations");
         resourceTester.assertDesiredResource("-STS.yaml", zc -> zc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getTolerations());
@@ -350,7 +353,7 @@ public class ZookeeperClusterTest {
         return zc.generateNodesSecret();
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateBrokerSecret() throws CertificateParsingException {
         Secret secret = generateNodeSecret();
         assertThat(secret.getData().keySet(), is(set(
@@ -373,7 +376,7 @@ public class ZookeeperClusterTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testTemplate() {
         Map<String, String> ssLabels = TestUtils.map("l1", "v1", "l2", "v2",
                 Labels.KUBERNETES_PART_OF_LABEL, "custom-part",
@@ -491,7 +494,7 @@ public class ZookeeperClusterTest {
         assertThat(pdb.getMetadata().getAnnotations().entrySet().containsAll(pdbAnots.entrySet()), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testGracePeriod() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, emptyMap()))
@@ -511,7 +514,7 @@ public class ZookeeperClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(123)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultGracePeriod() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, emptyMap()))
@@ -522,7 +525,7 @@ public class ZookeeperClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(30)));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecrets() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -547,7 +550,7 @@ public class ZookeeperClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecretsFromCO() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -566,7 +569,7 @@ public class ZookeeperClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullSecretsFromBoth() {
         LocalObjectReference secret1 = new LocalObjectReference("some-pull-secret");
         LocalObjectReference secret2 = new LocalObjectReference("some-other-pull-secret");
@@ -591,7 +594,7 @@ public class ZookeeperClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultImagePullSecrets() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, emptyMap()))
@@ -602,7 +605,7 @@ public class ZookeeperClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testSecurityContext() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, emptyMap()))
@@ -625,7 +628,7 @@ public class ZookeeperClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsUser(), is(Long.valueOf(789)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultSecurityContext() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, emptyMap()))
@@ -636,7 +639,7 @@ public class ZookeeperClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testPodDisruptionBudget() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, emptyMap()))
@@ -656,7 +659,7 @@ public class ZookeeperClusterTest {
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(2)));
     }
 
-    @Test
+    @ParallelTest
     public void testDefaultPodDisruptionBudget() {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, emptyMap()))
@@ -667,7 +670,7 @@ public class ZookeeperClusterTest {
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
     }
 
-    @Test
+    @ParallelTest
     public void testImagePullPolicy() {
         Kafka kafkaAssembly = ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, emptyMap());
@@ -681,7 +684,7 @@ public class ZookeeperClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
     }
 
-    @Test
+    @ParallelTest
     public void testNetworkPolicyNewKubernetesVersions() {
         Kafka kafkaAssembly = ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, emptyMap());
@@ -763,7 +766,7 @@ public class ZookeeperClusterTest {
         assertThat(np.getSpec().getIngress().get(1).getFrom().get(3), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).withNamespaceSelector(namespaceSelector).build()));
     }
 
-    @Test
+    @ParallelTest
     public void testGeneratePersistentVolumeClaimsPersistentWithClaimDeletion() {
         Kafka ka = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, zooConfigurationJson))
                 .editSpec()
@@ -792,7 +795,7 @@ public class ZookeeperClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testGeneratePersistentVolumeClaimsPersistentWithoutClaimDeletion() {
         Kafka ka = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, zooConfigurationJson))
                 .editSpec()
@@ -821,7 +824,7 @@ public class ZookeeperClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testGeneratePersistentVolumeClaimsPersistentWithOverride() {
         Kafka ka = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, zooConfigurationJson))
                 .editSpec()
@@ -866,7 +869,7 @@ public class ZookeeperClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testGeneratePersistentVolumeClaimsWithTemplate() {
         Kafka ka = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, zooConfigurationJson))
                 .editSpec()
@@ -902,7 +905,7 @@ public class ZookeeperClusterTest {
         }
     }
 
-    @Test
+    @ParallelTest
     public void testGeneratePersistentVolumeClaimsEphemeral()    {
         Kafka ka = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, zooConfigurationJson))
                 .editSpec()
@@ -923,7 +926,7 @@ public class ZookeeperClusterTest {
         assertThat(pvcs.size(), is(0));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateSTSWithPersistentVolumeEphemeral()    {
         Kafka ka = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, zooConfigurationJson))
                 .editSpec()
@@ -938,7 +941,7 @@ public class ZookeeperClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateSTSWithPersistentVolumeEphemeralWithSizeLimit()    {
         String sizeLimit = "1Gi";
         Kafka ka = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, jmxMetricsConfig, configurationJson, zooConfigurationJson))
@@ -954,7 +957,7 @@ public class ZookeeperClusterTest {
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit(), is(new Quantity("1", "Gi")));
     }
 
-    @Test
+    @ParallelTest
     public void testStorageReverting() {
         SingleVolumeStorage ephemeral = new EphemeralStorageBuilder().build();
         SingleVolumeStorage persistent = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build();
@@ -988,7 +991,7 @@ public class ZookeeperClusterTest {
         assertThat(zc.getWarningConditions().get(0).getReason(), is("ZooKeeperStorage"));
     }
 
-    @Test
+    @ParallelTest
     public void testStorageValidationAfterInitialDeployment() {
         assertThrows(InvalidResourceException.class, () -> {
             Storage oldStorage = new PersistentClaimStorageBuilder()
@@ -1007,7 +1010,7 @@ public class ZookeeperClusterTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testZookeeperContainerEnvVars() {
 
         ContainerEnvVar envVar1 = new ContainerEnvVar();
@@ -1052,7 +1055,7 @@ public class ZookeeperClusterTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testZookeeperContainerEnvVarsConflict() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = ZookeeperCluster.ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED;
@@ -1095,7 +1098,7 @@ public class ZookeeperClusterTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testZookeeperContainerSecurityContext() {
 
         SecurityContext securityContext = new SecurityContextBuilder()
@@ -1131,7 +1134,7 @@ public class ZookeeperClusterTest {
                 )));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingInline() {
         Map<String, Object> dummyMetrics = singletonMap("dummy", "metrics");
 
@@ -1151,7 +1154,7 @@ public class ZookeeperClusterTest {
         assertThat(zc.getMetricsConfigInCm(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingFromConfigMap() {
         MetricsConfig metrics = new JmxPrometheusExporterMetricsBuilder()
                 .withNewValueFrom()
@@ -1175,7 +1178,7 @@ public class ZookeeperClusterTest {
         assertThat(zc.getMetricsConfig(), is(nullValue()));
     }
 
-    @Test
+    @ParallelTest
     public void testMetricsParsingNoMetrics() {
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout), VERSIONS);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -55,7 +55,6 @@ import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
-import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.security.cert.CertificateParsingException;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -41,7 +41,6 @@ import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -41,6 +41,7 @@ import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -50,6 +50,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -50,7 +50,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -9,6 +9,7 @@ import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.IsolatedTest;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -113,7 +114,7 @@ public class KafkaConnectApiTest {
         vertx.close();
     }
 
-    @Test
+    @IsolatedTest
     @SuppressWarnings({"unchecked", "checkstyle:MethodLength", "checkstyle:NPathComplexity"})
     public void test(VertxTestContext context) {
         KafkaConnectApi client = new KafkaConnectApiImpl(vertx);
@@ -258,7 +259,7 @@ public class KafkaConnectApiTest {
             }));
     }
 
-    @Test
+    @IsolatedTest
     public void testChangeLoggers(VertxTestContext context) throws InterruptedException {
         String desired = "log4j.rootLogger=TRACE, CONSOLE\n" +
                 "log4j.logger.org.apache.zookeeper=WARN\n" +

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;

--- a/cluster-operator/src/test/resources/junit-platform.properties
+++ b/cluster-operator/src/test/resources/junit-platform.properties
@@ -4,6 +4,5 @@
 junit.jupiter.execution.parallel.enabled=true
 junit.jupiter.execution.parallel.mode.default=same_thread
 junit.jupiter.execution.parallel.mode.classes.default=same_thread
-junit.jupiter.execution.parallel.config.strategy=fixed
-junit.jupiter.execution.parallel.config.fixed.parallelism=20
+junit.jupiter.execution.parallel.config.strategy=dynamic
 junit.platform.output.capture.maxBuffer=true

--- a/cluster-operator/src/test/resources/junit-platform.properties
+++ b/cluster-operator/src/test/resources/junit-platform.properties
@@ -1,0 +1,9 @@
+# These are default values if @ParallelTest or @ParallelSuite is not specified
+# junit.jupiter.execution.parallel.mode.default <==> ParallelTest = concurrent
+# junit.jupiter.execution.parallel.mode.classes.default <==> ParallelSuite = concurrent
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=same_thread
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=20
+junit.platform.output.capture.maxBuffer=true

--- a/test/src/main/java/io/strimzi/test/annotations/IsolatedTest.java
+++ b/test/src/main/java/io/strimzi/test/annotations/IsolatedTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.annotations;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/***
+ * Annotation for running isolated tests in strimzi test suite
+ * please be sure that you know laws of parallel execution and concurrent programming
+ * be sure that you do not use shared resources, and if you use shared resources please work with synchronization
+ */
+@Target(ElementType.METHOD)
+@Retention(RUNTIME)
+@Inherited
+@ResourceLock(mode = ResourceAccessMode.READ_WRITE, value = "global")
+@Test
+public @interface IsolatedTest {
+    String value() default "";
+}

--- a/test/src/main/java/io/strimzi/test/annotations/ParallelSuite.java
+++ b/test/src/main/java/io/strimzi/test/annotations/ParallelSuite.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.annotations;
+
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/***
+ * Annotation for running parallel tests in strimzi test suite
+ * please be sure that you know laws of parallel execution and concurrent programming
+ * be sure that you do not use shared resources, and if you use shared resources please work with synchronization
+ */
+@Retention(RUNTIME)
+@Execution(ExecutionMode.CONCURRENT)
+public @interface ParallelSuite {
+}

--- a/test/src/main/java/io/strimzi/test/annotations/ParallelTest.java
+++ b/test/src/main/java/io/strimzi/test/annotations/ParallelTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.annotations;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/***
+ * Annotation for running parallel tests in strimzi test suite
+ * please be sure that you know laws of parallel execution and concurrent programming
+ * be sure that you do not use shared resources, and if you use shared resources please work with synchronization
+ */
+@Target(ElementType.METHOD)
+@Retention(RUNTIME)
+@Execution(ExecutionMode.CONCURRENT)
+@ResourceLock(mode = ResourceAccessMode.READ, value = "global")
+@Test
+public @interface ParallelTest {
+}
+


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature

### Description

This PR adding support for all tests inside `cluster-operator/io/strimzi/operator/cluster/model` package which can be executed by method and class-wide parallelism.

### Checklist

- [x] Make sure all tests pass